### PR TITLE
feat: new option to define a default image registry

### DIFF
--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
       {{- end }}
       containers:
       {{- if not .Values.vcluster.disabled }}
-      - image: {{ .Values.vcluster.image }}
+      - image: {{ .Values.defaultImageRegistry }}{{ .Values.vcluster.image }}
         name: vcluster
         command:
           {{- range $f := .Values.vcluster.command }}
@@ -94,9 +94,9 @@ spec:
       {{- if not .Values.syncer.disabled }}
       - name: syncer
         {{- if .Values.syncer.image }}
-        image: "{{ .Values.syncer.image }}"
+        image: "{{ .Values.defaultImageRegistry }}{{ .Values.syncer.image }}"
         {{- else }}
-        image: "loftsh/vcluster:{{ .Chart.Version }}"
+        image: "{{ .Values.defaultImageRegistry }}loftsh/vcluster:{{ .Chart.Version }}"
         {{- end }}
         {{- if .Values.syncer.workingDir }}
         workingDir: {{ .Values.syncer.workingDir }}
@@ -151,7 +151,13 @@ spec:
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
         env:
-{{ toYaml .Values.syncer.env | indent 10 }}
+          - name: DEFAULT_IMAGE_REGISTRY
+            value: {{ .Values.defaultImageRegistry }}
+          {{- if .Values.syncer.env }}
+          {{- range $key, $value := .Values.syncer.env }}
+          - {{ toJson $value }}
+          {{- end }}
+          {{- end }}
         volumeMounts:
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -5,6 +5,10 @@
 # The Service "faulty-service" is invalid: spec.clusterIP: Invalid value: "1.1.1.1": provided IP is not in the valid range. The range of valid IPs is 10.96.0.0/12
 serviceCIDR: "10.96.0.0/12"
 
+# DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
+# images within the vcluster will not be rewritten.
+defaultImageRegistry: ""
+
 # Syncer configuration
 syncer:
   # Image to use for the syncer

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
       {{- end }}
       containers:
       {{- if not .Values.vcluster.disabled }}
-      - image: {{ .Values.vcluster.image }}
+      - image: {{ .Values.defaultImageRegistry }}{{ .Values.vcluster.image }}
         name: vcluster
         command:
           {{- range $f := .Values.vcluster.command }}
@@ -94,9 +94,9 @@ spec:
       {{- if not .Values.syncer.disabled }}
       - name: syncer
         {{- if .Values.syncer.image }}
-        image: "{{ .Values.syncer.image }}"
+        image: "{{ .Values.defaultImageRegistry }}{{ .Values.syncer.image }}"
         {{- else }}
-        image: "loftsh/vcluster:{{ .Chart.Version }}"
+        image: "{{ .Values.defaultImageRegistry }}loftsh/vcluster:{{ .Chart.Version }}"
         {{- end }}
         {{- if .Values.syncer.workingDir }}
         workingDir: {{ .Values.syncer.workingDir }}
@@ -146,7 +146,13 @@ spec:
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
         env:
-{{ toYaml .Values.syncer.env | indent 10 }}
+          - name: DEFAULT_IMAGE_REGISTRY
+            value: {{ .Values.defaultImageRegistry }}
+          {{- if .Values.syncer.env }}
+          {{- range $key, $value := .Values.syncer.env }}
+          - {{ toJson $value }}
+          {{- end }}
+          {{- end }}
         volumeMounts:
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -5,6 +5,10 @@
 # The Service "faulty-service" is invalid: spec.clusterIP: Invalid value: "1.1.1.1": provided IP is not in the valid range. The range of valid IPs is 10.96.0.0/12
 #serviceCIDR: "10.96.0.0/12"
 
+# DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
+# images within the vcluster will not be rewritten.
+defaultImageRegistry: ""
+
 # Syncer configuration
 syncer:
   # Image to use for the syncer

--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- end }}
       containers:
       - name: kube-apiserver
-        image: "{{ .Values.api.image }}"
+        image: "{{ .Values.defaultImageRegistry }}{{ .Values.api.image }}"
         command:
           - kube-apiserver
           - '--advertise-address=0.0.0.0'

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- end }}
       containers:
       - name: kube-controller-manager
-        image: "{{ .Values.controller.image }}"
+        image: "{{ .Values.defaultImageRegistry }}{{ .Values.controller.image }}"
         command:
           - kube-controller-manager
           - '--authentication-kubeconfig=/run/config/pki/controller-manager.conf'

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
       - name: etcd
-        image: "{{ .Values.etcd.image }}"
+        image: "{{ .Values.defaultImageRegistry }}{{ .Values.etcd.image }}"
         command:
           - etcd
           - '--cert-file=/run/config/pki/etcd-server.crt'

