### PR TITLE
fix(ci): changes to charts should trigger e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,7 +12,7 @@ on:
       - "!**_test.go" # exclude test files to ignore unit test changes
       - "e2e/**_test.go" # include test files in e2e again
       - ".github/workflows/e2e-tests.yaml"
-      - "charts/"
+      - "charts/**"
 
 jobs:
   e2e:


### PR DESCRIPTION
I made a mistake last time I was trying to enable e2e on charts changes.
This time I am using a correct pattern, as per docs:
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#patterns-to-match-file-paths