### PR TITLE
fix: add sync.* values and RBAC changes to EKS chart

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -57,3 +57,54 @@ Get
 {{- define "vcluster.admin.accessKey" -}}
 {{- now | unixEpoch | toString | trunc 8 | sha256sum -}}
 {{- end -}}
+
+{{/*
+Syncer flags for enabling/disabling controllers
+Prints only the flags that modify the defaults:
+- when default controller has enabled: false => `- "--sync=-controller`
+- when non-default controller has enabled: true => `- "--sync=controller`
+*/}}
+{{- define "vcluster.syncer.syncArgs" -}}
+{{- $defaultEnabled := list "services" "configmaps" "secrets" "endpoints" "pods" "events" "persistentvolumeclaims" "ingresses" "fake-nodes" "fake-persistentvolumes" -}}
+{{- range $key, $val := .Values.sync }}
+{{- if and (has $key $defaultEnabled) (not $val.enabled) }}
+- --sync=-{{ $key }}
+{{- else if and (not (has $key $defaultEnabled)) ($val.enabled)}}
+- --sync={{ $key }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Cluster role rules defined by plugins
+*/}}
+{{- define "vcluster.plugin.clusterRoleExtraRules" -}}
+{{- range $key, $container := .Values.plugin }}
+{{- if $container.rbac }}
+{{- if $container.rbac.clusterRole }}
+{{- if $container.rbac.clusterRole.extraRules }}
+{{- range $ruleIndex, $rule := $container.rbac.clusterRole.extraRules }}
+- {{ toJson $rule }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Role rules defined by plugins
+*/}}
+{{- define "vcluster.plugin.roleExtraRules" -}}
+{{- range $key, $container := .Values.plugin }}
+{{- if $container.rbac }}
+{{- if $container.rbac.role }}
+{{- if $container.rbac.role.extraRules }}
+{{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
+- {{ toJson $rule }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.clusterRole.create }}
+{{- if or (not (empty (include "vcluster.plugin.clusterRoleExtraRules" . ))) .Values.rbac.clusterRole.create .Values.sync.nodes.enabled .Values.sync.persistentvolumes.enabled .Values.sync.storageclasses.enabled .Values.sync.priorityclasses.enabled .Values.sync.volumesnapshots.enabled -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,36 +9,41 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
+  {{- if or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: [""]
     resources: ["nodes", "nodes/status"]
-    verbs: ["get", "watch", "list", "update", "patch"]
+    verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["pods", "nodes/proxy", "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
+  {{- end }}
+  {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/status"]
+    verbs: ["update", "patch"]
+  {{- end }}
+  {{- if or .Values.sync.persistentvolumes.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
+  {{- end }}
+  {{- if or .Values.sync.storageclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
-    verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
+  {{- if or .Values.sync.priorityclasses.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["scheduling.k8s.io"]
     resources: ["priorityclasses"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.volumesnapshots.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
-  {{- range $key, $container := .Values.plugin }}
-  {{- if $container.rbac }}
-  {{- if $container.rbac.clusterRole }}
-  {{- if $container.rbac.clusterRole.extraRules }}
-  {{- range $ruleIndex, $rule := $container.rbac.clusterRole.extraRules }}
-  - {{ toJson $rule }}
   {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- include "vcluster.plugin.clusterRoleExtraRules" . | indent 2 }}
 {{- end }}

--- a/charts/eks/templates/rbac/clusterrolebinding.yaml
+++ b/charts/eks/templates/rbac/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.clusterRole.create }}
+{{- if or (not (empty (include "vcluster.plugin.clusterRoleExtraRules" . ))) .Values.rbac.clusterRole.create .Values.sync.nodes.enabled .Values.sync.persistentvolumes.enabled .Values.sync.storageclasses.enabled .Values.sync.priorityclasses.enabled .Values.sync.volumesnapshots.enabled -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/eks/templates/rbac/role.yaml
+++ b/charts/eks/templates/rbac/role.yaml
@@ -22,12 +22,24 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments"]
     verbs: ["get", "list", "watch"]
-  {{- if .Values.rbac.role.extended }}
+  {{- if or .Values.sync.networkpolicies.enabled .Values.rbac.role.extended }}
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.volumesnapshots.enabled .Values.rbac.role.extended }}
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
   {{- if .Values.openshift.enable }}
@@ -35,15 +47,5 @@ rules:
     resources: ["endpoints/restricted"]
     verbs: ["create"]
   {{- end }}
-  {{- range $key, $container := .Values.plugin }}
-  {{- if $container.rbac }}
-  {{- if $container.rbac.role }}
-  {{- if $container.rbac.role.extraRules }}
-  {{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
-  - {{ toJson $rule }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
 {{- end }}

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -101,6 +101,13 @@ spec:
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}
           {{- end }}
+          {{- include "vcluster.syncer.syncArgs" . | indent 10 -}}
+          {{- if .Values.sync.nodes.syncAllNodes }}
+          - --sync-all-nodes
+          {{- end }}
+          {{- if .Values.sync.nodes.nodeSelector }}
+          - --node-selector={{ .Values.sync.nodes.nodeSelector }}
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -25,6 +25,58 @@ plugin: {}
 #     role:
 #       extraRules: ...
 
+# Resource syncers that should be enabled/disabled.
+# Enabling syncers will impact RBAC Role and ClusterRole permissions.
+# To disable a syncer set "enabled: false".
+# See docs for details - https://www.vcluster.com/docs/architecture/synced-resources
+sync:
+  services:
+    enabled: true
+  configmaps:
+    enabled: true
+  secrets:
+    enabled: true
+  endpoints:
+    enabled: true
+  pods:
+    enabled: true
+  events:
+    enabled: true
+  persistentvolumeclaims:
+    enabled: true
+  ingresses:
+    enabled: true
+  fake-nodes:
+    enabled: true # will be ignored if nodes.enabled = true
+  fake-persistentvolumes:
+    enabled: true # will be ignored if persistentvolumes.enabled = true
+  nodes:
+    enabled: false
+    # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster 
+    # will sync all nodes instead of only the ones where some pods are running. 
+    syncAllNodes: false
+    # nodeSelector is used to limit which nodes get synced to the vcluster,
+    # and which nodes are used to run vcluster pods. 
+    # A valid string representation of a label selector must be used. 
+    nodeSelector: ""
+    # syncNodeChanges allows vcluster user edits of the nodes to be synced down to the host nodes.
+    # Write permissions on node resource will be given to the vcluster.
+    syncNodeChanges: false
+  persistentvolumes:
+    enabled: false
+  storageclasses:
+    enabled: false
+  priorityclasses:
+    enabled: false
+  networkpolicies:
+    enabled: false
+  volumesnapshots:
+    enabled: false
+  poddisruptionbudgets:
+    enabled: false
+  serviceaccounts:
+    enabled: false
+
 # Syncer configuration
 syncer:
   # Image to use for the syncer
@@ -145,13 +197,18 @@ serviceAccount:
 # Roles & ClusterRoles for the vcluster
 rbac:
   clusterRole:
-    # Enable this to let the vcluster sync
-    # real nodes, storage classes and priority classes
+    # Deprecated ! 
+    # Necessary cluster roles are created based on the enabled syncers (.sync.*.enabled)
+    # Support for this value will be removed in a future version of the vcluster
     create: false
   role:
-    # This is required for basic functionality of vcluster
+    # Deprecated !
+    # Support for this value will be removed in a future version of the vcluster
+    # and basic role will always be created
     create: true
-    # Extended role permissions are required for some optional features, e.g. Networkpolicy sync
+    # Deprecated ! 
+    # Necessary extended roles are created based on the enabled syncers (.sync.*.enabled)
+    # Support for this value will be removed in a future version of the vcluster
     extended: false
 
 # Service configurations

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -91,3 +91,20 @@ Cluster role rules defined by plugins
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Role rules defined by plugins
+*/}}
+{{- define "vcluster.plugin.roleExtraRules" -}}
+{{- range $key, $container := .Values.plugin }}
+{{- if $container.rbac }}
+{{- if $container.rbac.role }}
+{{- if $container.rbac.role.extraRules }}
+{{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
+- {{ toJson $rule }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -47,15 +47,5 @@ rules:
     resources: ["endpoints/restricted"]
     verbs: ["create"]
   {{- end }}
-  {{- range $key, $container := .Values.plugin }}
-  {{- if $container.rbac }}
-  {{- if $container.rbac.role }}
-  {{- if $container.rbac.role.extraRules }}
-  {{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
-  - {{ toJson $rule }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
 {{- end }}

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -91,3 +91,20 @@ Cluster role rules defined by plugins
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Role rules defined by plugins
+*/}}
+{{- define "vcluster.plugin.roleExtraRules" -}}
+{{- range $key, $container := .Values.plugin }}
+{{- if $container.rbac }}
+{{- if $container.rbac.role }}
+{{- if $container.rbac.role.extraRules }}
+{{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
+- {{ toJson $rule }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -47,15 +47,5 @@ rules:
     resources: ["endpoints/restricted"]
     verbs: ["create"]
   {{- end }}
-  {{- range $key, $container := .Values.plugin }}
-  {{- if $container.rbac }}
-  {{- if $container.rbac.role }}
-  {{- if $container.rbac.role.extraRules }}
-  {{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
-  - {{ toJson $rule }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
 {{- end }}

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -91,3 +91,20 @@ Cluster role rules defined by plugins
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Role rules defined by plugins
+*/}}
+{{- define "vcluster.plugin.roleExtraRules" -}}
+{{- range $key, $container := .Values.plugin }}
+{{- if $container.rbac }}
+{{- if $container.rbac.role }}
+{{- if $container.rbac.role.extraRules }}
+{{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
+- {{ toJson $rule }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -47,15 +47,5 @@ rules:
     resources: ["endpoints/restricted"]
     verbs: ["create"]
   {{- end }}
-  {{- range $key, $container := .Values.plugin }}
-  {{- if $container.rbac }}
-  {{- if $container.rbac.role }}
-  {{- if $container.rbac.role.extraRules }}
-  {{- range $ruleIndex, $rule := $container.rbac.role.extraRules }}
-  - {{ toJson $rule }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
 {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This change brings EKS chart into sync with all other charts by adding changes done in #346 


**Please provide a short message that should be published in the vcluster release notes**
- fix: EKS chart now accepts `.sync.*` values as documented


**What else do we need to know?** 
I also moved plugin extra rules to a template helper. This has no impact on the functionality of the charts, it just makes the chart definitions more consistent.
I will also send a PR for v0.6 branch once this one is approved.