### PR TITLE
refactor: sync storageclasses from vcluster

### DIFF
--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
     verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
   - apiGroups: ["scheduling.k8s.io"]
     resources: ["priorityclasses"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/charts/k0s/templates/rbac/clusterrole.yaml
+++ b/charts/k0s/templates/rbac/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
   {{- if or .Values.sync.storageclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
   {{- end }}
   {{- if or .Values.sync.priorityclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["scheduling.k8s.io"]

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
   {{- if or .Values.sync.storageclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
   {{- end }}
   {{- if or .Values.sync.priorityclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["scheduling.k8s.io"]

--- a/charts/k8s/templates/rbac/clusterrole.yaml
+++ b/charts/k8s/templates/rbac/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
   {{- if or .Values.sync.storageclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
   {{- end }}
   {{- if or .Values.sync.priorityclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["scheduling.k8s.io"]

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -263,7 +263,7 @@ func (cmd *CreateCmd) Run(args []string) error {
 		return err
 	}
 
-	cmd.log.Donef("Successfully created virtual cluster %s in namespace %s. Use 'vcluster connect %s --namespace %s' to access the virtual cluster", args[0], cmd.Namespace, args[0], cmd.Namespace)
+	cmd.log.Donef("Successfully created virtual cluster %s in namespace %s. \n- Use 'vcluster connect %s --namespace %s' to access the virtual cluster\n- Use `vcluster connect %s --namespace %s -- kubectl get ns` to run a command directly within the vcluster", args[0], cmd.Namespace, args[0], cmd.Namespace, args[0], cmd.Namespace)
 
 	// check if we should connect to the vcluster
 	if cmd.Connect {

--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -3,14 +3,12 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -87,8 +85,7 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var pods *corev1.PodList
-	pods, err = client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
+	pods, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "app=vcluster",
 	})
 	if err != nil {
@@ -106,9 +103,9 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
+		} else {
+			return err
 		}
-	} else if len(pods.Items) == 0 {
-		return fmt.Errorf("can't find vcluster(s) in namespace %s", cmd.Namespace)
 	}
 
 	vclusters := []VCluster{}

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
@@ -3,6 +3,7 @@ package persistentvolumeclaims
 import (
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	"gotest.tools/assert"
 	"testing"
 	"time"
@@ -124,7 +125,11 @@ func TestSync(t *testing.T) {
 		Status:     backwardUpdateStatusPvc.Status,
 	}
 
-	generictesting.RunTests(t, []*generictesting.SyncTest{
+	generictesting.RunTestsWithContext(t, func(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *synccontext.RegisterContext {
+		ctx := generictesting.NewFakeRegisterContext(pClient, vClient)
+		ctx.Controllers["storageclasses"] = false
+		return ctx
+	}, []*generictesting.SyncTest{
 		{
 			Name:                "Create forward",
 			InitialVirtualState: []runtime.Object{basePvc},

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -35,6 +35,9 @@ func (s *persistentVolumeSyncer) translateBackwards(pPv *corev1.PersistentVolume
 		vObj.Spec.ClaimRef.UID = vPvc.UID
 		vObj.Spec.ClaimRef.Name = vPvc.Name
 		vObj.Spec.ClaimRef.Namespace = vPvc.Namespace
+		if vPvc.Spec.StorageClassName != nil {
+			vObj.Spec.StorageClassName = *vPvc.Spec.StorageClassName
+		}
 	}
 	if vObj.Annotations == nil {
 		vObj.Annotations = map[string]string{}
@@ -53,6 +56,9 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 		translatedSpec.ClaimRef.UID = vPvc.UID
 		translatedSpec.ClaimRef.Name = vPvc.Name
 		translatedSpec.ClaimRef.Namespace = vPvc.Namespace
+		if vPvc.Spec.StorageClassName != nil {
+			translatedSpec.StorageClassName = *vPvc.Spec.StorageClassName
+		}
 	}
 
 	// check storage class

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -1,8 +1,6 @@
 package priorityclasses
 
 import (
-	"time"
-
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -39,7 +37,7 @@ func (s *priorityClassSyncer) SyncDown(ctx *synccontext.SyncContext, vObj client
 	err := ctx.PhysicalClient.Create(ctx.Context, newPriorityClass)
 	if err != nil {
 		ctx.Log.Infof("error syncing %s to physical cluster: %v", vObj.GetName(), err)
-		return ctrl.Result{RequeueAfter: time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controllers/resources/storageclasses/syncer.go
+++ b/pkg/controllers/resources/storageclasses/syncer.go
@@ -1,17 +1,23 @@
 package storageclasses
 
 import (
+	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	storagev1 "k8s.io/api/storage/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	DefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+)
+
 func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 	return &storageClassSyncer{
-		Translator: translator.NewMirrorPhysicalTranslator("storageclass", &storagev1.StorageClass{}),
+		Translator: translator.NewClusterTranslator(ctx, "storageclass", &storagev1.StorageClass{}, NewStorageClassTranslator(ctx.Options.TargetNamespace), DefaultStorageClassAnnotation),
 	}, nil
 }
 
@@ -19,28 +25,49 @@ type storageClassSyncer struct {
 	translator.Translator
 }
 
-var _ syncer.UpSyncer = &storageClassSyncer{}
+var _ syncer.IndicesRegisterer = &storageClassSyncer{}
 
-func (s *storageClassSyncer) SyncUp(ctx *synccontext.SyncContext, pObj client.Object) (ctrl.Result, error) {
-	vObj := s.translateBackwards(pObj.(*storagev1.StorageClass))
-	ctx.Log.Infof("create storage class %s, because it does not exist in virtual cluster", vObj.Name)
-	return ctrl.Result{}, ctx.VirtualClient.Create(ctx.Context, vObj)
+func (s *storageClassSyncer) RegisterIndices(ctx *synccontext.RegisterContext) error {
+	return ctx.VirtualManager.GetFieldIndexer().IndexField(ctx.Context, &storagev1.StorageClass{}, constants.IndexByPhysicalName, func(rawObj client.Object) []string {
+		return []string{translateStorageClassName(ctx.Options.TargetNamespace, rawObj.GetName())}
+	})
 }
 
 var _ syncer.Syncer = &storageClassSyncer{}
 
 func (s *storageClassSyncer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj client.Object) (ctrl.Result, error) {
-	// check if there is a change
-	updated := s.translateUpdateBackwards(pObj.(*storagev1.StorageClass), vObj.(*storagev1.StorageClass))
+	// did the storage class change?
+	updated := s.translateUpdate(pObj.(*storagev1.StorageClass), vObj.(*storagev1.StorageClass))
 	if updated != nil {
-		ctx.Log.Infof("update storage class %s", vObj.GetName())
-		return ctrl.Result{}, ctx.VirtualClient.Update(ctx.Context, updated)
+		ctx.Log.Infof("updating physical storage class %s, because virtual storage class has changed", updated.Name)
+		err := ctx.PhysicalClient.Update(ctx.Context, updated)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil
 }
 
 func (s *storageClassSyncer) SyncDown(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {
-	ctx.Log.Infof("delete virtual storage class %s, because physical object is missing", vObj.GetName())
-	return ctrl.Result{}, ctx.VirtualClient.Delete(ctx.Context, vObj)
+	newStorageClass := s.translate(vObj.(*storagev1.StorageClass))
+	ctx.Log.Infof("create physical storage class %s", newStorageClass.Name)
+	err := ctx.PhysicalClient.Create(ctx.Context, newStorageClass)
+	if err != nil {
+		ctx.Log.Infof("error syncing %s to physical cluster: %v", vObj.GetName(), err)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func NewStorageClassTranslator(physicalNamespace string) translator.PhysicalNameTranslator {
+	return func(vName string, vObj client.Object) string {
+		return translateStorageClassName(physicalNamespace, vName)
+	}
+}
+
+func translateStorageClassName(physicalNamespace, name string) string {
+	// we have to prefix with vcluster as system is reserved
+	return translate.PhysicalNameClusterScoped(name, physicalNamespace)
 }

--- a/pkg/controllers/resources/storageclasses/translate.go
+++ b/pkg/controllers/resources/storageclasses/translate.go
@@ -5,61 +5,61 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
-func (s *storageClassSyncer) translateBackwards(pStorageClass *storagev1.StorageClass) *storagev1.StorageClass {
-	return s.TranslateMetadata(pStorageClass).(*storagev1.StorageClass)
+func (s *storageClassSyncer) translate(vStorageClass *storagev1.StorageClass) *storagev1.StorageClass {
+	return s.TranslateMetadata(vStorageClass).(*storagev1.StorageClass)
 }
 
-func (s *storageClassSyncer) translateUpdateBackwards(pObj, vObj *storagev1.StorageClass) *storagev1.StorageClass {
+func (s *storageClassSyncer) translateUpdate(pObj, vObj *storagev1.StorageClass) *storagev1.StorageClass {
 	var updated *storagev1.StorageClass
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, vObj)
+		updated = newIfNil(updated, pObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Provisioner, pObj.Provisioner) {
-		updated = newIfNil(updated, vObj)
-		updated.Provisioner = pObj.Provisioner
+		updated = newIfNil(updated, pObj)
+		updated.Provisioner = vObj.Provisioner
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Parameters, pObj.Parameters) {
-		updated = newIfNil(updated, vObj)
-		updated.Parameters = pObj.Parameters
+		updated = newIfNil(updated, pObj)
+		updated.Parameters = vObj.Parameters
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.ReclaimPolicy, pObj.ReclaimPolicy) {
-		updated = newIfNil(updated, vObj)
-		updated.ReclaimPolicy = pObj.ReclaimPolicy
+		updated = newIfNil(updated, pObj)
+		updated.ReclaimPolicy = vObj.ReclaimPolicy
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.MountOptions, pObj.MountOptions) {
-		updated = newIfNil(updated, vObj)
-		updated.MountOptions = pObj.MountOptions
+		updated = newIfNil(updated, pObj)
+		updated.MountOptions = vObj.MountOptions
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.AllowVolumeExpansion, pObj.AllowVolumeExpansion) {
-		updated = newIfNil(updated, vObj)
-		updated.AllowVolumeExpansion = pObj.AllowVolumeExpansion
+		updated = newIfNil(updated, pObj)
+		updated.AllowVolumeExpansion = vObj.AllowVolumeExpansion
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.VolumeBindingMode, pObj.VolumeBindingMode) {
-		updated = newIfNil(updated, vObj)
-		updated.VolumeBindingMode = pObj.VolumeBindingMode
+		updated = newIfNil(updated, pObj)
+		updated.VolumeBindingMode = vObj.VolumeBindingMode
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.AllowedTopologies, pObj.AllowedTopologies) {
-		updated = newIfNil(updated, vObj)
-		updated.AllowedTopologies = pObj.AllowedTopologies
+		updated = newIfNil(updated, pObj)
+		updated.AllowedTopologies = vObj.AllowedTopologies
 	}
 
 	return updated
 }
 
-func newIfNil(updated *storagev1.StorageClass, vObj *storagev1.StorageClass) *storagev1.StorageClass {
+func newIfNil(updated *storagev1.StorageClass, obj *storagev1.StorageClass) *storagev1.StorageClass {
 	if updated == nil {
-		return vObj.DeepCopy()
+		return obj.DeepCopy()
 	}
 	return updated
 }

--- a/pkg/controllers/syncer/testing/context.go
+++ b/pkg/controllers/syncer/testing/context.go
@@ -38,6 +38,10 @@ func FakeStartSyncer(t *testing.T, ctx *synccontext.RegisterContext, create func
 }
 
 func NewFakeRegisterContext(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *synccontext.RegisterContext {
+	enabledControllers := map[string]bool{}
+	for k, v := range controllercontext.ExistingControllers {
+		enabledControllers[k] = v
+	}
 	return &synccontext.RegisterContext{
 		Context: context.TODO(),
 		Options: &controllercontext.VirtualClusterOptions{
@@ -45,7 +49,7 @@ func NewFakeRegisterContext(pClient *testingutil.FakeIndexClient, vClient *testi
 			ServiceName:     DefaultTestVclusterServiceName,
 			TargetNamespace: DefaultTestTargetNamespace,
 		},
-		Controllers:            controllercontext.ExistingControllers,
+		Controllers:            enabledControllers,
 		TargetNamespace:        DefaultTestTargetNamespace,
 		CurrentNamespace:       DefaultTestCurrentNamespace,
 		CurrentNamespaceClient: pClient,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now sync storage classes from the virtual cluster to the host cluster if sync of storage classes is enabled. This will replace the current behaviour where storage classes where only synced from host to virtual cluster. 

We decided to replace the existing behaviour, because creating storage classes is a valid use case as long as the CSI driver is installed within the host cluster, but certain parameters for the CSI driver should get changed through a storage class. It also makes sense to not sync created storage classes from the host cluster anymore as this is not required to schedule persistent volume claims and currently just has informational purposes.

This is somewhat a breaking change as vclusters that currently have sync of storage classes enabled would now behave differently moving forward as changes to the host cluster storage classes are not propagated anymore. However migration should work as expected, as created storage classes within vcluster that mirrored host cluster storage classes before would just get created in the host cluster under a different name.

