### PR TITLE
fix: several sync fixes

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -117,7 +117,6 @@ var DefaultEnabledControllers = []string{
 	"ingresses",
 	"fake-nodes",
 	"fake-persistentvolumes",
-	"poddisruptionbudgets",
 }
 
 func NewControllerContext(currentNamespace string, localManager ctrl.Manager, virtualManager ctrl.Manager, options *VirtualClusterOptions) (*ControllerContext, error) {

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/AlecAivazis/survey.v1 v1.8.8
 	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -1,0 +1,86 @@
+package pods
+
+import (
+	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	generictesting "github.com/loft-sh/vcluster/pkg/controllers/syncer/testing"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func TestSync(t *testing.T) {
+	vObjectMeta := metav1.ObjectMeta{
+		Name:      "testpod",
+		Namespace: "testns",
+	}
+	pObjectMeta := metav1.ObjectMeta{
+		Name:      translate.PhysicalName("testpod", "testns"),
+		Namespace: "test",
+		Annotations: map[string]string{
+			translator.NameAnnotation:      vObjectMeta.Name,
+			translator.NamespaceAnnotation: vObjectMeta.Namespace,
+		},
+		Labels: map[string]string{
+			translate.NamespaceLabel: vObjectMeta.Namespace,
+			translate.MarkerLabel:    translate.Suffix,
+		},
+	}
+	basePod := &corev1.Pod{
+		ObjectMeta: vObjectMeta,
+		Spec: corev1.PodSpec{
+			NodeName: "test123",
+		},
+	}
+	createdPod := &corev1.Pod{
+		ObjectMeta: pObjectMeta,
+		Spec: corev1.PodSpec{
+			NodeName: "test456",
+		},
+	}
+	deletingPod := &corev1.Pod{
+		ObjectMeta: pObjectMeta,
+		Spec: corev1.PodSpec{
+			NodeName: "test456",
+		},
+	}
+	now := metav1.Now()
+	deletingPod.DeletionTimestamp = &now
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name:                 "Delete physical pod",
+			InitialVirtualState:  []runtime.Object{basePod.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{createdPod},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {basePod},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := generictesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).Sync(syncCtx, createdPod.DeepCopy(), basePod)
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                 "Don't delete virtual pod",
+			InitialVirtualState:  []runtime.Object{basePod.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{deletingPod},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {basePod.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {deletingPod},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := generictesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).Sync(syncCtx, deletingPod, basePod.DeepCopy())
+				assert.NilError(t, err)
+			},
+		},
+	})
+}

