### PR TITLE
refactor: use vcluster service as owner

### DIFF
--- a/pkg/controllers/resources/nodes/nodeservice/node_service.go
+++ b/pkg/controllers/resources/nodes/nodeservice/node_service.go
@@ -181,7 +181,7 @@ func (n *nodeServiceProvider) GetNodeIP(ctx context.Context, name types.Namespac
 
 	// set owning stateful set if defined
 	if translate.Owner != nil {
-		nodeService.SetOwnerReferences(translate.GetOwnerReference())
+		nodeService.SetOwnerReferences(translate.GetOwnerReference(nil))
 	}
 
 	// create the service

--- a/pkg/controllers/syncer/translator/namespaced_translator.go
+++ b/pkg/controllers/syncer/translator/namespaced_translator.go
@@ -247,7 +247,7 @@ func setupMetadataWithName(targetNamespace string, vObj client.Object, translato
 
 		// set owning stateful set if defined
 		if translate.Owner != nil {
-			m.SetOwnerReferences(translate.GetOwnerReference())
+			m.SetOwnerReferences(translate.GetOwnerReference(vObj))
 		}
 	}
 

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -73,7 +73,7 @@ func WriteKubeConfig(ctx context.Context, client client.Client, secretName, secr
 
 		// set owner reference
 		if translate.Owner != nil && translate.Owner.GetNamespace() == kubeConfigSecret.Namespace {
-			kubeConfigSecret.OwnerReferences = translate.GetOwnerReference()
+			kubeConfigSecret.OwnerReferences = translate.GetOwnerReference(nil)
 		}
 
 		err = clienthelper.Apply(ctx, client, kubeConfigSecret, loghelper.New("apply-secret"))

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -16,6 +16,8 @@ var (
 	NamespaceLabel = "vcluster.loft.sh/namespace"
 	MarkerLabel    = "vcluster.loft.sh/managed-by"
 	Suffix         = "suffix"
+
+	t = true
 )
 
 var Owner client.Object
@@ -65,6 +67,7 @@ func GetOwnerReference() []metav1.OwnerReference {
 			Kind:       typeAccessor.GetKind(),
 			Name:       Owner.GetName(),
 			UID:        Owner.GetUID(),
+			Controller: &t,
 		},
 	}
 }

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -16,8 +16,6 @@ var (
 	NamespaceLabel = "vcluster.loft.sh/namespace"
 	MarkerLabel    = "vcluster.loft.sh/managed-by"
 	Suffix         = "suffix"
-
-	t = true
 )
 
 var Owner client.Object
@@ -51,7 +49,7 @@ func IsManaged(obj runtime.Object) bool {
 	return metaAccessor.GetLabels()[MarkerLabel] == Suffix
 }
 
-func GetOwnerReference() []metav1.OwnerReference {
+func GetOwnerReference(object client.Object) []metav1.OwnerReference {
 	if Owner == nil {
 		return nil
 	}
@@ -61,13 +59,18 @@ func GetOwnerReference() []metav1.OwnerReference {
 		return nil
 	}
 
+	isController := false
+	if object != nil {
+		ctrl := metav1.GetControllerOf(object)
+		isController = ctrl != nil
+	}
 	return []metav1.OwnerReference{
 		{
 			APIVersion: typeAccessor.GetAPIVersion(),
 			Kind:       typeAccessor.GetKind(),
 			Name:       Owner.GetName(),
 			UID:        Owner.GetUID(),
-			Controller: &t,
+			Controller: &isController,
 		},
 	}
 }


### PR DESCRIPTION
### Changes
- **syncer**: Use vcluster service as owner instead of deployment / statefulset, because we can set the `controller: true` in the owner reference for it, which allows node draining (#273)