### PR TITLE
Fix k3s not starting & add v1.23 support

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -82,5 +82,13 @@ jobs:
 
     # Skips NetworkPolicy tests because they require network plugin with support (e.g. Calico)
     - name: Execute e2e tests
+      id: execute-e2e-tests
       working-directory: ./e2e
       run: VCLUSTER_SUFFIX=vcluster go test -v -ginkgo.v -ginkgo.skip='.*NetworkPolicy.*'
+      continue-on-error: true
+
+    - name: Print vcluster logs if e2e tests fail
+      if: steps.execute-e2e-tests.outcome == 'failure'
+      run: |
+        kubectl logs -l app=vcluster -n vcluster -c syncer --tail=5000
+        exit 1

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -68,6 +68,9 @@ spec:
       {{- if not .Values.vcluster.disabled }}
       - image: {{ .Values.defaultImageRegistry }}{{ .Values.vcluster.image }}
         name: vcluster
+        # k3s has a problem running as pid 1 and disabled agents on cgroupv2
+        # nodes as it will try to evacuate the cgroups there. Starting k3s
+        # through a shell makes it non pid 1 and prevents this from happening
         command:
           - /bin/sh
         args:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -69,19 +69,22 @@ spec:
       - image: {{ .Values.defaultImageRegistry }}{{ .Values.vcluster.image }}
         name: vcluster
         command:
-          {{- range $f := .Values.vcluster.command }}
-          - {{ $f | quote }}
-          {{- end }}
+          - /bin/sh
         args:
+          - -c
+          - {{ range $f := .Values.vcluster.command -}}
+            {{ $f }}
+            {{- end }}
           {{- range $f := .Values.vcluster.baseArgs }}
-          - {{ $f | quote }}
+            {{ $f }}
           {{- end }}
           {{- if .Values.serviceCIDR }}
-          - --service-cidr={{ .Values.serviceCIDR }}
+            --service-cidr={{ .Values.serviceCIDR }}
           {{- end }}
           {{- range $f := .Values.vcluster.extraArgs }}
-          - {{ $f | quote }}
+            {{ $f }}
           {{- end }}
+            && true
         env:
 {{ toYaml .Values.vcluster.env | indent 10 }}
         securityContext:

--- a/cmd/vclusterctl/cmd/app/create/values/k3s.go
+++ b/cmd/vclusterctl/cmd/app/create/values/k3s.go
@@ -15,6 +15,7 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
+	"1.22": "rancher/k3s:v1.22.5-k3s1",
 	"1.21": "rancher/k3s:v1.21.4-k3s1",
 	"1.20": "rancher/k3s:v1.20.11-k3s2",
 	"1.19": "rancher/k3s:v1.19.13-k3s1",
@@ -60,10 +61,10 @@ func getDefaultK3SReleaseValues(client kubernetes.Interface, createOptions *crea
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 21 {
+			if serverMinorInt > 22 {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.21", serverVersionString)
-				image = K3SVersionMap["1.21"]
-				serverVersionString = "1.21"
+				image = K3SVersionMap["1.22"]
+				serverVersionString = "1.22"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]

--- a/cmd/vclusterctl/cmd/app/create/values/k3s.go
+++ b/cmd/vclusterctl/cmd/app/create/values/k3s.go
@@ -15,6 +15,7 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
+	"1.23": "rancher/k3s:v1.23.1-k3s1",
 	"1.22": "rancher/k3s:v1.22.5-k3s1",
 	"1.21": "rancher/k3s:v1.21.4-k3s1",
 	"1.20": "rancher/k3s:v1.20.11-k3s2",
@@ -61,10 +62,10 @@ func getDefaultK3SReleaseValues(client kubernetes.Interface, createOptions *crea
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 22 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.21", serverVersionString)
-				image = K3SVersionMap["1.22"]
-				serverVersionString = "1.22"
+			if serverMinorInt > 23 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
+				image = K3SVersionMap["1.23"]
+				serverVersionString = "1.23"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,7 +3,7 @@ vars:
   - name: SYNCER_IMAGE
     value: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
   - name: K3S_IMAGE
-    value: rancher/k3s:v1.21.4-k3s1
+    value: rancher/k3s:v1.22.5-k3s1
   # Replace this with your clusters service CIDR, you can find it out via
   # kubectl apply -f hack/wrong-cluster-ip-service.yaml
   - name: SERVICE_CIDR

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,7 +3,7 @@ vars:
   - name: SYNCER_IMAGE
     value: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
   - name: K3S_IMAGE
-    value: rancher/k3s:v1.22.5-k3s1
+    value: rancher/k3s:v1.23.1-k3s1
   # Replace this with your clusters service CIDR, you can find it out via
   # kubectl apply -f hack/wrong-cluster-ip-service.yaml
   - name: SERVICE_CIDR

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,4 @@
+### How to execute the e2e tests locally
+
+1. Start the vcluster via `devspace run dev` and running `go run -mod vendor cmd/vcluster/main.go start --sync 'networkpolicies'` in the terminal
+2. Then start the e2e tests via `VCLUSTER_SUFFIX=vcluster go test -v -ginkgo.v -ginkgo.skip='.*NetworkPolicy.*'`

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -159,12 +159,12 @@ func CreateFramework(ctx context.Context, scheme *runtime.Scheme) error {
 		}
 
 		// try to use the client with retry in case port forwarding is not ready yet
-		namespaces, err := vclusterClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+		_, err = vclusterClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
 
-		return len(namespaces.Items) > 0, nil
+		return true, nil
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Changes
- **syncer**: Start controllers after api server started
- **chart**: Fixed a problem where k3s would not startup correctly on cgroupsv2 nodes (#264)
- **cli**: Add v1.23 support for k3s