### PR TITLE
feat: new --set-owner flag

### DIFF
--- a/chart/templates/rbac/role.yaml
+++ b/chart/templates/rbac/role.yaml
@@ -20,6 +20,6 @@ rules:
     resources: ["ingresses"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["statefulsets"]
+    resources: ["statefulsets", "replicasets", "deployments"]
     verbs: ["get", "list", "watch"]
 {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -105,7 +105,7 @@ spec:
         args:
           - --service-name={{ .Release.Name }}
           - --suffix={{ .Release.Name }}
-          - --owning-statefulset={{ .Release.Name }}
+          - --set-owner
           - --out-kube-config-secret=vc-{{ .Release.Name }}
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -31,7 +31,9 @@ type VirtualClusterOptions struct {
 	TargetNamespace      string
 	ServiceName          string
 	ServiceNamespace     string
-	OwningStatefulSet    string
+	
+	DeprecatedOwningStatefulSet string
+	SetOwner                    bool
 
 	SyncAllNodes             bool
 	SyncNodeChanges          bool

--- a/pkg/controllers/resources/nodes/nodeservice/node_service.go
+++ b/pkg/controllers/resources/nodes/nodeservice/node_service.go
@@ -6,7 +6,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -179,15 +178,8 @@ func (n *nodeServiceProvider) GetNodeIP(ctx context.Context, name types.Namespac
 	}
 
 	// set owning stateful set if defined
-	if translate.OwningStatefulSet != nil {
-		nodeService.SetOwnerReferences([]metav1.OwnerReference{
-			{
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-				Kind:       "StatefulSet",
-				Name:       translate.OwningStatefulSet.Name,
-				UID:        translate.OwningStatefulSet.UID,
-			},
-		})
+	if translate.Owner != nil {
+		nodeService.SetOwnerReferences(translate.GetOwnerReference())
 	}
 
 	// create the service

--- a/pkg/controllers/resources/storageclasses/syncer.go
+++ b/pkg/controllers/resources/storageclasses/syncer.go
@@ -38,7 +38,7 @@ func (s *syncer) BackwardCreate(ctx context.Context, pObj client.Object, log log
 	vObj.ResourceVersion = ""
 	vObj.UID = ""
 	vObj.ManagedFields = nil
-	log.Infof("create storage class %s, because it is not exist in virtual cluster", vObj.Name)
+	log.Infof("create storage class %s, because it does not exist in virtual cluster", vObj.Name)
 	return ctrl.Result{}, s.virtualClient.Create(ctx, vObj)
 }
 


### PR DESCRIPTION
### Changes
- **syncer**: New `--set-owner` flag that will figure out automatically the owning object of the vcluster pod and set that to the vcluster created objects (#181)
- **syncer**: Deprecated the flag `--owning-statefulset`