### PR TITLE
Support IPv6 on service CIDR

### DIFF
--- a/cmd/vclusterctl/cmd/app/create/values/k3s.go
+++ b/cmd/vclusterctl/cmd/app/create/values/k3s.go
@@ -150,7 +150,12 @@ func getKubernetesVersion(client kubernetes.Interface, createOptions *create.Cre
 	return serverVersionString, serverMinorInt, nil
 }
 
-func GetServiceCIDR(client kubernetes.Interface, namespace string) (string, error) {
+func GetServiceCIDR(client kubernetes.Interface, namespace string, ipv6 bool) (string, error) {
+	clusterIP := "4.4.4.4"
+	if ipv6 {
+		// https://www.ietf.org/rfc/rfc3849.txt
+		clusterIP = "2001:DB8::1"
+	}
 	_, err := client.CoreV1().Services(namespace).Create(context.Background(), &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-service-",
@@ -161,7 +166,7 @@ func GetServiceCIDR(client kubernetes.Interface, namespace string) (string, erro
 					Port: 80,
 				},
 			},
-			ClusterIP: "4.4.4.4",
+			ClusterIP: clusterIP,
 		},
 	}, metav1.CreateOptions{})
 	if err == nil {

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -23,6 +23,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var errorMessageIPFamily = "expected an IPv6 value as indicated by "    // Dual-stack cluster with .spec.ipFamilies=["IPv6"]
+var errorMessageIPv4Disabled = "IPv4 is not configured on this cluster" // IPv6 only cluster
+
 // CreateCmd holds the login cmd flags
 type CreateCmd struct {
 	*flags.GlobalFlags
@@ -154,10 +157,17 @@ func (cmd *CreateCmd) Run(args []string) error {
 
 	// get service cidr
 	if cmd.CIDR == "" {
-		cmd.CIDR, err = values.GetServiceCIDR(client, cmd.Namespace)
+		cmd.CIDR, err = values.GetServiceCIDR(client, cmd.Namespace, false)
 		if err != nil {
-			cmd.log.Warn(err)
-			cmd.CIDR = "10.96.0.0/12"
+			idx := strings.Index(err.Error(), errorMessageIPFamily)
+			idz := strings.Index(err.Error(), errorMessageIPv4Disabled)
+			if idx != -1 || idz != -1 {
+				cmd.CIDR, err = values.GetServiceCIDR(client, cmd.Namespace, true)
+			}
+			if err != nil {
+				cmd.log.Warn(err)
+				cmd.CIDR = "10.96.0.0/12"
+			}
 		}
 	}
 


### PR DESCRIPTION
First step to solve #18 

Add logic to detect if cluster does not have support for IPv4 or if vcluster is forced to use IPv6 only with policy engine.

At least combination of dual stack cluster with Kyverno policy like this:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: service-ipv6-only
spec:
  validationFailureAction: enforce
  background: false
  rules:
  - name: service-ipv6-only
    match:
      resources:
        kinds:
        - Service
        namespaces:
        - "vcluster-*"
    preconditions:
      all:
      - key: "{{request.operation}}"
        operator: In
        value:
        - CREATE
    mutate:
      patchStrategicMerge:
        spec:
          ipFamilyPolicy: SingleStack
          ipFamilies:
          - IPv6
```
and using `--distro k8s` works.

Pure IPv6 only env where also host cluster is IPv6 only will need more work. K0s needs this PR https://github.com/k0sproject/k0s/pull/1292 and K3s needs this PR https://github.com/k3s-io/k3s/pull/4450 before those can be used with this one.