### PR TITLE
feat: add namespace labels to synced pods

### DIFF
--- a/pkg/util/translate/cluster_metadata.go
+++ b/pkg/util/translate/cluster_metadata.go
@@ -3,6 +3,7 @@ package translate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -49,5 +50,5 @@ func (d *defaultClusterTranslator) TranslateAnnotations(vObj client.Object, pObj
 
 func convertNamespacedLabelKey(physicalNamespace, key string) string {
 	digest := sha256.Sum256([]byte(key))
-	return SafeConcatName("vcluster.loft.sh/label", physicalNamespace, "x", Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
+	return SafeConcatName(LabelPrefix, physicalNamespace, "x", Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
 }

--- a/pkg/util/translate/metadata.go
+++ b/pkg/util/translate/metadata.go
@@ -3,18 +3,20 @@ package translate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"sort"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
-	"strings"
 )
 
 var (
 	ManagedAnnotationsAnnotation = "vcluster.loft.sh/managed-annotations"
 	NamespaceAnnotation          = "vcluster.loft.sh/object-namespace"
 	NameAnnotation               = "vcluster.loft.sh/object-name"
+	LabelPrefix                  = "vcluster.loft.sh/label"
 )
 
 type Translator interface {
@@ -152,8 +154,12 @@ func setupMetadataWithName(targetNamespace string, vObj client.Object, translato
 }
 
 func ConvertLabelKey(key string) string {
+	return ConvertLabelKeyWithPrefix(LabelPrefix, key)
+}
+
+func ConvertLabelKeyWithPrefix(prefix, key string) string {
 	digest := sha256.Sum256([]byte(key))
-	return SafeConcatName("vcluster.loft.sh/label", Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
+	return SafeConcatName(prefix, Suffix, "x", hex.EncodeToString(digest[0:])[0:10])
 }
 
 func exists(a []string, k string) bool {


### PR DESCRIPTION
The labels of the namespace in vcluster are now added to the pods created in the host cluster.
This is a first step towards implementing features that use namespace label selectors, e.g. NetworkPolicies (#155) or PodAffinity (#52).

```
$ k get ns default --show-labels
NAME      STATUS   AGE   LABELS
default   Active   14h   kubernetes.io/metadata.name=default,test-label=Hello_PR_reviewer
```
![image](https://user-images.githubusercontent.com/1605799/143066928-ca0c3271-3df8-418b-ad12-a1d413617387.png)
