### PR TITLE
feat: add global --context flag

### DIFF
--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -16,8 +16,7 @@ import (
 type ListCmd struct {
 	*flags.GlobalFlags
 
-	Namespace string
-	log       log.Logger
+	log log.Logger
 }
 
 // NewListCmd creates a new command
@@ -47,14 +46,15 @@ vcluster list --namespace test
 		},
 	}
 
-	cobraCmd.Flags().StringVarP(&cmd.Namespace, "namespace", "n", "", "The namespace the vcluster was created in")
 	return cobraCmd
 }
 
 // Run executes the functionality
 func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	// first load the kube config
-	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
+		CurrentContext: cmd.Context,
+	})
 	namespace := metav1.NamespaceAll
 	if cmd.Namespace != "" {
 		namespace = cmd.Namespace

--- a/cmd/vclusterctl/flags/flags.go
+++ b/cmd/vclusterctl/flags/flags.go
@@ -6,9 +6,11 @@ import (
 
 // GlobalFlags is the flags that contains the global flags
 type GlobalFlags struct {
-	Silent bool
-	Debug  bool
-	Config string
+	Silent    bool
+	Debug     bool
+	Config    string
+	Context   string
+	Namespace string
 }
 
 // SetGlobalFlags applies the global flags
@@ -16,6 +18,8 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	globalFlags := &GlobalFlags{}
 
 	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")
+	flags.StringVar(&globalFlags.Context, "context", "", "The kubernetes config context to use")
+	flags.StringVarP(&globalFlags.Namespace, "namespace", "n", "", "The kubernetes namespace to use")
 	flags.BoolVar(&globalFlags.Silent, "silent", false, "Run in silent mode and prevents any devspace log output except panics & fatals")
 
 	return globalFlags


### PR DESCRIPTION
### Changes
- **cli**: Added `--context` flag for vcluster commands to specify a kubernetes context