### PR TITLE
build(chart): syncer liveness & readiness probes

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -8,6 +8,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+  {{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-headless
   replicas: {{ .Values.replicas }}
@@ -60,6 +67,7 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+      {{- if not .Values.vcluster.disabled }}
       - image: {{ .Values.vcluster.image }}
         name: vcluster
         command:
@@ -79,6 +87,8 @@ spec:
 {{ toYaml .Values.vcluster.volumeMounts | indent 10 }}
         resources:
 {{ toYaml .Values.vcluster.resources | indent 10 }}
+      {{- end }}
+      {{- if not .Values.syncer.disabled }}
       - name: syncer
         {{- if .Values.syncer.image }}
         image: "{{ .Values.syncer.image }}"
@@ -98,9 +108,34 @@ spec:
         args:
 {{ toYaml .Values.syncer.extraArgs | indent 10 }}
         {{- end }}
+        {{- if .Values.syncer.livenessProbe }}
+        {{- if .Values.syncer.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+          failureThreshold: 15
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        {{- end }}
+        {{- end }}
+        {{- if .Values.syncer.readinessProbe }}
+        {{- if .Values.syncer.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
+          failureThreshold: 15
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        {{- end }}
+        {{- end }}
         env:
 {{ toYaml .Values.syncer.env | indent 10 }}
         volumeMounts:
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:
 {{ toYaml .Values.syncer.resources | indent 10 }}
+      {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,10 @@ syncer:
   # image: loftsh/vcluster
   extraArgs: []
   env: []
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
   volumeMounts:
     - mountPath: /data
       name: data
@@ -77,6 +81,12 @@ affinity: {}
 
 # Tolerations to apply to the vcluster statefulset
 tolerations: []
+
+# Extra Labels for the stateful set
+labels: {}
+
+# Extra Annotations for the stateful set
+annotations: {}
 
 # Service configurations
 service:

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -175,6 +175,7 @@ func Execute(cobraCmd *cobra.Command, args []string, options *context.VirtualClu
 			return false, nil
 		}
 
+		time.Sleep(time.Second)
 		return true, nil
 	})
 	if err != nil {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -21,11 +21,15 @@ deployments:
         vcluster:
           image: rancher/k3s:v1.20.5-k3s1
           extraArgs:
-            - --service-cidr=10.68.0.0/20
+            - --service-cidr=10.96.0.0/12
         rbac:
           clusterRole:
             create: true
         syncer:
+          readinessProbe:
+            enabled: false
+          livenessProbe:
+            enabled: false
           image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
           noArgs: true
 dev:
@@ -73,6 +77,10 @@ profiles:
             containerName: syncer
             replaceImage: golang:1.16
             patches:
+              - path: spec.containers[1].livenessProbe
+                op: remove
+              - path: spec.containers[1].readinessProbe
+                op: remove
               - path: spec.containers[1].workingDir
                 op: replace
                 value: /vcluster
@@ -101,16 +109,9 @@ profiles:
             chart:
               name: ./chart
             values:
-              serviceAccount:
-                create: false
-                name: default
               vcluster:
                 image: rancher/k3s:v1.20.5-k3s1
                 extraArgs:
-                  - --service-cidr=10.68.0.0/20
-              rbac:
-                clusterRole:
-                  create: true
+                  - --service-cidr=10.96.0.0/12
               syncer:
                 image: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
-                extraArgs: []


### PR DESCRIPTION
### Changes
- **chart**: `syncer.livenessProbe` and `syncer.readinessProbe` can now be configured in the helm chart 
- **chart**: statefulset `labels` and `annotations` can now be configured in the helm chart