### PR TITLE
refactor: add isolated network policies

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -155,8 +155,8 @@ data:
               name: metrics
               protocol: TCP
             securityContext:
-              runAsUser: {{.RUN_AS_USER}}
-              runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+              runAsUser: {{ .RUN_AS_USER }}
+              runAsNonRoot: {{ .RUN_AS_NON_ROOT }}
               allowPrivilegeEscalation: false
               capabilities:
                 drop:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -1,0 +1,237 @@
+{{- if .Values.coredns.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-coredns
+data:
+  coredns.yaml: |-
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: coredns
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+      name: system:coredns
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+          - services
+          - pods
+          - namespaces
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - list
+          - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+      labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+      name: system:coredns
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:coredns
+    subjects:
+      - kind: ServiceAccount
+        name: coredns
+        namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: coredns
+      namespace: kube-system
+    data:
+      Corefile: |
+        {{- if .Values.coredns.config }}
+{{ .Values.coredns.config | indent 8 }}
+        {{- else }}
+        .:1053 {
+            {{`{{.LOG_IN_DEBUG}}`}}
+            errors
+            health
+            ready
+            kubernetes cluster.local in-addr.arpa ip6.arpa {
+              pods insecure
+              fallthrough in-addr.arpa ip6.arpa
+            }
+            hosts /etc/coredns/NodeHosts {
+              ttl 60
+              reload 15s
+              fallthrough
+            }
+            prometheus :9153
+            {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            forward . /etc/resolv.conf 8.8.8.8 {
+              policy sequential
+            }
+            {{- else }}
+            forward . /etc/resolv.conf
+            {{- end }}
+            cache 30
+            loop
+            reload
+            loadbalance
+        }
+
+        import /etc/coredns/custom/*.server
+        {{- end }}
+      NodeHosts: ""
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: coredns
+      namespace: kube-system
+      labels:
+        k8s-app: kube-dns
+        kubernetes.io/name: "CoreDNS"
+    spec:
+      replicas: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: kube-dns
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-dns
+        spec:
+          priorityClassName: "system-cluster-critical"
+          serviceAccountName: coredns
+          nodeSelector:
+            kubernetes.io/os: linux
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: coredns
+              {{- if .Values.coredns.image }}
+              image: {{ .Values.coredns.image }}
+              {{- else }}
+              image: {{`{{.IMAGE}}`}}
+              {{- end }}
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 1000m
+                  memory: 170Mi
+                requests:
+                  cpu: 100m
+                  memory: 70Mi
+              args: [ "-conf", "/etc/coredns/Corefile" ]
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/coredns
+                  readOnly: true
+                - name: custom-config-volume
+                  mountPath: /etc/coredns/custom
+                  readOnly: true
+              ports:
+                - containerPort: 1053
+                  name: dns
+                  protocol: UDP
+                - containerPort: 1053
+                  name: dns-tcp
+                  protocol: TCP
+                - containerPort: 9153
+                  name: metrics
+                  protocol: TCP
+              securityContext:
+                runAsUser: {{`{{.RUN_AS_USER}}`}}
+                runAsNonRoot: {{`{{.RUN_AS_NON_ROOT}}`}}
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                periodSeconds: 10
+                timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 3
+              readinessProbe:
+                httpGet:
+                  path: /ready
+                  port: 8181
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 2
+                timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 3
+          dnsPolicy: Default
+          volumes:
+            - name: config-volume
+              configMap:
+                name: coredns
+                items:
+                  - key: Corefile
+                    path: Corefile
+                  - key: NodeHosts
+                    path: NodeHosts
+            - name: custom-config-volume
+              configMap:
+                name: coredns-custom
+                optional: true
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: kube-dns
+      namespace: kube-system
+      annotations:
+        prometheus.io/port: "9153"
+        prometheus.io/scrape: "true"
+      labels:
+        k8s-app: kube-dns
+        kubernetes.io/cluster-service: "true"
+        kubernetes.io/name: "CoreDNS"
+    spec:
+      selector:
+        k8s-app: kube-dns
+      ports:
+        - name: dns
+          port: 53
+          targetPort: 1053
+          protocol: UDP
+        - name: dns-tcp
+          port: 53
+          targetPort: 1053
+          protocol: TCP
+        - name: metrics
+          port: 9153
+          protocol: TCP
+{{- end }}

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.isolation.enabled .Values.isolation.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-workloads
+spec:
+  podSelector:
+    matchLabels:
+      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: 443
+        - port: 8443
+      to:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 127.0.0.0/8
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-control-plane
+spec:
+  podSelector:
+    matchLabels:
+      release: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: 443
+        - port: 8443
+    - to:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: 'kube-system'
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+  policyTypes:
+    - Egress
+{{- end }}

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -8,6 +8,7 @@ spec:
     matchLabels:
       vcluster.loft.sh/managed-by: {{ .Release.Name }}
   egress:
+    # Allows outgoing connections to the vcluster control plane
     - ports:
         - port: 443
         - port: 8443
@@ -15,11 +16,14 @@ spec:
         - podSelector:
             matchLabels:
               release: {{ .Release.Name }}
+    # Allows outgoing connections to DNS server
     - ports:
       - port: 53
         protocol: UDP
       - port: 53
         protocol: TCP
+    # Allows outgoing connections to the internet or
+    # other vcluster workloads
     - to:
         - podSelector:
             matchLabels:
@@ -43,9 +47,14 @@ spec:
     matchLabels:
       release: {{ .Release.Name }}
   egress:
+    # Allows outgoing connections to all pods with
+    # port 443 or 8443. This is needed for host Kubernetes
+    # access
     - ports:
         - port: 443
         - port: 8443
+    # Allows outgoing connections to all vcluster workloads
+    # or kube system dns server
     - to:
         - podSelector: {}
         - namespaceSelector:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -60,6 +60,11 @@ spec:
         - name: k0s-config
           secret:
             secretName: vc-{{ .Release.Name }}-config
+      {{- if .Values.coredns.enabled }}
+        - name: coredns
+          configMap:
+            name: {{ .Release.Name }}-coredns
+      {{- end }}
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
       {{- end }}
@@ -166,6 +171,11 @@ spec:
         env:
 {{ toYaml .Values.syncer.env | indent 10 }}
         volumeMounts:
+        {{- if .Values.coredns.enabled }}
+          - name: coredns
+            mountPath: /manifests/coredns
+            readOnly: true
+        {{- end }}
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:
 {{ toYaml .Values.syncer.resources | indent 10 }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -224,6 +224,8 @@ securityContext:
 openshift:
   enable: false
 
+# If enabled will deploy vcluster in an isolated mode with pod security
+# standards, limit ranges and resource quotas
 isolation:
   enabled: false
 
@@ -235,10 +237,11 @@ isolation:
       cpu: 10
       memory: 20Gi
       pods: 10
+      requests.storage: "100Gi"
     scopeSelector:
       matchExpressions:
     scopes:
-  
+
   limitRange:
     enabled: true
     default:
@@ -247,3 +250,6 @@ isolation:
     defaultRequest:
       memory: 128Mi
       cpu: 100m
+
+  networkPolicy:
+    enabled: true

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -224,6 +224,14 @@ securityContext:
 openshift:
   enable: false
 
+# If enabled will deploy the coredns configmap
+coredns:
+  enabled: true
+  # image: my-core-dns-image:latest
+  # config: |-
+  #   .:1053 {
+  #      ...
+
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas
 isolation:

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -1,0 +1,237 @@
+{{- if .Values.coredns.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-coredns
+data:
+  coredns.yaml: |-
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: coredns
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+      name: system:coredns
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+          - services
+          - pods
+          - namespaces
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - list
+          - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+      labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+      name: system:coredns
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:coredns
+    subjects:
+      - kind: ServiceAccount
+        name: coredns
+        namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: coredns
+      namespace: kube-system
+    data:
+      Corefile: |
+        {{- if .Values.coredns.config }}
+{{ .Values.coredns.config | indent 8 }}
+        {{- else }}
+        .:1053 {
+            {{`{{.LOG_IN_DEBUG}}`}}
+            errors
+            health
+            ready
+            kubernetes cluster.local in-addr.arpa ip6.arpa {
+              pods insecure
+              fallthrough in-addr.arpa ip6.arpa
+            }
+            hosts /etc/coredns/NodeHosts {
+              ttl 60
+              reload 15s
+              fallthrough
+            }
+            prometheus :9153
+            {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            forward . /etc/resolv.conf 8.8.8.8 {
+              policy sequential
+            }
+            {{- else }}
+            forward . /etc/resolv.conf
+            {{- end }}
+            cache 30
+            loop
+            reload
+            loadbalance
+        }
+
+        import /etc/coredns/custom/*.server
+        {{- end }}
+      NodeHosts: ""
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: coredns
+      namespace: kube-system
+      labels:
+        k8s-app: kube-dns
+        kubernetes.io/name: "CoreDNS"
+    spec:
+      replicas: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: kube-dns
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-dns
+        spec:
+          priorityClassName: "system-cluster-critical"
+          serviceAccountName: coredns
+          nodeSelector:
+            kubernetes.io/os: linux
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: coredns
+              {{- if .Values.coredns.image }}
+              image: {{ .Values.coredns.image }}
+              {{- else }}
+              image: {{`{{.IMAGE}}`}}
+              {{- end }}
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 1000m
+                  memory: 170Mi
+                requests:
+                  cpu: 100m
+                  memory: 70Mi
+              args: [ "-conf", "/etc/coredns/Corefile" ]
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/coredns
+                  readOnly: true
+                - name: custom-config-volume
+                  mountPath: /etc/coredns/custom
+                  readOnly: true
+              ports:
+                - containerPort: 1053
+                  name: dns
+                  protocol: UDP
+                - containerPort: 1053
+                  name: dns-tcp
+                  protocol: TCP
+                - containerPort: 9153
+                  name: metrics
+                  protocol: TCP
+              securityContext:
+                runAsUser: {{`{{.RUN_AS_USER}}`}}
+                runAsNonRoot: {{`{{.RUN_AS_NON_ROOT}}`}}
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                periodSeconds: 10
+                timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 3
+              readinessProbe:
+                httpGet:
+                  path: /ready
+                  port: 8181
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 2
+                timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 3
+          dnsPolicy: Default
+          volumes:
+            - name: config-volume
+              configMap:
+                name: coredns
+                items:
+                  - key: Corefile
+                    path: Corefile
+                  - key: NodeHosts
+                    path: NodeHosts
+            - name: custom-config-volume
+              configMap:
+                name: coredns-custom
+                optional: true
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: kube-dns
+      namespace: kube-system
+      annotations:
+        prometheus.io/port: "9153"
+        prometheus.io/scrape: "true"
+      labels:
+        k8s-app: kube-dns
+        kubernetes.io/cluster-service: "true"
+        kubernetes.io/name: "CoreDNS"
+    spec:
+      selector:
+        k8s-app: kube-dns
+      ports:
+        - name: dns
+          port: 53
+          targetPort: 1053
+          protocol: UDP
+        - name: dns-tcp
+          port: 53
+          targetPort: 1053
+          protocol: TCP
+        - name: metrics
+          port: 9153
+          protocol: TCP
+{{- end }}

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.isolation.enabled .Values.isolation.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-workloads
+spec:
+  podSelector:
+    matchLabels:
+      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: 443
+        - port: 8443
+      to:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 127.0.0.0/8
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-control-plane
+spec:
+  podSelector:
+    matchLabels:
+      release: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: 443
+        - port: 8443
+    - to:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: 'kube-system'
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+  policyTypes:
+    - Egress
+{{- end }}

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -8,6 +8,7 @@ spec:
     matchLabels:
       vcluster.loft.sh/managed-by: {{ .Release.Name }}
   egress:
+    # Allows outgoing connections to the vcluster control plane
     - ports:
         - port: 443
         - port: 8443
@@ -15,11 +16,14 @@ spec:
         - podSelector:
             matchLabels:
               release: {{ .Release.Name }}
+    # Allows outgoing connections to DNS server
     - ports:
       - port: 53
         protocol: UDP
       - port: 53
         protocol: TCP
+    # Allows outgoing connections to the internet or
+    # other vcluster workloads
     - to:
         - podSelector:
             matchLabels:
@@ -43,9 +47,14 @@ spec:
     matchLabels:
       release: {{ .Release.Name }}
   egress:
+    # Allows outgoing connections to all pods with
+    # port 443 or 8443. This is needed for host Kubernetes
+    # access
     - ports:
         - port: 443
         - port: 8443
+    # Allows outgoing connections to all vcluster workloads
+    # or kube system dns server
     - to:
         - podSelector: {}
         - namespaceSelector:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -60,6 +60,11 @@ spec:
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
       {{- end }}
+      {{- if .Values.coredns.enabled }}
+        - name: coredns
+          configMap:
+            name: {{ .Release.Name }}-coredns
+      {{- end }}
       {{- if not .Values.storage.persistence }}
         - name: data
           emptyDir: {}
@@ -167,6 +172,11 @@ spec:
         env:
 {{ toYaml .Values.syncer.env | indent 10 }}
         volumeMounts:
+        {{- if .Values.coredns.enabled }}
+          - name: coredns
+            mountPath: /manifests/coredns
+            readOnly: true
+        {{- end }}
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:
 {{ toYaml .Values.syncer.resources | indent 10 }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -226,7 +226,9 @@ securityContext:
 # to manage service endpoints
 openshift:
   enable: false
-  
+
+# If enabled will deploy vcluster in an isolated mode with pod security
+# standards, limit ranges and resource quotas
 isolation:
   enabled: false
 
@@ -238,6 +240,7 @@ isolation:
       cpu: 10
       memory: 20Gi
       pods: 10
+      requests.storage: "100Gi"
     scopeSelector:
       matchExpressions:
     scopes:
@@ -250,3 +253,6 @@ isolation:
     defaultRequest:
       memory: 128Mi
       cpu: 100m
+
+  networkPolicy:
+    enabled: true

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -227,6 +227,14 @@ securityContext:
 openshift:
   enable: false
 
+# If enabled will deploy the coredns configmap
+coredns:
+  enabled: true
+  # image: my-core-dns-image:latest
+  # config: |-
+  #   .:1053 {
+  #      ...
+
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas
 isolation:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -1,0 +1,237 @@
+{{- if .Values.coredns.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-coredns
+data:
+  coredns.yaml: |-
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: coredns
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+      name: system:coredns
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+          - services
+          - pods
+          - namespaces
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - discovery.k8s.io
+        resources:
+          - endpointslices
+        verbs:
+          - list
+          - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+      labels:
+        kubernetes.io/bootstrapping: rbac-defaults
+      name: system:coredns
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:coredns
+    subjects:
+      - kind: ServiceAccount
+        name: coredns
+        namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: coredns
+      namespace: kube-system
+    data:
+      Corefile: |
+        {{- if .Values.coredns.config }}
+{{ .Values.coredns.config | indent 8 }}
+        {{- else }}
+        .:1053 {
+            {{`{{.LOG_IN_DEBUG}}`}}
+            errors
+            health
+            ready
+            kubernetes cluster.local in-addr.arpa ip6.arpa {
+              pods insecure
+              fallthrough in-addr.arpa ip6.arpa
+            }
+            hosts /etc/coredns/NodeHosts {
+              ttl 60
+              reload 15s
+              fallthrough
+            }
+            prometheus :9153
+            {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            forward . /etc/resolv.conf 8.8.8.8 {
+              policy sequential
+            }
+            {{- else }}
+            forward . /etc/resolv.conf
+            {{- end }}
+            cache 30
+            loop
+            reload
+            loadbalance
+        }
+
+        import /etc/coredns/custom/*.server
+        {{- end }}
+      NodeHosts: ""
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: coredns
+      namespace: kube-system
+      labels:
+        k8s-app: kube-dns
+        kubernetes.io/name: "CoreDNS"
+    spec:
+      replicas: 1
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: kube-dns
+      template:
+        metadata:
+          labels:
+            k8s-app: kube-dns
+        spec:
+          priorityClassName: "system-cluster-critical"
+          serviceAccountName: coredns
+          nodeSelector:
+            kubernetes.io/os: linux
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: coredns
+              {{- if .Values.coredns.image }}
+              image: {{ .Values.coredns.image }}
+              {{- else }}
+              image: {{`{{.IMAGE}}`}}
+              {{- end }}
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 1000m
+                  memory: 170Mi
+                requests:
+                  cpu: 100m
+                  memory: 70Mi
+              args: [ "-conf", "/etc/coredns/Corefile" ]
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/coredns
+                  readOnly: true
+                - name: custom-config-volume
+                  mountPath: /etc/coredns/custom
+                  readOnly: true
+              ports:
+                - containerPort: 1053
+                  name: dns
+                  protocol: UDP
+                - containerPort: 1053
+                  name: dns-tcp
+                  protocol: TCP
+                - containerPort: 9153
+                  name: metrics
+                  protocol: TCP
+              securityContext:
+                runAsUser: {{`{{.RUN_AS_USER}}`}}
+                runAsNonRoot: {{`{{.RUN_AS_NON_ROOT}}`}}
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                periodSeconds: 10
+                timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 3
+              readinessProbe:
+                httpGet:
+                  path: /ready
+                  port: 8181
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 2
+                timeoutSeconds: 1
+                successThreshold: 1
+                failureThreshold: 3
+          dnsPolicy: Default
+          volumes:
+            - name: config-volume
+              configMap:
+                name: coredns
+                items:
+                  - key: Corefile
+                    path: Corefile
+                  - key: NodeHosts
+                    path: NodeHosts
+            - name: custom-config-volume
+              configMap:
+                name: coredns-custom
+                optional: true
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: kube-dns
+      namespace: kube-system
+      annotations:
+        prometheus.io/port: "9153"
+        prometheus.io/scrape: "true"
+      labels:
+        k8s-app: kube-dns
+        kubernetes.io/cluster-service: "true"
+        kubernetes.io/name: "CoreDNS"
+    spec:
+      selector:
+        k8s-app: kube-dns
+      ports:
+        - name: dns
+          port: 53
+          targetPort: 1053
+          protocol: UDP
+        - name: dns-tcp
+          port: 53
+          targetPort: 1053
+          protocol: TCP
+        - name: metrics
+          port: 9153
+          protocol: TCP
+{{- end }}

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.isolation.enabled .Values.isolation.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-workloads
+spec:
+  podSelector:
+    matchLabels:
+      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: 443
+        - port: 8443
+      to:
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 127.0.0.0/8
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-control-plane
+spec:
+  podSelector:
+    matchLabels:
+      release: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: 443
+        - port: 8443
+    - to:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: 'kube-system'
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+  policyTypes:
+    - Egress
+{{- end }}

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -8,6 +8,7 @@ spec:
     matchLabels:
       vcluster.loft.sh/managed-by: {{ .Release.Name }}
   egress:
+    # Allows outgoing connections to the vcluster control plane
     - ports:
         - port: 443
         - port: 8443
@@ -15,11 +16,14 @@ spec:
         - podSelector:
             matchLabels:
               release: {{ .Release.Name }}
+    # Allows outgoing connections to DNS server
     - ports:
       - port: 53
         protocol: UDP
       - port: 53
         protocol: TCP
+    # Allows outgoing connections to the internet or
+    # other vcluster workloads
     - to:
         - podSelector:
             matchLabels:
@@ -43,9 +47,14 @@ spec:
     matchLabels:
       release: {{ .Release.Name }}
   egress:
+    # Allows outgoing connections to all pods with
+    # port 443 or 8443. This is needed for host Kubernetes
+    # access
     - ports:
         - port: 443
         - port: 8443
+    # Allows outgoing connections to all vcluster workloads
+    # or kube system dns server
     - to:
         - podSelector: {}
         - namespaceSelector:

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -60,6 +60,11 @@ spec:
         - name: certs
           secret:
             secretName: {{ .Release.Name }}-certs
+      {{- if .Values.coredns.enabled }}
+        - name: coredns
+          configMap:
+            name: {{ .Release.Name }}-coredns
+      {{- end }}
       {{- if .Values.syncer.volumes }}
 {{ toYaml .Values.syncer.volumes | indent 8 }}
       {{- end }}
@@ -143,6 +148,11 @@ spec:
         env:
 {{ toYaml .Values.syncer.env | indent 10 }}
         volumeMounts:
+        {{- if .Values.coredns.enabled }}
+          - name: coredns
+            mountPath: /manifests/coredns
+            readOnly: true
+        {{- end }}
 {{ toYaml .Values.syncer.volumeMounts | indent 10 }}
         resources:
 {{ toYaml .Values.syncer.resources | indent 10 }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -235,6 +235,14 @@ ingress:
 openshift:
   enable: false
 
+# If enabled will deploy the coredns configmap
+coredns:
+  enabled: true
+  # image: my-core-dns-image:latest
+  # config: |-
+  #   .:1053 {
+  #      ...
+
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas
 isolation:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -235,6 +235,8 @@ ingress:
 openshift:
   enable: false
 
+# If enabled will deploy vcluster in an isolated mode with pod security
+# standards, limit ranges and resource quotas
 isolation:
   enabled: false
 
@@ -246,10 +248,11 @@ isolation:
       cpu: 10
       memory: 20Gi
       pods: 10
+      requests.storage: "100Gi"
     scopeSelector:
       matchExpressions:
     scopes:
-  
+
   limitRange:
     enabled: true
     default:
@@ -258,3 +261,6 @@ isolation:
     defaultRequest:
       memory: 128Mi
       cpu: 100m
+
+  networkPolicy:
+    enabled: true

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -22,13 +22,6 @@ deployments:
       chart:
         name: ./charts/k3s
       values:
-        isolation:
-          enabled: true
-          podSecurityStandard: ""
-          resourceQuota:
-            enabled: false
-          limitRange:
-            enabled: false
         serviceCIDR: ${SERVICE_CIDR}
         etcd:
           replicas: 3

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -22,6 +22,12 @@ deployments:
       chart:
         name: ./charts/k3s
       values:
+        isolation:
+          enabled: true
+          resourceQuota:
+            enabled: false
+          limitRange:
+            enabled: false
         serviceCIDR: ${SERVICE_CIDR}
         etcd:
           replicas: 3
@@ -69,7 +75,6 @@ dev:
         - '!/cmd'
         - '!/vendor'
         - '!/hack'
-        - '!/manifests'
         - '!/go.mod'
         - '!/go.sum'
         - '!/devspace_start.sh'

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -78,6 +78,8 @@ dev:
         - '!/go.mod'
         - '!/go.sum'
         - '!/devspace_start.sh'
+        - '!/manifests'
+        - '/manifests/coredns'
 commands:
   - name: dev
     command: "devspace dev -n vcluster $@"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -22,6 +22,13 @@ deployments:
       chart:
         name: ./charts/k3s
       values:
+        isolation:
+          enabled: true
+          podSecurityStandard: ""
+          resourceQuota:
+            enabled: false
+          limitRange:
+            enabled: false
         serviceCIDR: ${SERVICE_CIDR}
         etcd:
           replicas: 3

--- a/docs/pages/operator/security.mdx
+++ b/docs/pages/operator/security.mdx
@@ -28,27 +28,28 @@ vcluster create my-vcluster -n my-vcluster-namespace --isolate
 ```
 
 This feature imposes a couple of restrictions on vcluster workloads to make sure they do not break out of their virtual environment:
-1. vcluster enforces a [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) on syncer level, which means that for example pods that try to run as privileged container or mount a host path will not be synced to the host cluster. Current valid options are baseline (default in isolated mode) and restricted.
+1. vcluster enforces a [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) on syncer level, which means that for example pods that try to run as a privileged container or mount a host path will not be synced to the host cluster. Current valid options are either baseline (default in isolated mode) or restricted. This works for every Kubernetes version regardless of Pod Security Standard support, as this is implemented in vcluster directly. Rejected pods will stay pending in the vcluster and in newer Kubernetes version they will be denied by the admission controller as well.
 2. vcluster deploys a [resource quota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) as well as a [limit range](https://kubernetes.io/docs/concepts/policy/limit-range/) alongside the vcluster itself. This allows restricting resource consumption of vcluster workloads. If enabled, sane defaults for those 2 resources are chosen.
-3. (Coming soon) vcluster deploys a network policy alongside itself that will restrict access of vcluster workloads to other pods in the host cluster.
+3. vcluster deploys a [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) alongside itself that will restrict access of vcluster workloads as well as the vcluster control plane to other pods in the host cluster. (only works if your host [cluster CNI supports network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites))
 
 You can adjust isolation settings through helm values. The default values are (also check [values.yaml](https://github.com/loft-sh/vcluster/blob/v0.7.0-alpha.1/charts/k3s/values.yaml)):
 ```yaml
 isolation:
   enabled: false
 
-  # Either baseline or restricted
   podSecurityStandard: baseline
 
-  # Resource Quota settings
   resourceQuota:
     enabled: true
     quota:
       cpu: 10
       memory: 20Gi
       pods: 10
+      requests.storage: "100Gi"
+    scopeSelector:
+      matchExpressions:
+    scopes:
 
-  # LimitRange settings
   limitRange:
     enabled: true
     default:
@@ -57,12 +58,15 @@ isolation:
     defaultRequest:
       memory: 128Mi
       cpu: 100m
+
+  networkPolicy:
+    enabled: true
 ```
 
 ## Workload Isolation
 
 vcluster by default will not isolate any workloads in the host cluster and only ensures that those are deployed in the same namespace.
-However, isolating workloads in a single namespace can be done with in-built Kubernetes features or using the isolated mode shown above.
+However, isolating workloads in a single namespace can be done with in-built Kubernetes features or using the [isolated mode](#isolated-mode) shown above.
 
 ### Resource Quota & Limit Range
 
@@ -129,7 +133,7 @@ Besides this basic workload isolation, you could also dive into more advanced is
 ## Network Isolation
 
 Workloads created by vcluster will be able to communicate with other workloads in the host cluster through their cluster ips. This can be sometimes beneficial if you want to purposely access a host cluster service, which is a good method to share services between vclusters. However, you often want to isolate namespaces and do not want the pods running inside vcluster to have access to other workloads in the host cluster.
-This requirement can be accomplished by using [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for the namespace where vcluster is installed in.
+This requirement can be accomplished by using [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for the namespace where vcluster is installed in or using the [isolated mode](#isolated-mode) shown above.
 
 :::info
 Network policies do not work in all Kubernetes clusters and need to be supported by the underlying CNI plugin.

--- a/manifests/coredns/coredns.yaml
+++ b/manifests/coredns/coredns.yaml
@@ -68,9 +68,7 @@ data:
           fallthrough
         }
         prometheus :9153
-        forward . /etc/resolv.conf 8.8.8.8 {
-          policy sequential
-        }
+        forward . /etc/resolv.conf
         cache 30
         loop
         reload

--- a/manifests/coredns/coredns.yaml
+++ b/manifests/coredns/coredns.yaml
@@ -68,7 +68,9 @@ data:
           fallthrough
         }
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf 8.8.8.8 {
+          policy sequential
+        }
         cache 30
         loop
         reload

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	Namespace             = "kube-system"
 	DefaultImage          = "coredns/coredns"
 	ManifestRelativePath  = "coredns/coredns.yaml"
 	ManifestsOutputFolder = "/tmp/manifests-to-apply"

--- a/pkg/server/filters/metrics.go
+++ b/pkg/server/filters/metrics.go
@@ -177,6 +177,7 @@ func rewriteStats(ctx context.Context, data []byte, targetNamespace string, vCli
 		pod.PodRef.Namespace = vPod.Namespace
 		pod.PodRef.UID = string(vPod.UID)
 
+		newVolumes := []statsv1alpha1.VolumeStats{}
 		for _, volume := range pod.VolumeStats {
 			if volume.PVCRef != nil {
 				vPVC := &corev1.PersistentVolumeClaim{}
@@ -190,7 +191,10 @@ func rewriteStats(ctx context.Context, data []byte, targetNamespace string, vCli
 				volume.PVCRef.Name = vPVC.Name
 				volume.PVCRef.Namespace = vPVC.Namespace
 			}
+
+			newVolumes = append(newVolumes, volume)
 		}
+		pod.VolumeStats = newVolumes
 
 		newPods = append(newPods, pod)
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
- Adds network policies to isolated mode
- Make coredns part of the helm chart to allow easier configuration of the coredns deployment
- vcluster now correctly rewrites PVC kubelet metrics
