### PR TITLE
fix: fixed arm build issue & --upgrade flag & v1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /vcluster
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 # Install kubectl for development
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -13,7 +13,7 @@ images:
     image: ${SYNCER_IMAGE}
     rebuildStrategy: ignoreContextChanges
     build:
-      docker:
+      buildKit:
         skipPush: true
         options:
           target: builder
@@ -65,8 +65,9 @@ profiles:
     patches:
       - op: remove
         path: images.vcluster.rebuildStrategy
-      - op: remove
-        path: images.vcluster.build
+      - op: replace
+        path: images.vcluster.build.buildKit
+        value: {}
       - op: replace
         path: deployments[0].helm.values.syncer
         value:


### PR DESCRIPTION
### Changes
- Fixed an issue where vcluster would not build arm64 versions correctly
- New `--upgrade` flag for `vcluster create` to disable upgrading the vcluster automatically