### PR TITLE
Custom resources for fake nodes

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -33,13 +33,18 @@ type VirtualClusterOptions struct {
 	ServiceNamespace     string
 	OwningStatefulSet    string
 
-	SyncAllNodes             bool
-	SyncNodeChanges          bool
-	UseFakeKubelets          bool
-	UseFakeNodes             bool
-	UseFakePersistentVolumes bool
-	EnableStorageClasses     bool
-	EnablePriorityClasses    bool
+	SyncAllNodes                  bool
+	SyncNodeChanges               bool
+	UseFakeKubelets               bool
+	UseFakeNodes                  bool
+	UseFakePersistentVolumes      bool
+	EnableStorageClasses          bool
+	EnablePriorityClasses         bool
+	FakeNodesCPUCount             string
+	FakeNodesMemSize              string
+	FakeNodesEphemeralStorageSize string
+	FakeNodesHugePages1GCount     string
+	FakeNodesHugePages2MCount     string
 
 	TranslateImages []string
 

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -112,11 +112,11 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&options.UseFakeNodes, "fake-nodes", true, "If enabled, the virtual cluster will create fake nodes instead of copying the actual physical nodes config")
 	cmd.Flags().BoolVar(&options.UseFakePersistentVolumes, "fake-persistent-volumes", true, "If enabled, the virtual cluster will create fake persistent volumes instead of copying the actual physical persistent volumes config")
 
-	cmd.Flags().StringVar(&options.FakeNodesCPUCount, "fake-nodes cpu count", "5", "If enabled fake-nodes, create node with this CPU cores")
-	cmd.Flags().StringVar(&options.FakeNodesMemSize, "fake-nodes mem size", "8Gi", "If enabled fake-nodes, create node with this Mem capacity")
-	cmd.Flags().StringVar(&options.FakeNodesEphemeralStorageSize, "fake-nodes storage size", "10Gi", "If enabled fake-nodes, create node with this storage size")
-	cmd.Flags().StringVar(&options.FakeNodesHugePages1GCount, "fake-nodes hugemem count pages with 1G size", "0", "If enabled fake-nodes, create node with this hugeMem count pages ith 1G size")
-	cmd.Flags().StringVar(&options.FakeNodesHugePages2MCount, "fake-nodes hugemem count pages wuth 2M size", "0", "If enabled fake-nodes, create node with this hugeMem count pages ith 2M size")
+	cmd.Flags().StringVar(&options.FakeNodesCPUCount, "fake-nodes-cpu-count", "5", "If enabled fake-nodes, create node with this CPU cores")
+	cmd.Flags().StringVar(&options.FakeNodesMemSize, "fake-nodes-mem-size", "8Gi", "If enabled fake-nodes, create node with this Mem capacity")
+	cmd.Flags().StringVar(&options.FakeNodesEphemeralStorageSize, "fake-nodes-storage-size", "10Gi", "If enabled fake-nodes, create node with this storage size")
+	cmd.Flags().StringVar(&options.FakeNodesHugePages1GCount, "fake-nodes-hugemem-1G-count", "0", "If enabled fake-nodes, create node with this hugeMem count pages ith 1G size")
+	cmd.Flags().StringVar(&options.FakeNodesHugePages2MCount, "fake-nodes-hugemem-2M-count", "0", "If enabled fake-nodes, create node with this hugeMem count pages ith 2M size")
 
 	cmd.Flags().BoolVar(&options.EnableStorageClasses, "enable-storage-classes", false, "If enabled, the virtual cluster will sync storage classes")
 	cmd.Flags().BoolVar(&options.EnablePriorityClasses, "enable-priority-classes", false, "If enabled, the virtual cluster will sync priority classes from and to the host cluster")

--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
 	"github.com/loft-sh/vcluster/pkg/apis"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	translatepods "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 	"github.com/loft-sh/vcluster/pkg/leaderelection"
 	"github.com/loft-sh/vcluster/pkg/util/kubeconfig"
-	"io/ioutil"
 	"k8s.io/client-go/discovery"
-	"os"
-	"time"
 
 	"github.com/loft-sh/kiosk/pkg/manager/blockingcacheclient"
 	"github.com/loft-sh/kiosk/pkg/util/log"
