### PR TITLE
node changes sync, labels sync & resource apply removal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 /api
 /kubeconfig.yaml
 /cmd/virtualclusterctl
+devspace.yaml

--- a/chart/templates/rbac/clusterrole.yaml
+++ b/chart/templates/rbac/clusterrole.yaml
@@ -10,7 +10,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "nodes/proxy", "persistentvolumes"]
+    resources: ["nodes"]
+    verbs: ["get", "watch", "list", "update"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy", "persistentvolumes"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]

--- a/chart/templates/rbac/clusterrolebinding.yaml
+++ b/chart/templates/rbac/clusterrolebinding.yaml
@@ -10,7 +10,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.serviceAccount.name }}
+    name: {{ .Values.serviceAccount.name }}
+    {{- else }}
     name: vc-{{ .Release.Name }}
+    {{- end }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/chart/templates/rbac/rolebinding.yaml
+++ b/chart/templates/rbac/rolebinding.yaml
@@ -11,7 +11,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
   - kind: ServiceAccount
+    {{- if .Values.serviceAccount.name }}
+    name: {{ .Values.serviceAccount.name }}
+    {{- else }}
     name: vc-{{ .Release.Name }}
+    {{- end }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -31,7 +31,11 @@ spec:
         release: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: 10
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- else }}
       serviceAccountName: vc-{{ .Release.Name }}
