### PR TITLE
cli version as chart version & log message for pvc delete

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -101,7 +101,7 @@ vcluster create test --namespace test
 	}
 
 	cobraCmd.Flags().StringVarP(&cmd.Namespace, "namespace", "n", "", "The namespace the vcluster should be created in")
-	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", "", "The virtual cluster chart version to use")
+	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use")
 	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
 	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", "https://charts.loft.sh", "The virtual cluster chart repo to use")
 	cobraCmd.Flags().StringVar(&cmd.ReleaseValues, "release-values", "", "Path where to load the virtual cluster helm release values from")

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -94,6 +94,7 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	cmd.log.Donef("Successfully deleted virtual cluster %s in namespace %s", args[0], namespace)
 
 	// try to delete the pvc
 	if cmd.KeepPVC == false {
@@ -109,11 +110,14 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		}
 
 		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
-		if err != nil && kerrors.IsNotFound(err) == false {
-			return errors.Wrap(err, "delete pvc")
+		if err != nil {
+			if kerrors.IsNotFound(err) == false {
+				return errors.Wrap(err, "delete pvc")
+			}
+		} else {
+			cmd.log.Donef("Successfully deleted virtual cluster pvc %s in namespace %s", pvcName, namespace)
 		}
 	}
 
-	cmd.log.Donef("Successfully deleted virtual cluster %s in namespace %s", args[0], namespace)
 	return nil
 }


### PR DESCRIPTION
### Changes
- **cli**: now uses the cli version as default vcluster chart version
- **cli**: `vcluster delete` will now print a message if it has successfully deleted the vcluster pvc aswell