@@ -110,6 +111,12 @@ func NewCommand() *cobra.Command {
 
 	cmd.Flags().BoolVar(&options.UseFakeNodes, "fake-nodes", true, "If enabled, the virtual cluster will create fake nodes instead of copying the actual physical nodes config")
 	cmd.Flags().BoolVar(&options.UseFakePersistentVolumes, "fake-persistent-volumes", true, "If enabled, the virtual cluster will create fake persistent volumes instead of copying the actual physical persistent volumes config")
+
+	cmd.Flags().StringVar(&options.FakeNodesCPUCount, "fake-nodes cpu count", "5", "If enabled fake-nodes, create node with this CPU cores")
+	cmd.Flags().StringVar(&options.FakeNodesMemSize, "fake-nodes mem size", "8Gi", "If enabled fake-nodes, create node with this Mem capacity")
+	cmd.Flags().StringVar(&options.FakeNodesEphemeralStorageSize, "fake-nodes storage size", "10Gi", "If enabled fake-nodes, create node with this storage size")
+	cmd.Flags().StringVar(&options.FakeNodesHugePages1GCount, "fake-nodes hugemem count pages with 1G size", "0", "If enabled fake-nodes, create node with this hugeMem count pages ith 1G size")
+	cmd.Flags().StringVar(&options.FakeNodesHugePages2MCount, "fake-nodes hugemem count pages wuth 2M size", "0", "If enabled fake-nodes, create node with this hugeMem count pages ith 2M size")
 
 	cmd.Flags().BoolVar(&options.EnableStorageClasses, "enable-storage-classes", false, "If enabled, the virtual cluster will sync storage classes")
 	cmd.Flags().BoolVar(&options.EnablePriorityClasses, "enable-priority-classes", false, "If enabled, the virtual cluster will sync priority classes from and to the host cluster")

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -30,6 +30,7 @@ func RegisterFakeSyncer(ctx *context2.ControllerContext) error {
 		sharedNodesMutex:    ctx.LockFactory.GetLock("nodes-controller"),
 		nodeServiceProvider: ctx.NodeServiceProvider,
 		virtualClient:       ctx.VirtualManager.GetClient(),
+		paramOptions:        ctx.Options,
 	}, "fake-node")
 }
 