+      {{- end }}
       containers:
       - image: {{ .Values.vcluster.image }}
         name: vcluster

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -27,7 +27,7 @@ type VirtualClusterOptions struct {
 	OwningStatefulSet    string
 
 	SyncAllNodes             bool
-	SyncNodeTaints           bool
+	SyncNodeChanges          bool
 	UseFakeNodes             bool
 	UseFakePersistentVolumes bool
 	EnableStorageClasses     bool

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -27,6 +27,7 @@ type VirtualClusterOptions struct {
 	OwningStatefulSet    string
 
 	SyncAllNodes             bool
+	SyncNodeTaints           bool
 	UseFakeNodes             bool
 	UseFakePersistentVolumes bool
 	EnableStorageClasses     bool

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -97,7 +97,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().IntVar(&options.Port, "port", 8443, "The port to bind to")
 
 	cmd.Flags().BoolVar(&options.SyncAllNodes, "sync-all-nodes", false, "If enabled and --fake-nodes is false, the virtual cluster will sync all nodes instead of only the needed ones")
-	cmd.Flags().BoolVar(&options.SyncNodeTaints, "sync-node-taints", false, "If enabled and --fake-nodes is false, the virtual cluster will sync new node taints from the virtual cluster to the host cluster")
+	cmd.Flags().BoolVar(&options.SyncNodeChanges, "sync-node-changes", false, "If enabled and --fake-nodes is false, the virtual cluster will sync node changes from the virtual cluster to the host cluster")
 	cmd.Flags().BoolVar(&options.UseFakeNodes, "fake-nodes", true, "If enabled, the virtual cluster will create fake nodes instead of copying the actual physical nodes config")
 	cmd.Flags().BoolVar(&options.UseFakePersistentVolumes, "fake-persistent-volumes", true, "If enabled, the virtual cluster will create fake persistent volumes instead of copying the actual physical persistent volumes config")
 	cmd.Flags().BoolVar(&options.EnableStorageClasses, "enable-storage-classes", false, "If enabled, the virtual cluster will sync storage classes")

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -97,6 +97,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().IntVar(&options.Port, "port", 8443, "The port to bind to")
 
 	cmd.Flags().BoolVar(&options.SyncAllNodes, "sync-all-nodes", false, "If enabled and --fake-nodes is false, the virtual cluster will sync all nodes instead of only the needed ones")
+	cmd.Flags().BoolVar(&options.SyncNodeTaints, "sync-node-taints", false, "If enabled and --fake-nodes is false, the virtual cluster will sync new node taints from the virtual cluster to the host cluster")
 	cmd.Flags().BoolVar(&options.UseFakeNodes, "fake-nodes", true, "If enabled, the virtual cluster will create fake nodes instead of copying the actual physical nodes config")
 	cmd.Flags().BoolVar(&options.UseFakePersistentVolumes, "fake-persistent-volumes", true, "If enabled, the virtual cluster will create fake persistent volumes instead of copying the actual physical persistent volumes config")
 	cmd.Flags().BoolVar(&options.EnableStorageClasses, "enable-storage-classes", false, "If enabled, the virtual cluster will sync storage classes")

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v1beta9
 images:
   vcluster:
-    image: loftsh/vcluster
+    image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
     preferSyncOverRebuild: true
     entrypoint: ["sleep", "99999999"]
     build:
@@ -19,7 +19,7 @@ deployments:
           clusterRole:
             create: true
         syncer:
-          image: loftsh/vcluster
+          image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
           noArgs: true
 dev:
   interactive:
@@ -27,6 +27,7 @@ dev:
   sync:
     - imageName: vcluster
       disableDownload: true
+      waitInitialSync: true
       excludePaths:
         - bin/
         - .vscode/
@@ -48,12 +49,22 @@ profiles:
     replace:
       images:
         manager:
-          image: loftsh/vcluster
+          image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
       deployments:
         - name: vcluster
           helm:
             chart:
               name: ./chart
             values:
+              vcluster:
+                image: rancher/k3s:v1.19.8-k3s1
+              rbac:
+                clusterRole:
+                  create: true
               syncer:
-                image: loftsh/vcluster
+                image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
+                extraArgs:
+                  - --service-cidr=10.120.0.0/20
+                  - --sync-all-nodes
+                  - --sync-node-taints
+                  - --fake-nodes=false

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -60,9 +60,9 @@ profiles:
                 create: false
                 name: default
               vcluster:
-                image: rancher/k3s:v1.19.8-k3s1
+                image: rancher/k3s:v1.20.5-k3s1
                 extraArgs:
-                  - --service-cidr=10.120.0.0/20
+                  - --service-cidr=10.84.0.0/20
               rbac:
                 clusterRole:
                   create: true
@@ -70,5 +70,5 @@ profiles:
                 image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
                 extraArgs:
                   - --sync-all-nodes
-                  - --sync-node-taints
+                  - --sync-node-changes
                   - --fake-nodes=false

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -48,7 +48,7 @@ profiles:
   - name: deploy
     replace:
       images:
-        manager:
+        vcluster:
           image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
       deployments:
         - name: vcluster
@@ -56,15 +56,19 @@ profiles:
             chart:
               name: ./chart
             values:
+              serviceAccount:
+                create: false
+                name: default
               vcluster:
                 image: rancher/k3s:v1.19.8-k3s1
+                extraArgs:
+                  - --service-cidr=10.120.0.0/20
               rbac:
                 clusterRole:
                   create: true
               syncer:
                 image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
                 extraArgs:
-                  - --service-cidr=10.120.0.0/20
                   - --sync-all-nodes
                   - --sync-node-taints
                   - --fake-nodes=false

--- a/hack/wrong-cluster-ip-service.yaml
+++ b/hack/wrong-cluster-ip-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-simple-service
+spec:
+  clusterIP: 1.1.1.1
+  selector:
+    app: service-simple-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/pkg/controllers/resources/configmaps/syncer_test.go
+++ b/pkg/controllers/resources/configmaps/syncer_test.go
@@ -45,6 +45,9 @@ func TestSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      translate.PhysicalName(baseConfigMap.Name, baseConfigMap.Namespace),
 			Namespace: "test",
+			Labels: map[string]string{
+				translate.NamespaceLabel: translate.NamespaceLabelValue(baseConfigMap.Namespace),
+			},
 		},
 	}
 	updatedSyncedConfigMap := &corev1.ConfigMap{

--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/generic"
-	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,7 +66,8 @@ func (s *syncer) ForwardCreate(ctx context.Context, vObj client.Object, log logh
 		return ctrl.Result{}, err
 	}
 
-	err = clienthelper.Apply(ctx, s.localClient, newEndpoints, log)
+	log.Debugf("create physical endpoints %s/%s", newEndpoints.Namespace, newEndpoints.Name)
+	err = s.localClient.Create(ctx, newEndpoints)
 	if err != nil {
 		log.Infof("error syncing %s/%s to physical cluster: %v", vEndpoints.Namespace, vEndpoints.Name, err)
 		s.eventRecoder.Eventf(vEndpoints, "Warning", "SyncError", "Error syncing to physical cluster: %v", err)
@@ -87,21 +88,53 @@ func (s *syncer) ForwardCreateNeeded(vObj client.Object) (bool, error) {
 }
 
 func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
-	return s.ForwardCreate(ctx, vObj, log)
+	// did the configmap change?
+	pEndpoints := pObj.(*corev1.Endpoints)
+	vEndpoints := vObj.(*corev1.Endpoints)
+	updated := calcEndpointsDiff(pEndpoints, vEndpoints)
+	if updated != nil {
+		log.Debugf("updating physical endpoints %s/%s, because virtual configmap has changed", updated.Namespace, updated.Name)
+		err := s.localClient.Update(ctx, updated)
+		if err != nil {
+			s.eventRecoder.Eventf(vEndpoints, "Warning", "SyncError", "Error syncing to physical cluster: %v", err)
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (s *syncer) ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
-	newSecret, err := s.translate(vObj)
-	if err != nil {
-		return false, err
+	updated := calcEndpointsDiff(pObj.(*corev1.Endpoints), vObj.(*corev1.Endpoints))
+	return updated != nil, nil
+}
+
+func calcEndpointsDiff(pObj, vObj *corev1.Endpoints) *corev1.Endpoints {
+	var updated *corev1.Endpoints
+
+	// check subsets
+	if !equality.Semantic.DeepEqual(vObj.Subsets, pObj.Subsets) {
+		updated = pObj.DeepCopy()
+		updated.Subsets = vObj.Subsets
 	}
 
-	equal, err := clienthelper.AppliedObjectsEqual(pObj, newSecret)
-	if err != nil {
-		return false, err
+	// check annotations
+	if !equality.Semantic.DeepEqual(vObj.Annotations, pObj.Annotations) {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Annotations = vObj.Annotations
 	}
 
-	return equal == false, nil
+	// check labels
+	if !translate.LabelsEqual(vObj.Namespace, vObj.Labels, pObj.Labels) {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Labels = translate.TranslateLabels(vObj.Namespace, vObj.Labels)
+	}
+
+	return updated
 }
 
 func (s *syncer) BackwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {

--- a/pkg/controllers/resources/endpoints/syncer_test.go
+++ b/pkg/controllers/resources/endpoints/syncer_test.go
@@ -49,6 +49,9 @@ func TestSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      translate.PhysicalName(baseEndpoints.Name, baseEndpoints.Namespace),
 			Namespace: "test",
+			Labels: map[string]string{
+				translate.NamespaceLabel: translate.NamespaceLabelValue(baseEndpoints.Namespace),
+			},
 		},
 	}
 	syncedUpdatedEndpoints := &corev1.Endpoints{

--- a/pkg/controllers/resources/generic/backward_cluster.go
+++ b/pkg/controllers/resources/generic/backward_cluster.go
@@ -13,8 +13,7 @@ import (
 )
 
 type backwardClusterController struct {
-	synced          func()
-	targetNamespace string
+	synced func()
 
 	target    ClusterSyncer
 	lifecycle BackwardLifecycle

--- a/pkg/controllers/resources/generic/forward_cluster.go
+++ b/pkg/controllers/resources/generic/forward_cluster.go
@@ -1,0 +1,117 @@
+package generic
+
+import (
+	"context"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type forwardClusterController struct {
+	synced func()
+
+	target        ClusterSyncer
+	log           loghelper.Logger
+	localClient   client.Client
+	virtualClient client.Client
+	scheme        *runtime.Scheme
+}
+
+func (r *forwardClusterController) GarbageCollect(queue workqueue.RateLimitingInterface) error {
+	ctx := context.Background()
+
+	// list all virtual objects first
+	vList := r.target.NewList()
+	err := r.virtualClient.List(ctx, vList)
+	if err != nil {
+		return err
+	}
+
+	// check if physical object exists
+	vItems, err := meta.ExtractList(vList)
+	if err != nil {
+		return err
+	}
+	for _, vObj := range vItems {
+		vAccessor, _ := meta.Accessor(vObj)
+		pObj := r.target.New()
+		err = r.localClient.Get(ctx, types.NamespacedName{
+			Name: vAccessor.GetName(),
+		}, pObj)
+		if kerrors.IsNotFound(err) {
+			// we ignore this case as we only update cluster resources on host, but never create them ourselves
+			continue
+		} else if err != nil {
+			r.log.Infof("cannot get physical object %s: %v", vAccessor.GetName(), err)
+			continue
+		}
+
+		updateNeeded, err := r.target.ForwardUpdateNeeded(pObj, vObj.(client.Object))
+		if err != nil {
+			r.log.Infof("error in update needed for virtual object %s: %v", vAccessor.GetName(), err)
+			continue
+		}
+
+		if updateNeeded {
+			r.log.Debugf("resync virtual object %s", vAccessor.GetName())
+			queue.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: vAccessor.GetName(),
+				},
+			})
+		}
+	}
+
+	return nil
+}
+
+func (r *forwardClusterController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// make sure the caches are synced
+	r.synced()
+
+	// check if we should skip reconcile
+	lifecycle, ok := r.target.(ForwardLifecycle)
+	if ok {
+		skip, err := lifecycle.ForwardStart(ctx, req)
+		defer lifecycle.ForwardEnd()
+		if skip || err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// get virtual object
+	vObj := r.target.New()
+	vExists := true
+	err := r.virtualClient.Get(ctx, req.NamespacedName, vObj)
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return ctrl.Result{}, err
+		}
+
+		vExists = false
+	}
+
+	// get physical object
+	pObj := r.target.New()
+	pExists := true
+	err = r.localClient.Get(ctx, req.NamespacedName, pObj)
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return ctrl.Result{}, err
+		}
+
+		pExists = false
+	}
+
+	if vExists && pExists {
+		return r.target.ForwardUpdate(ctx, pObj, vObj, r.log)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/resources/generic/types.go
+++ b/pkg/controllers/resources/generic/types.go
@@ -22,9 +22,7 @@ type Syncer interface {
 	Object
 
 	ForwardCreate(ctx context.Context, vObj client.Object, log loghelper.Logger) (ctrl.Result, error)
-	ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error)
-	ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error)
-
+	ForwardUpdate
 	BackwardUpdate
 }
 
@@ -33,11 +31,17 @@ type ForwardCreate interface {
 	ForwardCreateNeeded(vObj client.Object) (bool, error)
 }
 
+type ForwardUpdate interface {
+	ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error)
+	ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error)
+}
+
 type ClusterSyncer interface {
 	Object
 
 	BackwardCreate(ctx context.Context, pObj client.Object, log loghelper.Logger) (ctrl.Result, error)
 	BackwardCreateNeeded(pObj client.Object) (bool, error)
+	ForwardUpdate
 	BackwardUpdate
 }
 

