### PR TITLE
fix(syncer): fix issues with syncing to another namespace

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -30,6 +30,7 @@ type VirtualClusterOptions struct {
 	DisableSyncResources string
 	TargetNamespace      string
 	ServiceName          string
+	ServiceNamespace     string
 	OwningStatefulSet    string
 
 	SyncAllNodes             bool
@@ -85,7 +86,7 @@ func NewControllerContext(localManager ctrl.Manager, virtualManager ctrl.Manager
 		Context:             ctx,
 		LocalManager:        localManager,
 		VirtualManager:      virtualManager,
-		NodeServiceProvider: nodeservice.NewNodeServiceProvider(localManager.GetClient(), virtualManager.GetClient(), uncachedVirtualClient),
+		NodeServiceProvider: nodeservice.NewNodeServiceProvider(localManager.GetClient(), virtualManager.GetClient(), uncachedVirtualClient, options.TargetNamespace),
 		LockFactory:         locks.NewDefaultLockFactory(),
 		CacheSynced: func() {
 			cacheSynced.Do(func() {

--- a/pkg/controllers/resources/endpoints/syncer_test.go
+++ b/pkg/controllers/resources/endpoints/syncer_test.go
@@ -15,10 +15,12 @@ import (
 
 func newFakeSyncer(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *syncer {
 	return &syncer{
-		eventRecoder:    &testingutil.FakeEventRecorder{},
-		targetNamespace: "test",
-		virtualClient:   vClient,
-		localClient:     pClient,
+		eventRecoder:     &testingutil.FakeEventRecorder{},
+		targetNamespace:  "test",
+		serviceNamespace: "test",
+		serviceClient:    pClient,
+		virtualClient:    vClient,
+		localClient:      pClient,
 	}
 }
 

--- a/pkg/controllers/resources/services/syncer_test.go
+++ b/pkg/controllers/resources/services/syncer_test.go
@@ -17,11 +17,13 @@ import (
 
 func newFakeSyncer(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *syncer {
 	return &syncer{
-		eventRecoder:    &testingutil.FakeEventRecorder{},
-		targetNamespace: "test",
-		serviceName:     "myservice",
-		virtualClient:   vClient,
-		localClient:     pClient,
+		eventRecoder:     &testingutil.FakeEventRecorder{},
+		targetNamespace:  "test",
+		serviceName:      "myservice",
+		serviceNamespace: "test",
+		serviceClient:    pClient,
+		virtualClient:    vClient,
+		localClient:      pClient,
 	}
 }
 

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -3,7 +3,6 @@ package leaderelection
 import (
 	"context"
 	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
-	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -23,12 +22,6 @@ import (
 func StartLeaderElection(ctx *context2.ControllerContext, scheme *runtime.Scheme, run func() error) error {
 	localConfig := ctx.LocalManager.GetConfig()
 
-	// retrieve the current namespace
-	namespace, err := clienthelper.CurrentNamespace()
-	if err != nil {
-		return errors.Wrap(err, "get current namespace")
-	}
-
 	// create the event recorder
 	recorderClient, err := kubernetes.NewForConfig(localConfig)
 	if err != nil {
@@ -36,7 +29,7 @@ func StartLeaderElection(ctx *context2.ControllerContext, scheme *runtime.Scheme
 	}
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(func(format string, args ...interface{}) { klog.Infof(format, args...) })
-	eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: recorderClient.CoreV1().Events(namespace)})
+	eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: recorderClient.CoreV1().Events(ctx.Options.TargetNamespace)})
 	recorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "vcluster"})
 
 	// create the leader election client
@@ -54,7 +47,7 @@ func StartLeaderElection(ctx *context2.ControllerContext, scheme *runtime.Scheme
 	// Lock required for leader election
 	rl := resourcelock.ConfigMapLock{
 		ConfigMapMeta: metav1.ObjectMeta{
-			Namespace: namespace,
+			Namespace: ctx.Options.TargetNamespace,
 			Name:      translate.SafeConcatName("vcluster", translate.Suffix, "controller"),
 		},
 		Client: leaderElectionClient.CoreV1(),

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -5,6 +5,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func WriteKubeConfig(ctx context.Context, client client.Client, secretName, secr
 
 		err = clienthelper.Apply(ctx, client, kubeConfigSecret, loghelper.New("apply-secret"))
 		if err != nil {
-			return err
+			return errors.Wrap(err, "apply generated kube config secret")
 		}
 	}
 


### PR DESCRIPTION
### Changes
- **syncer**: New flag `--service-namespace` to specify where the vcluster service is available
- **syncer**: Fixed several issues where using `--target-namespace` would not work correctly