### PR TITLE
etcd: use pod IP instead of localhost on startup and liveness probes

### DIFF
--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   serviceName: {{ .Release.Name }}-etcd-headless
   replicas: {{ .Values.etcd.replicas }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: vcluster-etcd
@@ -127,7 +128,6 @@ spec:
           httpGet:
             path: /health
             port: 2381
-            host: 127.0.0.1
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 15
@@ -138,7 +138,6 @@ spec:
           httpGet:
             path: /health
             port: 2381
-            host: 127.0.0.1
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 15


### PR DESCRIPTION
I'm not exactly sure why this is the case but looks that #212 did broke on etcd startup totally on my env where I use Calico + BGP without any overlay or NAT.

This was the error:
```
kubectl -n vcluster-test describe pod/test-etcd-0
  Normal   Started                 72s                kubelet                  Started container etcd
  Warning  Unhealthy               9s (x6 over 59s)   kubelet                  Startup probe failed: Get "http://127.0.0.1:2381/health": dial tcp 127.0.0.1:2381: connect: connection refused
```
and if I only updated startup probe then error was:
```
kubectl -n vcluster-test describe pod/test-etcd-0
  Warning  Unhealthy               8s    kubelet                  Liveness probe failed: Get "http://127.0.0.1:2381/health": dial tcp 127.0.0.1:2381: connect: connection refused
```

Solution looks to be not defining `host:` value so pod IP gets used instead of https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes