### PR TITLE
refactor: deprecate k3s-image, release-values & add kubernetes-version

### DIFF
--- a/cmd/vclusterctl/cmd/app/create/types.go
+++ b/cmd/vclusterctl/cmd/app/create/types.go
@@ -10,14 +10,14 @@ type CreateOptions struct {
 	CIDR         string
 	ExtraValues  []string
 
+	KubernetesVersion string
+
 	CreateNamespace    bool
 	DisableIngressSync bool
 	CreateClusterRole  bool
 	Expose             bool
 	Connect            bool
 	Upgrade            bool
-
-	RunAsUser int64
 
 	ReleaseValues string
 }

--- a/cmd/vclusterctl/cmd/app/create/values/k0s.go
+++ b/cmd/vclusterctl/cmd/app/create/values/k0s.go
@@ -14,7 +14,7 @@ var K0SVersionMap = map[string]string{
 }
 
 func getDefaultK0SReleaseValues(client kubernetes.Interface, createOptions *create.CreateOptions, log log.Logger) (string, error) {
-	serverVersionString, serverMinorInt, err := getKubernetesVersion(client)
+	serverVersionString, serverMinorInt, err := getKubernetesVersion(client, createOptions)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/vclusterctl/cmd/app/create/values/k8s.go
+++ b/cmd/vclusterctl/cmd/app/create/values/k8s.go
@@ -26,7 +26,7 @@ var K8SEtcdVersionMap = map[string]string{
 }
 
 func getDefaultK8SReleaseValues(client kubernetes.Interface, createOptions *create.CreateOptions, log log.Logger) (string, error) {
-	serverVersionString, serverMinorInt, err := getKubernetesVersion(client)
+	serverVersionString, serverMinorInt, err := getKubernetesVersion(client, createOptions)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -56,7 +56,7 @@ vcluster create test --namespace test
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Check for newer version
 			upgrade.PrintNewerVersionWarning()
-
+			validateDeprecated(&cmd.CreateOptions, cmd.log)
 			return cmd.Run(args)
 		},
 	}
@@ -64,18 +64,27 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.4.0)")
 	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
 	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", "https://charts.loft.sh", "The virtual cluster chart repo to use")
-	cobraCmd.Flags().StringVar(&cmd.K3SImage, "k3s-image", "", "If specified, use this k3s image version")
+	cobraCmd.Flags().StringVar(&cmd.K3SImage, "k3s-image", "", "DEPRECATED: use --extra-values instead")
 	cobraCmd.Flags().StringVar(&cmd.Distro, "distro", "k3s", fmt.Sprintf("Kubernetes distro to use for the virtual cluster. Allowed distros: %s", strings.Join(values.AllowedDistros, ", ")))
 	cobraCmd.Flags().StringVar(&cmd.ReleaseValues, "release-values", "", "DEPRECATED: use --extra-values instead")
+	cobraCmd.Flags().StringVar(&cmd.KubernetesVersion, "kubernetes-version", "", "The kubernetes version to use (e.g. v1.20). Patch versions are not supported")
 	cobraCmd.Flags().StringSliceVarP(&cmd.ExtraValues, "extra-values", "f", []string{}, "Path where to load extra helm values from")
 	cobraCmd.Flags().BoolVar(&cmd.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")
 	cobraCmd.Flags().BoolVar(&cmd.DisableIngressSync, "disable-ingress-sync", false, "If true the virtual cluster will not sync any ingresses")
 	cobraCmd.Flags().BoolVar(&cmd.CreateClusterRole, "create-cluster-role", false, "If true a cluster role will be created to access nodes, storageclasses and priorityclasses")
 	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
 	cobraCmd.Flags().BoolVar(&cmd.Connect, "connect", false, "If true will run vcluster connect directly after the vcluster was created")
-	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "upgrade", true, "If true will try to upgrade the vcluster instead of failing if it already exists")
-	cobraCmd.Flags().Int64Var(&cmd.RunAsUser, "run-as-user", -1, "User UID that will be used to run the containers in vcluster pod and vcluster CoreDNS. Set to a non-zero value to run vcluster as non-root user. The value must be in a range that is acceptable by your cluster.")
+	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "upgrade", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
 	return cobraCmd
+}
+
+func validateDeprecated(createOptions *create.CreateOptions, log log.Logger) {
+	if createOptions.ReleaseValues != "" {
+		log.Warn("Flag --release-values is deprecated, please use --extra-values instead. This flag will be removed in future!")
+	}
+	if createOptions.K3SImage != "" {
+		log.Warn("Flag --k3s-image is deprecated, please use --extra-values instead. This flag will be removed in future!")
+	}
 }
 
 // Run executes the functionality
