### PR TITLE
fix: etcd crash looping due to DNS cache

### DIFF
--- a/charts/k8s/templates/etcd-statefulset-service.yaml
+++ b/charts/k8s/templates/etcd-statefulset-service.yaml
@@ -10,6 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  publishNotReadyAddresses: true
   ports:
     - name: etcd
       port: 2379

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -123,3 +123,25 @@ spec:
         resources:
 {{ toYaml .Values.etcd.resources | indent 10 }}
 {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 2381
+            host: 127.0.0.1
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 8
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 2381
+            host: 127.0.0.1
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 24


### PR DESCRIPTION
etcd tries to resolve own DNS name, or names of peers,
but on the first resolution call coredns caches(for 30s) failed response,
etcd keeps trying for 30s before exiting, which results in container restart.
This can result in a crash loop, as Coredns keeps caching failed response.
Setting publishNotReadyAddresses: true seems to prevent this.
First DNS resolution still fails and gets cached for 30s,
resulting in one restart of all etcd pods except last one,
but after CoreDNS cache expires it returns a valid response and
etcd cluster becomes ready.

In my local minikube I was reliably reproducing the crash looping behavior of the original implementation.
With this fix, the k8s flavor of vcluster starts reliably after the aforementioned one restart per etcd pod.
This results into vcluster readiness in around 1min 22sec (on my machine).

Another improvement, which I didn't include due to it being rather hacky, is to add an init container with 5s sleep and `podManagementPolicy: Parallel`. This starts all the replicas at once, and 5s delay is enough to avoid failing DNS resolution and subsequently waiting 30s for DNS cache to expire. etcd pods to resolve each other's addresses successfully on the first attempt.
With that, the time to vcluster readiness is cut to ~38s. But this is not an ideal solution because it unnecessarily delays etcd pod startup in all other cases, when other replicas are already available. I am not sure if there is some way to leverage this without the downside of 5s sleep every time the etcd pod starts.

btw: editing coredns cache setting to cache for 5s instead of the default 30s also works(without these changes), but since this is outside of our control, it's not a solution, but I wanted to mention it in support of my explanation of the problem.