--- a/charts/k8s/templates/pre-install-hook-job.yaml
+++ b/charts/k8s/templates/pre-install-hook-job.yaml
@@ -25,9 +25,9 @@ spec:
       containers:
         - name: certs
           {{- if .Values.syncer.image }}
-          image: "{{ .Values.syncer.image }}"
+          image: "{{ .Values.defaultImageRegistry }}{{ .Values.syncer.image }}"
           {{- else }}
-          image: "loftsh/vcluster:{{ .Chart.Version }}"
+          image: "{{ .Values.defaultImageRegistry }}loftsh/vcluster:{{ .Chart.Version }}"
           {{- end }}
           imagePullPolicy: IfNotPresent
           securityContext:

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -66,9 +66,9 @@ spec:
       containers:
       - name: syncer
         {{- if .Values.syncer.image }}
-        image: "{{ .Values.syncer.image }}"
+        image: "{{ .Values.defaultImageRegistry }}{{ .Values.syncer.image }}"
         {{- else }}
-        image: "loftsh/vcluster:{{ .Chart.Version }}"
+        image: "{{ .Values.defaultImageRegistry }}loftsh/vcluster:{{ .Chart.Version }}"
         {{- end }}
         {{- if .Values.syncer.workingDir }}
         workingDir: {{ .Values.syncer.workingDir }}
@@ -128,7 +128,13 @@ spec:
         securityContext:
 {{ toYaml .Values.syncer.securityContext | indent 10 }}
         env:
-{{ toYaml .Values.syncer.env | indent 10 }}
+          - name: DEFAULT_IMAGE_REGISTRY
+            value: {{ .Values.defaultImageRegistry }}
+          {{- if .Values.syncer.env }}
+          {{- range $key, $value := .Values.syncer.env }}
+          - {{ toJson $value }}
+          {{- end }}
+          {{- end }}
         volumeMounts:
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -5,6 +5,10 @@
 # The Service "faulty-service" is invalid: spec.clusterIP: Invalid value: "1.1.1.1": provided IP is not in the valid range. The range of valid IPs is 10.96.0.0/12
 serviceCIDR: "10.96.0.0/12"
 
+# DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
+# images within the vcluster will not be rewritten.
+defaultImageRegistry: ""
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false

--- a/pkg/controllers/resources/pods/translate/hosts.go
+++ b/pkg/controllers/resources/pods/translate/hosts.go
@@ -1,12 +1,15 @@
 package translate
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	DisableSubdomainRewriteAnnotation = "vcluster.loft.sh/disable-subdomain-rewrite"
 	HostsRewrittenAnnotation          = "vcluster.loft.sh/hosts-rewritten"
 	HostsVolumeName                   = "vcluster-rewrite-hosts"
-	HostsRewriteImage                 = "alpine:3.13.1"
+	HostsRewriteImage                 = "library/alpine:3.13.1"
 	HostsRewriteContainerName         = "vcluster-rewrite-hosts"
 )
 
@@ -14,7 +17,7 @@ func rewritePodHostnameFQDN(pPod *corev1.Pod, hostsRewriteImage, fromHost, toHos
 	if pPod.Annotations == nil || pPod.Annotations[DisableSubdomainRewriteAnnotation] != "true" || pPod.Annotations[HostsRewrittenAnnotation] != "true" {
 		initContainer := corev1.Container{
 			Name:    HostsRewriteContainerName,
-			Image:   hostsRewriteImage,
+			Image:   translate.DefaultImageRegistry() + hostsRewriteImage,
 			Command: []string{"sh"},
 			Args:    []string{"-c", "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)" + fromHost + "$/\\1 " + toHostnameFQDN + " " + toHostname + "/' /etc/hosts > /hosts/hosts"},
 			VolumeMounts: []corev1.VolumeMount{

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"os"
 	"path"
 	"strconv"
@@ -72,6 +73,8 @@ func getManifestVariables(serverVersion *version.Info) map[string]interface{} {
 	if !found {
 		vars[VarImage] = DefaultImage
 	}
+	vars[VarImage] = translate.DefaultImageRegistry() + vars[VarImage].(string)
+
 	vars[VarRunAsUser] = strconv.Itoa(os.Getuid())
 	if os.Getuid() == 0 {
 		vars[VarRunAsNonRoot] = "false"

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -3,6 +3,7 @@ package translate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
@@ -17,6 +18,10 @@ var (
 )
 
 var Owner client.Object
+
+func DefaultImageRegistry() string {
+	return os.Getenv("DEFAULT_IMAGE_REGISTRY")
+}
 
 func SafeConcatGenerateName(name ...string) string {
 	fullPath := strings.Join(name, "-")


### PR DESCRIPTION
### Changes
- **chart**: New option `defaultImageRegistry` that allows you to specify an image registry that should be prepended to all deployed system pods by vcluster