### PR TITLE
docs: fix typos in architecture/basics

### DIFF
--- a/docs/pages/architecture/basics.mdx
+++ b/docs/pages/architecture/basics.mdx
@@ -35,17 +35,17 @@ It is possible to run multiple vclusters inside the same namespace and you can e
 The core idea of virtual clusters is to provision isolated Kubernetes control planes (e.g. API servers) that run on top of "real" Kubernetes clusters. When working with the virtual cluster's API server, resources first only exist in the virtual cluster. However, some low-level Kubernetes resources need to be synchronized to the underlying cluster.
 
 ### High-Level = Purely Virtual
-Generally, all Kuberentes resource objects that you create using the vcluster API server are stored in the data store of the vcluster (sqlite by default). That applies in particular to all higher level Kubernetes resources, such as Deployments, StatefulSets, CRDs, etc. These objects only exist inside the virtual cluster and never reach the API server or data store (etcd) of the underlying host cluster.
+Generally, all Kubernetes resource objects that you create using the vcluster API server are stored in the data store of the vcluster (sqlite by default). That applies in particular to all higher level Kubernetes resources, such as Deployments, StatefulSets, CRDs, etc. These objects only exist inside the virtual cluster and never reach the API server or data store (etcd) of the underlying host cluster.
 
 ### Low-Level = Sync'd Resources
-To be able to actually start containers, the vcluster synchronizes certain low-level resources (e.g. Pods, ConfigMaps mounted in Pods) to the underlying host namespace, so that the scheduler of the underlying host cluster can schedule these pods. The huge 
+To be able to actually start containers, the vcluster synchronizes certain low-level resources (e.g. Pods, ConfigMaps mounted in Pods) to the underlying host namespace, so that the scheduler of the underlying host cluster can schedule these pods.
 
 
 ## Design Principles
 vcluster has been designed following these principles:
 
 ### 1. Lightweight / Low-Overhead
-vclusters should be as lightweight as possibl to minimize resource overhead inside the underlying [host cluster](#host-cluster--namespace).
+vclusters should be as lightweight as possible to minimize resource overhead inside the underlying [host cluster](#host-cluster--namespace).
 
 **Implementation:** This is mainly achieved by bundling the vcluster inside a single Pod using k3s as a control plane.
 


### PR DESCRIPTION
Fix some typos in architecture/basics documentation page.