@@ -166,7 +175,7 @@ func (cmd *CreateCmd) Run(args []string) error {
 	if cmd.Upgrade == false {
 		_, err = client.AppsV1().StatefulSets(cmd.Namespace).Get(context.TODO(), args[0], metav1.GetOptions{})
 		if err == nil {
-			return fmt.Errorf("vcluster %s already exists in namespace %s", args[0], cmd.Namespace)
+			return fmt.Errorf("vcluster %s already exists in namespace %s. If you want to upgrade the vcluster, run with the --upgrade flag", args[0], cmd.Namespace)
 		}
 	}
 

--- a/pkg/helm/labels.go
+++ b/pkg/helm/labels.go
@@ -1,0 +1,32 @@
+package helm
+
+// labels is a map of key value pairs to be included as metadata in a configmap object.
+type labels map[string]string
+
+func (lbs *labels) init()                { *lbs = labels(make(map[string]string)) }
+func (lbs labels) get(key string) string { return lbs[key] }
+func (lbs labels) set(key, val string)   { lbs[key] = val }
+
+func (lbs labels) keys() (ls []string) {
+	for key := range lbs {
+		ls = append(ls, key)
+	}
+	return
+}
+
+func (lbs labels) match(set labels) bool {
+	for _, key := range set.keys() {
+		if lbs.get(key) != set.get(key) {
+			return false
+		}
+	}
+	return true
+}
+
+func (lbs labels) toMap() map[string]string { return lbs }
+
+func (lbs *labels) fromMap(kvs map[string]string) {
+	for k, v := range kvs {
+		lbs.set(k, v)
+	}
+}

--- a/pkg/helm/secrets.go
+++ b/pkg/helm/secrets.go
@@ -1,0 +1,278 @@
+/*
+	Copyright The Helm Authors.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package helm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kblabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+var b64 = base64.StdEncoding
+
+var magicGzip = []byte{0x1f, 0x8b, 0x08}
+
+// Release describes a deployment of a chart, together with the chart
+// and the variables used to deploy that chart.
+type Release struct {
+	// Name is the name of the release
+	Name string `json:"name,omitempty"`
+	// Info provides information about a release
+	Info *Info `json:"info,omitempty"`
+	// Chart is the chart that was released.
+	Chart *Chart `json:"chart,omitempty"`
+	// Config is the set of extra Values added to the chart.
+	// These values override the default values inside of the chart.
+	Config map[string]interface{} `json:"config,omitempty"`
+	// Version is an int which represents the version of the release.
+	Version int `json:"version,omitempty"`
+	// Namespace is the kubernetes namespace of the release.
+	Namespace string `json:"namespace,omitempty"`
+
+	Secret *v1.Secret `json:"-"`
+}
+
+// Info describes release information.
+type Info struct {
+	// FirstDeployed is when the release was first deployed.
+	// +optional
+	FirstDeployed Time `json:"first_deployed,omitempty"`
+	// LastDeployed is when the release was last deployed.
+	// +optional
+	LastDeployed Time `json:"last_deployed,omitempty"`
+	// Deleted tracks when this object was deleted.
+	// +optional
+	Deleted Time `json:"deleted,omitempty"`
+	// Description is human-friendly "log entry" about this release.
+	// +optional
+	Description string `json:"description,omitempty"`
+	// Status is the current state of the release
+	// +optional
+	Status string `json:"status,omitempty"`
+	// Contains the rendered templates/NOTES.txt if available
+	// +optional
+	Notes string `json:"notes,omitempty"`
+}
+
+// Maintainer describes a Chart maintainer.
+type Maintainer struct {
+	// Name is a user name or organization name
+	// +optional
+	Name string `json:"name,omitempty"`
+	// Email is an optional email address to contact the named maintainer
+	// +optional
+	Email string `json:"email,omitempty"`
+	// URL is an optional URL to an address for the named maintainer
+	// +optional
+	URL string `json:"url,omitempty"`
+}
+
+// Metadata for a Chart file. This models the structure of a Chart.yaml file.
+type Metadata struct {
+	// The name of the chart
+	// +optional
+	Name string `json:"name,omitempty"`
+	// The URL to a relevant project page, git repo, or contact person
+	// +optional
+	Home string `json:"home,omitempty"`
+	// Source is the URL to the source code of this chart
+	// +optional
+	Sources []string `json:"sources,omitempty"`
+	// A SemVer 2 conformant version string of the chart
+	// +optional
+	Version string `json:"version,omitempty"`
+	// A one-sentence description of the chart
+	// +optional
+	Description string `json:"description,omitempty"`
+	// A list of string keywords
+	// +optional
+	Keywords []string `json:"keywords,omitempty"`
+	// A list of name and URL/email address combinations for the maintainer(s)
+	// +optional
+	Maintainers []*Maintainer `json:"maintainers,omitempty"`
+	// The URL to an icon file.
+	// +optional
+	Icon string `json:"icon,omitempty"`
+	// The API Version of this chart.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+	// The condition to check to enable chart
+	// +optional
+	Condition string `json:"condition,omitempty"`
+	// The tags to check to enable chart
+	// +optional
+	Tags string `json:"tags,omitempty"`
+	// The version of the application enclosed inside of this chart.
+	// +optional
+	AppVersion string `json:"appVersion,omitempty"`
+	// Whether or not this chart is deprecated
+	// +optional
+	Deprecated bool `json:"deprecated,omitempty"`
+	// Annotations are additional mappings uninterpreted by Helm,
+	// made available for inspection by other applications.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+	// KubeVersion is a SemVer constraint specifying the version of Kubernetes required.
+	// +optional
+	KubeVersion string `json:"kubeVersion,omitempty"`
+	// Specifies the chart type: application or library
+	// +optional
+	Type string `json:"type,omitempty"`
+	// Urls where to find the chart contents
+	// +optional
+	Urls []string `json:"urls,omitempty"`
+}
+
+// Chart holds the chart metadata
+type Chart struct {
+	Metadata *Metadata `json:"metadata,omitempty"`
+}
+
+// Secrets is a wrapper around an implementation of a kubernetes
+// SecretsInterface.
+type Secrets struct {
+	kubeClient kubernetes.Interface
+}
+
+// NewSecrets initializes a new Secrets wrapping an implementation of
+// the kubernetes SecretsInterface.
+func NewSecrets(clientSet kubernetes.Interface) *Secrets {
+	return &Secrets{
+		kubeClient: clientSet,
+	}
+}
+
+func (secrets *Secrets) Update(ctx context.Context, secret *v1.Secret) (*v1.Secret, error) {
+	return secrets.kubeClient.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})
+}
+
+// List fetches all releases and returns the list releases such
+// that filter(release) == true. An error is returned if the
+// secret fails to retrieve the releases.
+func (secrets *Secrets) List(ctx context.Context, labels kblabels.Selector, namespace string) ([]*Release, error) {
+	req, err := kblabels.NewRequirement("owner", selection.Equals, []string{"helm"})
+	if err != nil {
+		return nil, err
+	}
+	if labels == nil {
+		labels = kblabels.Everything()
+	}
+	labels = labels.Add(*req)
+	list, err := secrets.kubeClient.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// iterate over the secrets object list
+	// and decode each release
+	var results []*Release
+	for _, item := range list.Items {
+		cpy := item
+		rls, err := decodeRelease(&cpy, string(item.Data["release"]))
+		if err != nil {
+			klog.Infof("list: failed to decode release: %v", err)
+			continue
+		} else if rls.Chart == nil || rls.Chart.Metadata == nil || rls.Info == nil {
+			klog.Infof("list: metadata info is empty of release: %s", rls.Name)
+			continue
+		} else if rls.Info.Status == "superseded" || rls.Info.Status == "uninstalled" {
+			continue
+		}
+
+		// check if this release superseeds an already existing release
+		found := false
+		for i, r := range results {
+			if r.Name == rls.Name && r.Namespace == rls.Namespace && r.Version < rls.Version {
+				results[i] = rls
+				found = true
+				break
+			}
+		}
+		if !found {
+			results = append(results, rls)
+		}
+	}
+	return results, nil
+}
+
+// Query fetches all releases that match the provided map of labels.
+// An error is returned if the secret fails to retrieve the releases.
+func (secrets *Secrets) Get(ctx context.Context, name string, namespace string) (*Release, error) {
+	ls := kblabels.Set{}
+	ls["name"] = name
+	list, err := secrets.List(ctx, ls.AsSelector(), namespace)
+	if err != nil {
+		return nil, err
+	} else if len(list) == 0 {
+		return nil, kerrors.NewNotFound(v1.SchemeGroupVersion.WithResource("secrets").GroupResource(), name)
+	}
+
+	var latest *Release
+	for _, rls := range list {
+		if latest == nil || latest.Version < rls.Version {
+			latest = rls
+		}
+	}
+
+	return latest, nil
+}
+
+// decodeRelease decodes the bytes of data into a release
+// type. Data must contain a base64 encoded gzipped string of a
+// valid release, otherwise an error is returned.
+func decodeRelease(secret *v1.Secret, data string) (*Release, error) {
+	// base64 decode string
+	b, err := b64.DecodeString(data)
+	if err != nil {
+		return nil, err
+	} else if len(b) < 3 {
+		return nil, fmt.Errorf("unexpected secret content: %s", data)
+	}
+
+	// For backwards compatibility with releases that were stored before
+	// compression was introduced we skip decompression if the
+	// gzip magic header is not found
+	if bytes.Equal(b[0:3], magicGzip) {
+		r, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		b2, err := ioutil.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		b = b2
+	}
+
+	var rls Release
+	// unmarshal release object bytes
+	if err := json.Unmarshal(b, &rls); err != nil {
+		return nil, fmt.Errorf("error decoding %s: %v", string(b), err)
+	}
+
+	rls.Secret = secret
+	return &rls, nil
+}

--- a/pkg/helm/time.go
+++ b/pkg/helm/time.go
@@ -1,0 +1,70 @@
+package helm
+
+import (
+	"bytes"
+	"time"
+)
+
+// emptyString contains an empty JSON string value to be used as output
+var emptyString = `""`
+
+// Time is a convenience wrapper around stdlib time, but with different
+// marshalling and unmarshaling for zero values
+type Time struct {
+	time.Time
+}
+
+// Now returns the current time. It is a convenience wrapper around time.Now()
+func Now() Time {
+	return Time{time.Now()}
+}
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.Time.IsZero() {
+		return []byte(emptyString), nil
+	}
+
+	return t.Time.MarshalJSON()
+}
+
+func (t *Time) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte("null")) {
+		return nil
+	}
+	// If it is empty, we don't have to set anything since time.Time is not a
+	// pointer and will be set to the zero value
+	if bytes.Equal([]byte(emptyString), b) {
+		return nil
+	}
+
+	return t.Time.UnmarshalJSON(b)
+}
+
+func Parse(layout, value string) (Time, error) {
+	t, err := time.Parse(layout, value)
+	return Time{Time: t}, err
+}
+func ParseInLocation(layout, value string, loc *time.Location) (Time, error) {
+	t, err := time.ParseInLocation(layout, value, loc)
+	return Time{Time: t}, err
+}
+
+func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
+	return Time{Time: time.Date(year, month, day, hour, min, sec, nsec, loc)}
+}
+
+func Unix(sec int64, nsec int64) Time { return Time{Time: time.Unix(sec, nsec)} }
+
+func (t Time) Add(d time.Duration) Time { return Time{Time: t.Time.Add(d)} }
+func (t Time) AddDate(years int, months int, days int) Time {
+	return Time{Time: t.Time.AddDate(years, months, days)}
+}
+func (t Time) After(u Time) bool             { return t.Time.After(u.Time) }
+func (t Time) Before(u Time) bool            { return t.Time.Before(u.Time) }
+func (t Time) Equal(u Time) bool             { return t.Time.Equal(u.Time) }
+func (t Time) In(loc *time.Location) Time    { return Time{Time: t.Time.In(loc)} }
+func (t Time) Local() Time                   { return Time{Time: t.Time.Local()} }
+func (t Time) Round(d time.Duration) Time    { return Time{Time: t.Time.Round(d)} }
+func (t Time) Sub(u Time) time.Duration      { return t.Time.Sub(u.Time) }
+func (t Time) Truncate(d time.Duration) Time { return Time{Time: t.Time.Truncate(d)} }
+func (t Time) UTC() Time                     { return Time{Time: t.Time.UTC()} }


### PR DESCRIPTION
### Changes
- Deprecation of `vcluster create` flags `--release-values` and `--k3s-image`. Use `--extra-values` instead
- Changed default value of `vcluster create` flag `--upgrade` from `true` to `false`. vcluster will not try to upgrade an existing vcluster by default anymore
- New flag `--kubernetes-version` for `vcluster create` to override the kubernetes version used for creating the vcluster. This allows you to create vclusters like this:
```
vcluster create my-vcluster -n vcluster --distro k8s --kubernetes-version v1.20
```