### PR TITLE
refactor: get rid of shared persistent volume mutex

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -452,6 +452,12 @@ func (cmd *ConnectCmd) executeCommand(vKubeConfig api.Config, command []string, 
 
 		return errors.Wrap(err, "error port-forwarding")
 	case err := <-commandErrChan:
+		if _, ok := err.(*exec.ExitError); ok {
+			// we ignore exit errors as the stderr was printed to the console already
+			// anyways
+			return nil
+		}
+
 		return err
 	}
 }

--- a/pkg/controllers/resources/events/syncer.go
+++ b/pkg/controllers/resources/events/syncer.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"k8s.io/apimachinery/pkg/api/equality"
 	"strings"
 
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
@@ -176,7 +177,11 @@ func (s *eventSyncer) reconcile(ctx *synccontext.SyncContext, req ctrl.Request) 
 	// copy metadata
 	vObj.ObjectMeta = *vOldObj.ObjectMeta.DeepCopy()
 
-	// update existing event
+	// update existing event only if changed
+	if equality.Semantic.DeepEqual(vObj, vOldObj) {
+		return nil
+	}
+
 	ctx.Log.Infof("update virtual event %s/%s", vObj.Namespace, vObj.Name)
 	return ctx.VirtualClient.Update(ctx.Context, vObj)
 }

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
@@ -123,37 +123,6 @@ func TestSync(t *testing.T) {
 		Spec:       backwardUpdateStatusPvc.Spec,
 		Status:     backwardUpdateStatusPvc.Status,
 	}
-	persistentVolume := &corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "myvolume",
-			Labels: map[string]string{
-				"vcluster.loft.sh/fake-pv": "true",
-			},
-			Annotations: map[string]string{
-				"kubernetes.io/createdby":              "fake-pv-provisioner",
-				"pv.kubernetes.io/bound-by-controller": "true",
-				"pv.kubernetes.io/provisioned-by":      "fake-pv-provisioner",
-			},
-		},
-		Spec: corev1.PersistentVolumeSpec{
-			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				FlexVolume: &corev1.FlexPersistentVolumeSource{
-					Driver: "fake",
-				},
-			},
-			ClaimRef: &corev1.ObjectReference{
-				Kind:            "PersistentVolumeClaim",
-				Namespace:       "testns",
-				Name:            "testpvc",
-				APIVersion:      corev1.SchemeGroupVersion.Version,
-				ResourceVersion: generictesting.FakeClientResourceVersion,
-			},
-			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
-		},
-		Status: corev1.PersistentVolumeStatus{
-			Phase: corev1.VolumeBound,
-		},
-	}
 
 	generictesting.RunTests(t, []*generictesting.SyncTest{
 		{
@@ -257,7 +226,6 @@ func TestSync(t *testing.T) {
 			InitialPhysicalState: []runtime.Object{backwardUpdateStatusPvc.DeepCopy()},
 			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
 				corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"): {backwardUpdatedStatusPvc.DeepCopy()},
-				corev1.SchemeGroupVersion.WithKind("PersistentVolume"):      {persistentVolume.DeepCopy()},
 			},
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
 				corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"): {backwardUpdateStatusPvc.DeepCopy()},

--- a/pkg/controllers/resources/persistentvolumes/fake_syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/fake_syncer.go
@@ -53,7 +53,7 @@ var _ syncer.ControllerModifier = &fakePersistentVolumeSyncer{}
 func (r *fakePersistentVolumeSyncer) ModifyController(ctx *synccontext.RegisterContext, builder *builder.Builder) (*builder.Builder, error) {
 	return builder.Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, handler.EnqueueRequestsFromMapFunc(func(object client.Object) []reconcile.Request {
 		pvc, ok := object.(*corev1.PersistentVolumeClaim)
-		if !ok || pvc == nil {
+		if !ok || pvc == nil || pvc.Spec.VolumeName == "" {
 			return []reconcile.Request{}
 		}
 
@@ -65,17 +65,6 @@ func (r *fakePersistentVolumeSyncer) ModifyController(ctx *synccontext.RegisterC
 			},
 		}
 	})), nil
-}
-
-var _ syncer.Starter = &fakePersistentVolumeSyncer{}
-
-func (r *fakePersistentVolumeSyncer) ReconcileStart(ctx *synccontext.SyncContext, req ctrl.Request) (bool, error) {
-	r.sharedMutex.Lock()
-	return false, nil
-}
-
-func (r *fakePersistentVolumeSyncer) ReconcileEnd() {
-	r.sharedMutex.Unlock()
 }
 
 var _ syncer.FakeSyncer = &fakePersistentVolumeSyncer{}


### PR DESCRIPTION
### Changes
- Refactored fake persistent volume & persitent volume claim controller to not use a shared mutex anymore
- `vcluster connect ... -- command` does not show a fatal anymore if the command has failed.
- Events are only updated if they actually have been changed