### PR TITLE
Add missing colon in OpenShift values example

### DIFF
--- a/docs/pages/fragments/deploy-to-openshift.mdx
+++ b/docs/pages/fragments/deploy-to-openshift.mdx
@@ -13,8 +13,8 @@ import TabItem from '@theme/TabItem'
 
 Create a `values.yaml` file with the following lines:
 
-```
-openshift
+```yaml
+openshift:
   enable: true
 ```
 
@@ -31,7 +31,7 @@ Update the `vcluster.yaml` file described in the [deployment guide](../getting-s
 You will need to add the `openshift` block as shown below:
 
 ```yaml
-openshift
+openshift:
   enable: true
 ```
 


### PR DESCRIPTION
The documentation misses a colon in the example values.