--- a/pkg/controllers/syncer/testing/manager.go
+++ b/pkg/controllers/syncer/testing/manager.go
@@ -28,7 +28,7 @@ type fakeManager struct {
 
 func (f *fakeManager) SetFields(interface{}) error { return nil }
 
-func (f *fakeManager) GetConfig() *rest.Config { return nil }
+func (f *fakeManager) GetConfig() *rest.Config { return &rest.Config{Host: "127.0.0.1"} }
 
 func (f *fakeManager) GetScheme() *runtime.Scheme { return f.client.Scheme() }
 

--- a/pkg/controllers/syncer/testing/testing.go
+++ b/pkg/controllers/syncer/testing/testing.go
@@ -98,7 +98,7 @@ func compareObjs(t *testing.T, state string, ctx context.Context, c client.Clien
 
 		t.Logf("\n\nExpected: \n%s\n\nExisting: \n%s\n", expectedObjsYaml, existingObjsYaml)
 		assert.Equal(t, string(expectedObjsYaml), string(existingObjsYaml), state+" mismatch")
-		return fmt.Errorf("expected objs and existing objs length do not match (%d != %d). \n\nExpected: \n%s\n\nExisting: \n%s", len(objs), len(existingObjs), expectedObjsYaml, existingObjsYaml)
+		return fmt.Errorf("expected objs and existing objs length do not match (%d != %d)", len(objs), len(existingObjs))
 	}
 
 	for _, expectedObj := range objs {
@@ -120,26 +120,26 @@ func compareObjs(t *testing.T, state string, ctx context.Context, c client.Clien
 
 				// compare objs
 				existingObj := stripObject(existingObjRaw)
+				expectedObjsYaml, err := yaml.Marshal(expectedObj)
+				if err != nil {
+					return err
+				}
+				existingObjsYaml, err := yaml.Marshal(existingObj)
+				if err != nil {
+					return err
+				}
+
 				isEqual := false
 				if compare != nil {
 					isEqual = compare(expectedObj, existingObj)
 				} else {
-					isEqual = apiequality.Semantic.DeepEqual(expectedObj, existingObj)
+					isEqual = apiequality.Semantic.DeepEqual(expectedObj, existingObj) || string(expectedObjsYaml) == string(existingObjsYaml)
 				}
 
 				if !isEqual {
-					expectedObjsYaml, err := yaml.Marshal(expectedObj)
-					if err != nil {
-						return err
-					}
-					existingObjsYaml, err := yaml.Marshal(existingObj)
-					if err != nil {
-						return err
-					}
-
 					t.Logf("\n\nExpected: \n%s\n\nExisting: \n%s\n", expectedObjsYaml, existingObjsYaml)
 					assert.Equal(t, string(expectedObjsYaml), string(existingObjsYaml), state+" mismatch")
-					return fmt.Errorf("expected obj %s/%s and existing obj are different. \n\nExpected: %s\n\nExisting: %s", expectedAccessor.GetNamespace(), expectedAccessor.GetName(), expectedObjsYaml, existingObjsYaml)
+					return fmt.Errorf("expected obj %s/%s and existing obj are different", expectedAccessor.GetNamespace(), expectedAccessor.GetName())
 				}
 
 				break

--- a/pkg/controllers/syncer/translator/namespaced_translator.go
+++ b/pkg/controllers/syncer/translator/namespaced_translator.go
@@ -139,8 +139,8 @@ func (n *namespacedTranslator) TranslateMetadata(vObj client.Object) client.Obje
 	return TranslateMetadata(n.physicalNamespace, vObj, n.excludedAnnotations...)
 }
 
-func TranslateMetadata(phyiscalNamespace string, vObj client.Object, excludedAnnotations ...string) client.Object {
-	pObj, err := setupMetadataWithName(phyiscalNamespace, vObj, DefaultPhysicalName)
+func TranslateMetadata(physicalNamespace string, vObj client.Object, excludedAnnotations ...string) client.Object {
+	pObj, err := setupMetadataWithName(physicalNamespace, vObj, DefaultPhysicalName)
 	if err != nil {
 		return nil
 	}

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -151,7 +151,6 @@ func updateService(req *http.Request, decoder encoding.Decoder, localClient clie
 
 	// we try to patch the service as this has the best chances to go through
 	originalPService := pService.DeepCopy()
-	pService.Spec.Ports = newVService.Spec.Ports
 	pService.Spec.Type = newVService.Spec.Type
 	pService.Spec.ClusterIP = ""
 	err = localClient.Patch(ctx, pService, client.MergeFrom(originalPService))
@@ -206,6 +205,7 @@ func createService(req *http.Request, decoder encoding.Decoder, localClient clie
 	}
 	newService.Annotations[services.ServiceBlockDeletion] = "true"
 	newService.Spec.Selector = nil
+	services.StripNodePorts(newService)
 	err = localClient.Create(req.Context(), newService)
 	if err != nil {
 		klog.Infof("Error creating service in physical cluster: %v", err)

--- a/pkg/util/applier/util.go
+++ b/pkg/util/applier/util.go
@@ -15,10 +15,10 @@ func ApplyManifestFile(inClusterConfig *rest.Config, filename string) error {
 		return fmt.Errorf("function ApplyManifestFile failed, unable to read %s file: %v", filename, err)
 	}
 
-	return ApplyManifest(inClusterConfig, &manifest)
+	return ApplyManifest(inClusterConfig, manifest)
 }
 
-func ApplyManifest(inClusterConfig *rest.Config, manifest *[]byte) error {
+func ApplyManifest(inClusterConfig *rest.Config, manifest []byte) error {
 	restMapper, err := apiutil.NewDynamicRESTMapper(inClusterConfig)
 	if err != nil {
 		return fmt.Errorf("unable to initialize NewDynamicRESTMapper")
@@ -26,7 +26,7 @@ func ApplyManifest(inClusterConfig *rest.Config, manifest *[]byte) error {
 
 	a := DirectApplier{}
 	opts := ApplierOptions{
-		Manifest:   string(*manifest),
+		Manifest:   string(manifest),
 		RESTConfig: inClusterConfig,
 		RESTMapper: restMapper,
 	}

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -50,12 +50,12 @@ func IsManaged(obj runtime.Object) bool {
 }
 
 func GetOwnerReference(object client.Object) []metav1.OwnerReference {
-	if Owner == nil {
+	if Owner == nil || Owner.GetName() == "" || Owner.GetUID() == "" {
 		return nil
 	}
 
 	typeAccessor, err := meta.TypeAccessor(Owner)
-	if err != nil {
+	if err != nil || typeAccessor.GetAPIVersion() == "" || typeAccessor.GetKind() == "" {
 		return nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -595,6 +595,7 @@ gopkg.in/square/go-jose.v2/jwt
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.4.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 gopkg.in/yaml.v3


### PR DESCRIPTION
### Changes
- **syncer**: Removed `poddisruptionbudgets` as default syncer
- **syncer**: Make initial kube config secret creation non-fatal
- **syncer**: If phyiscal and virtual pod have a node assigned and they differ, delete the physical pod 
- **syncer**: Sync service nodePort from host cluster instead of virtual cluster
- **syncer**: Only write coredns manifests to local file if environment variable "DEBUG" is "true"