### PR TITLE
docs(chart): ability to define a storage class

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,6 +60,9 @@ storage:
   persistence: true
   # Size of the persistent volume claim
   size: 5Gi
+  # Optional StorageClass used for the pvc
+  # if empty default StorageClass defined in your host cluster will be used
+  #className:
   
 # Extra volumes that should be created for the StatefulSet
 volumes: []


### PR DESCRIPTION
Related to: https://github.com/loft-sh/vcluster/issues/145

Looking at the default values in `values.yaml` I did not see that it was possible to modify the storage class while it is quite possible by specifying `className`.
The purpose of this PR is to add visibility on this ability.