### PR TITLE
Change empty volume indention to match certs volume

### DIFF
--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -70,8 +70,8 @@ spec:
 {{ toYaml .Values.etcd.volumes | indent 8 }}
       {{- end }}
       {{- if not .Values.etcd.storage.persistence }}
-      - name: data
-        emptyDir: {}
+        - name: data
+          emptyDir: {}
       {{- end }}
       containers:
       - name: etcd


### PR DESCRIPTION
To render the YAML array correctly with the persistent storage option disabled each value of the volumes 
block should be on the same indention level. 

Before fix It renders like:
```yaml
      volumes:
        - name: certs
          secret:
            secretName: t-manual-certs
      - name: data
        emptyDir: {}
```

What produces an issue in helm: 
`Error: YAML parse error on vcluster-k8s/templates/etcd-statefulset.yaml: error converting YAML to JSON: yaml: line 36: did not find expected key`