### PR TITLE
ci: reorganize GH workflows and improve triggers

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,17 +1,21 @@
-name: PR checks
+name: E2E tests
 
 on:
+  release:
+    types: [created]
   pull_request:
     branches:
       - main
     paths:
       - "Dockerfile"
       - "**.go"
-      - ".github/workflows/e2e.yaml"
+      - "!**_test.go" # exclude test files to ignore unit test changes
+      - "e2e/**_test.go" # include test files in e2e again
+      - ".github/workflows/e2e-tests.yaml"
 
 jobs:
   e2e:
-    name: E2E Tests
+    name: Execute testsuite
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,26 +3,8 @@ name: Release
 on:
   release:
     types: [created]
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "**.go"
-      - "hack/test.sh"
-      - ".github/workflows/release.yaml"
 
 jobs:
-  test:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.16
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-      - name: Test
-        run: ./hack/test.sh
   publish-cli:
     if: startsWith(github.ref, 'refs/tags/v') == true
     runs-on: macos-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,27 @@
+name: Unit tests
+
+on:
+  release:
+    types: [created]
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - "!e2e/**" # exclude changes in e2e tests
+      - ".github/workflows/unit-tests.yaml"
+      - "hack/test.sh"
+
+jobs:
+  unit-test:
+    name: Execute all tests
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Execute unit tests
+        run: ./hack/test.sh


### PR DESCRIPTION
I am trying to make the checks look a little less cluttered, and have them triggered only when it makes sense (based on the files that got changed in the PR).

State before:
![image](https://user-images.githubusercontent.com/1605799/139494585-f2141c39-1814-40ad-8fcd-684583f12aba.png)