@@ -37,6 +38,7 @@ type fakeSyncer struct {
 	sharedNodesMutex    sync.Locker
 	virtualClient       client.Client
 	nodeServiceProvider nodeservice.NodeServiceProvider
+	paramOptions        *context2.VirtualClusterOptions
 }
 
 func (r *fakeSyncer) New() client.Object {
@@ -73,7 +75,7 @@ func (r *fakeSyncer) ReconcileEnd() {
 
 func (r *fakeSyncer) Create(ctx context.Context, name types.NamespacedName, log loghelper.Logger) error {
 	log.Infof("Create fake node %s", name.Name)
-	return CreateFakeNode(ctx, r.nodeServiceProvider, r.virtualClient, name)
+	return CreateFakeNode(ctx, r.nodeServiceProvider, r.virtualClient, name, r.paramOptions)
 }
 
 func (r *fakeSyncer) CreateNeeded(ctx context.Context, name types.NamespacedName) (bool, error) {
@@ -121,7 +123,7 @@ func newGuid() string {
 	return random.RandomString(8) + "-" + random.RandomString(4) + "-" + random.RandomString(4) + "-" + random.RandomString(4) + "-" + random.RandomString(12)
 }
 
-func CreateFakeNode(ctx context.Context, nodeServiceProvider nodeservice.NodeServiceProvider, virtualClient client.Client, name types.NamespacedName) error {
+func CreateFakeNode(ctx context.Context, nodeServiceProvider nodeservice.NodeServiceProvider, virtualClient client.Client, name types.NamespacedName, params *context2.VirtualClusterOptions) error {
 	nodeServiceProvider.Lock()
 	defer nodeServiceProvider.Unlock()
 
@@ -156,19 +158,19 @@ func CreateFakeNode(ctx context.Context, nodeServiceProvider nodeservice.NodeSer
 	orig := node.DeepCopy()
 	node.Status = corev1.NodeStatus{
 		Capacity: corev1.ResourceList{
-			corev1.ResourceCPU:                     resource.MustParse("16"),
-			corev1.ResourceMemory:                  resource.MustParse("32Gi"),
-			corev1.ResourceEphemeralStorage:        resource.MustParse("100Gi"),
-			corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("0"),
-			corev1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("0"),
+			corev1.ResourceCPU:                     resource.MustParse(params.FakeNodesCPUCount),
+			corev1.ResourceMemory:                  resource.MustParse(params.FakeNodesMemSize),
+			corev1.ResourceEphemeralStorage:        resource.MustParse(params.FakeNodesEphemeralStorageSize),
+			corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse(params.FakeNodesHugePages1GCount),
+			corev1.ResourceHugePagesPrefix + "2Mi": resource.MustParse(params.FakeNodesHugePages2MCount),
 			corev1.ResourcePods:                    resource.MustParse("110"),
 		},
 		Allocatable: corev1.ResourceList{
-			corev1.ResourceCPU:                     resource.MustParse("16"),
-			corev1.ResourceMemory:                  resource.MustParse("32Gi"),
-			corev1.ResourceEphemeralStorage:        resource.MustParse("100Gi"),
-			corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse("0"),
-			corev1.ResourceHugePagesPrefix + "2Mi": resource.MustParse("0"),
+			corev1.ResourceCPU:                     resource.MustParse(params.FakeNodesCPUCount),
+			corev1.ResourceMemory:                  resource.MustParse(params.FakeNodesMemSize),
+			corev1.ResourceEphemeralStorage:        resource.MustParse(params.FakeNodesEphemeralStorageSize),
+			corev1.ResourceHugePagesPrefix + "1Gi": resource.MustParse(params.FakeNodesHugePages1GCount),
+			corev1.ResourceHugePagesPrefix + "2Mi": resource.MustParse(params.FakeNodesHugePages2MCount),
 			corev1.ResourcePods:                    resource.MustParse("110"),
 		},
 		Conditions: []corev1.NodeCondition{

--- a/pkg/controllers/resources/nodes/fake_syncer_test.go
+++ b/pkg/controllers/resources/nodes/fake_syncer_test.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"context"
+	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	"strings"
 	"testing"
@@ -40,11 +41,18 @@ func newFakeFakeSyncer(ctx context.Context, lockFactory locks.LockFactory, vClie
 	if err != nil {
 		return nil, err
 	}
-
+	param := &context2.VirtualClusterOptions{
+		FakeNodesCPUCount:             "16",
+		FakeNodesMemSize:              "32Gi",
+		FakeNodesHugePages1GCount:     "0",
+		FakeNodesHugePages2MCount:     "0",
+		FakeNodesEphemeralStorageSize: "100Gi",
+	}
 	return &fakeSyncer{
 		sharedNodesMutex:    lockFactory.GetLock("nodes-controller"),
 		nodeServiceProvider: &fakeNodeServiceProvider{},
 		virtualClient:       vClient,
+		paramOptions:        param,
 	}, nil
 }
 

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -96,6 +96,8 @@ func Register(ctx *context2.ControllerContext) error {
 		podTranslator: translator,
 		useFakeNodes:  ctx.Options.UseFakeNodes,
 
+		params: ctx.Options,
+
 		nodeSelector: nodeSelector,
 	}, "pod", generic.RegisterSyncerOptions{})
 }
@@ -114,6 +116,8 @@ type syncer struct {
 	virtualClient        client.Client
 	virtualClusterClient kubernetes.Interface
 	nodeServiceProvider  nodeservice.NodeServiceProvider
+
+	params *context2.VirtualClusterOptions
 
 	nodeSelector *metav1.LabelSelector
 }
@@ -413,7 +417,7 @@ func (s *syncer) ensureNode(ctx context.Context, pObj *corev1.Pod, vObj *corev1.
 			log.Infof("create virtual fake node %s, because pod %s/%s uses it and it is not available in virtual cluster", pObj.Spec.NodeName, vObj.Namespace, vObj.Name)
 
 			// create fake node
-			err = nodes.CreateFakeNode(ctx, s.nodeServiceProvider, s.virtualClient, types.NamespacedName{Name: pObj.Spec.NodeName})
+			err = nodes.CreateFakeNode(ctx, s.nodeServiceProvider, s.virtualClient, types.NamespacedName{Name: pObj.Spec.NodeName}, s.params)
 			if err != nil {
 				log.Infof("error creating virtual fake node %s: %v", pObj.Spec.NodeName, err)
 				return err


### PR DESCRIPTION
Good day!
I propose to consider the option of specifying resources for fake nodes

New parameters:

--fake-nodes-cpu-count    = If enabled fake-nodes, create node with this CPU cores
--fake-nodes-mem-size   = If enabled fake-nodes, create node with this Mem capacity
--fake-nodes-storage-size = If enabled fake-nodes, create node with this storage size
--fake-nodes-hugemem-1G-count  = If enabled fake-nodes, create node with this hugeMem count pages ith 1G size
--fake-nodes-hugemem-2M-count = If enabled fake-nodes, create node with this hugeMem count pages ith 2M size



Thanks