### PR TITLE
better fake node version & priority classes

### DIFF
--- a/chart/templates/rbac/clusterrole.yaml
+++ b/chart/templates/rbac/clusterrole.yaml
@@ -18,4 +18,7 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["*"]
 {{- end }}

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -32,6 +32,7 @@ type VirtualClusterOptions struct {
 	UseFakeNodes             bool
 	UseFakePersistentVolumes bool
 	EnableStorageClasses     bool
+	EnablePriorityClasses    bool
 
 	TranslateImages []string
 

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -102,6 +102,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&options.UseFakeKubelets, "fake-kubelets", true, "If enabled, the virtual cluster will create fake kubelet endpoints to support metrics-servers")
 	cmd.Flags().BoolVar(&options.UseFakePersistentVolumes, "fake-persistent-volumes", true, "If enabled, the virtual cluster will create fake persistent volumes instead of copying the actual physical persistent volumes config")
 	cmd.Flags().BoolVar(&options.EnableStorageClasses, "enable-storage-classes", false, "If enabled, the virtual cluster will sync storage classes")
+	cmd.Flags().BoolVar(&options.EnablePriorityClasses, "enable-priority-classes", false, "If enabled, the virtual cluster will sync priority classes from and to the host cluster")
 	cmd.Flags().StringSliceVar(&options.TranslateImages, "translate-image", []string{}, "Translates image names from the virtual pod to the physical pod (e.g. coredns/coredns=mirror.io/coredns/coredns)")
 
 	cmd.Flags().BoolVar(&options.EnforceNodeSelector, "enforce-node-selector", true, "If enabled and --node-selector is set then the virtual cluster will ensure that no pods are scheduled outside of the node selector")

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/persistentvolumeclaims"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/persistentvolumes"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/pods"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/priorityclasses"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/secrets"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/storageclasses"
@@ -30,6 +31,7 @@ var Resources = map[string]func(*context.ControllerContext) error{
 	"nodes":                  nodes.Register,
 	"persistentvolumes":      persistentvolumes.Register,
 	"storageclasses":         storageclasses.Register,
+	"priorityclasses":        priorityclasses.Register,
 }
 
 func Register(ctx *context.ControllerContext) error {

--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -79,7 +79,7 @@ func (s *syncer) ForwardCreateNeeded(vObj client.Object) (bool, error) {
 }
 
 func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
-	// did the configmap change?
+	// did the endpoints change?
 	pEndpoints := pObj.(*corev1.Endpoints)
 	vEndpoints := vObj.(*corev1.Endpoints)
 	updated, err := s.calcEndpointsDiff(pEndpoints, vEndpoints)
@@ -134,7 +134,7 @@ func (s *syncer) translate(vObj runtime.Object) (*corev1.Endpoints, error) {
 		}
 	}
 
