### PR TITLE
fix ingress port

### DIFF
--- a/docs/pages/operator/external-access.mdx
+++ b/docs/pages/operator/external-access.mdx
@@ -179,7 +179,8 @@ spec:
       - backend:
           service:
             name: my-vcluster
-            port: 443
+            port: 
+              number: 443
         path: /
         pathType: ImplementationSpecific
 ```


### PR DESCRIPTION
run into this error
error validating data: ValidationError(Ingress.spec.rules[0].http.paths[0].backend.service.port): invalid type for io.k8s.api.networking.v1.ServiceBackendPort: got "integer", expected "map";