### PR TITLE
fix: cache race condition after Service creation

### DIFF
--- a/pkg/controllers/resources/services/translate.go
+++ b/pkg/controllers/resources/services/translate.go
@@ -56,6 +56,10 @@ func (s *syncer) translateUpdate(pObj, vObj *corev1.Service) *corev1.Service {
 
 	// check annotations
 	updatedAnnotations := s.translator.TranslateAnnotations(vObj, pObj)
+	// remove the ServiceBlockDeletion annotation if it's not needed
+	if vObj.Spec.ClusterIP == pObj.Spec.ClusterIP {
+		delete(updatedAnnotations, ServiceBlockDeletion)
+	}
 	if !equality.Semantic.DeepEqual(updatedAnnotations, pObj.Annotations) {
 		updated = newIfNil(updated, pObj)
 		updated.Annotations = updatedAnnotations

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -3,11 +3,10 @@ package filters
 import (
 	"context"
 	"fmt"
-	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	"io/ioutil"
-	"k8s.io/client-go/rest"
 	"net/http"
 
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/encoding"
 	"github.com/loft-sh/vcluster/pkg/util/random"
@@ -23,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -234,16 +234,6 @@ func createService(req *http.Request, decoder encoding.Decoder, localClient clie
 		klog.Infof("Error creating service in virtual cluster: %v", err)
 		_ = localClient.Delete(context.Background(), newService)
 		return nil, err
-	}
-
-	// try to patch physical service that we are done
-	if newService.Annotations != nil {
-		oldNewService := newService.DeepCopy()
-		delete(newService.Annotations, services.ServiceBlockDeletion)
-		err = localClient.Patch(req.Context(), newService, client.MergeFrom(oldNewService))
-		if err != nil {
-			klog.Errorf("Error patching service %s/%s: %v", oldNewService.Namespace, oldNewService.Name, err)
-		}
 	}
 
 	return vService, nil


### PR DESCRIPTION
We are no longer sharing a cache between the server and controllers.
This unfortunately allowed for a race condition after Service creation.
The controller might be missing Service resource in vcluster cache,
which is causing the deletion of the Service in the host cluster
until it is recreated again by the controller based on Service resource
that gets eventually pulled into vcluster cache.
To prevent this race condition we leave the annotation
that prevents Service deletion in the host until the Service resource
in vcluster is in the expected state.

I also updated the unit test to cover this change too.
And the rest of the changes is due to go fmt :) 

### Notable changes:
- fix: syncer cache race condition after Service creation