### PR TITLE
fix: improve probes & kubernetes endpoints sync

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -115,9 +115,9 @@ spec:
             path: /healthz
             port: 8443
             scheme: HTTPS
-          failureThreshold: 15
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          failureThreshold: 10
+          initialDelaySeconds: 60
+          periodSeconds: 2
         {{- end }}
         {{- end }}
         {{- if .Values.syncer.readinessProbe }}
@@ -127,9 +127,8 @@ spec:
             path: /readyz
             port: 8443
             scheme: HTTPS
-          failureThreshold: 15
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          failureThreshold: 30
+          periodSeconds: 2
         {{- end }}
         {{- end }}
         env:

--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -238,7 +238,6 @@ func SyncKubernetesServiceEndpoints(ctx context.Context, virtualClient client.Cl
 	// build new subsets
 	newSubsets := pObj.DeepCopy().Subsets
 	for i := range newSubsets {
-		newSubsets[i].NotReadyAddresses = nil
 		for j := range newSubsets[i].Ports {
 			newSubsets[i].Ports[j].Name = "https"
 		}
@@ -246,6 +245,11 @@ func SyncKubernetesServiceEndpoints(ctx context.Context, virtualClient client.Cl
 			newSubsets[i].Addresses[j].Hostname = ""
 			newSubsets[i].Addresses[j].NodeName = nil
 			newSubsets[i].Addresses[j].TargetRef = nil
+		}
+		for j := range pObj.Subsets[i].NotReadyAddresses {
+			newSubsets[i].NotReadyAddresses[j].Hostname = ""
+			newSubsets[i].NotReadyAddresses[j].NodeName = nil
+			newSubsets[i].NotReadyAddresses[j].TargetRef = nil
 		}
 	}
 


### PR DESCRIPTION
### Changes
- Fixed an issue where vcluster would show errors during startup syncing the kubernetes endpoints
- Tuned readiness and liveliness probes