### PR TITLE
add --connect flag, kube config namespace & server flag and add owner reference

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -18,7 +18,10 @@ type VirtualClusterOptions struct {
 	RequestHeaderCaCert string
 	ClientCaCert        string
 	KubeConfig          string
-	KubeConfigSecret    string
+
+	KubeConfigSecret          string
+	KubeConfigSecretNamespace string
+	KubeConfigServer          string
 
 	BindAddress string
 	Port        int

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -66,6 +66,7 @@ type CreateCmd struct {
 	DisableIngressSync bool
 	CreateClusterRole  bool
 	Expose             bool
+	Connect            bool
 
 	log log.Logger
 }
@@ -109,6 +110,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().BoolVar(&cmd.DisableIngressSync, "disable-ingress-sync", false, "If true the virtual cluster will not sync any ingresses")
 	cobraCmd.Flags().BoolVar(&cmd.CreateClusterRole, "create-cluster-role", false, "If true a cluster role will be created to access nodes, storageclasses and priorityclasses")
 	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
+	cobraCmd.Flags().BoolVar(&cmd.Connect, "connect", false, "If true will run vcluster connect directly after the vcluster was created")
 	return cobraCmd
 }
 
@@ -208,6 +210,19 @@ func (cmd *CreateCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	cmd.log.Donef("Successfully created virtual cluster %s in namespace %s. Use 'vcluster connect %s --namespace %s' to access the virtual cluster", args[0], namespace, args[0], namespace)
+
+	// check if we should connect to the vcluster
+	if cmd.Connect {
+		connectCmd := &ConnectCmd{
+			GlobalFlags: cmd.GlobalFlags,
+			KubeConfig:  "./kubeconfig.yaml",
+			LocalPort:   8443,
+			log:         cmd.log,
+		}
+
+		return connectCmd.Connect(args[0])
+	}
+
 	return nil
 }
 

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -1,0 +1,65 @@
+package kubeconfig
+
+import (
+	"context"
+	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"io/ioutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WriteKubeConfig(ctx context.Context, client client.Client, secretName, secretNamespace string, config *api.Config, owner *appsv1.StatefulSet) error {
+	out, err := clientcmd.Write(*config)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll("/root/.kube", 0755)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile("/root/.kube/config", out, 0666)
+	if err != nil {
+		return err
+	}
+
+	if secretName != "" {
+		kubeConfigSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: secretNamespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"config": out,
+			},
+		}
+
+		// set owner reference
+		if owner != nil && owner.Namespace == kubeConfigSecret.Namespace {
+			kubeConfigSecret.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       "StatefulSet",
+					Name:       translate.OwningStatefulSet.Name,
+					UID:        translate.OwningStatefulSet.UID,
+				},
+			}
+		}
+
+		err = clienthelper.Apply(ctx, client, kubeConfigSecret, loghelper.New("apply-secret"))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Changes
- **cli**: New `--connect` flag for `vcluster create` that directly runs `vcluster connect` (#81)
- **syncer**: New `--out-kube-config-secret-namespace` flag to override the namespace where vcluster will store the generated kube config (#82)
- **syncer**: New `--out-kube-config-server` flag to override the server of the generated kube config (#84)
- **syncer**: Set owner reference to generated kube config secret if it is in the same namespace as owning statefulset (#83)