### PR TITLE
fix: move k0s and k8s syncer extraArgs to allow user defined ones

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,6 +12,7 @@ on:
       - "!**_test.go" # exclude test files to ignore unit test changes
       - "e2e/**_test.go" # include test files in e2e again
       - ".github/workflows/e2e-tests.yaml"
+      - "charts/"
 
 jobs:
   e2e:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -112,6 +112,11 @@ spec:
           - --service-name={{ .Release.Name }}
           - --suffix={{ .Release.Name }}
           - --set-owner
+          - --request-header-ca-cert=/data/k0s/pki/ca.crt
+          - --client-ca-cert=/data/k0s/pki/ca.crt
+          - --server-ca-cert=/data/k0s/pki/ca.crt
+          - --server-ca-key=/data/k0s/pki/ca.key
+          - --kube-config=/data/k0s/pki/admin.conf
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}
           {{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -9,12 +9,7 @@ serviceCIDR: "10.96.0.0/12"
 syncer:
   # Image to use for the syncer
   # image: loftsh/vcluster
-  extraArgs:
-    - --request-header-ca-cert=/data/k0s/pki/ca.crt
-    - --client-ca-cert=/data/k0s/pki/ca.crt
-    - --server-ca-cert=/data/k0s/pki/ca.crt
-    - --server-ca-key=/data/k0s/pki/ca.key
-    - --kube-config=/data/k0s/pki/admin.conf
+  extraArgs: []
   env: []
   livenessProbe:
     enabled: true

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -84,6 +84,11 @@ spec:
           - --service-name={{ .Release.Name }}
           - --suffix={{ .Release.Name }}
           - --set-owner
+          - --request-header-ca-cert=/pki/ca.crt
+          - --client-ca-cert=/pki/ca.crt
+          - --server-ca-cert=/pki/ca.crt
+          - --server-ca-key=/pki/ca.key
+          - --kube-config=/pki/admin.conf
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}
           {{- end }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -13,12 +13,7 @@ enableHA: false
 syncer:
   # Image to use for the syncer
   # image: loftsh/vcluster
-  extraArgs:
-    - --request-header-ca-cert=/pki/ca.crt
-    - --client-ca-cert=/pki/ca.crt
-    - --server-ca-cert=/pki/ca.crt
-    - --server-ca-key=/pki/ca.key
-    - --kube-config=/pki/admin.conf
+  extraArgs: []
   volumeMounts:
     - mountPath: /pki
       name: certs


### PR DESCRIPTION
This fixes a problem mentioned in [this comment](https://github.com/loft-sh/vcluster/issues/167#issuecomment-980006013).
Users are now free to define their own extraArgs for syncer, and the ones needed by default won't get overridden.