### PR TITLE
fix: vcluster kubelet PVC ref in /stats/summary

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -99,6 +99,13 @@ func NewServer(ctx *context2.ControllerContext, requestHeaderCaFile, clientCaFil
 		return nil, err
 	}
 	cachedVirtualClient, err := createCachedClient(ctx.Context, virtualConfig, corev1.NamespaceAll, uncachedVirtualClient.RESTMapper(), uncachedVirtualClient.Scheme(), func(cache cache.Cache) error {
+		err := cache.IndexField(ctx.Context, &corev1.PersistentVolumeClaim{}, constants.IndexByPhysicalName, func(rawObj client.Object) []string {
+			return []string{translator.ObjectPhysicalName(rawObj)}
+		})
+		if err != nil {
+			return err
+		}
+
 		return cache.IndexField(ctx.Context, &corev1.Pod{}, constants.IndexByPhysicalName, func(rawObj client.Object) []string {
 			return []string{translator.ObjectPhysicalName(rawObj)}
 		})


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Data returned by the vcluster kubelet /stats/summary endpoint contain correct PVC reference now.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where kubelet metrics proxied by vcluster contained PVC reference name and namespace from the host, instead of values used in the virtual cluster. 


**What else do we need to know?** 
Before:
```
$ curl -k --header "Authorization: Bearer $TOKEN" https://10.64.2.140:10250/stats/summary
...
  podRef": {
    "name": "prometheus-0",
    "namespace": "lens-metrics",
   ...
  "volume": [
   ...
      "name": "data",
      "pvcRef": {
        "name": "myclaim-x-lens-metrics-x-vcluster",
        "namespace": "vcluster"
      }}],
```


After:

```
$ curl -k --header "Authorization: Bearer $TOKEN" https://10.64.2.140:10250/stats/summary
...
  "podRef": {
    "name": "prometheus-0",
    "namespace": "lens-metrics",
   ...
  "volume": [
    ...
        "name": "data",
        "pvcRef": {
          "name": "myclaim",
          "namespace": "lens-metrics"
        }}],
```
Metrics in Prometheus:
![image](https://user-images.githubusercontent.com/1605799/157657676-b3069c98-3f69-4c23-b3fd-2aeb79d7688e.png)
![image](https://user-images.githubusercontent.com/1605799/157658864-54a51806-0c48-4907-bbe3-9e5b93ee0158.png)
