### PR TITLE
KubeletPort, PVC delete & flag fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,7 @@
 /api
 /kubeconfig.yaml
 /cmd/virtualclusterctl
+/test
+/conformance
+/docs
 devspace.yaml

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -188,7 +188,7 @@ func Execute(cobraCmd *cobra.Command, args []string, options *context.VirtualClu
 	}
 
 	// set kubelet port
-	nodeservice.KubeletPort = int32(options.Port)
+	nodeservice.KubeletTargetPort = options.Port
 
 	// retrieve current namespace
 	if options.TargetNamespace == "" {

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -105,7 +105,6 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
 	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", "https://charts.loft.sh", "The virtual cluster chart repo to use")
 	cobraCmd.Flags().StringVar(&cmd.ReleaseValues, "release-values", "", "Path where to load the virtual cluster helm release values from")
-	cobraCmd.Flags().StringVar(&cmd.ReleaseValues, "release-values", "", "Path where to load the virtual cluster helm release values from")
 	cobraCmd.Flags().StringVar(&cmd.K3SImage, "k3s-image", "", "If specified, use this k3s image version")
 	cobraCmd.Flags().StringSliceVarP(&cmd.ExtraValues, "extra-values", "f", []string{}, "Path where to load extra helm values from")
 	cobraCmd.Flags().BoolVar(&cmd.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -107,13 +107,10 @@ profiles:
               vcluster:
                 image: rancher/k3s:v1.20.5-k3s1
                 extraArgs:
-                  - --service-cidr=10.108.0.0/20
+                  - --service-cidr=10.68.0.0/20
               rbac:
                 clusterRole:
                   create: true
               syncer:
                 image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
-                extraArgs:
-                  - --sync-all-nodes
-                  - --sync-node-changes
-                  - --fake-nodes=false
+                extraArgs: []

--- a/docs/pages/operator/external-access.mdx
+++ b/docs/pages/operator/external-access.mdx
@@ -55,7 +55,7 @@ vcluster create my-vcluster -n my-vcluster -f values.yaml
 
 Retrieve the kube config via:
 ```
-vcluster connect my-vcluster -n my-vcluster --server=x.x.x.x
+vcluster connect my-vcluster -n my-vcluster --server=https://x.x.x.x
 ```
 
 Access the vcluster:
@@ -122,7 +122,7 @@ vcluster create my-vcluster -n my-vcluster -f values.yaml
 
 Retrieve the kube config via:
 ```
-vcluster connect my-vcluster -n my-vcluster --server=x.x.x.x
+vcluster connect my-vcluster -n my-vcluster --server=https://x.x.x.x
 ```
 
 Access the vcluster:
@@ -180,7 +180,7 @@ vcluster create my-vcluster -n my-vcluster -f values.yaml
 
 Retrieve the kube config via:
 ```
-vcluster connect my-vcluster -n my-vcluster --server=my-vcluster.example.com
+vcluster connect my-vcluster -n my-vcluster --server=https://my-vcluster.example.com
 ```
 
 Access the vcluster:

--- a/docs/pages/operator/external-datastore.mdx
+++ b/docs/pages/operator/external-datastore.mdx
@@ -110,7 +110,7 @@ vcluster:
     - mountPath: /path/to
       name: datastore-tls
 volumes:
-- name: foo
+- name: datastore-tls
   secret:
     secretName: my-datastore-secret
     items:

--- a/pkg/controllers/resources/nodes/nodeservice/node_service.go
+++ b/pkg/controllers/resources/nodes/nodeservice/node_service.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,7 +26,9 @@ var (
 	// ServiceNodeLabel specifies which node this service represents
 	ServiceNodeLabel = "vcluster.loft.sh/node"
 	// KubeletPort is the port we pretend the kubelet is running under
-	KubeletPort = int32(8443)
+	KubeletPort = int32(10250)
+	// KubeletTargetPort is the port vcluster will run under
+	KubeletTargetPort = 8443
 )
 
 type NodeServiceProvider interface {
@@ -175,7 +178,8 @@ func (n *nodeServiceProvider) GetNodeIP(ctx context.Context, name types.Namespac
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Port: int32(KubeletPort),
+					Port:       int32(KubeletPort),
+					TargetPort: intstr.FromInt(KubeletTargetPort),
 				},
 			},
 			Selector: labelSelector,

--- a/pkg/server/filters/metrics.go
+++ b/pkg/server/filters/metrics.go
@@ -230,5 +230,5 @@ func IsKubeletStats(path string) bool {
 }
 
 func IsKubeletMetrics(path string) bool {
-	return strings.HasSuffix(path, "/metrics/cadvisor") || strings.HasSuffix(path, "/metrics/probes") || strings.HasSuffix(path, "/metrics/resource") || strings.HasSuffix(path, "/metrics/resource/v1alpha1") || strings.HasSuffix(path, "/metrics/resource/v1beta1")
+	return strings.HasSuffix(path, "/metrics") || strings.HasSuffix(path, "/metrics/cadvisor") || strings.HasSuffix(path, "/metrics/probes") || strings.HasSuffix(path, "/metrics/resource") || strings.HasSuffix(path, "/metrics/resource/v1alpha1") || strings.HasSuffix(path, "/metrics/resource/v1beta1")
 }


### PR DESCRIPTION
### Changes
- Changes the fake kubelet port from 8443 to 10250
- `vcluster delete` now deletes the PVC as well except `--keep-pvc` is specified (#29)
- Fixed an issue where the flag `--release-values` was specified multiple times