### PR TITLE
Split daemonset filters into two

### DIFF
--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -243,7 +243,7 @@ func filterOutVirtualDaemonSets(pl *corev1.PodList) []corev1.Pod {
 
 // Filter away physical DaemonSet Pods using annotations to enable scale down
 func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
-	var podsNoDaemoSets []corev1.Pod
+	var podsNoDaemonSets []corev1.Pod
 
 	for _, item := range pl.Items {
 

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -250,11 +250,8 @@ func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
 	for _, item := range pl.Items {
 
 		annotations := item.GetAnnotations()
-		ownerSetKind, exists := annotations[translate.OwnerSetKind]
-		if exists {
-			if ownerSetKind != "DaemonSet" {
-				podsNoDaemonSets = append(podsNoDaemonSets, item)
-			}
+		if kind, ok := annotations[translate.OwnerSetKind]; ok && kind != "DaemonSet" {
+			podsNoDaemonSets = append(podsNoDaemonSets, item)
 		}
 	}
 	return podsNoDaemonSets

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -217,8 +217,8 @@ func CreateFakeNode(ctx context.Context, nodeServiceProvider nodeservice.NodeSer
 	return nil
 }
 
-// Filter away DaemonSet Pods using OwnerReferences
-func filterOutDaemonSets(pl *corev1.PodList) []corev1.Pod {
+// Filter away  virtual DaemonSet Pods using OwnerReferences to enable scale down
+func filterOutVirtualDaemonSets(pl *corev1.PodList) []corev1.Pod {
 	var podsNoDaemonSets []corev1.Pod
 
 	for _, item := range pl.Items {
@@ -239,4 +239,19 @@ func filterOutDaemonSets(pl *corev1.PodList) []corev1.Pod {
 	}
 
 	return podsNoDaemonSets
+}
+
+// Filter away physical DaemonSet Pods using annotations to enable scale down
+func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
+	var podsNoDaemoSets []corev1.Pod
+
+	for _, item := range pl.Items {
+
+		annotations := item.GetAnnotations()
+
+		if annotations["vcluster.loft.sh/owner-set-kind"] != "DaemonSet" {
+			podsNoDaemoSets = append(podsNoDaemoSets, item)
+		}
+	}
+	return podsNoDaemoSets
 }

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -3,7 +3,9 @@ package nodes
 import (
 	"context"
 	"fmt"
+
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/util/random"
@@ -248,9 +250,11 @@ func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
 	for _, item := range pl.Items {
 
 		annotations := item.GetAnnotations()
-
-		if annotations["vcluster.loft.sh/owner-set-kind"] != "DaemonSet" {
-			podsNoDaemonSets = append(podsNoDaemonSets, item)
+		ownerSetKind, exists := annotations[translate.OwnerSetKind]
+		if exists {
+			if ownerSetKind != "DaemonSet" {
+				podsNoDaemonSets = append(podsNoDaemonSets, item)
+			}
 		}
 	}
 	return podsNoDaemonSets

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -250,8 +250,8 @@ func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
 		annotations := item.GetAnnotations()
 
 		if annotations["vcluster.loft.sh/owner-set-kind"] != "DaemonSet" {
-			podsNoDaemoSets = append(podsNoDaemoSets, item)
+			podsNoDaemonSets = append(podsNoDaemonSets, item)
 		}
 	}
-	return podsNoDaemoSets
+	return podsNoDaemonSets
 }

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -248,9 +248,7 @@ func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
 	var podsNoDaemonSets []corev1.Pod
 
 	for _, item := range pl.Items {
-
-		annotations := item.GetAnnotations()
-		if kind, ok := annotations[translate.OwnerSetKind]; ok && kind != "DaemonSet" {
+		if item.Annotations == nil || item.Annotations[translate.OwnerSetKind] != "DaemonSet" {
 			podsNoDaemonSets = append(podsNoDaemonSets, item)
 		}
 	}

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -249,12 +249,13 @@ func (s *nodeSyncer) shouldSync(ctx context.Context, pObj *corev1.Node) (bool, e
 }
 
 func isNodeNeededByPod(ctx context.Context, virtualClient client.Client, physicalClient client.Client, nodeName string) (bool, error) {
+
 	// search virtual cache
 	podList := &corev1.PodList{}
 	err := virtualClient.List(ctx, podList, client.MatchingFields{constants.IndexByAssigned: nodeName})
 	if err != nil {
 		return false, err
-	} else if len(filterOutDaemonSets(podList)) > 0 {
+	} else if len(filterOutVirtualDaemonSets(podList)) > 0 {
 		return true, nil
 	}
 
@@ -263,7 +264,7 @@ func isNodeNeededByPod(ctx context.Context, virtualClient client.Client, physica
 	err = physicalClient.List(ctx, podList, client.MatchingFields{constants.IndexByAssigned: nodeName})
 	if err != nil {
 		return false, err
-	} else if len(filterOutDaemonSets(podList)) > 0 {
+	} else if len(filterOutPhysicalDaemonSets(podList)) > 0 {
 		return true, nil
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #252


**Please provide a short message that should be published in the vcluster release notes**
Split daemonset filters into two, because virtual and physical pods do not share exactly the same characteristics when it comes to daemonsets, hence filtering methods needs to be different. This enables the virtual cluster to get rid of lonely daemonsets staying on nodes, where previously valid workload had run. So now a cluster can actually scale down.


**What else do we need to know?** 