### PR TITLE
Bump k3s and k0s to latest v1.23

### DIFF
--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -95,7 +95,7 @@ syncer:
 # Virtual Cluster (k0s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: k0sproject/k0s:v1.22.4-k0s.0
+  image: k0sproject/k0s:v1.23.3-k0s.0
   command:
     - k0s
   baseArgs:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -95,7 +95,7 @@ syncer:
 # Virtual Cluster (k3s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: rancher/k3s:v1.21.4-k3s1
+  image: rancher/k3s:v1.23.3-k3s1
   command:
     - /bin/k3s
   baseArgs:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,7 +3,7 @@ vars:
   - name: SYNCER_IMAGE
     value: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
   - name: K3S_IMAGE
-    value: rancher/k3s:v1.23.1-k3s1
+    value: rancher/k3s:v1.23.3-k3s1
   # Replace this with your clusters service CIDR, you can find it out via
   # kubectl apply -f hack/wrong-cluster-ip-service.yaml
   - name: SERVICE_CIDR

--- a/pkg/helm/values/k0s.go
+++ b/pkg/helm/values/k0s.go
@@ -8,7 +8,8 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.22": "k0sproject/k0s:v1.22.4-k0s.0",
+	"1.23": "k0sproject/k0s:v1.23.3-k0s.0",
+	"1.22": "k0sproject/k0s:v1.22.6-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {
@@ -20,9 +21,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 22 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
-			image = K0SVersionMap["1.22"]
+		if serverMinorInt > 23 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
+			image = K0SVersionMap["1.23"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			image = K0SVersionMap["1.22"]

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -21,10 +21,10 @@ var (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.23": "rancher/k3s:v1.23.1-k3s1",
-	"1.22": "rancher/k3s:v1.22.5-k3s1",
-	"1.21": "rancher/k3s:v1.21.4-k3s1",
-	"1.20": "rancher/k3s:v1.20.11-k3s2",
+	"1.23": "rancher/k3s:v1.23.3-k3s1",
+	"1.22": "rancher/k3s:v1.22.6-k3s1",
+	"1.21": "rancher/k3s:v1.21.9-k3s1",
+	"1.20": "rancher/k3s:v1.20.15-k3s1",
 	"1.19": "rancher/k3s:v1.19.13-k3s1",
 	"1.18": "rancher/k3s:v1.18.20-k3s1",
 	"1.17": "rancher/k3s:v1.17.17-k3s1",


### PR DESCRIPTION
### Release notes:
####  k3s and k0s distros bumped to the latest v1.23
**k0s** based vcluster distro now **supports v1.23** (v1.23.3-k0s.0) 
**k3s** based vcluster distro images have been **bumped to the latest versions** to pick up [a fix for host that use cgroup v2](https://github.com/k3s-io/k3s/issues/4873). Bumped versions are v1.20.15-rc1+k3s1, v1.21.9-rc1+k3s1, v1.22.6-rc1+k3s1, and v1.23.3-rc1+k3s1 (default).