--- a/pkg/controllers/resources/ingresses/syncer_test.go
+++ b/pkg/controllers/resources/ingresses/syncer_test.go
@@ -109,7 +109,8 @@ func TestSync(t *testing.T) {
 		Name:      translate.PhysicalName("testingress", "testns"),
 		Namespace: "test",
 		Labels: map[string]string{
-			translate.MarkerLabel: translate.Suffix,
+			translate.MarkerLabel:    translate.Suffix,
+			translate.NamespaceLabel: translate.NamespaceLabelValue(vObjectMeta.Namespace),
 		},
 	}
 	baseIngress := &networkingv1beta1.Ingress{

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -35,14 +35,14 @@ func RegisterSyncer(ctx *context2.ControllerContext) error {
 		virtualClient:    ctx.VirtualManager.GetClient(),
 		scheme:           ctx.LocalManager.GetScheme(),
 		nodeSelector:     nodeSelector,
-		syncNodeTaints:   ctx.Options.SyncNodeTaints,
+		syncNodeChanges:  ctx.Options.SyncNodeChanges,
 	}, "node")
 }
 
 type syncer struct {
 	sharedNodesMutex sync.Locker
 	nodeSelector     labels.Selector
-	syncNodeTaints   bool
+	syncNodeChanges  bool
 
 	localClient   client.Client
 	virtualClient client.Client
@@ -183,8 +183,9 @@ func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj cli
 		return ctrl.Result{}, nil
 	}
 
