### PR TITLE
feat: add NetworkPolicy support

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -30,6 +30,27 @@ jobs:
       with:
         version: "v0.11.1"
         image: kindest/node:v1.21.1
+      
+      # Disabling the use of Calico plugin due to unstability
+    #     config: "./hack/kind-config.yaml"
+    #     wait: "120s" # Workaround because wait flag for kind always times out when cnofig contains networking.disableDefaultCNI: true. TODO: replace with something more sofisticated
+    # - name: Install Calico CNI for the NetworkPolicy support
+    #   id: wait-until-networking-is-ready
+    #   run: |
+    #       kubectl apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml
+    #       kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
+    #       kubectl wait --for=condition=ready pod -l k8s-app=calico-kube-controllers -n kube-system --timeout=300s
+    #       kubectl wait --for=condition=ready pod -l k8s-app=calico-node -n kube-system --timeout=300s
+    #       kubectl wait --for=condition=ready pod -l k8s-app=kube-dns -n kube-system --timeout=300s
+    #   continue-on-error: true
+    # - name: Collect deployment information in case Calico or CoreDNS fails to start
+    #   if: steps.wait-until-networking-is-ready.outcome == 'failure'
+    #   run: |
+    #     kubectl get pods -o yaml -n kube-system
+    #     kubectl get events -n kube-system
+    #     kubectl logs -l k8s-app=calico-kube-controllers -n kube-system --tail=200
+    #     kubectl logs -l k8s-app=calico-node -n kube-system --tail=200
+    #     exit 1
     - name: Testing kind cluster set-up
       run: |
           kubectl cluster-info
@@ -44,7 +65,7 @@ jobs:
       uses: loft-sh/setup-devspace@main
 
     - name: Deploy vcluster
-      run: devspace run deploy -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests --skip-push
+      run: devspace run deploy -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests -p sync-networkpolicies --skip-push
 
     - name: Wait until vcluster is ready
       id: wait-until-vcluster-is-ready
@@ -56,8 +77,10 @@ jobs:
       run: |
         kubectl get pods -o yaml -n vcluster
         kubectl get events -n vcluster
+        kubectl logs -l app=vcluster -n vcluster -c syncer --tail=500
         exit 1
 
+    # Skips NetworkPolicy tests because they require network plugin with support (e.g. Calico)
     - name: Execute e2e tests
       working-directory: ./e2e
-      run: VCLUSTER_SUFFIX=vcluster go test -v -ginkgo.v
+      run: VCLUSTER_SUFFIX=vcluster go test -v -ginkgo.v -ginkgo.skip='.*NetworkPolicy.*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Run `dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --ou
 Wait until the `API server listening at: [::]:2345` message appears.  
 Start the `Debug vcluster (localhost:2346)` configuration in VSCode to connect your debugger session.  
 If you are not using VSCode, configure your IDE to connect to `localhost:2346` for the "remote" delve debugging.  
-**Note:** vcluster won't start you connect with the debugger.  
+**Note:** vcluster won't start until you connect with the debugger.  
 **Note:** vcluster will be stopped once you detach your debugger session.  
 
 ### Running vcluster Tests

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -22,6 +22,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments"]
     verbs: ["get", "list", "watch"]
