### PR TITLE
Revert "Add --port flag to specify service port on the create command"

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - name: https
-      port: {{ .Values.service.port }}
+      port: 443
       targetPort: 8443
       protocol: TCP
   selector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -91,4 +91,3 @@ annotations: {}
 # Service configurations
 service:
   type: ClusterIP
-  port: 443

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -67,7 +67,6 @@ type CreateCmd struct {
 	CreateClusterRole  bool
 	Expose             bool
 	Connect            bool
-	Port               int
 
 	log log.Logger
 }
@@ -112,7 +111,6 @@ vcluster create test --namespace test
 	cobraCmd.Flags().BoolVar(&cmd.CreateClusterRole, "create-cluster-role", false, "If true a cluster role will be created to access nodes, storageclasses and priorityclasses")
 	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
 	cobraCmd.Flags().BoolVar(&cmd.Connect, "connect", false, "If true will run vcluster connect directly after the vcluster was created")
-	cobraCmd.Flags().IntVar(&cmd.Port, "port", 443, "If specified, use this port in the service")
 	return cobraCmd
 }
 
@@ -311,17 +309,6 @@ rbac:
 		values += `
 service:
   type: LoadBalancer`
-
-	if cmd.Port != 443 {
-		values += 	fmt.Sprintf(`
-  port: %v`, cmd.Port)
-		}
-	} else {
-		if cmd.Port != 443 {
-			values += 	fmt.Sprintf(`
-service:
-  port: %v`, cmd.Port)
-		}
 	}
 
 	values = strings.ReplaceAll(values, "##IMAGE##", image)


### PR DESCRIPTION
Reverts loft-sh/vcluster#89 because using a Kubernetes service with other than port 443 is not possible