### PR TITLE
fix: service envvar resolution in dependent envvar

### DIFF
--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -44,3 +44,8 @@ func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) 
 func ExpectEmpty(actual interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.BeEmpty(), explain...)
 }
+
+// ExpectMatchRegexp expects the the string to match the provided regular expression
+func ExpectMatchRegexp(actual string, regexp string, explain ...interface{}) {
+	gomega.ExpectWithOffset(1, actual).To(gomega.MatchRegexp(regexp), explain...)
+}

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
 	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/priorityclasses"
 	"github.com/loft-sh/vcluster/pkg/serviceaccount"
@@ -18,10 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/keyutil"
 	"k8s.io/utils/pointer"
-	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
-	"strings"
 )
 
 const (
@@ -612,9 +613,8 @@ func translateEphemerealContainerEnv(c *corev1.EphemeralContainer, vPod *corev1.
 	if c.Env == nil {
 		c.Env = []corev1.EnvVar{}
 	}
-	for _, e := range additionalEnvVars {
-		c.Env = append(c.Env, e)
-	}
+	// additional env vars should come first to allow for dependent environment variables
+	c.Env = append(additionalEnvVars, c.Env...)
 }
 
 func translateContainerEnv(c *corev1.Container, vPod *corev1.Pod, serviceEnvMap map[string]string) {
@@ -659,6 +659,8 @@ func translateContainerEnv(c *corev1.Container, vPod *corev1.Pod, serviceEnvMap 
 	for _, e := range additionalEnvVars {
 		c.Env = append(c.Env, e)
 	}
+	// additional env vars should come first to allow for dependent environment variables
+	c.Env = append(additionalEnvVars, c.Env...)
 }
 
 func translateDownwardAPI(env *corev1.EnvVar) {


### PR DESCRIPTION
Fixes #170 
In this PR I fix the order of synced environment variables to allow access to them in the dependent environment variables.
Additionally, I implemented an e2e test to cover this scenario, and a small tweak to e2e tests to improve performance (imagePullPolicy: IfNotPresent).

Kudos to @FabianKramm for pointing out where the problem might be, and which part of the code needs to be fixed :+1: 
