### PR TITLE
--delete-namespace & sync pods with .

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-// VirtualCluster holds the cmd flags
+// VirtualClusterOptions holds the cmd flags
 type VirtualClusterOptions struct {
 	ServiceAccountKey   string
 	ServerCaCert        string

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -56,6 +56,7 @@ dev:
         - '!/hack'
         - '!/go.mod'
         - '!/go.sum'
+        - '!/devspace_start.sh'
 commands:
   - name: dev
     command: "devspace dev -n vcluster"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -45,6 +45,7 @@ deployments:
 dev:
   terminal:
     imageSelector: ${SYNCER_IMAGE}
+    command: ["./devspace_start.sh"]
   sync:
     - imageSelector: ${SYNCER_IMAGE}
       excludePaths:

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set +e  # Continue on errors
+
+COLOR_CYAN="\033[0;36m"
+COLOR_RESET="\033[0m"
+
+echo -e "${COLOR_CYAN}
+   ____              ____
+  |  _ \  _____   __/ ___| _ __   __ _  ___ ___
+  | | | |/ _ \ \ / /\___ \| '_ \ / _\` |/ __/ _ \\
+  | |_| |  __/\ V /  ___) | |_) | (_| | (_|  __/
+  |____/ \___| \_/  |____/| .__/ \__,_|\___\___|
+                          |_|
+${COLOR_RESET}
+Welcome to your development container!
+This is how you can work with it:
+- Run \`${COLOR_CYAN}go run -mod vendor cmd/vcluster/main.go${COLOR_RESET}\` to start the application
+- ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
+"
+
+bash

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -14,7 +14,8 @@ echo -e "${COLOR_CYAN}
 ${COLOR_RESET}
 Welcome to your development container!
 This is how you can work with it:
-- Run \`${COLOR_CYAN}go run -mod vendor cmd/vcluster/main.go${COLOR_RESET}\` to start the application
+- Run \`${COLOR_CYAN}go run -mod vendor cmd/vcluster/main.go${COLOR_RESET}\` to start vcluster
+- Run \`devspace enter -n vcluster --pod ${HOSTNAME} -c syncer\` to create another shell into this container
 - ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
 "
 

--- a/pkg/controllers/resources/pods/translate/hosts.go
+++ b/pkg/controllers/resources/pods/translate/hosts.go
@@ -1,0 +1,87 @@
+package translate
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	DisableSubdomainRewriteAnnotation = "vcluster.loft.sh/disable-subdomain-rewrite"
+	HostsRewrittenAnnotation          = "vcluster.loft.sh/hosts-rewritten"
+	HostsVolumeName                   = "vcluster-rewrite-hosts"
+	HostsRewriteImage                 = "alpine:3.13.1"
+	HostsRewriteContainerName         = "vcluster-rewrite-hosts"
+)
+
+func rewritePodHostnameFQDN(pPod *corev1.Pod, hostsRewriteImage, fromHost, toHostname, toHostnameFQDN string) {
+	if pPod.Annotations == nil || pPod.Annotations[DisableSubdomainRewriteAnnotation] != "true" || pPod.Annotations[HostsRewrittenAnnotation] != "true" {
+		initContainer := corev1.Container{
+			Name:    HostsRewriteContainerName,
+			Image:   hostsRewriteImage,
+			Command: []string{"sh"},
+			Args:    []string{"-c", "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)" + fromHost + "$/\\1 " + toHostname + " " + toHostnameFQDN + "/' /etc/hosts > /hosts/hosts"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/hosts",
+					Name:      HostsVolumeName,
+				},
+			},
+		}
+
+		// Add volume
+		if pPod.Spec.Volumes == nil {
+			pPod.Spec.Volumes = []corev1.Volume{}
+		}
+		pPod.Spec.Volumes = append(pPod.Spec.Volumes, corev1.Volume{
+			Name: HostsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+
+		// Add init container
+		newContainers := []corev1.Container{initContainer}
+		newContainers = append(newContainers, pPod.Spec.InitContainers...)
+		pPod.Spec.InitContainers = newContainers
+
+		if pPod.Annotations == nil {
+			pPod.Annotations = map[string]string{}
+		}
+		pPod.Annotations[HostsRewrittenAnnotation] = "true"
+
+		// translate containers
+		for i := range pPod.Spec.Containers {
+			if pPod.Spec.Containers[i].VolumeMounts == nil {
+				pPod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{}
+			}
+			pPod.Spec.Containers[i].VolumeMounts = append(pPod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+				MountPath: "/etc/hosts",
+				Name:      HostsVolumeName,
+				SubPath:   "hosts",
+			})
+		}
+
+		// translate init containers
+		for i := range pPod.Spec.InitContainers {
+			if pPod.Spec.InitContainers[i].Name != HostsRewriteContainerName {
+				if pPod.Spec.InitContainers[i].VolumeMounts == nil {
+					pPod.Spec.InitContainers[i].VolumeMounts = []corev1.VolumeMount{}
+				}
+				pPod.Spec.InitContainers[i].VolumeMounts = append(pPod.Spec.InitContainers[i].VolumeMounts, corev1.VolumeMount{
+					MountPath: "/etc/hosts",
+					Name:      HostsVolumeName,
+					SubPath:   "hosts",
+				})
+			}
+		}
+
+		// translate ephemeral containers
+		for i := range pPod.Spec.EphemeralContainers {
+			if pPod.Spec.EphemeralContainers[i].VolumeMounts == nil {
+				pPod.Spec.EphemeralContainers[i].VolumeMounts = []corev1.VolumeMount{}
+			}
+			pPod.Spec.EphemeralContainers[i].VolumeMounts = append(pPod.Spec.EphemeralContainers[i].VolumeMounts, corev1.VolumeMount{
+				MountPath: "/etc/hosts",
+				Name:      HostsVolumeName,
+				SubPath:   "hosts",
+			})
+		}
+	}
+}


### PR DESCRIPTION
### Changes
- **cli**: New flag `--delete-namespace` to delete the vcluster namespace in `vcluster delete` (#126)
- **syncer**: Pods that have a `.` in the name are synced (#131)