### PR TITLE
restrict leader election & fix current pod failure

### DIFF
--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -84,6 +84,11 @@ spec:
           - --service-name={{ .Release.Name }}
           - --suffix={{ .Release.Name }}
           - --set-owner
+          {{- if .Values.enableHA }}
+          - '--leader-elect=true'
+          {{- else }}
+          - '--leader-elect=false'
+          {{- end }}
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}
           {{- end }}

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -53,6 +53,7 @@ type VirtualClusterOptions struct {
 
 	ClusterDomain string
 
+	LeaderElect   bool
 	LeaseDuration int64
 	RenewDeadline int64
 	RetryPeriod   int64
@@ -88,7 +89,7 @@ func NewControllerContext(localManager ctrl.Manager, virtualManager ctrl.Manager
 		Context:             ctx,
 		LocalManager:        localManager,
 		VirtualManager:      virtualManager,
-		NodeServiceProvider: nodeservice.NewNodeServiceProvider(localManager.GetClient(), virtualManager.GetClient(), uncachedVirtualClient, options.TargetNamespace),
+		NodeServiceProvider: nodeservice.NewNodeServiceProvider(localManager.GetClient(), virtualManager.GetClient(), uncachedVirtualClient),
 		LockFactory:         locks.NewDefaultLockFactory(),
 		CacheSynced: func() {
 			cacheSynced.Do(func() {


### PR DESCRIPTION
### Changes
- **syncer**: Fixed an issue where vcluster couldn't find the current pod if the flag `--target-namespace` was provided (#214)
- **syncer**: New flag `--leader-elect` that defaults to false to avoid unnecessary leader election