### PR TITLE
docs: add restricted hosts page to operator guide

### DIFF
--- a/docs/pages/fragments/deploy-to-openshift.mdx
+++ b/docs/pages/fragments/deploy-to-openshift.mdx
@@ -14,9 +14,8 @@ import TabItem from '@theme/TabItem'
 Create a `values.yaml` file with the following lines:
 
 ```
-securityContext:
-  runAsUser: 12345
-  runAsNonRoot: true
+openshift
+  enable: true
 ```
 
 Then create the vcluster with the following command:
@@ -29,12 +28,11 @@ vcluster create -f values.yaml
 
 Update the `vcluster.yaml` file described in the [deployment guide](../getting-started/deployment). 
 
-You will need to add the `securityContext` block as shown below:
+You will need to add the `openshift` block as shown below:
 
 ```yaml
-securityContext:
-  runAsUser: 12345
-  runAsNonRoot: true
+openshift
+  enable: true
 ```
 
 Then, install helm chart using `vcluster.yaml` for chart values as described in the [deployment guide](../getting-started/deployment). 
@@ -42,29 +40,24 @@ Then, install helm chart using `vcluster.yaml` for chart values as described in 
 </TabItem>
 <TabItem value="kubectl">
 
-Update the `vcluster-1.yaml` file described in the [deployment guide](../getting-started/deployment). 
+Update the `vcluster-1.yaml` file from the previous steps. 
 
-You will need to add the `securityContext` blocks to the containers as shown below:
+You will need to add a new rule as shown below:
 
-```yaml {10-12,15-17}
-apiVersion: apps/v1
-kind: StatefulSet
+```yaml {7-9}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: vcluster-1
+rules:
   ...
-spec:
-  template:
-    spec:
-      containers:
-      - name: virtual-cluster
-        securityContext:
-          runAsUser: 12345
-          runAsNonRoot: true
-        ...
-      - name: syncer
-        securityContext:
-          runAsUser: 12345
-          runAsNonRoot: true
-        ...
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"]
+    verbs: ["create"]
+```
+
+```bash
+kubectl apply -f vcluster-1.yaml -n host-namespace-1
 ```
 </TabItem>
 </Tabs>

--- a/docs/pages/getting-started/deployment.mdx
+++ b/docs/pages/getting-started/deployment.mdx
@@ -4,7 +4,6 @@ sidebar_label: 2. Deploy vclusters
 ---
 
 import DeploySegment from '../fragments/deploy-vcluster.mdx'
-import NonRootSegment from '../fragments/non-root-vcluster.mdx'
 
 Let's create a virtual cluster `vcluster-1` in namespace `host-namespace-1`:
 
@@ -23,13 +22,3 @@ If you want to deploy vclusters in an air-gapped environment, use the `kubectl` 
 One of the biggest benefits of vcluster compared to other virtual cluster approaches is that it does not require any special permissions. Even if you are not cluster-admin and only have access to deploy applications to one specific namespace, you will very likely be able to spin up a virtual cluster.
 
 Check out the `kubectl` tab above to see what `vcluster create` is actually deploying to the host-namespace.
-
-
-## Running as non-root user
-If your host cluster policies disallow running containers with root user, or you simply preffer to run them this way, it is possible to configure it for vcluster components. Steps below show how to set the desired UID for syncer and control plane. The syncer also passes this UID down to DNS deployment.
-
-<NonRootSegment/>
-
-:::info Container UID
-The UID configured for the vcluster is not applied to the workloads started inside the virtual cluster. It is applied only to the vcluster itself.
-:::

--- a/docs/pages/operator/restricted-hosts.mdx
+++ b/docs/pages/operator/restricted-hosts.mdx
@@ -1,0 +1,42 @@
+---
+title: Runing on restricted hosts
+sidebar_label: Runing on restricted hosts (non-root, OpenShift, etc.)
+---
+
+import NonRootSegment from '../fragments/non-root-vcluster.mdx'
+import OpenshiftSegment from '../fragments/deploy-to-openshift.mdx'
+
+Many Kubernetes cluster operators employ policies to restrict the usage of certain features, for example running pods with the root user.
+On this page you will see which options allow you to adjust vcluster configuration to successfully deploy it in such restricted host clusters.
+
+## Running as non-root user
+If your host cluster policies disallow running containers with root user, or you simply preffer to run them this way, it is possible to configure it for vcluster components. Steps below show how to set the desired UID for syncer and control plane. The syncer also passes this UID down to the vcluster DNS deployment.
+
+<NonRootSegment/>
+
+:::info Values of the securityContext fields
+You can substitute the runAsUser value as needed, e.g. if the host cluster limits the allowable UID ranges.  
+And you are free to set other [securityContext fields](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podsecuritycontext-v1-core) as necessary to fullfil your host cluster policies.
+:::
+
+:::caution
+Running as non-root is currently supported only for the k3s distribution. While [other distributions provided by vcluster](./other-distributions) may make use of the `securityContext` field from the `values.yaml` file, we do not guarantee that they will work as expected.
+:::
+
+:::caution
+Vcluster doesn't currently provide a migration path from an instance that was running as root to running with a non-root user.
+:::
+
+## Running on OpenShift
+By default, OpenShift doesn't allow running containers with the root user, but it assings a random UID from the allowed range automatically, which means that you can skip the steps described in the [Running as non-root user](#running-as-non-root-user) section of this document and your vcluster should run as non-root user by default.
+
+OpenShift also imposes some restrictions that are not common to other Kubernetes distributions.  
+When deploying vcluster to OpenShift you will need to follow these additional steps:
+
+<OpenshiftSegment/>
+
+:::info Additional permission when running on OpenShift
+Vcluster requires `create` permission for the `endpoints/restricted` resource in the default group when running on OpenShift.  
+This permission is required because OpenShift has additional built-in addmission controller for the Endpoint resources, which denies creation of the endpoints pointing into the cluster network or service network CIDR ranges, unless this additional permission is given.
+Following the steps outline above ensures that the vcluster Role includes this permission, as it is necessary for certain networking features. 
+:::

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -55,6 +55,7 @@ module.exports = {
         'operator/accessing-vcluster',
         'operator/monitoring',
         'operator/other-distributions',
+        'operator/restricted-hosts',
       ],
     },
     {


### PR DESCRIPTION
Docs chapter describing running as non root has been updated and moved to a new page under operators guide.
A chapter about deploying to OpenShift was added there as well.