-	return newObj.(*corev1.Endpoints), nil
+	return endpoints, nil
 }
 
 func (s *syncer) calcEndpointsDiff(pObj, vObj *corev1.Endpoints) (*corev1.Endpoints, error) {

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -19,6 +19,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	// FakeNodesVersion is the default version that will be used for fake nodes
+	FakeNodesVersion = "v1.19.1"
+)
+
 func RegisterFakeSyncer(ctx *context2.ControllerContext) error {
 	return generic.RegisterFakeSyncer(ctx, &fakeSyncer{
 		sharedNodesMutex:    ctx.LockFactory.GetLock("nodes-controller"),
@@ -213,8 +218,8 @@ func CreateFakeNode(ctx context.Context, nodeServiceProvider NodeServiceProvider
 			BootID:                  newGuid(),
 			ContainerRuntimeVersion: "docker://19.3.12",
 			KernelVersion:           "4.19.76-fakelinux",
-			KubeProxyVersion:        "v1.19.1",
-			KubeletVersion:          "v1.19.1",
+			KubeProxyVersion:        FakeNodesVersion,
+			KubeletVersion:          FakeNodesVersion,
 			MachineID:               newGuid(),
 			SystemUUID:              newGuid(),
 			OperatingSystem:         "linux",

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -74,8 +74,9 @@ func Register(ctx *context2.ControllerContext) error {
 		serviceAccountName: ctx.Options.ServiceAccount,
 		nodeSelector:       nodeSelector,
 
-		overrideHosts:      ctx.Options.OverrideHosts,
-		overrideHostsImage: ctx.Options.OverrideHostsContainerImage,
+		overrideHosts:          ctx.Options.OverrideHosts,
+		overrideHostsImage:     ctx.Options.OverrideHostsContainerImage,
+		priorityClassesEnabled: ctx.Options.EnablePriorityClasses,
 
 		clusterDomain: ctx.Options.ClusterDomain,
 	}, "pod", generic.RegisterSyncerOptions{})
@@ -101,6 +102,8 @@ type syncer struct {
 
 	overrideHosts      bool
 	overrideHostsImage string
+
+	priorityClassesEnabled bool
 }
 
 func (s *syncer) New() client.Object {
@@ -263,7 +266,7 @@ func (s *syncer) translatePod(vPod *corev1.Pod, pPod *corev1.Pod) error {
 		ptrServiceList = append(ptrServiceList, &s)
 	}
 
-	return translatePod(pPod, vPod, s.virtualClient, ptrServiceList, s.clusterDomain, dnsIP, kubeIP, s.serviceAccountName, s.translateImages, s.overrideHosts, s.overrideHostsImage)
+	return translatePod(pPod, vPod, s.virtualClient, ptrServiceList, s.clusterDomain, dnsIP, kubeIP, s.serviceAccountName, s.translateImages, s.overrideHosts, s.overrideHostsImage, s.priorityClassesEnabled)
 }
 
 func (s *syncer) findKubernetesIP() (string, error) {

--- a/pkg/controllers/resources/priorityclasses/controller.go
+++ b/pkg/controllers/resources/priorityclasses/controller.go
@@ -1,0 +1,192 @@
+package priorityclasses
+
+import (
+	"context"
+	controllercontext "github.com/loft-sh/vcluster/cmd/vcluster/context"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/controllers/garbagecollect"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/generic"
+	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func registerForwardSyncer(ctx *controllercontext.ControllerContext, syncer generic.Syncer, name string, isManaged func(obj runtime.Object) bool, physicalName func(name string) string) error {
+	forwardController := &forwardController{
+		isManaged:     isManaged,
+		physicalName:  physicalName,
+		target:        syncer,
+		synced:        ctx.CacheSynced,
+		localClient:   ctx.LocalManager.GetClient(),
+		virtualClient: ctx.VirtualManager.GetClient(),
+		scheme:        ctx.LocalManager.GetScheme(),
+		log:           loghelper.New(name + "-forward"),
+	}
+	b := ctrl.NewControllerManagedBy(ctx.VirtualManager).
+		Named(name+"-forward").
+		Watches(garbagecollect.NewGarbageCollectSource(forwardController, ctx.StopChan, forwardController.log), nil).
+		For(syncer.New())
+	return b.Complete(forwardController)
+}
+
+type forwardController struct {
+	synced func()
+
+	isManaged    func(obj runtime.Object) bool
+	physicalName func(name string) string
+
+	target        generic.Syncer
+	log           loghelper.Logger
+	localClient   client.Client
+	virtualClient client.Client
+	scheme        *runtime.Scheme
+}
+
+func (r *forwardController) GarbageCollect(queue workqueue.RateLimitingInterface) error {
+	ctx := context.Background()
+
+	// list all virtual objects first
+	vList := r.target.NewList()
+	err := r.virtualClient.List(ctx, vList)
+	if err != nil {
+		return err
+	}
+
+	// check if physical object exists
+	vItems, err := meta.ExtractList(vList)
+	if err != nil {
+		return err
+	}
+	for _, vObj := range vItems {
+		vAccessor, _ := meta.Accessor(vObj)
+		pObj := r.target.New()
+		err = r.localClient.Get(ctx, types.NamespacedName{
+			Name: r.physicalName(vAccessor.GetName()),
+		}, pObj)
+		if kerrors.IsNotFound(err) {
+			fc, ok := r.target.(generic.ForwardCreate)
+			if ok {
+				createNeeded, err := fc.ForwardCreateNeeded(vObj.(client.Object))
+				if err != nil {
+					r.log.Infof("error in create needed for virtual object %s: %v", vAccessor.GetName(), err)
+					continue
+				} else if createNeeded == false {
+					continue
+				}
+			}
+
+			r.log.Debugf("resync virtual object %s, because physical object was not found", vAccessor.GetName())
+			queue.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: vAccessor.GetName(),
+				},
+			})
+			continue
+		} else if err != nil {
+			r.log.Infof("cannot get physical object %s: %v", translate.PhysicalName(vAccessor.GetName(), vAccessor.GetNamespace()), err)
+			continue
+		}
+
+		updateNeeded, err := r.target.ForwardUpdateNeeded(pObj, vObj.(client.Object))
+		if err != nil {
+			r.log.Infof("error in update needed for virtual object %s/%s: %v", vAccessor.GetNamespace(), vAccessor.GetName(), err)
+			continue
+		}
+
+		if updateNeeded {
+			r.log.Debugf("resync virtual object %s/%s", vAccessor.GetNamespace(), vAccessor.GetName())
+			queue.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      vAccessor.GetName(),
+					Namespace: vAccessor.GetNamespace(),
+				},
+			})
+		}
+	}
+
+	// list all physical objects first
+	pList := r.target.NewList()
+	err = r.localClient.List(ctx, pList)
+	if err != nil {
+		return err
+	}
+
+	// check if physical object exists
+	items, err := meta.ExtractList(pList)
+	if err != nil {
+		return err
+	}
+	for _, pObj := range items {
+		if r.isManaged(pObj) == false {
+			continue
+		}
+
+		vObj := r.target.New()
+		pAccessor, _ := meta.Accessor(pObj)
+		err = clienthelper.GetByIndex(ctx, r.virtualClient, vObj, r.scheme, constants.IndexByVName, pAccessor.GetName())
+		if kerrors.IsNotFound(err) {
+			r.log.Debugf("resync physical object %s, because virtual object is missing", pAccessor.GetName())
+			queue.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: pAccessor.GetName(),
+				},
+			})
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (r *forwardController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// make sure the caches are synced
+	r.synced()
+
+	// get virtual object
+	vObj := r.target.New()
+	vExists := true
+	err := r.virtualClient.Get(ctx, req.NamespacedName, vObj)
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return ctrl.Result{}, err
+		}
+
+		vExists = false
+	}
+
+	// get physical object
+	pObj := r.target.New()
+	pExists := true
+	err = r.localClient.Get(ctx, types.NamespacedName{
+		Name: r.physicalName(req.Name),
+	}, pObj)
+	if err != nil {
+		if kerrors.IsNotFound(err) == false {
+			return ctrl.Result{}, err
+		}
+
+		pExists = false
+	}
+
+	if vExists && !pExists {
+		return r.target.ForwardCreate(ctx, vObj, r.log)
+	} else if vExists && pExists {
+		return r.target.ForwardUpdate(ctx, pObj, vObj, r.log)
+	} else if !vExists && pExists {
+		if !r.isManaged(pObj) {
+			return ctrl.Result{}, nil
+		}
+
+		return generic.DeleteObject(ctx, r.localClient, pObj, r.log)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/resources/priorityclasses/register.go
+++ b/pkg/controllers/resources/priorityclasses/register.go
@@ -1,0 +1,11 @@
+package priorityclasses
+
+import "github.com/loft-sh/vcluster/cmd/vcluster/context"
+
+func Register(ctx *context.ControllerContext) error {
+	if ctx.Options.EnablePriorityClasses {
+		return RegisterSyncer(ctx)
+	}
+
+	return nil
+}

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -1,0 +1,203 @@
+package priorityclasses
+
+import (
+	"context"
+	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+func RegisterSyncer(ctx *context2.ControllerContext) error {
+	// build syncer and register it
+	s := &syncer{
+		targetNamespace: ctx.Options.TargetNamespace,
+		virtualClient:   ctx.VirtualManager.GetClient(),
+		localClient:     ctx.LocalManager.GetClient(),
+	}
+	err := ctx.VirtualManager.GetFieldIndexer().IndexField(ctx.Context, &schedulingv1.PriorityClass{}, constants.IndexByVName, func(rawObj client.Object) []string {
+		metaAccessor, err := meta.Accessor(rawObj)
+		if err != nil {
+			return nil
+		}
+
+		return []string{s.priorityClassName(metaAccessor.GetName())}
+	})
+	if err != nil {
+		return err
+	}
+
+	return registerForwardSyncer(ctx, s, "priorityclass", func(obj runtime.Object) bool {
+		m, err := meta.Accessor(obj)
+		if err != nil {
+			return false
+		}
+
+		labels := m.GetLabels()
+		if labels == nil {
+			return false
+		}
+
+		return labels[translate.MarkerLabel] == s.markerLabel()
+	}, s.priorityClassName)
+}
+
+type syncer struct {
+	targetNamespace string
+	localClient     client.Client
+	virtualClient   client.Client
+}
+
+func (s *syncer) New() client.Object {
+	return &schedulingv1.PriorityClass{}
+}
+
+func (s *syncer) NewList() client.ObjectList {
+	return &schedulingv1.PriorityClassList{}
+}
+
+func (s *syncer) ForwardCreate(ctx context.Context, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	vPriorityClass := vObj.(*schedulingv1.PriorityClass)
+	newPriorityClass, err := s.translate(vObj)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.Infof("create physical priority class %s", newPriorityClass.Name)
+	err = s.localClient.Create(ctx, newPriorityClass)
+	if err != nil {
+		log.Infof("error syncing %s to physical cluster: %v", vPriorityClass.Name, err)
+		return ctrl.Result{RequeueAfter: time.Second}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (s *syncer) ForwardCreateNeeded(vObj client.Object) (bool, error) {
+	return true, nil
+}
+
+func (s *syncer) ForwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	// did the priority class change?
+	pPriorityClass := pObj.(*schedulingv1.PriorityClass)
+	vPriorityClass := vObj.(*schedulingv1.PriorityClass)
+	updated, err := s.calcPriorityClassDiff(pPriorityClass, vPriorityClass)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if updated != nil {
+		log.Infof("updating physical priority class %s, because virtual priority class has changed", updated.Name)
+		err := s.localClient.Update(ctx, updated)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (s *syncer) ForwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
+	updated, err := s.calcPriorityClassDiff(pObj.(*schedulingv1.PriorityClass), vObj.(*schedulingv1.PriorityClass))
+	return updated != nil, err
+}
+
+func (s *syncer) translate(vObj runtime.Object) (*schedulingv1.PriorityClass, error) {
+	target := vObj.DeepCopyObject()
+	m, err := meta.Accessor(target)
+	if err != nil {
+		return nil, err
+	}
+
+	// reset metadata & translate name
+	translate.ResetObjectMetadata(m)
+	m.SetName(s.priorityClassName(m.GetName()))
+
+	// set marker label
+	labels := map[string]string{}
+	labels[translate.MarkerLabel] = s.markerLabel()
+	m.SetLabels(labels)
+
+	// translate the priority class
+	priorityClass := target.(*schedulingv1.PriorityClass)
+	priorityClass.GlobalDefault = false
+	if priorityClass.Value > 1000000000 {
+		priorityClass.Value = 1000000000
+	}
+	return priorityClass, nil
+}
+
+func (s *syncer) calcPriorityClassDiff(pObj, vObj *schedulingv1.PriorityClass) (*schedulingv1.PriorityClass, error) {
+	var updated *schedulingv1.PriorityClass
+
+	// check subsets
+	if !equality.Semantic.DeepEqual(vObj.PreemptionPolicy, pObj.PreemptionPolicy) {
+		updated = pObj.DeepCopy()
+		updated.PreemptionPolicy = vObj.PreemptionPolicy
+	}
+
+	// check annotations
+	if !equality.Semantic.DeepEqual(vObj.Annotations, pObj.Annotations) {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Annotations = vObj.Annotations
+	}
+
+	// check labels
+	if !translate.LabelsEqual(vObj.Namespace, vObj.Labels, pObj.Labels) {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Labels = translate.TranslateLabels(vObj.Namespace, vObj.Labels)
+	}
+
+	// check description
+	if vObj.Description != pObj.Description {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Description = vObj.Description
+	}
+
+	// check value
+	translatedValue := vObj.Value
+	if translatedValue > 1000000000 {
+		translatedValue = 1000000000
+	}
+	if translatedValue != pObj.Value {
+		if updated == nil {
+			updated = pObj.DeepCopy()
+		}
+		updated.Value = translatedValue
+	}
+
+	return updated, nil
+}
+
+func (s *syncer) BackwardUpdate(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
+func (s *syncer) BackwardUpdateNeeded(pObj client.Object, vObj client.Object) (bool, error) {
+	return false, nil
+}
+
+func (s *syncer) markerLabel() string {
+	return translate.SafeConcatName(s.targetNamespace, "x", translate.Suffix)
+}
+
+func (s *syncer) priorityClassName(name string) string {
+	return TranslatePriorityClassName(name, s.targetNamespace)
+}
+
+func TranslatePriorityClassName(name, namespace string) string {
+	// we have to prefix with vcluster as system is reserved
+	return translate.SafeConcatName("vcluster", name, "x", namespace, "x", translate.Suffix)
+}


### PR DESCRIPTION
### Changes
- vcluster will now use the virtual cluster k3s version as fake node version
- New flag `--enable-priority-classes` to sync priority classes from vcluster to the host cluster
- reduce failed conformance test amount from 5 to 1