### PR TITLE
Node selector can be enforced with fake nodes as well. Docs improvements.

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -106,7 +106,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&options.TranslateImages, "translate-image", []string{}, "Translates image names from the virtual pod to the physical pod (e.g. coredns/coredns=mirror.io/coredns/coredns)")
 	cmd.Flags().BoolVar(&options.EnforceNodeSelector, "enforce-node-selector", true, "If enabled and --node-selector is set then the virtual cluster will ensure that no pods are scheduled outside of the node selector")
 	cmd.Flags().StringSliceVar(&options.Tolerations, "enforce-toleration", []string{}, "If set will apply the provided tolerations to all pods in the vcluster")
-	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "If set, nodes with the given node selector will be synced to the virtual cluster. This will implicitly set --fake-nodes=false")
+	cmd.Flags().StringVar(&options.NodeSelector, "node-selector", "", "If nodes sync is enabled, nodes with the given node selector will be synced to the virtual cluster. If fake nodes are used, and --enforce-node-selector flag is set, then vcluster will ensure that no pods are scheduled outside of the node selector.")
 	cmd.Flags().StringVar(&options.ServiceAccount, "service-account", "", "If set, will set this host service account on the synced pods")
 
 	cmd.Flags().BoolVar(&options.OverrideHosts, "override-hosts", true, "If enabled, vcluster will override a containers /etc/hosts file if there is a subdomain specified for the pod (spec.subdomain).")

--- a/docs/pages/architecture/scheduling.mdx
+++ b/docs/pages/architecture/scheduling.mdx
@@ -8,7 +8,11 @@ sidebar_label: Pod Scheduling
   <figcaption>vcluster - Pod Scheduling</figcaption>
 </figure>
 
