### PR TITLE
docs: instructions for running e2e and debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .devspace/
 /test
 .DS_Store
+profile.out

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+          "name": "Debug vcluster (localhost:2346)",
+          "type": "go",
+          "request": "attach",
+          "mode": "remote",
+          "port": 2346,
+          "host": "localhost",
+          "substitutePath": [
+            {
+              "from": "${workspaceFolder}",
+              "to": "/vcluster",
+            },
+          ],
+          "showLog": true,
+          //"trace": "verbose", // use for debugging problems with delve (breakpoints not working, etc.)
+        },
+		{
+            "name": "Launch e2e tests",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "remotePath": "",
+            "program": "${workspaceRoot}/e2e/e2e_suite_test.go",
+            "env": {
+                "VCLUSTER_CLIENT_TIMEOUT": 32, // 32 is the default; increase to high number when debugging vcluster backend server
+                //"VCLUSTER_SUFFIX": "vcluster", // suffix is set to "vcluster" when deployed with `devspace run deploy`
+            },
+            "args": ["-ginkgo.v"], // add "-ginkgo.focus=.*part of test name.*" to run just the test containing said regexp
+            "showLog": true,
+        } 
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,24 @@ root@vcluster-0:/vcluster#
 
 `kubectl` within the syncer container will point to the virtual cluster and you can access it from there. If you need to recreate the vcluster, delete the `vcluster` namespace and rerun `devspace run dev` again. 
 
+#### Debug vcluster with Delve
+If you wish to run vcluster in the debug mode with delve, run `devspace run dev` and wait until you see the command prompt (`root@vcluster-0:/vcluster#`).  
+Run `dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags="-mod=vendor" -- --lease-duration=99999`  
+Wait until the `API server listening at: [::]:2345` message appears.  
+Start the `Debug vcluster (localhost:2346)` configuration in VSCode to connect your debugger session.  
+If you are not using VSCode, configure your IDE to connect to `localhost:2346` for the "remote" delve debugging.  
+**Note:** vcluster won't start you connect with the debugger.  
+**Note:** vcluster will be stopped once you detach your debugger session.  
+
 ### Running vcluster Tests
 
-You can run the unit test suite with `./hack/test.sh` which should execute all the vcluster tests. For running conformance tests, please take a look at [conformance tests](https://github.com/loft-sh/vcluster/tree/main/conformance/v1.20)
+You can run the unit test suite with `./hack/test.sh` which should execute all the vcluster tests.  
+
+The e2e test suite can be run from the e2e folder(`cd e2e`) with this command - `VCLUSTER_SUFFIX=vcluster go test -v -ginkgo.v`.  
+Alternatively, if you [install ginkgo binary](https://github.com/onsi/ginkgo#global-installation), you can run it with `VCLUSTER_SUFFIX=vcluster ginkgo -v`.  
+If you are running vcluster with `devspace run dev` then the `VCLUSTER_SUFFIX` environment variable shouldn't be set, and you should run the tests with `go test -v -ginkgo.v` or `ginkgo -v`.  
+
+For running conformance tests, please take a look at [conformance tests](https://github.com/loft-sh/vcluster/tree/main/conformance/v1.21)
 
 ### License
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG TARGETARCH
 # Install kubectl for development
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
 
+# Install Delve for debugging
+RUN go get github.com/go-delve/delve/cmd/dlv
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -45,6 +45,11 @@ dev:
   terminal:
     imageSelector: ${SYNCER_IMAGE}
     command: ["./devspace_start.sh"]
+  ports:
+    - imageSelector: ${SYNCER_IMAGE}
+      forward:
+        - port: 2346
+          remotePort: 2345
   sync:
     - imageSelector: ${SYNCER_IMAGE}
       excludePaths:

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -18,6 +18,13 @@ This is how you can work with it:
 - Run \`${COLOR_CYAN}devspace enter -n vcluster --pod ${HOSTNAME} -c syncer${COLOR_RESET}\` to create another shell into this container
 - Run \`${COLOR_CYAN}kubectl ...${COLOR_RESET}\` from within the container to access the vcluster if its started
 - ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
+
+If you wish to run vcluster in the debug mode with delve, run:
+  \`${COLOR_CYAN}dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- --lease-duration=99999${COLOR_RESET}\`
+  Wait until the \`${COLOR_CYAN}API server listening at: [::]:2345${COLOR_RESET}\` message appears
+  Start the \"Debug vcluster (localhost:2346)\" configuration in VSCode to connect your debugger session.
+  ${COLOR_CYAN}Note:${COLOR_RESET} vcluster won't start you connect with the debugger.
+  ${COLOR_CYAN}Note:${COLOR_RESET} vcluster will be stopped once you detach your debugger session.
 "
 
 bash


### PR DESCRIPTION
I added some documentation for running e2e tests and documentation and config for running the vcluster with the debugger.

The `.vscode/` folder is in the `.gitignore`, so I had to force add the `.vscode/launch.json`, I hope that's okay. I would keep it in .gitignore to let everyone easily customize the config locally without the changes showing up in git all the time.