### PR TITLE
feat: configurable .spec.dnsPolicy of CoreDNS pod

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -108,6 +108,8 @@ func NewStartCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&options.ClusterDomain, "cluster-domain", "cluster.local", "The cluster domain ending that should be used for the virtual cluster")
 
+	cmd.Flags().StringArrayVar(&options.CorednsVariables, "coredns-var", []string{}, "Provides custom value for the template variable used in the CoreDNS manifest(e.g. DNS_POLICY=Default). The manifest file is located in /manifests/coredns/coredns.yaml file in the syncer image, or at the same path in the source code repo.")
+
 	cmd.Flags().BoolVar(&options.LeaderElect, "leader-elect", false, "If enabled, syncer will use leader election")
 	cmd.Flags().Int64Var(&options.LeaseDuration, "lease-duration", 60, "Lease duration of the leader election in seconds")
 	cmd.Flags().Int64Var(&options.RenewDeadline, "renew-deadline", 40, "Renew deadline of the leader election in seconds")
@@ -297,7 +299,7 @@ func startControllers(ctx *context2.ControllerContext, rawConfig *api.Config, se
 	// setup CoreDNS according to the manifest file
 	go func() {
 		_ = wait.ExponentialBackoff(wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func() (bool, error) {
-			err := coredns.ApplyManifest(ctx.VirtualManager.GetConfig(), serverVersion)
+			err := coredns.ApplyManifest(ctx.VirtualManager.GetConfig(), serverVersion, ctx.Options.CorednsVariables)
 			if err != nil {
 				klog.Infof("Failed to apply CoreDNS cofiguration from the manifest file: %v", err)
 				return false, nil

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -3,14 +3,15 @@ package context
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
 	"github.com/loft-sh/vcluster/pkg/util/locks"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"sync"
 )
 
 // VirtualClusterOptions holds the cmd flags
@@ -52,6 +53,8 @@ type VirtualClusterOptions struct {
 	OverrideHostsContainerImage string
 
 	ClusterDomain string
+
+	CorednsVariables []string
 
 	LeaderElect   bool
 	LeaseDuration int64

--- a/manifests/coredns/coredns.yaml
+++ b/manifests/coredns/coredns.yaml
@@ -172,7 +172,7 @@ spec:
           timeoutSeconds: 1
           successThreshold: 1
           failureThreshold: 3
-      dnsPolicy: Default
+      dnsPolicy: {{.DNS_POLICY}}
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
In [a discussion on the Slack channel](https://loft-sh.slack.com/archives/C01N273CF4P/p1640339530234300) it became apparent that `dnsPolicy: Default` doesn't work everywhere, and we needed to set `dnsPolicy: ClusterFirst` on the vcluster CoreDNS pod to make vcluster work in a particular environment.
I was a bit on the fence with the idea of adding a new flag for such an edge case, but then I thought that adding a more general flag (`--coredns-var`) could be an acceptable fix, as it might have other uses for CoreDNS customizations. We already do templating of the CoreDNS manifest, so the new flag simply allows for the template variable overrides.

The other half of the fix is within the pod translator. When the `dnsPolicy: ClusterFirst` is set on pods within the vcluster, the translator will adjust the DNS config of the pod to point to the vcluster CoreDNS instance. This is obviously not desirable for the CoreDNS pod itself, so I added code to skip the DNS config translation for CoreDNS pods. But I am definitely open to ideas, if there is a more elegant solution for this.