### PR TITLE
Add `--sync-labels` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /test
 .DS_Store
 profile.out
+*.swp

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -130,6 +130,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.DefaultImageRegistry, "default-image-registry", "", "This address will be prepended to all deployed system images by vcluster")
 
 	cmd.Flags().StringVar(&options.EnforcePodSecurityStandard, "enforce-pod-security-standard", "", "This can be set to privileged, baseline, restricted and vcluster would make sure during translation that these policies are enforced.")
+	cmd.Flags().StringSliceVar(&options.SyncLabels, "sync-labels", []string{}, "The specified labels will be synced to physical resources, in addition to their vcluster translated versions.")
 
 	// Deprecated Flags
 	cmd.Flags().BoolVar(&options.DeprecatedUseFakeKubelets, "fake-kubelets", true, "DEPRECATED: use --disable-fake-kubelets instead")

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -64,7 +64,7 @@ type VirtualClusterOptions struct {
 
 	EnforcePodSecurityStandard string `json:"enforcePodSecurityStandard"`
 
-	SyncLabels []string `json:syncLabels`
+	SyncLabels []string `json:"syncLabels"`
 
 	// DEPRECATED FLAGS
 	DeprecatedDisableSyncResources     string

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -63,6 +63,9 @@ type VirtualClusterOptions struct {
 	DefaultImageRegistry string `json:"defaultImageRegistry"`
 
 	EnforcePodSecurityStandard string `json:"enforcePodSecurityStandard"`
+
+	SyncLabels []string `json:syncLabels`
+
 	// DEPRECATED FLAGS
 	DeprecatedDisableSyncResources     string
 	DeprecatedOwningStatefulSet        string

--- a/pkg/controllers/resources/secrets/syncer_test.go
+++ b/pkg/controllers/resources/secrets/syncer_test.go
@@ -23,10 +23,15 @@ func newFakeSyncer(t *testing.T, ctx *synccontext.RegisterContext) (*synccontext
 }
 
 func TestSync(t *testing.T) {
+	testLabel := "test-label"
+	testLabelValue := "label-value"
 	baseSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test",
+			Labels: map[string]string{
+				testLabel: testLabelValue,
+			},
 		},
 	}
 	updatedSecret := &corev1.Secret{
@@ -44,7 +49,9 @@ func TestSync(t *testing.T) {
 				translator.NamespaceAnnotation: baseSecret.Namespace,
 			},
 			Labels: map[string]string{
-				translate.NamespaceLabel: baseSecret.Namespace,
+				translate.NamespaceLabel:              baseSecret.Namespace,
+				testLabel:                             testLabelValue,
+				translator.ConvertLabelKey(testLabel): testLabelValue,
 			},
 		},
 	}
@@ -98,6 +105,7 @@ func TestSync(t *testing.T) {
 				},
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
+				ctx.Options.SyncLabels = []string{testLabel}
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				_, err := syncer.(*secretSyncer).SyncDown(syncContext, baseSecret)
 				assert.NilError(t, err)
@@ -118,6 +126,7 @@ func TestSync(t *testing.T) {
 				},
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
+				ctx.Options.SyncLabels = []string{testLabel}
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				_, err := syncer.(*secretSyncer).Sync(syncContext, syncedSecret, updatedSecret)
 				assert.NilError(t, err)

