### PR TITLE
Use host-namespace-1 for helm install

### DIFF
--- a/docs/pages/fragments/deploy-vcluster.mdx
+++ b/docs/pages/fragments/deploy-vcluster.mdx
@@ -42,7 +42,7 @@ Then, install helm chart using `vcluster.yaml` for chart values:
 helm upgrade --install vcluster-1 vcluster \
   --values vcluster.yaml \
   --repo https://charts.loft.sh \
-  --namespace vcluster-1 \
+  --namespace host-namespace-1 \
   --repository-config=''
 ```
 


### PR DESCRIPTION
The directions currently indicate that vcluster will be installed in
host-namespace-1, but the helm install uses namespace vcluster-1. This
updates the directions to be consistent.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>