+{{- if .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+{{- end }}
 {{- if .Values.openshift.enable }}
   - apiGroups: [""]
     resources: ["endpoints/restricted"]

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -85,6 +85,8 @@ rbac:
   role:
     # This is required for basic functionality of vcluster
     create: true
+    # Extended role permissions are required for some optional features, e.g. Networkpolicy sync
+    extended: false
 
 # The amount of replicas to run the statefulset with
 replicas: 1

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -22,6 +22,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments"]
     verbs: ["get", "list", "watch"]
+{{- if .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+{{- end }}
 {{- if .Values.openshift.enable }}
   - apiGroups: [""]
     resources: ["endpoints/restricted"]

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -93,6 +93,8 @@ rbac:
   role:
     # This is required for basic functionality of vcluster
     create: true
+    # Extended role permissions are required for some optional features, e.g. Networkpolicy sync
+    extended: false
 
 # The amount of replicas to run the statefulset with
 replicas: 1

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -22,6 +22,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments"]
     verbs: ["get", "list", "watch"]
+{{- if .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+{{- end }}
 {{- if .Values.openshift.enable }}
   - apiGroups: [""]
     resources: ["endpoints/restricted"]

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -132,6 +132,8 @@ rbac:
   role:
     # This is required for basic functionality of vcluster
     create: true
+    # Extended role permissions are required for some optional features, e.g. Networkpolicy sync
+    extended: false
 
 # Service configurations
 service:

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -3,6 +3,9 @@ package context
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
@@ -12,8 +15,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"sync"
 )
 
 // VirtualClusterOptions holds the cmd flags
@@ -105,6 +106,7 @@ var ExistingControllers = map[string]bool{
 	"persistentvolumes":      true,
 	"storageclasses":         true,
 	"priorityclasses":        true,
+	"networkpolicies":        true,
 }
 
 var DefaultEnabledControllers = []string{

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -40,6 +40,8 @@ deployments:
         rbac:
           clusterRole:
             create: true
+          role:
+            extended: true
         syncer:
           readinessProbe:
             enabled: false
@@ -85,8 +87,10 @@ profiles:
     patches:
       - op: remove
         path: deployments.name=vcluster.helm.values.syncer.command
-      - op: remove
-        path: deployments.name=vcluster.helm.values.syncer.extraArgs
+      - op: replace
+        path: deployments.name=vcluster.helm.values.syncer
+        value:
+          image: ${SYNCER_IMAGE}
   - name: deploy
     parents: 
       - profile: parent-deploy
@@ -96,10 +100,6 @@ profiles:
       - op: replace
         path: images.vcluster.build.buildKit
         value: {}
-      - op: replace
-        path: deployments.name=vcluster.helm.values.syncer
-        value:
-          image: ${SYNCER_IMAGE}
   - name: k3s
     # This profile is empty for now because the default config is for k3s
     # Keep the empty profile because it's used in the distribution matrix of the GH workflow for e2e. 
@@ -151,6 +151,11 @@ profiles:
         value: 
           requests:
             cpu: "0"
+  - name: sync-networkpolicies
+    patches:
+      - op: replace
+        path: deployments.name=vcluster.helm.values.syncer.extraArgs
+        value: ['--sync=networkpolicies']
   - name: parent-crc
     patches:
       - op: replace

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -4,7 +4,7 @@ set +e  # Continue on errors
 COLOR_CYAN="\033[0;36m"
 COLOR_RESET="\033[0m"
 
-RUN_CMD="go run -mod vendor cmd/vcluster/main.go start"
+RUN_CMD="go run -mod vendor cmd/vcluster/main.go start --sync 'networkpolicies'"
 DEBUG_CMD="dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- --lease-duration=99999 --renew-deadline=99998"
 
 echo -e "${COLOR_CYAN}
@@ -26,7 +26,7 @@ If you wish to run vcluster in the debug mode with delve, run:
   \`${COLOR_CYAN}${DEBUG_CMD}${COLOR_RESET}\`
   Wait until the \`${COLOR_CYAN}API server listening at: [::]:2345${COLOR_RESET}\` message appears
   Start the \"Debug vcluster (localhost:2346)\" configuration in VSCode to connect your debugger session.
-  ${COLOR_CYAN}Note:${COLOR_RESET} vcluster won't start you connect with the debugger.
+  ${COLOR_CYAN}Note:${COLOR_RESET} vcluster won't start until you connect with the debugger.
   ${COLOR_CYAN}Note:${COLOR_RESET} vcluster will be stopped once you detach your debugger session.
 
 ${COLOR_CYAN}TIP:${COLOR_RESET} hit an up arrow on your keyboard to find the commands mentioned above :) 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	// Register tests
 	_ "github.com/loft-sh/vcluster/e2e/test/coredns"
+	_ "github.com/loft-sh/vcluster/e2e/test/syncer/networkpolicies"
 	_ "github.com/loft-sh/vcluster/e2e/test/syncer/pods"
 	_ "github.com/loft-sh/vcluster/e2e/test/syncer/services"
 )

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -125,7 +125,8 @@ func CreateFramework(ctx context.Context, scheme *runtime.Scheme) error {
 			Namespace: ns,
 		},
 		KubeConfig: file.Name(),
-		LocalPort:  8440, // choosing a port that usually should be unused
+		LocalPort:  8440,        // choosing a port that usually should be unused
+		Address:    "127.0.0.1", // setting only ipv4 address may reduce a number of errors, see comments on kubernetes#74551
 	}
 	go func() {
 		//TODO: perhaps forward stdout/stder to debug level logs?

--- a/e2e/test/syncer/networkpolicies/networkpolicies.go
+++ b/e2e/test/syncer/networkpolicies/networkpolicies.go
@@ -1,0 +1,188 @@
+package networkpolicies
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/loft-sh/vcluster/e2e/framework"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/retry"
+)
+
+var _ = ginkgo.Describe("NetworkPolicies are created as expected", func() {
+	var (
+		f            *framework.Framework
+		iteration    int
+		nsA          *corev1.Namespace
+		nsB          *corev1.Namespace
+		curlPod      *corev1.Pod
+		nginxService *corev1.Service
+		nginxPod     *corev1.Pod
+	)
+
+	ginkgo.JustBeforeEach(func() {
+		// use default framework
+		f = framework.DefaultFramework
+		iteration++
+		nsNameA := fmt.Sprintf("e2e-syncer-networkpolicies-a-%d-%s", iteration, random.RandomString(5))
+		nsNameB := fmt.Sprintf("e2e-syncer-networkpolicies-b-%d-%s", iteration, random.RandomString(5))
+
+		// create test namespaces with different labels
+		var err error
+		nsA, err = f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   nsNameA,
+			Labels: map[string]string{"key-a": fmt.Sprintf("e2e-syncer-networkpolicies-aaa-%d", iteration)},
+		}}, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		nsB, err = f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   nsNameB,
+			Labels: map[string]string{"key-b": fmt.Sprintf("e2e-syncer-networkpolicies-bbb-%d", iteration)},
+		}}, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		curlPod, err = f.CreateCurlPod(nsNameA)
+		framework.ExpectNoError(err)
+
+		nginxPod, nginxService, err = f.CreateNginxPodAndService(nsNameB)
+		framework.ExpectNoError(err)
+		err = f.WaitForPodRunning(nginxPod.GetName(), nginxPod.GetNamespace())
+		framework.ExpectNoError(err, "A pod created in the vcluster is expected to be in the Running phase eventually.")
+
+		err = f.WaitForPodRunning(curlPod.GetName(), curlPod.GetNamespace())
+		framework.ExpectNoError(err, "A pod created in the vcluster is expected to be in the Running phase eventually.")
+	})
+
+	ginkgo.AfterEach(func() {
+		// delete test namespace
+		err := f.DeleteTestNamespace(nsA.GetName(), true)
+		framework.ExpectNoError(err)
+		err = f.DeleteTestNamespace(nsB.GetName(), true)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("Test Egress NetworkPolicy works as expected", func() {
+		// no NetworkPolicy yet - verify communication to test service
+		framework.DefaultFramework.TestServiceIsEventuallyReachable(curlPod, nginxService)
+
+		// create a policy that will allow Egress to the coreDNS so we can use .svc urls
+		_, err := f.CreateEgressNetworkPolicyForDNS(nsA.GetName())
+		framework.ExpectNoError(err)
+
+		f.Log.Info("deny all Egress from the Namespace that hosts curl pod")
+		networkPolicy, err := f.VclusterClient.NetworkingV1().NetworkPolicies(nsA.GetName()).Create(f.Context, &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Namespace: nsA.GetName(), Name: "my-egress-policy"},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			},
+		}, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		// sleep to reduce the rate of pod/exec calls made when checking if service is reacheable
+		time.Sleep(time.Second * 10)
+		framework.DefaultFramework.TestServiceIsEventuallyUnreachable(curlPod, nginxService)
+
+		f.Log.Info("allow Egress to the testService Namespace")
+		err = updateNetworkPolicyWithRetryOnConflict(f, networkPolicy, func(np *networkingv1.NetworkPolicy) {
+			np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: nginxService.Spec.Ports[0].Port}}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: nsB.GetLabels(),
+							},
+						},
+					},
+				},
+			}
+		})
+		framework.ExpectNoError(err)
+		// sleep to reduce the rate of pod/exec calls made when checking if service is reacheable
+		time.Sleep(time.Second * 10)
+		framework.DefaultFramework.TestServiceIsEventuallyReachable(curlPod, nginxService)
+
+		f.Log.Info("deny Egress to the testService by using non matching pod selector")
+		err = updateNetworkPolicyWithRetryOnConflict(f, networkPolicy, func(np *networkingv1.NetworkPolicy) {
+			np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: nginxService.Spec.Ports[0].Port}}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: nsB.GetLabels(),
+							},
+							PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"wrong": "label"}},
+						},
+					},
+				},
+			}
+		})
+		framework.ExpectNoError(err)
+		// sleep to reduce the rate of pod/exec calls made when checking if service is reacheable
+		time.Sleep(time.Second * 10)
+		framework.DefaultFramework.TestServiceIsEventuallyUnreachable(curlPod, nginxService)
+
+		f.Log.Info("allow Egress to the testService Namespace and nginx pod")
+		err = updateNetworkPolicyWithRetryOnConflict(f, networkPolicy, func(np *networkingv1.NetworkPolicy) {
+			np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: nginxService.Spec.Ports[0].Port}}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: nsB.GetLabels(),
+							},
+							PodSelector: &metav1.LabelSelector{MatchLabels: nginxPod.GetLabels()},
+						},
+					},
+				},
+			}
+		})
+		framework.ExpectNoError(err)
+		// sleep to reduce the rate of pod/exec calls made when checking if service is reacheable
+		time.Sleep(time.Second * 10)
+		framework.DefaultFramework.TestServiceIsEventuallyReachable(curlPod, nginxService)
+
+		f.Log.Info("deny Egress on the nginx port (by allowing Egress only on a different pod)")
+		err = updateNetworkPolicyWithRetryOnConflict(f, networkPolicy, func(np *networkingv1.NetworkPolicy) {
+			np.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 1}}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: nsB.GetLabels(),
+							},
+							PodSelector: &metav1.LabelSelector{MatchLabels: nginxPod.GetLabels()},
+						},
+					},
+				},
+			}
+		})
+		framework.ExpectNoError(err)
+		// sleep to reduce the rate of pod/exec calls made when checking if service is reacheable
+		time.Sleep(time.Second * 10)
+		framework.DefaultFramework.TestServiceIsEventuallyUnreachable(curlPod, nginxService)
+	})
+
+})
+
+func updateNetworkPolicyWithRetryOnConflict(f *framework.Framework, networkPolicy *networkingv1.NetworkPolicy, mutator func(np *networkingv1.NetworkPolicy)) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var err error
+		networkPolicy, err = f.VclusterClient.NetworkingV1().NetworkPolicies(networkPolicy.GetNamespace()).Get(f.Context, networkPolicy.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		mutator(networkPolicy)
+
+		networkPolicy, err = f.VclusterClient.NetworkingV1().NetworkPolicies(networkPolicy.GetNamespace()).Update(f.Context, networkPolicy, metav1.UpdateOptions{})
+		return err
+	})
+}

--- a/e2e/test/syncer/pods/pods.go
+++ b/e2e/test/syncer/pods/pods.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/vcluster/e2e/framework"
 	podtranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
+	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
@@ -35,13 +36,10 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		// use default framework
 		f = framework.DefaultFramework
 		iteration++
-		ns = fmt.Sprintf("e2e-syncer-pods-%d", iteration)
-		// execute cleanup in case previous e2e test were terminated prematurely
-		err := f.DeleteTestNamespace(ns, true)
-		framework.ExpectNoError(err)
+		ns = fmt.Sprintf("e2e-syncer-pods-%d-%s", iteration, random.RandomString(5))
 
 		// create test namespace
-		_, err = f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		_, err := f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name:   ns,
 			Labels: map[string]string{initialNsLabelKey: initialNsLabelValue},
 		}}, metav1.CreateOptions{})

--- a/e2e/test/syncer/services/services.go
+++ b/e2e/test/syncer/services/services.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/loft-sh/vcluster/e2e/framework"
+	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
@@ -33,13 +34,10 @@ var _ = ginkgo.Describe("Services are created as expected", func() {
 		// use default framework
 		f = framework.DefaultFramework
 		iteration++
-		ns = fmt.Sprintf("e2e-syncer-services-%d", iteration)
-		// execute cleanup in case previous e2e test were terminated prematurely
-		err := f.DeleteTestNamespace(ns, true)
-		framework.ExpectNoError(err)
+		ns = fmt.Sprintf("e2e-syncer-services-%d-%s", iteration, random.RandomString(5))
 
 		// create test namespace
-		_, err = f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		_, err := f.VclusterClient.CoreV1().Namespaces().Create(f.Context, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 	})
 

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/endpoints"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/events"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/ingresses"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/networkpolicies"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/persistentvolumeclaims"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/persistentvolumes"
@@ -38,6 +39,7 @@ var ResourceControllers = map[string]func(*context.ControllerContext, record.Eve
 	"priorityclasses":        priorityclasses.Register,
 	"nodes,fake-nodes":       nodes.Register,
 	"persistentvolumes,fake-persistentvolumes": persistentvolumes.Register,
+	"networkpolicies":                          networkpolicies.Register,
 }
 
 var ResourceIndices = map[string]func(*context.ControllerContext) error{
@@ -53,6 +55,7 @@ var ResourceIndices = map[string]func(*context.ControllerContext) error{
 	"priorityclasses":        priorityclasses.RegisterIndices,
 	"nodes,fake-nodes":       nodes.RegisterIndices,
 	"persistentvolumes,fake-persistentvolumes": persistentvolumes.RegisterIndices,
+	"networkpolicies":                          networkpolicies.RegisterIndices,
 }
 
 func RegisterIndices(ctx *context.ControllerContext) error {

--- a/pkg/controllers/resources/networkpolicies/syncer.go
+++ b/pkg/controllers/resources/networkpolicies/syncer.go
@@ -1,0 +1,66 @@
+package networkpolicies
+
+import (
+	"context"
+
+	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/generic"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RegisterIndices(ctx *context2.ControllerContext) error {
+	err := generic.RegisterSyncerIndices(ctx, &networkingv1.NetworkPolicy{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func Register(ctx *context2.ControllerContext, eventBroadcaster record.EventBroadcaster) error {
+	return generic.RegisterSyncer(ctx, "networkpolicy", &syncer{
+		Translator: generic.NewNamespacedTranslator(ctx.Options.TargetNamespace, ctx.VirtualManager.GetClient(), &networkingv1.NetworkPolicy{}),
+
+		virtualClient: ctx.VirtualManager.GetClient(),
+		localClient:   ctx.LocalManager.GetClient(),
+
+		creator:    generic.NewGenericCreator(ctx.LocalManager.GetClient(), eventBroadcaster.NewRecorder(ctx.VirtualManager.GetScheme(), corev1.EventSource{Component: "networkpolicy-syncer"}), "networkpolicy"),
+		translator: translate.NewDefaultTranslator(ctx.Options.TargetNamespace),
+	})
+}
+
+type syncer struct {
+	generic.Translator
+
+	virtualClient client.Client
+	localClient   client.Client
+
+	creator    *generic.GenericCreator
+	translator translate.Translator
+}
+
+func (s *syncer) New() client.Object {
+	return &networkingv1.NetworkPolicy{}
+}
+
+func (s *syncer) Forward(ctx context.Context, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	pObj, err := s.translate(vObj.(*networkingv1.NetworkPolicy))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return s.creator.Create(ctx, vObj, pObj, log)
+}
+
+func (s *syncer) Update(ctx context.Context, pObj client.Object, vObj client.Object, log loghelper.Logger) (ctrl.Result, error) {
+	pNetworkPolicy := pObj.(*networkingv1.NetworkPolicy)
+	vNetworkPolicy := vObj.(*networkingv1.NetworkPolicy)
+
+	translated := s.translateUpdate(pNetworkPolicy, vNetworkPolicy)
+	return s.creator.Update(ctx, vObj, translated, log)
+}

--- a/pkg/controllers/resources/networkpolicies/syncer_test.go
+++ b/pkg/controllers/resources/networkpolicies/syncer_test.go
@@ -1,0 +1,424 @@
+package networkpolicies
+
+import (
+	"context"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/generic"
+
+	generictesting "github.com/loft-sh/vcluster/pkg/controllers/resources/generic/testing"
+	podstranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+func newFakeSyncer(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *syncer {
+	return &syncer{
+		virtualClient: vClient,
+		localClient:   pClient,
+
+		creator:    generic.NewGenericCreator(pClient, &testingutil.FakeEventRecorder{}, "networkpolicies"),
+		translator: translate.NewDefaultTranslator("test"),
+	}
+}
+
+func TestSync(t *testing.T) {
+	somePorts := []networkingv1.NetworkPolicyPort{
+		{
+			Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 32},
+		},
+		{
+			Port:    &intstr.IntOrString{Type: intstr.Int, IntVal: 1024},
+			EndPort: pointer.Int32(2 ^ 32),
+		},
+		{
+			Port: &intstr.IntOrString{Type: intstr.String, StrVal: "namedport"},
+		},
+	}
+	vObjectMeta := metav1.ObjectMeta{
+		Name:      "testnetworkpolicy",
+		Namespace: "test",
+	}
+	vBaseSpec := networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{"mykey": "mylabel"},
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "secondkey",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"label-A", "label-B"},
+				},
+			},
+		},
+	}
+	pBaseSpec := networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				translate.ConvertLabelKey("mykey"): "mylabel",
+				translate.NamespaceLabel:           vObjectMeta.Namespace,
+				translate.MarkerLabel:              translate.Suffix,
+			},
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      translate.ConvertLabelKey("secondkey"),
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"label-A", "label-B"},
+				},
+			},
+		},
+	}
+	pObjectMeta := metav1.ObjectMeta{
+		Name:      translate.PhysicalName("testnetworkpolicy", "test"),
+		Namespace: "test",
+		Annotations: map[string]string{
+			translate.NameAnnotation:      vObjectMeta.Name,
+			translate.NamespaceAnnotation: vObjectMeta.Namespace,
+		},
+		Labels: map[string]string{
+			translate.MarkerLabel:    translate.Suffix,
+			translate.NamespaceLabel: vObjectMeta.Namespace,
+		},
+	}
+	vBaseNetworkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: vObjectMeta,
+		Spec:       vBaseSpec,
+	}
+	pBaseNetworkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: pObjectMeta,
+		Spec:       pBaseSpec,
+	}
+
+	vnetworkPolicyNoPodSelector := vBaseNetworkPolicy.DeepCopy()
+	vnetworkPolicyNoPodSelector.Spec.PodSelector = metav1.LabelSelector{}
+
+	pnetworkPolicyNoPodSelector := pBaseNetworkPolicy.DeepCopy()
+	pnetworkPolicyNoPodSelector.Spec.PodSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			translate.NamespaceLabel: vObjectMeta.Namespace,
+			translate.MarkerLabel:    translate.Suffix,
+		},
+	}
+
+	vnetworkPolicyWithIPBlock := vBaseNetworkPolicy.DeepCopy()
+	vnetworkPolicyWithIPBlock.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			Ports: somePorts,
+			From: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{
+				CIDR:   "10.0.0.0/24",
+				Except: []string{"10.25.0.0/30"},
+			}}},
+		},
+	}
+	pnetworkPolicyWithIPBlock := pBaseNetworkPolicy.DeepCopy()
+	pnetworkPolicyWithIPBlock.Spec.Ingress = vnetworkPolicyWithIPBlock.Spec.Ingress
+
+	vnetworkPolicyWithPodSelectorNoNs := vBaseNetworkPolicy.DeepCopy()
+	vnetworkPolicyWithPodSelectorNoNs.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			Ports: somePorts,
+			From: []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"random-key": "value"},
+			}}},
+		},
+	}
+	pnetworkPolicyWithLabelSelectorNoNs := pBaseNetworkPolicy.DeepCopy()
+	pnetworkPolicyWithLabelSelectorNoNs.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			Ports: somePorts,
+			From: []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					translate.ConvertLabelKey("random-key"): "value",
+					translate.MarkerLabel:                   translate.Suffix,
+					translate.NamespaceLabel:                vnetworkPolicyWithPodSelectorNoNs.GetNamespace(),
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{},
+			}}},
+		},
+	}
+
+	vnetworkPolicyWithPodSelectorEmptyNs := vnetworkPolicyWithPodSelectorNoNs.DeepCopy()
+	vnetworkPolicyWithPodSelectorEmptyNs.Spec.Ingress[0].From[0].NamespaceSelector = &metav1.LabelSelector{}
+
+	pnetworkPolicyWithLabelSelectorEmptyNs := pnetworkPolicyWithLabelSelectorNoNs.DeepCopy()
+	delete(pnetworkPolicyWithLabelSelectorEmptyNs.Spec.Ingress[0].From[0].PodSelector.MatchLabels, translate.NamespaceLabel)
+
+	vnetworkPolicyWithPodSelectorNsSelector := vnetworkPolicyWithPodSelectorNoNs.DeepCopy()
+	vnetworkPolicyWithPodSelectorNsSelector.Spec.Ingress[0].From[0].NamespaceSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"nslabelkey": "abc"},
+	}
+
+	pnetworkPolicyWithLabelSelectorNsSelector := pnetworkPolicyWithLabelSelectorNoNs.DeepCopy()
+	delete(pnetworkPolicyWithLabelSelectorNsSelector.Spec.Ingress[0].From[0].PodSelector.MatchLabels, translate.NamespaceLabel)
+	pnetworkPolicyWithLabelSelectorNsSelector.Spec.Ingress[0].From[0].PodSelector.MatchLabels[translate.ConvertLabelKeyWithPrefix(podstranslate.NamespaceLabelPrefix, "nslabelkey")] = "abc"
+
+	vnetworkPolicyEgressWithPodSelectorNoNs := vBaseNetworkPolicy.DeepCopy()
+	vnetworkPolicyEgressWithPodSelectorNoNs.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+		{
+			Ports: somePorts,
+			To:    []networkingv1.NetworkPolicyPeer{vnetworkPolicyWithPodSelectorNoNs.Spec.Ingress[0].From[0]},
+		},
+	}
+	pnetworkPolicyEgressWithLabelSelectorNoNs := pBaseNetworkPolicy.DeepCopy()
+	pnetworkPolicyEgressWithLabelSelectorNoNs.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+		{
+			Ports: somePorts,
+			To:    []networkingv1.NetworkPolicyPeer{pnetworkPolicyWithLabelSelectorNoNs.Spec.Ingress[0].From[0]},
+		},
+	}
+
+	vnetworkPolicyWithMatchExpressions := vBaseNetworkPolicy.DeepCopy()
+	vnetworkPolicyWithMatchExpressions.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			Ports: somePorts,
+			From: []networkingv1.NetworkPolicyPeer{{
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "pod-expr-key",
+							Operator: metav1.LabelSelectorOpExists,
+							Values:   []string{"some-pod-key"},
+						},
+					},
+				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "ns-expr-key",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+							Values:   []string{"forbidden-ns-key"},
+						},
+					},
+				},
+			}},
+		},
+	}
+	pnetworkPolicyWithMatchExpressions := pBaseNetworkPolicy.DeepCopy()
+	pnetworkPolicyWithMatchExpressions.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{
+		{
+			Ports: somePorts,
+			From: []networkingv1.NetworkPolicyPeer{{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						translate.MarkerLabel: translate.Suffix,
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      translate.ConvertLabelKey("pod-expr-key"),
+							Operator: metav1.LabelSelectorOpExists,
+							Values:   []string{"some-pod-key"},
+						},
+						{
+							Key:      translate.ConvertLabelKeyWithPrefix(podstranslate.NamespaceLabelPrefix, "ns-expr-key"),
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+							Values:   []string{"forbidden-ns-key"},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name:                "Create forward",
+			InitialVirtualState: []runtime.Object{vBaseNetworkPolicy.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vBaseNetworkPolicy.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pBaseNetworkPolicy.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vBaseNetworkPolicy.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - empty pod selector",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyNoPodSelector.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyNoPodSelector.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyNoPodSelector.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyNoPodSelector.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name: "Update forward",
+			InitialVirtualState: []runtime.Object{&networkingv1.NetworkPolicy{
+				ObjectMeta: vObjectMeta,
+				Spec:       vBaseSpec,
+			}},
+			InitialPhysicalState: []runtime.Object{&networkingv1.NetworkPolicy{
+				ObjectMeta: pObjectMeta,
+				Spec:       networkingv1.NetworkPolicySpec{},
+			}},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vBaseNetworkPolicy.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {&networkingv1.NetworkPolicy{
+					ObjectMeta: pObjectMeta,
+					Spec:       pBaseSpec,
+				}},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				pNetworkPolicy := &networkingv1.NetworkPolicy{
+					ObjectMeta: pObjectMeta,
+					Spec:       networkingv1.NetworkPolicySpec{},
+				}
+				pNetworkPolicy.ResourceVersion = "999"
+
+				_, err := syncer.Update(ctx, pNetworkPolicy, &networkingv1.NetworkPolicy{
+					ObjectMeta: vObjectMeta,
+					Spec:       vBaseSpec,
+				}, log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Update forward not needed",
+			InitialVirtualState:  []runtime.Object{vBaseNetworkPolicy.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pBaseNetworkPolicy.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vBaseNetworkPolicy.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pBaseNetworkPolicy.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				vNetworkPolicy := vBaseNetworkPolicy.DeepCopy()
+				vNetworkPolicy.ResourceVersion = "999"
+
+				_, err := syncer.Update(ctx, pBaseNetworkPolicy.DeepCopy(), vNetworkPolicy, log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - ingress policy that uses IPBlock",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyWithIPBlock.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyWithIPBlock},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyWithIPBlock},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyWithIPBlock.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - ingress policy that uses pod label selector",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyWithPodSelectorNoNs.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyWithPodSelectorNoNs},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyWithLabelSelectorNoNs},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyWithPodSelectorNoNs.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - ingress policy that uses pod label selector with empty namespace selector",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyWithPodSelectorEmptyNs.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyWithPodSelectorEmptyNs},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyWithLabelSelectorEmptyNs},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyWithPodSelectorEmptyNs.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - ingress policy that uses pod label selector and namespace selector",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyWithPodSelectorNsSelector.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyWithPodSelectorNsSelector},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyWithLabelSelectorNsSelector},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyWithPodSelectorNsSelector.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - ingress policy that uses pod label selector and namespace selector which use MatchExpressions",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyWithMatchExpressions.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyWithMatchExpressions},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyWithMatchExpressions},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyWithMatchExpressions.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                "Create forward - egress policy that uses pod label selector",
+			InitialVirtualState: []runtime.Object{vnetworkPolicyEgressWithPodSelectorNoNs.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {vnetworkPolicyEgressWithPodSelectorNoNs},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy"): {pnetworkPolicyEgressWithLabelSelectorNoNs},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vnetworkPolicyEgressWithPodSelectorNoNs.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	})
+}

--- a/pkg/controllers/resources/networkpolicies/translate.go
+++ b/pkg/controllers/resources/networkpolicies/translate.go
@@ -1,0 +1,128 @@
+package networkpolicies
+
+import (
+	"fmt"
+
+	podstranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (s *syncer) translate(vObj client.Object) (*networkingv1.NetworkPolicy, error) {
+	vNetworkPolicy, ok := vObj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return nil, fmt.Errorf("error converting to NetworkPolicy object named: %s", vObj.GetName())
+	}
+	newObj, err := s.translator.Translate(vObj)
+	if err != nil {
+		return nil, fmt.Errorf("error setting metadata: %s", err)
+	}
+	newNetworkPolicy, ok := newObj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return nil, fmt.Errorf("error converting to NetworkPolicy object named: %s", vObj.GetName())
+	}
+
+	newNetworkPolicy.Spec = *translateSpec(&vNetworkPolicy.Spec, vNetworkPolicy.GetNamespace())
+	return newNetworkPolicy, nil
+}
+
+func (s *syncer) translateUpdate(pObj, vObj *networkingv1.NetworkPolicy) *networkingv1.NetworkPolicy {
+	var updated *networkingv1.NetworkPolicy
+
+	translatedSpec := *translateSpec(&vObj.Spec, vObj.GetNamespace())
+	if !equality.Semantic.DeepEqual(translatedSpec, pObj.Spec) {
+		updated = newIfNil(updated, pObj)
+		updated.Spec = translatedSpec
+	}
+
+	translatedAnnotations := s.translator.TranslateAnnotations(vObj, pObj)
+	if !equality.Semantic.DeepEqual(translatedAnnotations, pObj.Annotations) {
+		updated = newIfNil(updated, pObj)
+		updated.Annotations = translatedAnnotations
+	}
+
+	translatedLabels := s.translator.TranslateLabels(vObj)
+	if !equality.Semantic.DeepEqual(translatedLabels, pObj.Labels) {
+		updated = newIfNil(updated, pObj)
+		updated.Labels = translatedLabels
+	}
+
+	return updated
+}
+
+func translateSpec(spec *networkingv1.NetworkPolicySpec, namespace string) *networkingv1.NetworkPolicySpec {
+	if spec == nil {
+		return nil
+	}
+
+	outSpec := &networkingv1.NetworkPolicySpec{}
+	for _, er := range spec.Egress {
+		if outSpec.Egress == nil {
+			outSpec.Egress = []networkingv1.NetworkPolicyEgressRule{}
+		}
+		outSpec.Egress = append(outSpec.Egress, networkingv1.NetworkPolicyEgressRule{
+			Ports: er.Ports,
+			To:    translateNetworkPolicyPeers(er.To, namespace),
+		})
+	}
+	for _, ir := range spec.Ingress {
+		if outSpec.Ingress == nil {
+			outSpec.Ingress = []networkingv1.NetworkPolicyIngressRule{}
+		}
+		outSpec.Ingress = append(outSpec.Ingress, networkingv1.NetworkPolicyIngressRule{
+			Ports: ir.Ports,
+			From:  translateNetworkPolicyPeers(ir.From, namespace),
+		})
+	}
+
+	outSpec.PodSelector = *translate.TranslateLabelSelector(&spec.PodSelector)
+	if outSpec.PodSelector.MatchLabels == nil {
+		outSpec.PodSelector.MatchLabels = map[string]string{}
+	}
+	// add selector for namespace as NetworkPolicy podSelector applies to pods withing it's namespace
+	outSpec.PodSelector.MatchLabels[translate.NamespaceLabel] = namespace
+	// add selector for the marker label to select only from pods belonging this vcluster instance
+	outSpec.PodSelector.MatchLabels[translate.MarkerLabel] = translate.Suffix
+
+	outSpec.PolicyTypes = spec.PolicyTypes
+	return outSpec
+}
+
+func translateNetworkPolicyPeers(peers []networkingv1.NetworkPolicyPeer, namespace string) []networkingv1.NetworkPolicyPeer {
+	if peers == nil {
+		return nil
+	}
+	out := []networkingv1.NetworkPolicyPeer{}
+	for _, peer := range peers {
+		newPeer := networkingv1.NetworkPolicyPeer{
+			PodSelector:       translate.TranslateLabelSelector(peer.PodSelector),
+			NamespaceSelector: nil, // must be set to nil as all vcluster pods are in the same host namespace as the NetworkPolicy
+		}
+		if peer.IPBlock == nil {
+			translatedNamespaceSelectors := translate.TranslateLabelSelectorWithPrefix(podstranslate.NamespaceLabelPrefix, peer.NamespaceSelector)
+			newPeer.PodSelector = translate.MergeLabelSelectors(newPeer.PodSelector, translatedNamespaceSelectors)
+
+			if newPeer.PodSelector.MatchLabels == nil {
+				newPeer.PodSelector.MatchLabels = map[string]string{}
+			}
+			if peer.NamespaceSelector == nil {
+				newPeer.PodSelector.MatchLabels[translate.NamespaceLabel] = namespace
+			}
+			// add selector for the marker label to select only from pods belonging this vcluster instance
+			newPeer.PodSelector.MatchLabels[translate.MarkerLabel] = translate.Suffix
+		} else {
+			newPeer.IPBlock = peer.IPBlock.DeepCopy()
+		}
+		out = append(out, newPeer)
+	}
+	return out
+}
+
+func newIfNil(updated *networkingv1.NetworkPolicy, pObj *networkingv1.NetworkPolicy) *networkingv1.NetworkPolicy {
+	if updated == nil {
+		return pObj.DeepCopy()
+	}
+	return updated
+}

--- a/pkg/util/translate/util.go
+++ b/pkg/util/translate/util.go
@@ -64,6 +64,28 @@ func TranslateLabelSelectorWithPrefix(labelPrefix string, labelSelector *metav1.
 	return newLabelSelector
 }
 
+func MergeLabelSelectors(elems ...*metav1.LabelSelector) *metav1.LabelSelector {
+	out := &metav1.LabelSelector{}
+	for _, selector := range elems {
+		if selector == nil {
+			continue
+		}
+		for k, v := range selector.MatchLabels {
+			if out.MatchLabels == nil {
+				out.MatchLabels = map[string]string{}
+			}
+			out.MatchLabels[k] = v
+		}
+		for _, expr := range selector.MatchExpressions {
+			if out.MatchExpressions == nil {
+				out.MatchExpressions = []metav1.LabelSelectorRequirement{}
+			}
+			out.MatchExpressions = append(out.MatchExpressions, expr)
+		}
+	}
+	return out
+}
+
 // ObjectPhysicalName returns the translated physical name of this object
 func ObjectPhysicalName(obj runtime.Object) string {
 	metaAccessor, err := meta.Accessor(obj)


### PR DESCRIPTION
This should enable NetworPolicy synchronization with all necessary rewrites for the pod label selectors and namespace label selectors.

Fixes #155 