-By default, certain Kubernetes objects such as Services or Ingresses are synced from the virtual cluster to the host cluster. The syncer translates problematic fields (such as pod labels) and also transforms certain fields of these objects before sending them to the host cluster, to ensure integrity of the virtual cluster.
+Vcluster runs your workloads by replicating pods from the virtual cluster to the host cluster. We call this process synchronization or sync for short. This process is executed by the "syncer" component of the vcluster.
+To control how vcluster pods are scheduled on the host cluster, you may need to pass additional arguments to the syncer, or set certain helm chart values during vcluster installation and upgrade. Some of these options are described in the chapters below.
+
+
+### Using priority classes
 
 If you need to use priority classes, you can enable this by adding the following to your `values.yaml`:
 ```
@@ -21,3 +25,73 @@ then create or upgrade the vcluster with:
 ```
 vcluster create my-vcluster -n my-vcluster-namespace --upgrade -f values.yaml
 ```
+
+This will pass the necessary flags to the "syncer" container and create or update the ClusterRole used by vcluster to include necessary permissions. 
+
+
+### Limiting pod scheduling to selected nodes
+
+Vcluster allows you to limit on which nodes the pods synced by vcluster will run.
+You can achieve this by combining `--node-selector` and `--enforce-node-selector` syncer flags. 
+The `--enforce-node-selector` flag is enabled by default.
+When using vcluster helm chart or CLI, there are two options for setting the `--node-selector` flag.
+
+This first option is recommended if you are not enabling node synchronization, and use [the fake nodes](./nodes), which are enabled by default. In such case, you would write a string representation of your node selector(e.g. "nodeLabel=labelValue") and set it as the value of `--node-selector` argument for syncer in your `values.yaml`:
+```
+syncer:
+  extraArgs:
+  - --node-selector="nodeLabel=labelValue"
+```
+then create or upgrade the vcluster with:
+
+```
+vcluster create my-vcluster -n my-vcluster-namespace --upgrade -f values.yaml
+```
+
+This second option is recommended if you are enabling synchronization of [the real nodes](./nodes) via helm values. This is how you would then set the selector in your `values.yaml`:
+```
+sync:
+  nodes:
+    enabled: true
+    nodeSelector: "nodeLabel=labelValue"
+```
+then create or upgrade the vcluster with:
+
+```
+vcluster create my-vcluster -n my-vcluster-namespace --upgrade -f values.yaml
+```
+
+:::info
+When sync of the real nodes is enabled and nodeSelector is set, all nodes that match the selector will be synced into vcluster. Read more about Node sync modes on the [Nodes documentation page](./nodes).
+::: 
+
+
+### Automatically applying tolerations to all pods synced by vcluster 
+
+Kubernetes has a concept of [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), which is used for controlling scheduling. If you have a use case requiring all pods synced by vcluster to have a toleration set automatically, then you can achieve this with the `--enforce-toleration` syncer flag. You can pass multiple `--enforce-toleration` flags with different toleration expressions, and syncer will add them to every new pod that gets synced by vcluster.
+
+This is how toleration is set in yaml format:
+```
+- key: "key1"
+  operator: "Equal"
+  value: "value1"
+  effect: "NoSchedule"
+```
+We will need to write this information in a string format to pass it as value of the `--enforce-toleration` flag.
+
+The example above would be represented as `key1=value1:NoSchedule`.
+The Exists operator is written as - `key1:Effect`.
+And if you need to write a toleration with empty effect, here is an example for that - `key1=value1`, or just `key` if value is also empty.
+There is also a special case of a toleration that contains only operator Exists without effect or key, which would match every taint, and we express this as `*`.
+
+You can set the `--enforce-toleration` falgs as arguments for syncer in your `values.yaml`:
+```
+syncer:
+  extraArgs:
+  - --enforce-toleration="key1=value1:NoSchedule"
+  - --enforce-toleration="anotherKey1=value2:NoSchedule"
+```
+
+:::info
+Vcluster does not support setting the `tolerationSeconds` field of a toleration through the syntax that the `--enforce-toleration` flag uses. If your use case requires this, please raise an issue in [the vcluster repo on GitHub](https://github.com/loft-sh/vcluster/issues).
+::: 

--- a/pkg/controllers/resources/nodes/register.go
+++ b/pkg/controllers/resources/nodes/register.go
@@ -18,7 +18,7 @@ func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 
 	nodeService := nodeservice.NewNodeServiceProvider(ctx.CurrentNamespace, ctx.CurrentNamespaceClient, ctx.VirtualManager.GetClient(), uncachedVirtualClient)
 
-	if !ctx.Controllers["nodes"] && ctx.Options.NodeSelector == "" {
+	if !ctx.Controllers["nodes"] {
 		return NewFakeSyncer(ctx, nodeService)
 	}
 	return NewSyncer(ctx, nodeService)

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -160,7 +160,12 @@ func (s *podSyncer) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (
 		// 1. Pod already has a nodeName -> then we check if the node exists in the virtual cluster
 		// 2. Pod has no nodeName -> then we set the nodeSelector
 		if pPod.Spec.NodeName == "" {
-			pPod.Spec.NodeSelector = s.nodeSelector.MatchLabels
+			if pPod.Spec.NodeSelector == nil {
+				pPod.Spec.NodeSelector = map[string]string{}
+			}
+			for k, v := range s.nodeSelector.MatchLabels {
+				pPod.Spec.NodeSelector[k] = v
+			}
 		} else {
 			// make sure the node does exist in the virtual cluster
 			err = ctx.VirtualClient.Get(ctx.Context, types.NamespacedName{Name: pPod.Spec.NodeName}, &corev1.Node{})

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -1,6 +1,9 @@
 package pods
 
 import (
+	"testing"
+
+	podtranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	generictesting "github.com/loft-sh/vcluster/pkg/controllers/syncer/testing"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
@@ -10,55 +13,130 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
+	"k8s.io/utils/pointer"
 )
 
 func TestSync(t *testing.T) {
+	pVclusterService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generictesting.DefaultTestVclusterServiceName,
+			Namespace: generictesting.DefaultTestCurrentNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "1.2.3.4",
+		},
+	}
+	translate.Suffix = generictesting.DefaultTestVclusterName
+	pDNSService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      translate.PhysicalName("kube-dns", "kube-system"),
+			Namespace: generictesting.DefaultTestTargetNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "2.2.2.2",
+		},
+	}
+	vNamespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testns",
+		},
+	}
 	vObjectMeta := metav1.ObjectMeta{
 		Name:      "testpod",
-		Namespace: "testns",
+		Namespace: vNamespace.Name,
 	}
 	pObjectMeta := metav1.ObjectMeta{
 		Name:      translate.PhysicalName("testpod", "testns"),
 		Namespace: "test",
 		Annotations: map[string]string{
-			translator.NameAnnotation:      vObjectMeta.Name,
-			translator.NamespaceAnnotation: vObjectMeta.Namespace,
+			podtranslate.ClusterAutoScalerAnnotation:  "false",
+			podtranslate.LabelsAnnotation:             "",
+			podtranslate.NameAnnotation:               vObjectMeta.Name,
+			podtranslate.NamespaceAnnotation:          vObjectMeta.Namespace,
+			translator.NameAnnotation:                 vObjectMeta.Name,
+			translator.NamespaceAnnotation:            vObjectMeta.Namespace,
+			podtranslate.ServiceAccountNameAnnotation: "",
+			podtranslate.UIDAnnotation:                string(vObjectMeta.UID),
 		},
 		Labels: map[string]string{
 			translate.NamespaceLabel: vObjectMeta.Namespace,
 			translate.MarkerLabel:    translate.Suffix,
 		},
 	}
-	basePod := &corev1.Pod{
+	pPodBase := &corev1.Pod{
+		ObjectMeta: pObjectMeta,
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: pointer.Bool(false),
+			EnableServiceLinks:           pointer.Bool(false),
+			HostAliases: []corev1.HostAlias{{
+				IP:        pVclusterService.Spec.ClusterIP,
+				Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+			}},
+			Hostname: vObjectMeta.Name,
+		},
+	}
+	vPodWithNodeName := &corev1.Pod{
 		ObjectMeta: vObjectMeta,
 		Spec: corev1.PodSpec{
 			NodeName: "test123",
 		},
 	}
-	createdPod := &corev1.Pod{
-		ObjectMeta: pObjectMeta,
+	pPodWithNodeName := pPodBase.DeepCopy()
+	pPodWithNodeName.Spec.NodeName = "test456"
+
+	vPodWithNodeSelector := &corev1.Pod{
+		ObjectMeta: vObjectMeta,
 		Spec: corev1.PodSpec{
-			NodeName: "test456",
+			NodeSelector: map[string]string{
+				"labelA": "valueA",
+				"labelB": "valueB",
+			},
 		},
+	}
+	nodeSelectorOption := "labelB=enforcedB,otherLabel=abc"
+	pPodWithNodeSelector := pPodBase.DeepCopy()
+	pPodWithNodeSelector.Spec.NodeSelector = map[string]string{
+		"labelA":     "valueA",
+		"labelB":     "enforcedB",
+		"otherLabel": "abc",
 	}
 
 	generictesting.RunTests(t, []*generictesting.SyncTest{
 		{
 			Name:                 "Delete virtual pod",
-			InitialVirtualState:  []runtime.Object{basePod.DeepCopy()},
-			InitialPhysicalState: []runtime.Object{createdPod},
+			InitialVirtualState:  []runtime.Object{vPodWithNodeName.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pPodWithNodeName},
 			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
 				corev1.SchemeGroupVersion.WithKind("Pod"): {},
 			},
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
 				corev1.SchemeGroupVersion.WithKind("Pod"): {
-					createdPod,
+					pPodWithNodeName,
 				},
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := generictesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).Sync(syncCtx, createdPod.DeepCopy(), basePod)
+				_, err := syncer.(*podSyncer).Sync(syncCtx, pPodWithNodeName.DeepCopy(), vPodWithNodeName)
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                 "Sync and enforce NodeSelector",
+			InitialVirtualState:  []runtime.Object{vPodWithNodeSelector.DeepCopy(), vNamespace.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{pVclusterService.DeepCopy(), pDNSService.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {vPodWithNodeSelector.DeepCopy()},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {
+					pPodWithNodeSelector,
+				},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				ctx.Options.EnforceNodeSelector = true
+				ctx.Options.NodeSelector = nodeSelectorOption
+				syncCtx, syncer := generictesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).SyncDown(syncCtx, vPodWithNodeSelector.DeepCopy())
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -249,6 +249,14 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 	// translate pod affinity
 	t.translatePodAffinity(vPod, pPod)
 
+	// translate node selector
+	for k, v := range vPod.Spec.NodeSelector {
+		if pPod.Spec.NodeSelector == nil {
+			pPod.Spec.NodeSelector = map[string]string{}
+		}
+		pPod.Spec.NodeSelector[k] = v
+	}
+
 	return pPod, nil
 }
 

--- a/pkg/controllers/syncer/testing/context.go
+++ b/pkg/controllers/syncer/testing/context.go
@@ -2,6 +2,8 @@ package testing
 
 import (
 	"context"
+	"testing"
+
 	controllercontext "github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -12,7 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"testing"
+)
+
+const (
+	DefaultTestTargetNamespace     = "test"
+	DefaultTestCurrentNamespace    = "vcluster"
+	DefaultTestVclusterName        = "vcluster"
+	DefaultTestVclusterServiceName = "vcluster"
 )
 
 func FakeStartSyncer(t *testing.T, ctx *synccontext.RegisterContext, create func(ctx *synccontext.RegisterContext) (syncer.Object, error)) (*synccontext.SyncContext, syncer.Object) {
@@ -33,13 +41,13 @@ func NewFakeRegisterContext(pClient *testingutil.FakeIndexClient, vClient *testi
 	return &synccontext.RegisterContext{
 		Context: context.TODO(),
 		Options: &controllercontext.VirtualClusterOptions{
-			Name:            "vcluster",
-			ServiceName:     "vcluster",
-			TargetNamespace: "test",
+			Name:            DefaultTestVclusterName,
+			ServiceName:     DefaultTestVclusterServiceName,
+			TargetNamespace: DefaultTestTargetNamespace,
 		},
 		Controllers:            controllercontext.ExistingControllers,
-		TargetNamespace:        "test",
-		CurrentNamespace:       "test",
+		TargetNamespace:        DefaultTestTargetNamespace,
+		CurrentNamespace:       DefaultTestCurrentNamespace,
 		CurrentNamespaceClient: pClient,
 		VirtualManager:         newFakeManager(vClient),
 		PhysicalManager:        newFakeManager(pClient),


### PR DESCRIPTION
### Release notes:
#### Breaking changes:
- setting the `--node-selector` flag does not implicitly enable synchronization of real nodes anymore. Consult [the Nodes documentation page](https://www.vcluster.com/docs/architecture/nodes) to see the recommended way of enabling real node sync.

#### Changes:
- feat: the `--node-selector` and `--enforce-node-selector` flags can now be used with fake nodes
- docs: [Architecture - Pod Scheduling page](https://www.vcluster.com/docs/architecture/scheduling) has been improved and covers more use cases, including the new `--enforce-toleration` flag.