### PR TITLE
refactor: rename skip translate annotation

### DIFF
--- a/docs/pages/architecture/storage.mdx
+++ b/docs/pages/architecture/storage.mdx
@@ -79,4 +79,4 @@ spec:
       storage: 5Gi
 ```
 
-This only happens if persistent volume sync is enabled in the vcluster. There might be cases where you want to disable this automatic rewriting of PVCs (for example if you want to mount an already existing PV of the host cluster to a PVC in the vcluster), for that case you can set the annotation called `vcluster.loft.sh/translate-pv` to `true`, which will tell vcluster to not rewrite the PVC `volumeName`, `storageClass` or `selectors`. 
+This only happens if persistent volume sync is enabled in the vcluster. There might be cases where you want to disable this automatic rewriting of PVCs (for example if you want to mount an already existing PV of the host cluster to a PVC in the vcluster), for that case you can set the annotation called `vcluster.loft.sh/skip-translate` to `true`, which will tell vcluster to not rewrite the PVC `volumeName`, `storageClass` or `selectors`. 

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -36,7 +36,7 @@ const (
 	boundByControllerAnnotation  = "pv.kubernetes.io/bound-by-controller"
 	storageProvisionerAnnotation = "volume.beta.kubernetes.io/storage-provisioner"
 
-	skipPVTranslationAnnotation = "vcluster.loft.sh/translate-pv"
+	skipPVTranslationAnnotation = "vcluster.loft.sh/skip-translate"
 )
 
 func RegisterIndices(ctx *context2.ControllerContext) error {


### PR DESCRIPTION
### Changes
- Rename the annotation `vcluster.loft.sh/translate-pv` to `vcluster.loft.sh/skip-translate`