### PR TITLE
Filter out DaemonSet Pods when evaluating if Node is needed

### DIFF
--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -199,7 +199,7 @@ func (s *nodeSyncer) shouldSync(ctx context.Context, pObj *corev1.Node) (bool, e
 		return false, err
 	}
 
-	return len(podList.Items) > 0, nil
+	return len(filterOutDaemonSets(podList)) > 0, nil
 }
 
 var _ syncer.Starter = &nodeSyncer{}


### PR DESCRIPTION
Filter out DaemonSet Pods when evaluating if Node is needed, to avoid DaemonSets being left on Nodes where no other Pods run see #252

Thanks for a create project.

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>