### PR TITLE
fix: glusterfs volume endpointsName translation on sync

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"regexp"
 	"sort"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -459,6 +459,9 @@ func (t *translator) translateVolumes(pPod *corev1.Pod, vPod *corev1.Pod) error 
 		}
 		if pPod.Spec.Volumes[i].CSI != nil && pPod.Spec.Volumes[i].CSI.NodePublishSecretRef != nil {
 			pPod.Spec.Volumes[i].CSI.NodePublishSecretRef.Name = translate.PhysicalName(pPod.Spec.Volumes[i].CSI.NodePublishSecretRef.Name, vPod.Namespace)
+		}
+		if pPod.Spec.Volumes[i].Glusterfs != nil && pPod.Spec.Volumes[i].Glusterfs.EndpointsName != "" {
+			pPod.Spec.Volumes[i].Glusterfs.EndpointsName = translate.PhysicalName(pPod.Spec.Volumes[i].Glusterfs.EndpointsName, vPod.Namespace)
 		}
 	}
 


### PR DESCRIPTION
Fixes the issue reported in slack - https://loft-sh.slack.com/archives/C01N273CF4P/p1633101568199400

GlusterFS volumes use an Endpoint that is local to the pod(created in the same namespace as the pod).
The value of the `glusterfs.endpoints` field is now appropriately translated by the syncer:

![image](https://user-images.githubusercontent.com/1605799/142963861-a39d1f50-ef1a-4208-beee-253543d3a545.png)
```
$ k get endpoints -n vcluster
NAME                                ENDPOINTS                                     AGE
glusterfs-cluster-x-test-x-suffix   192.168.122.21:1,192.168.122.22:1             4m51s
```
