### PR TITLE
Volume snapshot unit tests and docs

### DIFF
--- a/docs/pages/architecture/storage.mdx
+++ b/docs/pages/architecture/storage.mdx
@@ -79,3 +79,59 @@ spec:
 ```
 
 This only happens if persistent volume sync is enabled in the vcluster. There might be cases where you want to disable this automatic rewriting of PVCs (for example if you want to mount an already existing PV of the host cluster to a PVC in the vcluster), for that case you can set the annotation called `vcluster.loft.sh/skip-translate` to `true`, which will tell vcluster to not rewrite the PVC `volumeName`, `storageClass`, `selectors` or `dataSource`. 
+
+
+### Sync Volume Snapshots
+Kubernetes VolumeSnapshot resource represents a snapshot of a volume on a storage system. You can read more about volume snapshots on [the official Kubernetes documentation page of this feature](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).
+
+By default, VolumeSnapshot syncing is disabled, and creating a VolumeSnapshot custom resource in the vcluster will have no effect. Following chapters describe how to enable this feature in the vcluster.
+
+:::caution Tech-preview feature
+This vcluster feature is still in the early state of maturity, so it is highly recommended to perform testing with your specific storage configurations and use cases.
+
+We offer this feature to the community as a tech-preview to gather feedback and information about compatibility with various CSI implementations and Kubernetes distributions. Please share your experience with us via *#vcluster* channel in [our Slack instance](https://slack.loft.sh/) or via [GitHub issues](https://github.com/loft-sh/vcluster/issues).
+:::
+
+#### Host prerequisites
+Vcluster relies fully on the volume snapshot capabilities of the host cluster, which has to fullfil certain criteria.
+
+Host cluster must have all relevant [snapshot CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd) installed, whitout which the vcluster will fail to start when volume snapshots sync is enabled.
+
+Host cluster should have a common snapshot controller installed, as well as a compatible CSI driver. Without these the volume snapshots will not be created in the storage backend.
+
+It is also recommended for the host cluster to have [the volume snapshots validating webhook](https://github.com/kubernetes-csi/external-snapshotter#validating-webhook) installed. 
+
+#### Create a vcluster with volume snapshots sync
+
+Create a `values.yaml` file in the form of:
+
+```yaml
+rbac: 
+  clusterRole:
+    create: true
+  role:
+    extended: true
+syncer:
+  extraArgs:
+  - --sync=volumesnapshots
+```
+
+Then deploy the vcluster with:
+
+```
+vcluster create my-vcluster -n my-vcluster -f values.yaml
+```
+
+:::info 
+It is recommend to install [the volume snapshots validating webhook](https://github.com/kubernetes-csi/external-snapshotter#validating-webhook) in your vcluster instance. 
+:::
+
+#### How does it work?
+
+When you enable volume snapshot sync, vcluster will start watching VolumeSnapshot, VolumeSnapshotContent, and VolumeSnapshotClass CRs and syncing them between vcluster and host cluster. These resource types are synced in the following ways:
+
+**VolumeSnapshot** resources created in the vcluster will be synced to the host cluster with the name in form of `vcluster-VOLUME_SNAPSHOT_NAME-x-VOLUME_SNAPSHOT_NAMESPACE-x-VCLUSTER_NAME`. The status and finalizers of this resource will be synced back into vcluster. The `.spec.source` field of the VolumeSnapshot resource in the host cluster will be rewritten to reference the expected PersistentVolumeClaim or VolumeSnapshotContent resource.
+
+**VolumeSnapshotContent** resources created in the vcluster will be synced to the host cluster with the name in form of `vcluster-VOLUME_SNAPSHOT_NAME-x-VCLUSTER_NAMESPACE-x-VCLUSTER_NAME`. VolumeSnapshotContent resources created in the host cluster and referencing VolumeSnapshot from the vcluster will be synced into vcluster. The status and finalizers of the resource in host cluster will be synced into its vcluster representation. The `.spec.volumeSnapshotRef` field of the VolumeSnapshotContent resource will be rewritten to reference the expected VolumeSnapshot resource.
+
+**VolumeSnapshotClass** resources will be synced from the host cluster into vcluster only.

--- a/e2e/test/syncer/services/services.go
+++ b/e2e/test/syncer/services/services.go
@@ -101,6 +101,9 @@ var _ = ginkgo.Describe("Services are created as expected", func() {
 		_, err = f.VclusterClient.RESTClient().Post().AbsPath("/api/v1/namespaces/" + ns + "/services").Body(body).DoRaw(f.Context)
 		framework.ExpectNoError(err)
 
+		err = f.WaitForService(service.Name, service.Namespace)
+		framework.ExpectNoError(err)
+
 		_, err = f.VclusterClient.CoreV1().Services(ns).Get(f.Context, service.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer_test.go
@@ -1,0 +1,349 @@
+package volumesnapshotcontents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	generictesting "github.com/loft-sh/vcluster/pkg/controllers/resources/generic/testing"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	targetNamespace = "testns"
+)
+
+func newFakeSyncer(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *syncer {
+	err := vClient.IndexField(ctx, &volumesnapshotv1.VolumeSnapshotContent{}, constants.IndexByPhysicalName, newIndexByVSCPhysicalName(targetNamespace))
+	if err != nil {
+		panic(err)
+	}
+	err = vClient.IndexField(ctx, &volumesnapshotv1.VolumeSnapshot{}, constants.IndexByPhysicalName, func(rawObj client.Object) []string {
+		return []string{translate.ObjectPhysicalName(rawObj)}
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return &syncer{
+		virtualClient:   vClient,
+		localClient:     pClient,
+		targetNamespace: targetNamespace,
+		translator:      translate.NewDefaultClusterTranslator(targetNamespace, NewVolumeSnapshotContentTranslator(targetNamespace)),
+	}
+}
+
+func TestSync(t *testing.T) {
+	vVolumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "snapshoty-mcsnapshotface",
+			Namespace:       "ns-abc",
+			ResourceVersion: "1111",
+		},
+	}
+	pVolumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      translate.PhysicalName(vVolumeSnapshot.Name, vVolumeSnapshot.Namespace),
+			Namespace: targetNamespace,
+		},
+	}
+
+	vObjectMeta := metav1.ObjectMeta{
+		Name:            "test-snapshotcontent",
+		ResourceVersion: "789",
+	}
+	vPreProvisioned := &volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: vObjectMeta,
+		Spec: volumesnapshotv1.VolumeSnapshotContentSpec{
+			VolumeSnapshotRef: corev1.ObjectReference{
+				Name:      vVolumeSnapshot.Name,
+				Namespace: vVolumeSnapshot.Namespace,
+			},
+			DeletionPolicy: volumesnapshotv1.VolumeSnapshotContentRetain,
+			Driver:         "something.csi.k8s.io",
+			Source: volumesnapshotv1.VolumeSnapshotContentSource{
+				SnapshotHandle: pointer.String("some-UID-I-guess"),
+			},
+		},
+	}
+
+	pPreProvisionedObjectMeta := metav1.ObjectMeta{
+		Name:            translate.PhysicalNameClusterScoped(vPreProvisioned.Name, targetNamespace),
+		ResourceVersion: "12345",
+		Annotations: map[string]string{
+			translate.NameAnnotation: vObjectMeta.Name,
+		},
+	}
+	pPreProvisioned := &volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: pPreProvisionedObjectMeta,
+		Spec:       *vPreProvisioned.Spec.DeepCopy(),
+	}
+	pPreProvisioned.Spec.VolumeSnapshotRef = corev1.ObjectReference{
+		Name:      translate.PhysicalName(vPreProvisioned.Spec.VolumeSnapshotRef.Name, vPreProvisioned.Spec.VolumeSnapshotRef.Namespace),
+		Namespace: targetNamespace,
+	}
+
+	pDynamicObjectMeta := metav1.ObjectMeta{
+		Name:            "snap-abcd",
+		ResourceVersion: "12345",
+	}
+	pDynamic := &volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: pDynamicObjectMeta,
+		Spec: volumesnapshotv1.VolumeSnapshotContentSpec{
+			VolumeSnapshotRef: corev1.ObjectReference{
+				Name:      translate.PhysicalName(vVolumeSnapshot.Name, vVolumeSnapshot.Namespace),
+				Namespace: targetNamespace,
+			},
+			DeletionPolicy:          volumesnapshotv1.VolumeSnapshotContentDelete,
+			Driver:                  "something.csi.k8s.io",
+			VolumeSnapshotClassName: pointer.String("classy-class"),
+			Source: volumesnapshotv1.VolumeSnapshotContentSource{
+				SnapshotHandle: pointer.String("some-UID-I-guess"),
+			},
+		},
+	}
+
+	vDynamic := pDynamic.DeepCopy()
+	if vDynamic.Annotations == nil {
+		vDynamic.Annotations = map[string]string{}
+	}
+	vDynamic.Annotations[HostClusterVSCAnnotation] = pDynamic.Name
+	vDynamic.Spec.VolumeSnapshotRef = corev1.ObjectReference{
+		Name:            vVolumeSnapshot.Name,
+		Namespace:       vVolumeSnapshot.Namespace,
+		ResourceVersion: vVolumeSnapshot.ResourceVersion,
+	}
+
+	gcFinalizers := []string{PhysicalVSCGarbageCollectionFinalizer}
+	vWithGCFinalizer := vDynamic.DeepCopy()
+	vWithGCFinalizer.Finalizers = gcFinalizers
+
+	vInvalidMutation := vWithGCFinalizer.DeepCopy()
+	vInvalidMutation.Spec.VolumeSnapshotRef = corev1.ObjectReference{
+		Name:      "bad-one-not-allowed",
+		Namespace: vVolumeSnapshot.Namespace,
+	}
+
+	pWithStatus := pDynamic.DeepCopy()
+	pWithStatus.Status = &volumesnapshotv1.VolumeSnapshotContentStatus{
+		ReadyToUse: pointer.Bool(false),
+		Error:      &volumesnapshotv1.VolumeSnapshotError{Message: pointer.String("the stars didn't align error")},
+	}
+	vWithStatus := vWithGCFinalizer.DeepCopy()
+	vWithStatus.Status = pWithStatus.Status
+
+	vModifiedDeletionPolicy := vPreProvisioned.DeepCopy()
+	vModifiedDeletionPolicy.Spec.DeletionPolicy = volumesnapshotv1.VolumeSnapshotContentRetain
+	pModifiedDeletionPolicy := pPreProvisioned.DeepCopy()
+	pModifiedDeletionPolicy.Spec.DeletionPolicy = vModifiedDeletionPolicy.Spec.DeletionPolicy
+
+	vDeleting := vPreProvisioned.DeepCopy()
+	deletionTime := metav1.NewTime(time.Now().Add(-5 * time.Second)).Rfc3339Copy()
+	vDeleting.DeletionTimestamp = &deletionTime
+
+	vDeletingWithGCFinalizer := vWithGCFinalizer.DeepCopy()
+	vDeletingWithGCFinalizer.DeletionTimestamp = &deletionTime
+
+	pDeletingWithOneFinalizer := pDynamic.DeepCopy()
+	pDeletingWithOneFinalizer.DeletionTimestamp = &deletionTime
+	pDeletingWithOneFinalizer.Finalizers = []string{"finalizer-from-csi"}
+	vDeletingWithMoreFinalizers := vDynamic.DeepCopy()
+	vDeletingWithMoreFinalizers.DeletionTimestamp = &deletionTime
+	vDeletingWithMoreFinalizers.Finalizers = append(pDeletingWithOneFinalizer.Finalizers, "another-finalizer")
+	vDeletingWithOneFinalizer := vDeletingWithGCFinalizer.DeepCopy()
+	vDeletingWithOneFinalizer.Finalizers = pDeletingWithOneFinalizer.Finalizers
+
+	pDeletingWithStatus := pDeletingWithOneFinalizer.DeepCopy()
+	pDeletingWithStatus.Status = pWithStatus.Status
+	vDeletingWithStatus := vDeletingWithOneFinalizer.DeepCopy()
+	vDeletingWithStatus.Status = pDeletingWithStatus.Status
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name:                 "Create dynamic VolumeSnapshotContent from host",
+			InitialVirtualState:  []runtime.Object{vVolumeSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pDynamic.DeepCopy(), pVolumeSnapshot.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vDynamic.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDynamic.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Backward(ctx, pDynamic.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Create pre-provisioned VolumeSnapshotContent from vcluster",
+			InitialVirtualState:  []runtime.Object{vPreProvisioned.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vPreProvisioned.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pPreProvisioned.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Forward(ctx, vPreProvisioned.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Ensure a finalizer is added to a virtual VolumeSnapshotContent",
+			InitialVirtualState:  []runtime.Object{vDynamic.DeepCopy(), vVolumeSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pDynamic.DeepCopy(), pVolumeSnapshot.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vWithGCFinalizer.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDynamic.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pDynamic.DeepCopy(), vDynamic.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Immutable .spec.VolumeSnapshotRef field is not synced on update",
+			InitialVirtualState:  []runtime.Object{vDynamic.DeepCopy(), vVolumeSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pDynamic.DeepCopy(), pVolumeSnapshot.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vDynamic.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDynamic.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pDynamic.DeepCopy(), vInvalidMutation.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Update status from physical to virtual",
+			InitialVirtualState:  []runtime.Object{vWithGCFinalizer.DeepCopy(), vVolumeSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pWithStatus.DeepCopy(), pVolumeSnapshot.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vWithStatus.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pWithStatus.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pWithStatus.DeepCopy(), vWithGCFinalizer.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Update .spec.DeletionPolicy from virtual to physical",
+			InitialVirtualState:  []runtime.Object{vModifiedDeletionPolicy.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pPreProvisioned.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vModifiedDeletionPolicy.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pModifiedDeletionPolicy.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pModifiedDeletionPolicy.DeepCopy(), vModifiedDeletionPolicy.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Delete in host when virtual is being deleted",
+			InitialVirtualState:  []runtime.Object{vDeleting.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pPreProvisioned.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vDeleting.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {}},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pPreProvisioned.DeepCopy(), vDeleting.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Clear finalizers from virtual resource that is being deleted after physical is deleted",
+			InitialVirtualState:  []runtime.Object{vDeletingWithGCFinalizer.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {}, // fakeClient seems to delete the object that has deletionTimestamp and no finalizers, so we will check its absence
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {}},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Forward(ctx, vDeletingWithGCFinalizer.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Sync finalizers from physical to virtual during deletion",
+			InitialVirtualState:  []runtime.Object{vDeletingWithMoreFinalizers.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pDeletingWithOneFinalizer.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vDeletingWithOneFinalizer.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDeletingWithOneFinalizer.DeepCopy()}},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pDeletingWithOneFinalizer.DeepCopy(), vDeletingWithMoreFinalizers.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Sync status from physical to virtual during deletion",
+			InitialVirtualState:  []runtime.Object{vDeletingWithOneFinalizer.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pDeletingWithStatus.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {vDeletingWithStatus.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDeletingWithStatus.DeepCopy()}},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(ctx, pClient, vClient)
+				_, err := syncer.Update(ctx, pDeletingWithStatus.DeepCopy(), vDeletingWithOneFinalizer.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	})
+}

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshots/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshots/syncer_test.go
@@ -1,0 +1,261 @@
+package volumesnapshots
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/generic"
+	generictesting "github.com/loft-sh/vcluster/pkg/controllers/resources/generic/testing"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	targetNamespace = "testns"
+)
+
+func newFakeSyncer(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *syncer {
+	return &syncer{
+		Translator:    generic.NewNamespacedTranslator(targetNamespace, vClient, &volumesnapshotv1.VolumeSnapshot{}),
+		virtualClient: vClient,
+		localClient:   pClient,
+
+		targetNamespace: targetNamespace,
+
+		creator:    generic.NewGenericCreator(pClient, &testingutil.FakeEventRecorder{}, "volumesnapshot"),
+		translator: translate.NewDefaultTranslator(targetNamespace),
+
+		volumeSnapshotContentNameTranslator: volumesnapshotcontents.NewVolumeSnapshotContentTranslator(targetNamespace),
+	}
+}
+
+func TestSync(t *testing.T) {
+	vObjectMeta := metav1.ObjectMeta{
+		Name:            "test-snapshot",
+		Namespace:       "test",
+		ResourceVersion: "999",
+	}
+	vPVSourceSnapshot := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: vObjectMeta,
+		Spec: volumesnapshotv1.VolumeSnapshotSpec{
+			Source: volumesnapshotv1.VolumeSnapshotSource{
+				PersistentVolumeClaimName: pointer.String("my-pv-name"),
+			},
+			VolumeSnapshotClassName: pointer.String("my-class-delete"),
+		},
+	}
+	vDeletingSnapshot := vPVSourceSnapshot.DeepCopy()
+	deletionTime := metav1.NewTime(time.Now().Add(-5 * time.Second)).Rfc3339Copy()
+	vDeletingSnapshot.DeletionTimestamp = &deletionTime
+
+	vVolumeSnapshotContent := volumesnapshotv1.VolumeSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-vsc-name",
+		},
+	}
+
+	vVSCSourceSnapshot := vPVSourceSnapshot.DeepCopy()
+	vVSCSourceSnapshot.Spec.Source = volumesnapshotv1.VolumeSnapshotSource{
+		VolumeSnapshotContentName: pointer.String(vVolumeSnapshotContent.Name),
+	}
+
+	pObjectMeta := metav1.ObjectMeta{
+		Name:            translate.PhysicalName(vObjectMeta.Name, vObjectMeta.Namespace),
+		Namespace:       targetNamespace,
+		ResourceVersion: "1234",
+		Annotations: map[string]string{
+			translate.NameAnnotation:      vObjectMeta.Name,
+			translate.NamespaceAnnotation: vObjectMeta.Namespace,
+		},
+		Labels: map[string]string{
+			translate.MarkerLabel:    translate.Suffix,
+			translate.NamespaceLabel: vObjectMeta.Namespace,
+		},
+	}
+	pPVSourceSnapshot := &volumesnapshotv1.VolumeSnapshot{
+		ObjectMeta: pObjectMeta,
+		Spec: volumesnapshotv1.VolumeSnapshotSpec{
+			Source: volumesnapshotv1.VolumeSnapshotSource{
+				PersistentVolumeClaimName: pointer.String(translate.PhysicalName(*vPVSourceSnapshot.Spec.Source.PersistentVolumeClaimName, vObjectMeta.Namespace)),
+			},
+			VolumeSnapshotClassName: vPVSourceSnapshot.Spec.VolumeSnapshotClassName,
+		},
+	}
+	pVSCSourceSnapshot := pPVSourceSnapshot.DeepCopy()
+	pVSCSourceSnapshot.Spec.Source = volumesnapshotv1.VolumeSnapshotSource{
+		VolumeSnapshotContentName: pointer.String(translate.PhysicalNameClusterScoped(*vVSCSourceSnapshot.Spec.Source.VolumeSnapshotContentName, targetNamespace)),
+	}
+
+	pWithNilClass := pPVSourceSnapshot.DeepCopy()
+	pWithNilClass.Spec.VolumeSnapshotClassName = nil
+	vWithNilClass := vPVSourceSnapshot.DeepCopy()
+	vWithNilClass.Spec.VolumeSnapshotClassName = nil
+
+	finalizers := []string{"test.csi.k8s.io"}
+	vWithFinalizers := vPVSourceSnapshot.DeepCopy()
+	vWithFinalizers.Finalizers = finalizers
+	pWithFinalizers := pPVSourceSnapshot.DeepCopy()
+	pWithFinalizers.Finalizers = finalizers
+
+	pWithStatus := pPVSourceSnapshot.DeepCopy()
+	pWithStatus.Status = &volumesnapshotv1.VolumeSnapshotStatus{
+		ReadyToUse: pointer.Bool(false),
+		Error:      &volumesnapshotv1.VolumeSnapshotError{Message: pointer.String("random error")},
+	}
+	vWithStatus := vPVSourceSnapshot.DeepCopy()
+	vWithStatus.Status = pWithStatus.Status
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name:                 "Create with PersistentVolume source",
+			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vPVSourceSnapshot.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pPVSourceSnapshot.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vPVSourceSnapshot.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Create with VolumeSnapshotContent source",
+			InitialVirtualState:  []runtime.Object{vVSCSourceSnapshot.DeepCopy(), vVolumeSnapshotContent.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vVSCSourceSnapshot.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pVSCSourceSnapshot.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Forward(ctx, vVSCSourceSnapshot.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Immutable .spec.source field is not synced on update",
+			InitialVirtualState:  []runtime.Object{vVSCSourceSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pPVSourceSnapshot.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vVSCSourceSnapshot.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pPVSourceSnapshot.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Update(ctx, pPVSourceSnapshot.DeepCopy(), vVSCSourceSnapshot.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Nil VolumeSnapshotClassName is handled correctly on update",
+			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pWithNilClass.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vPVSourceSnapshot.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pPVSourceSnapshot.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Update(ctx, pWithNilClass.DeepCopy(), vPVSourceSnapshot.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "VolumeSnapshotClassName is changed on update",
+			InitialVirtualState:  []runtime.Object{vWithNilClass.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pWithNilClass.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vWithNilClass.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pWithNilClass.DeepCopy()},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Update(ctx, pWithNilClass.DeepCopy(), vWithNilClass.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Sync finalizers from physical to virtual",
+			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pWithFinalizers},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vWithFinalizers},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pWithFinalizers},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Update(ctx, pWithFinalizers, vPVSourceSnapshot.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Sync status from physical to virtual",
+			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pWithStatus},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vWithStatus},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {pWithStatus},
+			},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Update(ctx, pWithStatus, vPVSourceSnapshot.DeepCopy(), log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name:                 "Delete in host when virtual is being deleted",
+			InitialVirtualState:  []runtime.Object{vDeletingSnapshot},
+			InitialPhysicalState: []runtime.Object{pPVSourceSnapshot.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {vDeletingSnapshot},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {}},
+			Sync: func(ctx context.Context, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient, scheme *runtime.Scheme, log loghelper.Logger) {
+				syncer := newFakeSyncer(pClient, vClient)
+				_, err := syncer.Update(ctx, pPVSourceSnapshot.DeepCopy(), vDeletingSnapshot, log)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	})
+}

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshots/translate.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshots/translate.go
@@ -44,7 +44,7 @@ func (s *syncer) translateUpdate(pVS, vVS *volumesnapshotv1.VolumeSnapshot) *vol
 	var updated *volumesnapshotv1.VolumeSnapshot
 
 	// snapshot class can be updated
-	if pVS.Spec.VolumeSnapshotClassName != vVS.Spec.VolumeSnapshotClassName {
+	if !equality.Semantic.DeepEqual(pVS.Spec.VolumeSnapshotClassName, vVS.Spec.VolumeSnapshotClassName) {
 		updated = newIfNil(updated, pVS)
 		updated.Spec.VolumeSnapshotClassName = vVS.Spec.VolumeSnapshotClassName
 	}


### PR DESCRIPTION
I am adding unit tests for the VolumeSnapshot and VolumeSnapshotContent syncers and small fixes to the implementation.
Plus one small e2e fix for [this problem](https://github.com/loft-sh/vcluster/runs/4712598512?check_suite_focus=true#step:10:91).
Plus docs for volume snapshot feature, which I marked as "tech-preview" (let me know if you prefer some other term, alpha?).

### Notable changes:
- docs: volume snapshot feature documented on the Storage page

