### PR TITLE
test(e2e): run e2e in GH workflows for all charts

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,6 +17,10 @@ jobs:
   e2e:
     name: Execute testsuite
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution: ["k3s", "k8s", "k0s"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -39,14 +43,11 @@ jobs:
       uses: loft-sh/setup-devspace@main
 
     - name: Deploy vcluster
-      run: devspace run deploy --skip-push
-
-    - name: Load built image into kind cluster
-      run: docker images | grep ghcr.io/loft-sh/loft-enterprise/dev-vcluster | head -n 1 | awk '{print $1":"$2}' | xargs kind load docker-image
+      run: devspace run deploy -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests --skip-push
 
     - name: Wait until vcluster is ready
       id: wait-until-vcluster-is-ready
-      run: kubectl wait --for=condition=ready pod vcluster-0 -n vcluster --timeout=120s
+      run: kubectl wait --for=condition=ready pod -l app=vcluster -n vcluster --timeout=300s
       continue-on-error: true
     
     - name: Collect deployment information in case vcluster fails to start

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -100,6 +100,57 @@ profiles:
         path: deployments.name=vcluster.helm.values.syncer
         value:
           image: ${SYNCER_IMAGE}
+  - name: k3s
+    # This profile is empty for now because the default config is for k3s
+    # Keep the empty profile because it's used in the distribution matrix of the GH workflow for e2e. 
+  - name: k0s
+    patches:
+      - op: replace
+        path: deployments.name=vcluster.helm.chart.name
+        value: ./charts/k0s
+      - op: remove
+        path: deployments.name=vcluster.helm.values.vcluster.image
+  - name: k8s
+    patches:
+      - op: replace
+        path: deployments.name=vcluster.helm.chart.name
+        value: ./charts/k8s
+  - name: kind-load
+    patches:
+      - op: add
+        path: hooks
+        value:
+          - name: "post-image-build-hook"
+            command: |
+              kind load docker-image image(vcluster):tag(vcluster)
+            events: ["after:build:vcluster"]
+  - name: no-cpu-requests
+    patches:
+      - op: replace
+        path: deployments.name=vcluster.helm.values.syncer.resources
+        value: 
+          requests:
+            cpu: "0"
+      - op: replace
+        path: deployments.name=vcluster.helm.values.vcluster.resources
+        value: 
+          requests:
+            cpu: "0"
+      - op: replace
+        path: deployments.name=vcluster.helm.values.etcd.resources
+        value: 
+          requests:
+            cpu: "0"
+      - op: replace
+        path: deployments.name=vcluster.helm.values.controller.resources
+        value: 
+          requests:
+            cpu: "0"
+      - op: replace
+        path: deployments.name=vcluster.helm.values.api.resources
+        value: 
+          requests:
+            cpu: "0"
   - name: parent-crc
     patches:
       - op: replace


### PR DESCRIPTION
We should run e2e tests against all distributions/charts that are provided - k3s, k8s and k0s.
These changes will ensure that e2e tests in GH workflows(on PRs) are triggered for each distribution/chart.