### PR TITLE
feat(pod): Add annotation to overwrite phyiscal SA

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -29,15 +29,16 @@ import (
 )
 
 const (
-	OwnerSetKind                  = "vcluster.loft.sh/owner-set-kind"
-	NamespaceAnnotation           = "vcluster.loft.sh/namespace"
-	NameAnnotation                = "vcluster.loft.sh/name"
-	LabelsAnnotation              = "vcluster.loft.sh/labels"
-	NamespaceLabelPrefix          = "vcluster.loft.sh/ns-label"
-	UIDAnnotation                 = "vcluster.loft.sh/uid"
-	ClusterAutoScalerAnnotation   = "cluster-autoscaler.kubernetes.io/safe-to-evict"
-	ServiceAccountNameAnnotation  = "vcluster.loft.sh/service-account-name"
-	ServiceAccountTokenAnnotation = "vcluster.loft.sh/token-"
+	OwnerSetKind                          = "vcluster.loft.sh/owner-set-kind"
+	NamespaceAnnotation                   = "vcluster.loft.sh/namespace"
+	NameAnnotation                        = "vcluster.loft.sh/name"
+	LabelsAnnotation                      = "vcluster.loft.sh/labels"
+	NamespaceLabelPrefix                  = "vcluster.loft.sh/ns-label"
+	UIDAnnotation                         = "vcluster.loft.sh/uid"
+	ClusterAutoScalerAnnotation           = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	ServiceAccountNameAnnotation          = "vcluster.loft.sh/service-account-name"
+	ServiceAccountTokenAnnotation         = "vcluster.loft.sh/token-"
+	OverwriteServiceAccountNameAnnotation = "vcluster.loft.sh/overwrite-service-account-name"
 )
 
 var (
@@ -133,6 +134,9 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 		pPod.Annotations[ServiceAccountNameAnnotation] = vPod.Annotations[ServiceAccountNameAnnotation]
 		if _, ok := vPod.Annotations[LabelsAnnotation]; ok {
 			pPod.Annotations[LabelsAnnotation] = vPod.Annotations[LabelsAnnotation]
+		}
+		if overWriteSAName, ok := vPod.Annotations[OverwriteServiceAccountNameAnnotation]; ok {
+			pPod.Spec.ServiceAccountName = overWriteSAName
 		}
 	}
 	if pPod.Annotations[NamespaceAnnotation] == "" {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

This adds the possibility to overwrite the `spec.serviceAccountName` of the physical pod via an optional annotation.

resolves #370 

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

---