--- a/pkg/controllers/syncer/translator/cluster_translator.go
+++ b/pkg/controllers/syncer/translator/cluster_translator.go
@@ -96,12 +96,14 @@ func (n *clusterTranslator) TranslateLabels(vObj client.Object) map[string]strin
 	newLabels := map[string]string{}
 	if vObj != nil {
 		vObjLabels := vObj.GetLabels()
-		for k, v := range vObj.GetLabels() {
+		for k, v := range vObjLabels {
 			newLabels[convertNamespacedLabelKey(n.physicalNamespace, k)] = v
 		}
-		for _, k := range n.syncedLabels {
-			if value, ok := vObjLabels[k]; ok {
-				newLabels[k] = value
+		if vObjLabels != nil {
+			for _, k := range n.syncedLabels {
+				if value, ok := vObjLabels[k]; ok {
+					newLabels[k] = value
+				}
 			}
 		}
 	}

--- a/pkg/controllers/syncer/translator/namespaced_translator.go
+++ b/pkg/controllers/syncer/translator/namespaced_translator.go
@@ -227,9 +227,11 @@ func translateLabels(vObj client.Object, syncedLabels []string) map[string]strin
 
 		newLabels[ConvertLabelKey(k)] = v
 	}
-	for _, k := range syncedLabels {
-		if value, ok := vObjLabels[k]; ok {
-			newLabels[k] = value
+	if vObjLabels != nil {
+		for _, k := range syncedLabels {
+			if value, ok := vObjLabels[k]; ok {
+				newLabels[k] = value
+			}
 		}
 	}
 

--- a/pkg/controllers/syncer/translator/namespaced_translator.go
+++ b/pkg/controllers/syncer/translator/namespaced_translator.go
@@ -38,6 +38,7 @@ func NewNamespacedTranslator(ctx *context.RegisterContext, name string, obj clie
 		name: name,
 
 		physicalNamespace:   ctx.TargetNamespace,
+		syncedLabels:        ctx.Options.SyncLabels,
 		excludedAnnotations: excludedAnnotations,
 
 		virtualClient: ctx.VirtualManager.GetClient(),
@@ -52,6 +53,7 @@ type namespacedTranslator struct {
 
 	physicalNamespace   string
 	excludedAnnotations []string
+	syncedLabels        []string
 
 	virtualClient client.Client
 	obj           client.Object
@@ -136,27 +138,27 @@ func (n *namespacedTranslator) PhysicalToVirtual(pObj client.Object) types.Names
 }
 
 func (n *namespacedTranslator) TranslateMetadata(vObj client.Object) client.Object {
-	return TranslateMetadata(n.physicalNamespace, vObj, n.excludedAnnotations...)
+	return TranslateMetadata(n.physicalNamespace, vObj, n.syncedLabels, n.excludedAnnotations...)
 }
 
-func TranslateMetadata(physicalNamespace string, vObj client.Object, excludedAnnotations ...string) client.Object {
+func TranslateMetadata(physicalNamespace string, vObj client.Object, syncedLabels []string, excludedAnnotations ...string) client.Object {
 	pObj, err := setupMetadataWithName(physicalNamespace, vObj, DefaultPhysicalName)
 	if err != nil {
 		return nil
 	}
 
-	pObj.SetLabels(translateLabels(vObj))
+	pObj.SetLabels(translateLabels(vObj, syncedLabels))
 	pObj.SetAnnotations(translateAnnotations(vObj, nil, excludedAnnotations))
 	return pObj
 }
 
 func (n *namespacedTranslator) TranslateMetadataUpdate(vObj client.Object, pObj client.Object) (bool, map[string]string, map[string]string) {
-	return TranslateMetadataUpdate(vObj, pObj, n.excludedAnnotations...)
+	return TranslateMetadataUpdate(vObj, pObj, n.syncedLabels, n.excludedAnnotations...)
 }
 
-func TranslateMetadataUpdate(vObj client.Object, pObj client.Object, excludedAnnotations ...string) (bool, map[string]string, map[string]string) {
+func TranslateMetadataUpdate(vObj client.Object, pObj client.Object, syncedLabels []string, excludedAnnotations ...string) (bool, map[string]string, map[string]string) {
 	updatedAnnotations := translateAnnotations(vObj, pObj, excludedAnnotations)
-	updatedLabels := translateLabels(vObj)
+	updatedLabels := translateLabels(vObj, syncedLabels)
 	return !equality.Semantic.DeepEqual(updatedAnnotations, pObj.GetAnnotations()) || !equality.Semantic.DeepEqual(updatedLabels, pObj.GetLabels()), updatedAnnotations, updatedLabels
 }
 
@@ -214,15 +216,21 @@ func translateAnnotations(vObj client.Object, pObj client.Object, excluded []str
 	return retMap
 }
 
-func translateLabels(vObj client.Object) map[string]string {
+func translateLabels(vObj client.Object, syncedLabels []string) map[string]string {
 	newLabels := map[string]string{}
-	for k, v := range vObj.GetLabels() {
+	vObjLabels := vObj.GetLabels()
+	for k, v := range vObjLabels {
 		if k == translate.NamespaceLabel {
 			newLabels[k] = v
 			continue
 		}
 
 		newLabels[ConvertLabelKey(k)] = v
+	}
+	for _, k := range syncedLabels {
+		if value, ok := vObjLabels[k]; ok {
+			newLabels[k] = value
+		}
 	}
 
 	newLabels[translate.MarkerLabel] = translate.Suffix

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -158,7 +158,7 @@ func NewServer(ctx *context2.ControllerContext, requestHeaderCaFile, clientCaFil
 	}
 
 	h := handler.ImpersonatingHandler("", virtualConfig)
-	h = filters.WithServiceCreateRedirect(h, uncachedLocalClient, uncachedVirtualClient, virtualConfig, ctx.Options.TargetNamespace)
+	h = filters.WithServiceCreateRedirect(h, uncachedLocalClient, uncachedVirtualClient, virtualConfig, ctx.Options.TargetNamespace, ctx.Options.SyncLabels)
 	h = filters.WithRedirect(h, localConfig, uncachedLocalClient.Scheme(), uncachedVirtualClient, admissionHandler, ctx.Options.TargetNamespace, s.redirectResources)
 	h = filters.WithMetricsProxy(h, localConfig, cachedVirtualClient, ctx.Options.TargetNamespace)
 	if ctx.Options.SyncNodeChanges {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #
This resolves issue https://github.com/loft-sh/vcluster/issues/386 by adding a `--sync-labels` flag to the syncer. This flag will result in the specified labels being copied directly from virtual resources onto physical resources, in addition to the labels with the vclusted-translated key `vcluster.loft.sh/label-...`. 

**Please provide a short message that should be published in the vcluster release notes**
Adds `--sync-label` flag to sync untranslated labels onto physical resources


**What else do we need to know?** 
- I also added a line to ignore vim swp files to `.gitignore`. 
- Tested via devspace deployment as well as a little spec addition 