+	pNode.Labels = vNode.Labels
 	pNode.Spec.Taints = vNode.Spec.Taints
-	log.Debugf("update physical node %s, because taints have changed", pNode.Name)
+	log.Debugf("update physical node %s, because taints or labels have changed", pNode.Name)
 	err = s.localClient.Update(ctx, pNode)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -194,11 +195,11 @@ func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj cli
 }
 
 func (s *syncer) ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
-	if !s.syncNodeTaints {
+	if !s.syncNodeChanges {
 		return false, nil
 	}
 
 	pNode := pObj.(*corev1.Node)
 	vNode := vObj.(*corev1.Node)
-	return !equality.Semantic.DeepEqual(vNode.Spec.Taints, pNode.Spec.Taints), nil
+	return !equality.Semantic.DeepEqual(vNode.Spec.Taints, pNode.Spec.Taints) || !equality.Semantic.DeepEqual(vNode.Labels, pNode.Labels), nil
 }

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -35,12 +35,14 @@ func RegisterSyncer(ctx *context2.ControllerContext) error {
 		virtualClient:    ctx.VirtualManager.GetClient(),
 		scheme:           ctx.LocalManager.GetScheme(),
 		nodeSelector:     nodeSelector,
+		syncNodeTaints:   ctx.Options.SyncNodeTaints,
 	}, "node")
 }
 
 type syncer struct {
 	sharedNodesMutex sync.Locker
 	nodeSelector     labels.Selector
+	syncNodeTaints   bool
 
 	localClient   client.Client
 	virtualClient client.Client
@@ -169,4 +171,34 @@ func (s *syncer) BackwardStart(ctx context.Context, req ctrl.Request) (bool, err
 
 func (s *syncer) BackwardEnd() {
 	s.sharedNodesMutex.Unlock()
+}
+
+func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	pNode := pObj.(*corev1.Node)
+	vNode := vObj.(*corev1.Node)
+	updateNeeded, err := s.ForwardUpdateNeeded(pObj, vObj)
+	if err != nil {
+		return ctrl.Result{}, err
+	} else if !updateNeeded {
+		return ctrl.Result{}, nil
+	}
+
+	pNode.Spec.Taints = vNode.Spec.Taints
+	log.Debugf("update physical node %s, because taints have changed", pNode.Name)
+	err = s.localClient.Update(ctx, pNode)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (s *syncer) ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
+	if !s.syncNodeTaints {
+		return false, nil
+	}
+
+	pNode := pObj.(*corev1.Node)
+	vNode := vObj.(*corev1.Node)
+	return !equality.Semantic.DeepEqual(vNode.Spec.Taints, pNode.Spec.Taints), nil
 }

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -267,6 +267,14 @@ func calcPVCDiff(pObj, vObj *corev1.PersistentVolumeClaim) *corev1.PersistentVol
 		updated.Annotations = translate.SetExcept(vObj.Annotations, updated.Annotations, bindCompletedAnnotation, boundByControllerAnnotation, storageProvisionerAnnotation)
 	}
 
+	// check labels
+	if !translate.LabelsEqual(vObj.Namespace, vObj.Labels, pObj.Labels) {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Labels = translate.TranslateLabels(vObj.Namespace, vObj.Labels)
+	}
+
 	return updated
 }
 

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
@@ -39,7 +39,8 @@ func TestSync(t *testing.T) {
 		Name:      translate.PhysicalName("testpvc", "testns"),
 		Namespace: "test",
 		Labels: map[string]string{
-			translate.MarkerLabel: translate.Suffix,
+			translate.MarkerLabel:    translate.Suffix,
+			translate.NamespaceLabel: translate.NamespaceLabelValue(vObjectMeta.Namespace),
 		},
 	}
 	changedResources := corev1.ResourceRequirements{
@@ -84,6 +85,7 @@ func TestSync(t *testing.T) {
 			Annotations: map[string]string{
 				"otherAnnotationKey": "update this",
 			},
+			Labels: pObjectMeta.Labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			Resources: changedResources,
@@ -99,6 +101,7 @@ func TestSync(t *testing.T) {
 				storageProvisionerAnnotation: "testannotation3",
 				"otherAnnotationKey":         "don't update this",
 			},
+			Labels: pObjectMeta.Labels,
 		},
 	}
 	backwardUpdatedAnnotationsPvc := &corev1.PersistentVolumeClaim{

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -153,3 +153,11 @@ func buildVirtualPV(vPv *corev1.PersistentVolume, pPv *corev1.PersistentVolume, 
 	vObj.Spec.ClaimRef.Namespace = vPvc.Namespace
 	return vObj
 }
+
+func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+func (s *syncer) ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
+	return false, nil
+}

--- a/pkg/controllers/resources/pods/diff.go
+++ b/pkg/controllers/resources/pods/diff.go
@@ -15,11 +15,19 @@ func calcPodDiff(pPod, vPod *corev1.Pod, translateImages ImageTranslator) *corev
 	}
 
 	// check annotations
