### PR TITLE
Add support for automatic tolerations

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -185,20 +185,9 @@ func ExecuteStart(options *context2.VirtualClusterOptions) error {
 		return err
 	}
 
-	if len(options.Tolerations) > 0 {
-		for _, toleration := range options.Tolerations {
-			eqSplit := strings.Split(toleration, "=")
-			if len(eqSplit) < 2 {
-				klog.Fatalf("Toleration: %v improperly formatted", toleration)
-				return errors.New("Toleration improperly formatted")
-			} else {
-				clSplit := strings.Split(eqSplit[1], ":")
-				if len(clSplit) < 2 {
-					klog.Fatalf("Toleration: %v improperly formatted", toleration)
-					return errors.New("Toleration improperly formatted")
-				}
-			}
-		}
+	err = validateTolerations(options.Tolerations)
+	if err != nil {
+		return err
 	}
 
 	// set suffix
@@ -336,6 +325,25 @@ func ExecuteStart(options *context2.VirtualClusterOptions) error {
 	}
 
 	<-ctx.StopChan
+	return nil
+}
+
+func validateTolerations(tolerations []string) error {
+	if len(tolerations) > 0 {
+		for _, toleration := range tolerations {
+			eqSplit := strings.Split(toleration, "=")
+			if len(eqSplit) < 2 {
+				klog.Fatalf("Toleration: %v improperly formatted", toleration)
+				return errors.New("Toleration improperly formatted")
+			} else {
+				clSplit := strings.Split(eqSplit[1], ":")
+				if len(clSplit) < 2 {
+					klog.Fatalf("Toleration: %v improperly formatted", toleration)
+					return errors.New("Toleration improperly formatted")
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/kubeconfig"
+	"github.com/loft-sh/vcluster/pkg/util/toleration"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -184,10 +184,11 @@ func ExecuteStart(options *context2.VirtualClusterOptions) error {
 	if err != nil {
 		return err
 	}
-
-	err = validateTolerations(options.Tolerations)
-	if err != nil {
-		return err
+	for _, t := range options.Tolerations {
+		_, err := toleration.ParseToleration(t)
+		if err != nil {
+			return err
+		}
 	}
 
 	// set suffix
@@ -325,25 +326,6 @@ func ExecuteStart(options *context2.VirtualClusterOptions) error {
 	}
 
 	<-ctx.StopChan
-	return nil
-}
-
-func validateTolerations(tolerations []string) error {
-	if len(tolerations) > 0 {
-		for _, toleration := range tolerations {
-			eqSplit := strings.Split(toleration, "=")
-			if len(eqSplit) < 2 {
-				klog.Fatalf("Toleration: %v improperly formatted", toleration)
-				return errors.New("Toleration improperly formatted")
-			} else {
-				clSplit := strings.Split(eqSplit[1], ":")
-				if len(clSplit) < 2 {
-					klog.Fatalf("Toleration: %v improperly formatted", toleration)
-					return errors.New("Toleration improperly formatted")
-				}
-			}
-		}
-	}
 	return nil
 }
 

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -106,7 +106,7 @@ func NewStartCommand() *cobra.Command {
 
 	cmd.Flags().StringSliceVar(&options.TranslateImages, "translate-image", []string{}, "Translates image names from the virtual pod to the physical pod (e.g. coredns/coredns=mirror.io/coredns/coredns)")
 	cmd.Flags().BoolVar(&options.EnforceNodeSelector, "enforce-node-selector", true, "If enabled and --node-selector is set then the virtual cluster will ensure that no pods are scheduled outside of the node selector")
-	cmd.Flags().StringSliceVar(&options.Tolerations, "toleration", []string{}, "If set will apply the provided tolerations to all pods in the vcluster")
+	cmd.Flags().StringSliceVar(&options.Tolerations, "enforce-toleration", []string{}, "If set will apply the provided tolerations to all pods in the vcluster")
 	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "If set, nodes with the given node selector will be synced to the virtual cluster. This will implicitly set --fake-nodes=false")
 	cmd.Flags().StringVar(&options.ServiceAccount, "service-account", "", "If set, will set this host service account on the synced pods")
 

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -22,9 +22,10 @@ type VirtualClusterOptions struct {
 	ClientCaCert        string   `json:"clientCaCert"`
 	KubeConfig          string   `json:"kubeConfig"`
 
-	KubeConfigSecret          string `json:"kubeConfigSecret"`
-	KubeConfigSecretNamespace string `json:"kubeConfigSecretNamespace"`
-	KubeConfigServer          string `json:"kubeConfigServer"`
+	KubeConfigSecret          string   `json:"kubeConfigSecret"`
+	KubeConfigSecretNamespace string   `json:"kubeConfigSecretNamespace"`
+	KubeConfigServer          string   `json:"kubeConfigServer"`
+	Tolerations               []string `json:"tolerations,omitempty"`
 
 	BindAddress string `json:"bindAddress"`
 	Port        int    `json:"port"`

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -150,10 +150,11 @@ func (s *podSyncer) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (
 		return ctrl.Result{}, err
 	}
 
-	// ensure node selector
+	// ensure tolerations
 	for _, toleration := range s.tolerations {
 		pPod.Spec.Tolerations = append(pPod.Spec.Tolerations, *toleration)
 	}
+	// ensure node selector
 	if s.nodeSelector != nil {
 		// 2 cases:
 		// 1. Pod already has a nodeName -> then we check if the node exists in the virtual cluster

--- a/pkg/util/toleration/toleration.go
+++ b/pkg/util/toleration/toleration.go
@@ -1,0 +1,62 @@
+package toleration
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func ParseToleration(st string) (corev1.Toleration, error) {
+	var toleration corev1.Toleration
+	var key string
+	var value string
+	var effect corev1.TaintEffect
+	var operator corev1.TolerationOperator
+
+	if st == "*" {
+		toleration.Operator = corev1.TolerationOpExists
+		return toleration, nil
+	}
+	partsCl := strings.Split(st, ":")
+	partsEq := strings.Split(st, "=")
+	switch len(partsCl) {
+	case 1:
+		switch len(partsEq) {
+		case 1:
+			key = partsEq[0]
+		case 2:
+			key = partsEq[0]
+			value = partsEq[1]
+			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+				return toleration, fmt.Errorf("invalid toleration spec: %v, %s", st, strings.Join(errs, "; "))
+			}
+		default:
+			return toleration, fmt.Errorf("invalid toleration spec: %v", st)
+		}
+	case 2:
+		effect = corev1.TaintEffect(partsCl[1])
+		operator = corev1.TolerationOpExists
+		partsKV := strings.Split(partsCl[0], "=")
+		if len(partsKV) > 2 {
+			return toleration, fmt.Errorf("invalid toleration spec: %v", st)
+		}
+		key = partsKV[0]
+		if len(partsKV) == 2 {
+			operator = corev1.TolerationOpEqual
+			value = partsKV[1]
+			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+				return toleration, fmt.Errorf("invalid toleration spec: %v, %s", st, strings.Join(errs, "; "))
+			}
+		}
+	default:
+		return toleration, fmt.Errorf("invalid toleration spec: %v", st)
+	}
+
+	toleration.Key = key
+	toleration.Value = value
+	toleration.Effect = effect
+	toleration.Operator = operator
+	return toleration, nil
+}

--- a/pkg/util/toleration/toleration_test.go
+++ b/pkg/util/toleration/toleration_test.go
@@ -1,0 +1,113 @@
+package toleration
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestParseToleration(t *testing.T) {
+	type args struct {
+		st string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    corev1.Toleration
+		wantErr bool
+	}{
+		{
+			name: "Should get toleration with Operator exists",
+			args: args{
+				st: "*",
+			},
+			want: corev1.Toleration{
+				Operator: corev1.TolerationOpExists,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should get toleration with key",
+			args: args{
+				st: "key",
+			},
+			want: corev1.Toleration{
+				Key: "key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should get toleration with key and value",
+			args: args{
+				st: "key=value",
+			},
+			want: corev1.Toleration{
+				Key:   "key",
+				Value: "value",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should get toleration with key value and effect",
+			args: args{
+				st: "key=value:NoSchedule",
+			},
+			want: corev1.Toleration{
+				Key:      "key",
+				Value:    "value",
+				Effect:   corev1.TaintEffectNoSchedule,
+				Operator: corev1.TolerationOpEqual,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should get toleration with key and effect",
+			args: args{
+				st: "key:NoSchedule",
+			},
+			want: corev1.Toleration{
+				Key:      "key",
+				Effect:   corev1.TaintEffectNoSchedule,
+				Operator: corev1.TolerationOpExists,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should get bad label error",
+			args: args{
+				st: "key=value,wrong:NoSchedule",
+			},
+			want:    corev1.Toleration{},
+			wantErr: true,
+		},
+		{
+			name: "Should get invalid toleration",
+			args: args{
+				st: "key=value:Effec:Effect",
+			},
+			want:    corev1.Toleration{},
+			wantErr: true,
+		},
+		{
+			name: "Should get invalid toleration",
+			args: args{
+				st: "key=value=value",
+			},
+			want:    corev1.Toleration{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseToleration(tt.args.st)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseToleration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseToleration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hey 👋! 

My humble and naive attempt at implementing https://github.com/loft-sh/vcluster/issues/330

I couldn't find any Kubernetes function to parse tolerations.  Kubectl doesn't really support toleration, just taint, and there's technically a difference since tolerations have an operator. This does not support the operator as is

The operator will default to `Equal`` which would enforce that both key and value match the taint.

Because of the above I force the user to provide  the following format `key=value:effect` , and will fail at startup if what's provided does not match.

Might be a good idea to adjust the format to be `key=value:effect:operator` and in that case the parsing and error handling need to be a little smarter. (for example the operator can allow the value to not be provided if set to `Exists`)

Open to suggestions about the whole thing.

I have tested this in devspace with the debugger fyi. Seems to do what I expect.