### PR TITLE
refactor: add --controllers, deprecate start flags

### DIFF
--- a/pkg/controllers/resources/nodes/register.go
+++ b/pkg/controllers/resources/nodes/register.go
@@ -25,7 +25,7 @@ func RegisterIndices(ctx *context2.ControllerContext) error {
 }
 
 func Register(ctx *context2.ControllerContext, eventBroadcaster record.EventBroadcaster) error {
-	if ctx.Options.UseFakeNodes && ctx.Options.NodeSelector == "" {
+	if !ctx.Controllers["nodes"] && ctx.Options.NodeSelector == "" {
 		return RegisterFakeSyncer(ctx)
 	}
 	return RegisterSyncer(ctx)

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -56,7 +56,7 @@ func RegisterSyncer(ctx *context2.ControllerContext) error {
 		nodeServiceProvider: ctx.NodeServiceProvider,
 		scheme:              ctx.LocalManager.GetScheme(),
 		nodeSelector:        nodeSelector,
-		useFakeKubelets:     ctx.Options.UseFakeKubelets,
+		useFakeKubelets:     !ctx.Options.DisableFakeKubelets,
 	})
 }
 

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -47,7 +47,7 @@ func Register(ctx *context2.ControllerContext, eventBroadcaster record.EventBroa
 	return generic.RegisterSyncer(ctx, "persistentvolumeclaim", &syncer{
 		Translator: generic.NewNamespacedTranslator(ctx.Options.TargetNamespace, ctx.VirtualManager.GetClient(), &corev1.PersistentVolumeClaim{}),
 
-		useFakePersistentVolumes:     ctx.Options.UseFakePersistentVolumes,
+		useFakePersistentVolumes:     !ctx.Controllers["persistentvolumes"],
 		sharedPersistentVolumesMutex: ctx.LockFactory.GetLock("persistent-volumes-controller"),
 
 		targetNamespace: ctx.Options.TargetNamespace,

--- a/pkg/controllers/resources/persistentvolumes/register.go
+++ b/pkg/controllers/resources/persistentvolumes/register.go
@@ -9,7 +9,7 @@ import (
 )
 
 func RegisterIndices(ctx *context2.ControllerContext) error {
-	if ctx.Options.UseFakePersistentVolumes {
+	if !ctx.Controllers["persistentvolumes"] {
 		// index pvcs by their assigned pv
 		err := ctx.VirtualManager.GetFieldIndexer().IndexField(ctx.Context, &corev1.PersistentVolumeClaim{}, constants.IndexByAssigned, func(rawObj client.Object) []string {
 			pod := rawObj.(*corev1.PersistentVolumeClaim)
@@ -29,7 +29,7 @@ func RegisterIndices(ctx *context2.ControllerContext) error {
 }
 
 func Register(ctx *context2.ControllerContext, eventBroadcaster record.EventBroadcaster) error {
-	if ctx.Options.UseFakePersistentVolumes {
+	if !ctx.Controllers["persistentvolumes"] {
 		return RegisterFakeSyncer(ctx)
 	}
 

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -90,7 +90,7 @@ func Register(ctx *context2.ControllerContext, eventBroadcaster record.EventBroa
 		nodeServiceProvider:  ctx.NodeServiceProvider,
 
 		podTranslator: translator,
-		useFakeNodes:  ctx.Options.UseFakeNodes,
+		useFakeNodes:  !ctx.Controllers["nodes"],
 
 		creator:      generic.NewGenericCreator(ctx.LocalManager.GetClient(), eventRecorder, "pod"),
 		nodeSelector: nodeSelector,

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -72,7 +72,7 @@ func NewTranslator(ctx *context2.ControllerContext, eventRecorder record.EventRe
 		serviceAccount:         ctx.Options.ServiceAccount,
 		overrideHosts:          ctx.Options.OverrideHosts,
 		overrideHostsImage:     ctx.Options.OverrideHostsContainerImage,
-		priorityClassesEnabled: ctx.Options.EnablePriorityClasses,
+		priorityClassesEnabled: ctx.Controllers["priorityclasses"],
 	}, nil
 }
 

--- a/pkg/controllers/resources/priorityclasses/register.go
+++ b/pkg/controllers/resources/priorityclasses/register.go
@@ -6,20 +6,9 @@ import (
 )
 
 func RegisterIndices(ctx *context.ControllerContext) error {
-	if ctx.Options.EnablePriorityClasses {
-		err := RegisterSyncerIndices(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return RegisterSyncerIndices(ctx)
 }
 
 func Register(ctx *context.ControllerContext, eventBroadcaster record.EventBroadcaster) error {
-	if ctx.Options.EnablePriorityClasses {
-		return RegisterSyncer(ctx)
-	}
-
-	return nil
+	return RegisterSyncer(ctx)
 }

--- a/pkg/controllers/resources/storageclasses/register.go
+++ b/pkg/controllers/resources/storageclasses/register.go
@@ -10,9 +10,5 @@ func RegisterIndices(ctx *context2.ControllerContext) error {
 }
 
 func Register(ctx *context2.ControllerContext, eventBroadcaster record.EventBroadcaster) error {
-	if ctx.Options.EnableStorageClasses {
-		return RegisterSyncer(ctx)
-	}
-
-	return nil
+	return RegisterSyncer(ctx)
 }


### PR DESCRIPTION
### Changes
- **syncer**: Renamed flag `--fake-kubelets` to `--disable-fake-kubelets` that makes it easier to understand how to disable fake kubelets as they are enabled by default. `--fake-kubelets` still exists and will be migrated automatically
- **syncer**: New flag `--sync` that defines enabled or disabled sync controllers similar to `--controllers` of [kube-controller-manager](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/). Examples: 
    - Default sync resources: `--sync=*`
    - Disable `ingresses`: `--sync=*,-ingresses`
    - Sync real nodes: `--sync=*,nodes`
    - Sync real persistent volumes: `--sync=*,persistentvolumes`
    - Sync storage classes and persistent volumes: `--sync=*,storageclasses,persistentvolumes`
    - Synced by default (`*`): `secrets,services,configmaps,endpoints,events,fake-persistentvolumes,ingresses,persistentvolumeclaims,pods,fake-nodes`
    - All available options: `secrets,services,configmaps,endpoints,events,fake-persistentvolumes,ingresses,nodes,persistentvolumeclaims,priorityclasses,pods,fake-nodes,persistentvolumes,storageclasses`
- **syncer**: Deprecated flags `--fake-kubelets`, `--disable-sync-resources`, `--enable-priority-classes`, `--enable-storage-classes`, `--fake-nodes` and `--fake-persistent-volumes` 