-	if !translate.EqualExcept(pPod.Annotations, vPod.Annotations, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation) {
+	if !translate.EqualExcept(pPod.Annotations, vPod.Annotations, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, LabelsAnnotation) {
 		if updatedPod == nil {
 			updatedPod = pPod.DeepCopy()
 		}
-		updatedPod.Annotations = translate.SetExcept(vPod.Annotations, pPod.Annotations, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation)
+		updatedPod.Annotations = translate.SetExcept(vPod.Annotations, pPod.Annotations, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, LabelsAnnotation)
+	}
+
+	// check labels
+	if !translate.LabelsEqual(vPod.Namespace, vPod.Labels, pPod.Labels) {
+		if updatedPod == nil {
+			updatedPod = pPod.DeepCopy()
+		}
+		updatedPod.Labels = translate.TranslateLabels(vPod.Namespace, vPod.Labels)
 	}
 
 	return updatedPod

--- a/pkg/controllers/resources/pods/diff.go
+++ b/pkg/controllers/resources/pods/diff.go
@@ -22,6 +22,14 @@ func calcPodDiff(pPod, vPod *corev1.Pod, translateImages ImageTranslator) *corev
 		updatedPod.Annotations = translate.SetExcept(vPod.Annotations, pPod.Annotations, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, LabelsAnnotation)
 	}
 
