### PR TITLE
fix: fixed persistent volume cleanup & --address

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -33,6 +33,7 @@ type ConnectCmd struct {
 	UpdateCurrent bool
 	Print         bool
 	LocalPort     int
+	Address       string
 
 	Server string
 
@@ -74,6 +75,7 @@ vcluster connect test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.PodName, "pod", "", "The pod to connect to")
 	cobraCmd.Flags().StringVar(&cmd.Server, "server", "", "The server to connect to")
 	cobraCmd.Flags().IntVar(&cmd.LocalPort, "local-port", 8443, "The local port to forward the virtual cluster to")
+	cobraCmd.Flags().StringVar(&cmd.Address, "address", "", "The local address to start port forwarding under")
 	return cobraCmd
 }
 
@@ -272,6 +274,9 @@ func (cmd *ConnectCmd) Connect(vclusterName string) error {
 	command := []string{"kubectl", "port-forward", "--namespace", cmd.Namespace, podName, forwardPorts}
 	if cmd.Context != "" {
 		command = append(command, "--context", cmd.Context)
+	}
+	if cmd.Address != "" {
+		command = append(command, "--address", cmd.Address)
 	}
 
 	cmd.log.Infof("Starting port forwarding: %s", strings.Join(command, " "))

--- a/pkg/controllers/garbagecollect/garbagecollect.go
+++ b/pkg/controllers/garbagecollect/garbagecollect.go
@@ -25,7 +25,7 @@ type Source struct {
 
 func NewGarbageCollectSource(collector GarbageCollect, stopChan <-chan struct{}, log loghelper.Logger) *Source {
 	return &Source{
-		Period: time.Minute,
+		Period: time.Second * 30,
 
 		log:      log,
 		run:      collector,


### PR DESCRIPTION
### Changes
- Fixed an issue where persistent volumes would sometimes not get cleaned up correctly
- **cli**: New `--address` flag for `vcluster connect` to start portforwarding with a specific address locally