### PR TITLE
fix: update latest supported minor version for k8s flavor

### DIFF
--- a/pkg/helm/values/k8s.go
+++ b/pkg/helm/values/k8s.go
@@ -39,11 +39,11 @@ func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	controllerImage := K8SControllerVersionMap[serverVersionString]
 	etcdImage, ok := K8SEtcdVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 22 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
-			apiImage = K8SAPIVersionMap["1.22"]
-			controllerImage = K8SControllerVersionMap["1.22"]
-			etcdImage = K8SEtcdVersionMap["1.22"]
+		if serverMinorInt > 23 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
+			apiImage = K8SAPIVersionMap["1.23"]
+			controllerImage = K8SControllerVersionMap["1.23"]
+			etcdImage = K8SEtcdVersionMap["1.23"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = K8SAPIVersionMap["1.20"]


### PR DESCRIPTION
I added 1.23 into the version map a while back, but the condition and fallback values were not updated. 
Since 0.5.0 release notes state `cli: Added support for k8s v1.23`, should I cherry-pick this into v0.5 branch?