+	// check labels annotation
+	if (vPod.Labels == nil || vPod.Labels[translate.MarkerLabel] == "") && pPod.Annotations[LabelsAnnotation] != translateLabelsAnnotation(vPod) {
+		if updatedPod == nil {
+			updatedPod = pPod.DeepCopy()
+		}
+		updatedPod.Annotations[LabelsAnnotation] = translateLabelsAnnotation(vPod)
+	}
+
 	// check labels
 	if !translate.LabelsEqual(vPod.Namespace, vPod.Labels, pPod.Labels) {
 		if updatedPod == nil {

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -198,7 +198,7 @@ func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj cli
 	// update the virtual pod if the spec has changed
 	updatedPod := calcPodDiff(pPod, vPod, s.translateImages)
 	if updatedPod != nil {
-		log.Debugf("update physical pod %s/%s, because spec or annotations have changed", pPod.Namespace, pPod.Name)
+		log.Debugf("update physical pod %s/%s, because spec, labels or annotations have changed", pPod.Namespace, pPod.Name)
 		err := s.localClient.Update(ctx, updatedPod)
 		if err != nil {
 			s.eventRecoder.Eventf(vPod, "Warning", "SyncError", "Error syncing to physical cluster: %v", err)

--- a/pkg/controllers/resources/pods/translate.go
+++ b/pkg/controllers/resources/pods/translate.go
@@ -2,8 +2,10 @@ package pods
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/pkg/errors"
+	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sort"
 	"strings"
@@ -18,6 +20,7 @@ const (
 	OwnerSetKind                 = "vcluster.loft.sh/owner-set-kind"
 	NamespaceAnnotation          = "vcluster.loft.sh/namespace"
 	NameAnnotation               = "vcluster.loft.sh/name"
+	LabelsAnnotation             = "vcluster.loft.sh/labels"
 	UIDAnnotation                = "vcluster.loft.sh/uid"
 	ServiceAccountNameAnnotation = "vcluster.loft.sh/service-account-name"
 
@@ -26,6 +29,10 @@ const (
 	HostsVolumeName                   = "vcluster-rewrite-hosts"
 	HostsRewriteImage                 = "alpine:3.13.1"
 	HostsRewriteContainerName         = "vcluster-rewrite-hosts"
+)
+
+var (
+	FieldPathLabelRegEx = regexp.MustCompile("^metadata\\.labels\\['(.+)'\\]$")
 )
 
 func translatePod(pPod *corev1.Pod, vPod *corev1.Pod, vClient client.Client, services []*corev1.Service, clusterDomain, dnsIP, kubeIP, serviceAccount string, translator ImageTranslator, enableOverrideHosts bool, overrideHostsImage string) error {
@@ -44,6 +51,9 @@ func translatePod(pPod *corev1.Pod, vPod *corev1.Pod, vClient client.Client, ser
 		pPod.Annotations[NameAnnotation] = vPod.Annotations[NameAnnotation]
 		pPod.Annotations[UIDAnnotation] = vPod.Annotations[UIDAnnotation]
 		pPod.Annotations[ServiceAccountNameAnnotation] = vPod.Annotations[ServiceAccountNameAnnotation]
+		if labels, ok := vPod.Annotations[LabelsAnnotation]; ok {
+			pPod.Annotations[LabelsAnnotation] = labels
+		}
 	}
 	if pPod.Annotations[NamespaceAnnotation] == "" {
 		pPod.Annotations[NamespaceAnnotation] = vPod.Namespace
@@ -56,6 +66,20 @@ func translatePod(pPod *corev1.Pod, vPod *corev1.Pod, vClient client.Client, ser
 	}
 	if pPod.Annotations[ServiceAccountNameAnnotation] == "" {
 		pPod.Annotations[ServiceAccountNameAnnotation] = vPod.Spec.ServiceAccountName
+	}
+	if _, ok := pPod.Annotations[LabelsAnnotation]; !ok {
+		labelsString := []string{}
+		for k, v := range vPod.Labels {
+			// escape pod labels
+			out, err := json.Marshal(v)
+			if err != nil {
+				return errors.Wrap(err, "escape label "+k)
+			}
+
+			labelsString = append(labelsString, k+"="+string(out))
+		}
+
+		pPod.Annotations[LabelsAnnotation] = strings.Join(labelsString, "\n")
 	}
 
 	// translate services to environment variables
@@ -212,6 +236,9 @@ func translatePod(pPod *corev1.Pod, vPod *corev1.Pod, vClient client.Client, ser
 		}
 	}
 
+	// translate topology spread constraints
+	translateTopologySpreadConstraints(vPod, pPod)
+
 	return nil
 }
 
@@ -247,7 +274,7 @@ func translateProjectedVolume(projectedVolume *corev1.ProjectedVolumeSource, vCl
 		}
 		if projectedVolume.Sources[i].DownwardAPI != nil {
 			for j := range projectedVolume.Sources[i].DownwardAPI.Items {
-				translateFieldRef(projectedVolume.Sources[i].DownwardAPI.Items[j].FieldRef)
+				translateFieldRef(vPod, projectedVolume.Sources[i].DownwardAPI.Items[j].FieldRef)
 			}
 		}
 		if projectedVolume.Sources[i].ServiceAccountToken != nil {
@@ -278,11 +305,21 @@ func translateProjectedVolume(projectedVolume *corev1.ProjectedVolumeSource, vCl
 	return nil
 }
 
-func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector) {
+func translateFieldRef(vPod *corev1.Pod, fieldSelector *corev1.ObjectFieldSelector) {
 	if fieldSelector == nil {
 		return
 	}
+
+	// check if its a label we have to rewrite
+	labelsMatch := FieldPathLabelRegEx.FindStringSubmatch(fieldSelector.FieldPath)
+	if len(labelsMatch) == 2 {
+		fieldSelector.FieldPath = "metadata.labels['" + translate.ConvertLabelKey(labelsMatch[0], vPod.Namespace) + "']"
+		return
+	}
+
 	switch fieldSelector.FieldPath {
+	case "metadata.labels":
+		fieldSelector.FieldPath = "metadata.annotations['" + LabelsAnnotation + "']"
 	case "metadata.name":
 		fieldSelector.FieldPath = "metadata.annotations['" + NameAnnotation + "']"
 	case "metadata.namespace":
@@ -317,7 +354,7 @@ func stripHostRewriteContainer(pPod *corev1.Pod) *corev1.Pod {
 func translateEphemerealContainerEnv(c *corev1.EphemeralContainer, vPod *corev1.Pod, serviceEnvMap map[string]string) {
 	envNameMap := make(map[string]struct{})
 	for j, env := range c.Env {
-		translateDownwardAPI(&c.Env[j])
+		translateDownwardAPI(vPod, &c.Env[j])
 		if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Name != "" {
 			c.Env[j].ValueFrom.ConfigMapKeyRef.Name = translate.PhysicalName(c.Env[j].ValueFrom.ConfigMapKeyRef.Name, vPod.Namespace)
 		}
@@ -361,7 +398,7 @@ func translateEphemerealContainerEnv(c *corev1.EphemeralContainer, vPod *corev1.
 func translateContainerEnv(c *corev1.Container, vPod *corev1.Pod, serviceEnvMap map[string]string) {
 	envNameMap := make(map[string]struct{})
 	for j, env := range c.Env {
-		translateDownwardAPI(&c.Env[j])
+		translateDownwardAPI(vPod, &c.Env[j])
 		if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Name != "" {
 			c.Env[j].ValueFrom.ConfigMapKeyRef.Name = translate.PhysicalName(c.Env[j].ValueFrom.ConfigMapKeyRef.Name, vPod.Namespace)
 		}
@@ -402,23 +439,14 @@ func translateContainerEnv(c *corev1.Container, vPod *corev1.Pod, serviceEnvMap 
 	}
 }
 
-func translateDownwardAPI(env *corev1.EnvVar) {
+func translateDownwardAPI(vPod *corev1.Pod, env *corev1.EnvVar) {
 	if env.ValueFrom == nil {
 		return
 	}
 	if env.ValueFrom.FieldRef == nil {
 		return
 	}
-	switch env.ValueFrom.FieldRef.FieldPath {
-	case "metadata.name":
-		env.ValueFrom.FieldRef.FieldPath = "metadata.annotations['" + NameAnnotation + "']"
-	case "metadata.namespace":
-		env.ValueFrom.FieldRef.FieldPath = "metadata.annotations['" + NamespaceAnnotation + "']"
-	case "metadata.uid":
-		env.ValueFrom.FieldRef.FieldPath = "metadata.annotations['" + UIDAnnotation + "']"
-	case "spec.serviceAccountName":
-		env.ValueFrom.FieldRef.FieldPath = "metadata.annotations['" + ServiceAccountNameAnnotation + "']"
-	}
+	translateFieldRef(vPod, env.ValueFrom.FieldRef)
 }
 
 func translateDNSConfig(pPod *corev1.Pod, vPod *corev1.Pod, clusterDomain, nameServer string) {
@@ -487,6 +515,12 @@ func deleteDuplicates(strs []string) []string {
 
 func hasClusterIP(service *corev1.Service) bool {
 	return service.Spec.ClusterIP != "None" && service.Spec.ClusterIP != ""
+}
+
+func translateTopologySpreadConstraints(vPod *corev1.Pod, pPod *corev1.Pod) {
+	for i := range pPod.Spec.TopologySpreadConstraints {
+		pPod.Spec.TopologySpreadConstraints[i].LabelSelector = translate.TranslateLabelSelector(vPod.Namespace, pPod.Spec.TopologySpreadConstraints[i].LabelSelector)
+	}
 }
 
 func translateServicesToEnvironmentVariables(enableServiceLinks *bool, services []*corev1.Service, kubeIP string) map[string]string {

--- a/pkg/controllers/resources/secrets/syncer_test.go
+++ b/pkg/controllers/resources/secrets/syncer_test.go
@@ -42,6 +42,9 @@ func TestSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      translate.PhysicalName(baseSecret.Name, baseSecret.Namespace),
 			Namespace: "test",
+			Labels: map[string]string{
+				translate.NamespaceLabel: translate.NamespaceLabelValue(baseSecret.Namespace),
+			},
 		},
 	}
 	updatedSyncedSecret := &corev1.Secret{

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -92,10 +92,10 @@ func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj cli
 	vService := vObj.(*corev1.Service)
 	pService := pObj.(*corev1.Service)
 
-	// did ports change?
+	// did the service change?
 	updated := calcServiceDiff(pService, vService)
 	if updated != nil {
-		log.Debugf("updating physical service %s/%s, because virtual service ports or annotations have changed", updated.Namespace, updated.Name)
+		log.Debugf("updating physical service %s/%s, because virtual service has changed", updated.Namespace, updated.Name)
 		err = s.localClient.Update(ctx, updated)
 		if err != nil {
 			s.eventRecoder.Eventf(vService, "Warning", "SyncError", "Error syncing to physical cluster: %v", err)
@@ -192,14 +192,6 @@ func calcServiceDiff(pObj, vObj *corev1.Service) *corev1.Service {
 			updated = pObj.DeepCopy()
 		}
 		updated.Spec.HealthCheckNodePort = vObj.Spec.HealthCheckNodePort
-	}
-
-	// IPFamilies
-	if !equality.Semantic.DeepEqual(vObj.Spec.IPFamilies, pObj.Spec.IPFamilies) {
-		if updated == nil {
-			updated = pObj.DeepCopy()
-		}
-		updated.Spec.IPFamilies = vObj.Spec.IPFamilies
 	}
 
 	// TopologyKeys

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -130,6 +130,14 @@ func calcServiceDiff(pObj, vObj *corev1.Service) *corev1.Service {
 		updated.Annotations = vObj.Annotations
 	}
 
+	// check labels
+	if !translate.LabelsEqual(vObj.Namespace, vObj.Labels, pObj.Labels) {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Labels = translate.TranslateLabels(vObj.Namespace, vObj.Labels)
+	}
+
 	// publish not ready addresses
 	if vObj.Spec.PublishNotReadyAddresses != pObj.Spec.PublishNotReadyAddresses {
 		if updated == nil {

--- a/pkg/controllers/resources/services/syncer_test.go
+++ b/pkg/controllers/resources/services/syncer_test.go
@@ -37,7 +37,8 @@ func TestSync(t *testing.T) {
 		Name:      translate.PhysicalName("testservice", "testns"),
 		Namespace: "test",
 		Labels: map[string]string{
-			translate.MarkerLabel: translate.Suffix,
+			translate.NamespaceLabel: translate.NamespaceLabelValue(vObjectMeta.Namespace),
+			translate.MarkerLabel:    translate.Suffix,
 		},
 	}
 	vKubernetesObjectMeta := metav1.ObjectMeta{
@@ -88,6 +89,7 @@ func TestSync(t *testing.T) {
 			Namespace:   pObjectMeta.Namespace,
 			ClusterName: pObjectMeta.ClusterName,
 			Annotations: map[string]string{"a": "b"},
+			Labels:      pObjectMeta.Labels,
 		},
 		Spec: updateForwardSpec,
 	}
@@ -109,6 +111,7 @@ func TestSync(t *testing.T) {
 			Name:        pObjectMeta.Name,
 			Namespace:   pObjectMeta.Namespace,
 			ClusterName: pObjectMeta.ClusterName,
+			Labels:      pObjectMeta.Labels,
 		},
 		Spec: updateBackwardSpec,
 	}
@@ -125,6 +128,7 @@ func TestSync(t *testing.T) {
 			Name:        pObjectMeta.Name,
 			Namespace:   pObjectMeta.Namespace,
 			ClusterName: pObjectMeta.ClusterName,
+			Labels:      pObjectMeta.Labels,
 		},
 		Spec: updateBackwardRecreateSpec,
 	}

--- a/pkg/controllers/resources/services/syncer_test.go
+++ b/pkg/controllers/resources/services/syncer_test.go
@@ -71,7 +71,6 @@ func TestSync(t *testing.T) {
 			ClientIP: &corev1.ClientIPConfig{},
 		},
 		HealthCheckNodePort: 112,
-		IPFamilies:          []corev1.IPFamily{corev1.IPv4Protocol},
 		TopologyKeys:        []string{"someKey"},
 	}
 	updateForwardService := &corev1.Service{

--- a/pkg/controllers/resources/storageclasses/syncer.go
+++ b/pkg/controllers/resources/storageclasses/syncer.go
@@ -73,6 +73,14 @@ func (s *syncer) BackwardUpdateNeeded(pObj client.Object, vObj client.Object) (b
 	return false, nil
 }
 
+func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+func (s *syncer) ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
+	return false, nil
+}
+
 func calcSCDiff(pObj, vObj *storagev1.StorageClass) *storagev1.StorageClass {
 	pObjCopy := pObj.DeepCopy()
 	pObjCopy.ObjectMeta = vObj.ObjectMeta

--- a/pkg/util/clienthelper/helper.go
+++ b/pkg/util/clienthelper/helper.go
@@ -120,36 +120,6 @@ var (
 	applyAnnotation = "vcluster.loft.sh/apply"
 )
 
-func AppliedObjectsEqual(oldObj runtime.Object, obj runtime.Object) (bool, error) {
-	om, err := meta.Accessor(oldObj)
-	if err != nil {
-		return false, err
-	}
-
-	annotations := om.GetAnnotations()
-	var originalJS []byte
-	if annotations != nil && annotations[applyAnnotation] != "" {
-		originalJS = []byte(annotations[applyAnnotation])
-	}
-
-	// create patch if changed
-	currentJS, err := encode(oldObj)
-	if err != nil {
-		return false, err
-	}
-
-	editedJS, err := encode(obj)
-	if err != nil {
-		return false, err
-	}
-
-	if originalJS != nil {
-		return reflect.DeepEqual(originalJS, editedJS), nil
-	}
-
-	return reflect.DeepEqual(currentJS, editedJS), nil
-}
-
 func Apply(ctx context.Context, c client.Client, obj runtime.Object, log loghelper.Logger) error {
 	gvk, err := GVKFrom(obj, DefaultScheme)
 	if err != nil {

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -216,12 +216,12 @@ func TranslateLabels(virtualNamespace string, labels map[string]string) map[stri
 }
 
 func NamespaceLabelValue(virtualNamespace string) string {
-	return virtualNamespace + "x" + Suffix
+	return SafeConcatName(virtualNamespace, "x", Suffix)
 }
 
 func ConvertLabelKey(key string, virtualNamespace string) string {
 	digest := sha256.Sum256([]byte(key))
-	return SafeConcatName("vcluster.loft.sh/label", virtualNamespace, "x", Suffix, "x", string(digest[:]))
+	return SafeConcatName("vcluster.loft.sh/label", virtualNamespace, "x", Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
 }
 
 var OwningStatefulSet *appsv1.StatefulSet

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -85,7 +85,7 @@ func LabelsEqual(virtualNamespace string, virtualLabels map[string]string, physi
 	return EqualExcept(physicalLabelsToCompare, physicalLabels)
 }
 
-func TranslateLabelSelector(virtualNamespace string, labelSelector *metav1.LabelSelector) *metav1.LabelSelector {
+func TranslateLabelSelector(labelSelector *metav1.LabelSelector) *metav1.LabelSelector {
 	if labelSelector == nil {
 		return nil
 	}
@@ -94,14 +94,14 @@ func TranslateLabelSelector(virtualNamespace string, labelSelector *metav1.Label
 	if labelSelector.MatchLabels != nil {
 		newLabelSelector.MatchLabels = map[string]string{}
 		for k, v := range labelSelector.MatchLabels {
-			newLabelSelector.MatchLabels[ConvertLabelKey(k, virtualNamespace)] = v
+			newLabelSelector.MatchLabels[ConvertLabelKey(k)] = v
 		}
 	}
 	if len(labelSelector.MatchExpressions) > 0 {
 		newLabelSelector.MatchExpressions = []metav1.LabelSelectorRequirement{}
 		for _, r := range labelSelector.MatchExpressions {
 			newLabelSelector.MatchExpressions = append(newLabelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
-				Key:      ConvertLabelKey(r.Key, virtualNamespace),
+				Key:      ConvertLabelKey(r.Key),
 				Operator: r.Operator,
 				Values:   r.Values,
 			})
@@ -205,7 +205,7 @@ func TranslateLabels(virtualNamespace string, labels map[string]string) map[stri
 			continue
 		}
 
-		newLabels[ConvertLabelKey(k, virtualNamespace)] = v
+		newLabels[ConvertLabelKey(k)] = v
 	}
 	newLabels[MarkerLabel] = Suffix
 	if virtualNamespace != "" && newLabels[NamespaceLabel] == "" {
@@ -219,9 +219,9 @@ func NamespaceLabelValue(virtualNamespace string) string {
 	return SafeConcatName(virtualNamespace, "x", Suffix)
 }
 
-func ConvertLabelKey(key string, virtualNamespace string) string {
+func ConvertLabelKey(key string) string {
 	digest := sha256.Sum256([]byte(key))
-	return SafeConcatName("vcluster.loft.sh/label", virtualNamespace, "x", Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
+	return SafeConcatName("vcluster.loft.sh/label", Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
 }
 
 var OwningStatefulSet *appsv1.StatefulSet


### PR DESCRIPTION
### Changes
- Adds a new flag `--sync-node-changes` that will sync the node taints & labels from the virtual cluster to the host cluster if enabled. This is part of an effort to make vcluster pass all Kubernetes conformance tests
- Secrets, endpoints and configmaps are now synced without "applying" changes. This has the advantage that synced resources do not need to store the original configuration anymore and differences between virtual and physical objects can be calculated more precisely 
- Labels of virtual objects will now be synced to allow features like downwardAPI `metadata.labels['my-label']`, pod topology constraints and network policies