### PR TITLE
Don't set tolerations for coredns pods

### DIFF
--- a/manifests/coredns/coredns.yaml
+++ b/manifests/coredns/coredns.yaml
@@ -101,15 +101,6 @@ spec:
     spec:
       priorityClassName: "system-cluster-critical"
       serviceAccountName: coredns
-      tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-        - key: "node-role.kubernetes.io/control-plane"
-          operator: "Exists"
-          effect: "NoSchedule"
-        - key: "node-role.kubernetes.io/master"
-          operator: "Exists"
-          effect: "NoSchedule"
       nodeSelector:
         kubernetes.io/os: linux
       topologySpreadConstraints:


### PR DESCRIPTION
This PR removes the tolerations for the coredns deployment. In many environments there are restrictions on who/what can run on the control-plane nodes. While coredns is required for DNS inside of vcluster it is not necessary or required that it runs on the control-plane nodes.

This was discussed somewhat in https://github.com/loft-sh/vcluster/issues/251 but I'm open to feedback if this isn't an approach you'd prefer to take.