### PR TITLE
fix: Service creation when .Kind is not sent

### DIFF
--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	// Register tests
 	_ "github.com/loft-sh/vcluster/e2e/test/syncer/pods"
+	_ "github.com/loft-sh/vcluster/e2e/test/syncer/services"
 )
 
 var (

--- a/e2e/test/syncer/services/services.go
+++ b/e2e/test/syncer/services/services.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/loft-sh/vcluster/e2e/framework"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("Services are created as expected", func() {
+	var (
+		f         *framework.Framework
+		iteration int
+		ns        string
+	)
+
+	ginkgo.JustBeforeEach(func() {
+		// use default framework
+		f = framework.DefaultFramework
+		iteration++
+		ns = fmt.Sprintf("e2e-syncer-services-%d", iteration)
+		// execute cleanup in case previous e2e test were terminated prematurely
+		err := f.DeleteTestNamespace(ns, true)
+		framework.ExpectNoError(err)
+
+		// create test namespace
+		_, err = f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.AfterEach(func() {
+		// delete test namespace
+		err := f.DeleteTestNamespace(ns, false)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("Test Service gets created when no Kind is present in body", func() {
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myservice",
+				Namespace: ns,
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{"doesnt": "matter"},
+				Ports: []corev1.ServicePort{
+					{Port: 80},
+				},
+			},
+		}
+		body, err := json.Marshal(service)
+		framework.ExpectNoError(err)
+
+		_, err = f.VclusterClient.RESTClient().Post().AbsPath("/api/v1/namespaces/" + ns + "/services").Body(body).DoRaw(f.Context)
+		framework.ExpectNoError(err)
+
+		_, err = f.VclusterClient.CoreV1().Services(ns).Get(f.Context, service.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		_, err = f.HostClient.CoreV1().Services(f.VclusterNamespace).Get(f.Context, translate.ObjectPhysicalName(&service), metav1.GetOptions{})
+		framework.ExpectNoError(err)
+	})
+})

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -3,13 +3,15 @@ package filters
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/encoding"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	requestpkg "github.com/loft-sh/vcluster/pkg/util/request"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversionscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
@@ -20,7 +22,6 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog"
-	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -126,7 +127,8 @@ func updateService(req *http.Request, decoder encoding.Decoder, localClient clie
 		return nil, err
 	}
 
-	svc, err := decoder.Decode(rawObj)
+	serviceGVK := corev1.SchemeGroupVersion.WithKind("Service")
+	svc, err := decoder.Decode(rawObj, &serviceGVK)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +194,8 @@ func createService(req *http.Request, decoder encoding.Decoder, localClient clie
 		return nil, err
 	}
 
-	svc, err := decoder.Decode(rawObj)
+	serviceGVK := corev1.SchemeGroupVersion.WithKind("Service")
+	svc, err := decoder.Decode(rawObj, &serviceGVK)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/encoding/decoder.go
+++ b/pkg/util/encoding/decoder.go
@@ -7,12 +7,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 // Decoder is the standard interface for decoding and encoding resources
 type Decoder interface {
-	Decode(data []byte) (runtime.Object, error)
+	Decode(data []byte, defaults *schema.GroupVersionKind) (runtime.Object, error)
 	EncodeYAML(obj runtime.Object) ([]byte, error)
 	EncodeJSON(obj runtime.Object) ([]byte, error)
 }
@@ -32,8 +33,8 @@ func NewDecoder(scheme *runtime.Scheme, strict bool) Decoder {
 	}
 }
 
-func (d *decoder) Decode(data []byte) (runtime.Object, error) {
-	obj, _, err := d.decoder.Decode(data, nil, nil)
+func (d *decoder) Decode(data []byte, defaults *schema.GroupVersionKind) (runtime.Object, error) {
+	obj, _, err := d.decoder.Decode(data, defaults, nil)
 	if err != nil {
 		// Decode into unstructured if the object is not registered
 		if runtime.IsNotRegisteredError(err) {

--- a/pkg/util/encoding/decoder_test.go
+++ b/pkg/util/encoding/decoder_test.go
@@ -45,7 +45,7 @@ spec:
 	scheme := kubernetesNativeScheme()
 	decoder := NewDecoder(scheme, false)
 
-	pod, err := decoder.Decode([]byte(examplePod))
+	pod, err := decoder.Decode([]byte(examplePod), nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if _, ok := pod.(*corev1.Pod); !ok {
@@ -66,7 +66,7 @@ spec:
 	scheme := kubernetesNativeScheme()
 	decoder := NewDecoder(scheme, false)
 
-	obj, err := decoder.Decode([]byte(examplePod))
+	obj, err := decoder.Decode([]byte(examplePod), nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #176 
I am fixing a Service creation flow in a scenario where the .Kind field is not part of the request body. 
Additionally, an e2e test is added to cover the fixed scenario, and reusable functions in e2e tests are moved to e2e/framework/util.go