### PR TITLE
refactor: omit * in --sync flag and enable default controllers

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -71,7 +71,7 @@ func NewStartCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Controllers, "sync", "*", "A list of sync controllers to enable. '*' enables all on-by-default sync controllers, 'foo' enables the sync controller named 'foo', '-foo' disables the sync controller named 'foo'")
+	cmd.Flags().StringVar(&options.Controllers, "sync", "", "A list of sync controllers to enable. 'foo' enables the sync controller named 'foo', '-foo' disables the sync controller named 'foo'")
 
 	cmd.Flags().StringVar(&options.RequestHeaderCaCert, "request-header-ca-cert", "/data/server/tls/request-header-ca.crt", "The path to the request header ca certificate")
 	cmd.Flags().StringVar(&options.ClientCaCert, "client-ca-cert", "/data/server/tls/client-ca.crt", "The path to the client ca certificate")

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -167,8 +167,11 @@ func NewControllerContext(currentNamespace string, localManager ctrl.Manager, vi
 }
 
 func parseControllers(options *VirtualClusterOptions) (map[string]bool, error) {
-	controllersString := strings.Replace(options.Controllers, "*", strings.Join(DefaultEnabledControllers, ","), -1)
-	controllers := strings.Split(controllersString, ",")
+	controllers := []string{}
+	if options.Controllers != "" {
+		controllers = strings.Split(options.Controllers, ",")
+	}
+	controllers = append(controllers, DefaultEnabledControllers...)
 
 	// migrate deprecated flags
 	if len(options.DeprecatedDisableSyncResources) > 0 {


### PR DESCRIPTION
### Changes
- **syncer**: Default controllers are now enabled by default, there is no need to specify `*` in the `--sync` flag anymore