### PR TITLE
test: scheme configurable in unit tests

### DIFF
--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotclasses/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotclasses/syncer_test.go
@@ -1,9 +1,10 @@
 package volumesnapshotclasses
 
 import (
+	"testing"
+
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"gotest.tools/assert"
-	"testing"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	generictesting "github.com/loft-sh/vcluster/pkg/controllers/syncer/testing"
@@ -13,6 +14,7 @@ import (
 )
 
 func TestSync(t *testing.T) {
+	addToSchemeFuncs := []func(s *runtime.Scheme) error{volumesnapshotv1.AddToScheme}
 	vObjectMeta := metav1.ObjectMeta{
 		Name:            "testclass",
 		Namespace:       "test",
@@ -29,6 +31,7 @@ func TestSync(t *testing.T) {
 
 	generictesting.RunTests(t, []*generictesting.SyncTest{
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Create backward",
 			InitialVirtualState:  []runtime.Object{},
 			InitialPhysicalState: []runtime.Object{vBaseVSC.DeepCopy()},
@@ -45,6 +48,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Update backward",
 			InitialVirtualState:  []runtime.Object{vBaseVSC.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{vMoreParamsVSC.DeepCopy()},
@@ -61,6 +65,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Ignore forward update",
 			InitialVirtualState:  []runtime.Object{vMoreParamsVSC.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{vBaseVSC.DeepCopy()},
@@ -77,6 +82,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:      addToSchemeFuncs,
 			Name:                  "Delete backward",
 			InitialVirtualState:   []runtime.Object{vBaseVSC.DeepCopy()},
 			InitialPhysicalState:  []runtime.Object{},

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer_test.go
@@ -1,11 +1,12 @@
 package volumesnapshotcontents
 
 import (
+	"testing"
+	"time"
+
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"gotest.tools/assert"
-	"testing"
-	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/loft-sh/vcluster/pkg/constants"
@@ -36,6 +37,7 @@ func newFakeSyncer(t *testing.T, ctx *synccontext.RegisterContext) (*synccontext
 }
 
 func TestSync(t *testing.T) {
+	addToSchemeFuncs := []func(s *runtime.Scheme) error{volumesnapshotv1.AddToScheme}
 	vVolumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "snapshoty-mcsnapshotface",
@@ -162,6 +164,7 @@ func TestSync(t *testing.T) {
 
 	generictesting.RunTests(t, []*generictesting.SyncTest{
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Create dynamic VolumeSnapshotContent from host",
 			InitialVirtualState:  []runtime.Object{vVolumeSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pDynamic.DeepCopy(), pVolumeSnapshot.DeepCopy()},
@@ -178,6 +181,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Create pre-provisioned VolumeSnapshotContent from vcluster",
 			InitialVirtualState:  []runtime.Object{vPreProvisioned.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{},
@@ -194,6 +198,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Ensure a finalizer is added to a virtual VolumeSnapshotContent",
 			InitialVirtualState:  []runtime.Object{vDynamic.DeepCopy(), vVolumeSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pDynamic.DeepCopy(), pVolumeSnapshot.DeepCopy()},
@@ -210,6 +215,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Immutable .spec.VolumeSnapshotRef field is not synced on update",
 			InitialVirtualState:  []runtime.Object{vDynamic.DeepCopy(), vVolumeSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pDynamic.DeepCopy(), pVolumeSnapshot.DeepCopy()},
@@ -226,6 +232,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Update status from physical to virtual",
 			InitialVirtualState:  []runtime.Object{vWithGCFinalizer.DeepCopy(), vVolumeSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pWithStatus.DeepCopy(), pVolumeSnapshot.DeepCopy()},
@@ -242,6 +249,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Update .spec.DeletionPolicy from virtual to physical",
 			InitialVirtualState:  []runtime.Object{vModifiedDeletionPolicy.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pPreProvisioned.DeepCopy()},
@@ -258,6 +266,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Delete in host when virtual is being deleted",
 			InitialVirtualState:  []runtime.Object{vDeleting.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pPreProvisioned.DeepCopy()},
@@ -273,6 +282,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Clear finalizers from virtual resource that is being deleted after physical is deleted",
 			InitialVirtualState:  []runtime.Object{vDeletingWithGCFinalizer.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{},
@@ -288,6 +298,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Sync finalizers from physical to virtual during deletion",
 			InitialVirtualState:  []runtime.Object{vDeletingWithMoreFinalizers.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pDeletingWithOneFinalizer.DeepCopy()},
@@ -303,6 +314,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Sync status from physical to virtual during deletion",
 			InitialVirtualState:  []runtime.Object{vDeletingWithOneFinalizer.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pDeletingWithStatus.DeepCopy()},

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshots/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshots/syncer_test.go
@@ -1,11 +1,12 @@
 package volumesnapshots
 
 import (
+	"testing"
+	"time"
+
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"gotest.tools/assert"
-	"testing"
-	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	generictesting "github.com/loft-sh/vcluster/pkg/controllers/syncer/testing"
@@ -21,6 +22,7 @@ const (
 )
 
 func TestSync(t *testing.T) {
+	addToSchemeFuncs := []func(s *runtime.Scheme) error{volumesnapshotv1.AddToScheme}
 	vObjectMeta := metav1.ObjectMeta{
 		Name:            "test-snapshot",
 		Namespace:       "test",
@@ -98,6 +100,7 @@ func TestSync(t *testing.T) {
 
 	generictesting.RunTests(t, []*generictesting.SyncTest{
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Create with PersistentVolume source",
 			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{},
@@ -114,6 +117,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Create with VolumeSnapshotContent source",
 			InitialVirtualState:  []runtime.Object{vVSCSourceSnapshot.DeepCopy(), vVolumeSnapshotContent.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{},
@@ -130,6 +134,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Immutable .spec.source field is not synced on update",
 			InitialVirtualState:  []runtime.Object{vVSCSourceSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pPVSourceSnapshot.DeepCopy()},
@@ -146,6 +151,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Nil VolumeSnapshotClassName is handled correctly on update",
 			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pWithNilClass.DeepCopy()},
@@ -162,6 +168,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "VolumeSnapshotClassName is changed on update",
 			InitialVirtualState:  []runtime.Object{vWithNilClass.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pWithNilClass.DeepCopy()},
@@ -178,6 +185,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Sync finalizers from physical to virtual",
 			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pWithFinalizers},
@@ -194,6 +202,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Sync status from physical to virtual",
 			InitialVirtualState:  []runtime.Object{vPVSourceSnapshot.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{pWithStatus},
@@ -210,6 +219,7 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
+			AddToSchemeFuncs:     addToSchemeFuncs,
 			Name:                 "Delete in host when virtual is being deleted",
 			InitialVirtualState:  []runtime.Object{vDeletingSnapshot},
 			InitialPhysicalState: []runtime.Object{pPVSourceSnapshot.DeepCopy()},

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 
-	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -20,11 +19,6 @@ import (
 func NewScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	err := clientgoscheme.AddToScheme(scheme)
-	if err != nil {
-		panic(err)
-	}
-
-	err = volumesnapshotv1.AddToScheme(scheme)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Thanks to this change it is possible to extend the fake client scheme from the unit test instead of adding them in the shared code.

This benefits mainly vcluster-sdk where we mirror the `pkg/controllers/syncer/testing` package, and then subsequently the plugins that can use it with custom CRDs. Plus, it will remove the `github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1` dependency from the SDK and all plugins.
I figured I would first add the change here and then copy it to the SDK to keep both in sync, but I am open to adding this to SDK only if there are good reasons for that. :) 