### PR TITLE
feat: add serviceaccount syncer

### DIFF
--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -32,6 +32,11 @@ rules:
     resources: ["volumesnapshots"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -70,6 +70,8 @@ sync:
     enabled: false
   poddisruptionbudgets:
     enabled: false
+  serviceaccounts:
+    enabled: false
 
 # Syncer configuration
 syncer:

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -32,6 +32,11 @@ rules:
     resources: ["volumesnapshots"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -70,6 +70,8 @@ sync:
     enabled: false
   poddisruptionbudgets:
     enabled: false
+  serviceaccounts:
+    enabled: false
 
 # Syncer configuration
 syncer:

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -32,6 +32,11 @@ rules:
     resources: ["volumesnapshots"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -74,6 +74,8 @@ sync:
     enabled: false
   poddisruptionbudgets:
     enabled: false
+  serviceaccounts:
+    enabled: false
 
 # Syncer configuration
 syncer:

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -108,6 +108,7 @@ var ExistingControllers = map[string]bool{
 	"networkpolicies":        true,
 	"volumesnapshots":        true,
 	"poddisruptionbudgets":   true,
+	"serviceaccounts":        true,
 }
 
 var DefaultEnabledControllers = []string{

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/serviceaccounts"
 	"strings"
 
 	"github.com/loft-sh/vcluster/cmd/vcluster/context"
@@ -46,6 +47,7 @@ var ResourceControllers = map[string][]func(*synccontext.RegisterContext) (synce
 	"poddisruptionbudgets":   newControllers(poddisruptionbudgets.New),
 	"networkpolicies":        newControllers(networkpolicies.New),
 	"volumesnapshots":        newControllers(volumesnapshotclasses.New, volumesnapshots.New, volumesnapshotcontents.New),
+	"serviceaccounts":        newControllers(serviceaccounts.New),
 	"persistentvolumes,fake-persistentvolumes": newControllers(persistentvolumes.New),
 }
 

--- a/pkg/controllers/resources/serviceaccounts/syncer.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer.go
@@ -1,0 +1,30 @@
+package serviceaccounts
+
+import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
+
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
+	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
+	return &serviceAccountSyncer{
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "serviceaccount", &corev1.ServiceAccount{}),
+	}, nil
+}
+
+type serviceAccountSyncer struct {
+	translator.NamespacedTranslator
+}
+
+func (s *serviceAccountSyncer) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {
+	return s.SyncDownCreate(ctx, vObj, s.translate(vObj.(*corev1.ServiceAccount)))
+}
+
+func (s *serviceAccountSyncer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj client.Object) (ctrl.Result, error) {
+	// did the service account change?
+	return s.SyncDownUpdate(ctx, vObj, s.translateUpdate(pObj.(*corev1.ServiceAccount), vObj.(*corev1.ServiceAccount)))
+}

--- a/pkg/controllers/resources/serviceaccounts/syncer_test.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer_test.go
@@ -1,0 +1,69 @@
+package serviceaccounts
+
+import (
+	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	generictesting "github.com/loft-sh/vcluster/pkg/controllers/syncer/testing"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func TestSync(t *testing.T) {
+	vSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-serviceaccount",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"test": "test",
+			},
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Kind: "Test",
+			},
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{
+				Name: "test",
+			},
+		},
+	}
+	pSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      translate.PhysicalName(vSA.Name, vSA.Namespace),
+			Namespace: "test",
+			Annotations: map[string]string{
+				"test":                                  "test",
+				translator.ManagedAnnotationsAnnotation: "test",
+				translator.NameAnnotation:               vSA.Name,
+				translator.NamespaceAnnotation:          vSA.Namespace,
+			},
+			Labels: map[string]string{
+				translate.NamespaceLabel: vSA.Namespace,
+			},
+		},
+		AutomountServiceAccountToken: &f,
+	}
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name: "ServiceAccount sync",
+			InitialVirtualState: []runtime.Object{
+				vSA,
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): {pSA},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := generictesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*serviceAccountSyncer).SyncDown(syncCtx, vSA)
+				assert.NilError(t, err)
+			},
+		},
+	})
+}

--- a/pkg/controllers/resources/serviceaccounts/translate.go
+++ b/pkg/controllers/resources/serviceaccounts/translate.go
@@ -1,0 +1,41 @@
+package serviceaccounts
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	f = false
+)
+
+func (s *serviceAccountSyncer) translate(vObj client.Object) *corev1.ServiceAccount {
+	pObj := s.TranslateMetadata(vObj).(*corev1.ServiceAccount)
+
+	// Don't sync the secrets here as we will override them anyways
+	pObj.Secrets = nil
+	pObj.AutomountServiceAccountToken = &f
+	pObj.ImagePullSecrets = nil
+	return pObj
+}
+
+func (s *serviceAccountSyncer) translateUpdate(pObj, vObj *corev1.ServiceAccount) *corev1.ServiceAccount {
+	var updated *corev1.ServiceAccount
+
+	// check annotations & labels
+	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
+	if changed {
+		updated = newIfNil(updated, pObj)
+		updated.Labels = updatedLabels
+		updated.Annotations = updatedAnnotations
+	}
+
+	return updated
+}
+
+func newIfNil(updated *corev1.ServiceAccount, pObj *corev1.ServiceAccount) *corev1.ServiceAccount {
+	if updated == nil {
+		return pObj.DeepCopy()
+	}
+	return updated
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #370


**Please provide a short message that should be published in the vcluster release notes**
Added a new service account syncer that makes it possible to sync service accounts from the vcluster to the host cluster with certain annotations and labels. This is useful for features such as [IAM Roles for ServiceAccounts](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html) where the service account needs a certain annotation to give AWS permissions to a pod
