### PR TITLE
Add option to skip serviceAccountToken issuing in physical pod

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -132,6 +132,7 @@ func NewStartCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&options.EnforcePodSecurityStandard, "enforce-pod-security-standard", "", "This can be set to privileged, baseline, restricted and vcluster would make sure during translation that these policies are enforced.")
 	cmd.Flags().StringSliceVar(&options.SyncLabels, "sync-labels", []string{}, "The specified labels will be synced to physical resources, in addition to their vcluster translated versions.")
+	cmd.Flags().BoolVar(&options.SyncServiceAccountToken, "sync-service-account-token", true, "Sync vcluster-issued ServiceAccountToken onto physical pod")
 
 	// Deprecated Flags
 	cmd.Flags().BoolVar(&options.DeprecatedUseFakeKubelets, "fake-kubelets", true, "DEPRECATED: use --disable-fake-kubelets instead")

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -132,7 +132,7 @@ func NewStartCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&options.EnforcePodSecurityStandard, "enforce-pod-security-standard", "", "This can be set to privileged, baseline, restricted and vcluster would make sure during translation that these policies are enforced.")
 	cmd.Flags().StringSliceVar(&options.SyncLabels, "sync-labels", []string{}, "The specified labels will be synced to physical resources, in addition to their vcluster translated versions.")
-	cmd.Flags().BoolVar(&options.SyncServiceAccountToken, "sync-service-account-token", true, "Sync vcluster-issued ServiceAccountToken onto physical pod")
+	cmd.Flags().BoolVar(&options.SkipServiceAccountToken, "skip-service-account-token", false, "Skip issuing of serviceAccountToken to physical pod by vcluster")
 
 	// Deprecated Flags
 	cmd.Flags().BoolVar(&options.DeprecatedUseFakeKubelets, "fake-kubelets", true, "DEPRECATED: use --disable-fake-kubelets instead")

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -65,7 +65,7 @@ type VirtualClusterOptions struct {
 	EnforcePodSecurityStandard string `json:"enforcePodSecurityStandard"`
 
 	SyncLabels              []string `json:"syncLabels"`
-	SyncServiceAccountToken bool     `json:"syncServiceAccountToken"`
+	SkipServiceAccountToken bool     `json:"skipServiceAccountToken"`
 
 	// DEPRECATED FLAGS
 	DeprecatedDisableSyncResources     string

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -64,7 +64,8 @@ type VirtualClusterOptions struct {
 
 	EnforcePodSecurityStandard string `json:"enforcePodSecurityStandard"`
 
-	SyncLabels []string `json:"syncLabels"`
+	SyncLabels              []string `json:"syncLabels"`
+	SyncServiceAccountToken bool     `json:"syncServiceAccountToken"`
 
 	// DEPRECATED FLAGS
 	DeprecatedDisableSyncResources     string

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -75,7 +75,7 @@ func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder record.EventR
 		serviceAccountsEnabled:  ctx.Controllers["serviceaccounts"],
 		priorityClassesEnabled:  ctx.Controllers["priorityclasses"],
 		syncedLabels:            ctx.Options.SyncLabels,
-		syncServiceAccountToken: ctx.Options.SyncServiceAccountToken,
+		skipServiceAccountToken: ctx.Options.SkipServiceAccountToken,
 	}, nil
 }
 
@@ -96,7 +96,7 @@ type translator struct {
 	overrideHostsImage      string
 	priorityClassesEnabled  bool
 	syncedLabels            []string
-	syncServiceAccountToken bool
+	skipServiceAccountToken bool
 }
 
 func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string) (*corev1.Pod, error) {
@@ -363,7 +363,7 @@ func (t *translator) translateProjectedVolume(projectedVolume *corev1.ProjectedV
 			}
 		}
 		if projectedVolume.Sources[i].ServiceAccountToken != nil {
-			if !t.syncServiceAccountToken {
+			if t.skipServiceAccountToken {
 				continue
 			}
 			serviceAccountName := "default"

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -67,14 +67,15 @@ func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder record.EventR
 
 		defaultImageRegistry: ctx.Options.DefaultImageRegistry,
 
-		targetNamespace:        ctx.Options.TargetNamespace,
-		clusterDomain:          ctx.Options.ClusterDomain,
-		serviceAccount:         ctx.Options.ServiceAccount,
-		overrideHosts:          ctx.Options.OverrideHosts,
-		overrideHostsImage:     ctx.Options.OverrideHostsContainerImage,
-		serviceAccountsEnabled: ctx.Controllers["serviceaccounts"],
-		priorityClassesEnabled: ctx.Controllers["priorityclasses"],
-		syncedLabels:           ctx.Options.SyncLabels,
+		targetNamespace:         ctx.Options.TargetNamespace,
+		clusterDomain:           ctx.Options.ClusterDomain,
+		serviceAccount:          ctx.Options.ServiceAccount,
+		overrideHosts:           ctx.Options.OverrideHosts,
+		overrideHostsImage:      ctx.Options.OverrideHostsContainerImage,
+		serviceAccountsEnabled:  ctx.Controllers["serviceaccounts"],
+		priorityClassesEnabled:  ctx.Controllers["priorityclasses"],
+		syncedLabels:            ctx.Options.SyncLabels,
+		syncServiceAccountToken: ctx.Options.SyncServiceAccountToken,
 	}, nil
 }
 
@@ -87,14 +88,15 @@ type translator struct {
 
 	defaultImageRegistry string
 
-	serviceAccountsEnabled bool
-	targetNamespace        string
-	clusterDomain          string
-	serviceAccount         string
-	overrideHosts          bool
-	overrideHostsImage     string
-	priorityClassesEnabled bool
-	syncedLabels           []string
+	serviceAccountsEnabled  bool
+	targetNamespace         string
+	clusterDomain           string
+	serviceAccount          string
+	overrideHosts           bool
+	overrideHostsImage      string
+	priorityClassesEnabled  bool
+	syncedLabels            []string
+	syncServiceAccountToken bool
 }
 
 func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string) (*corev1.Pod, error) {
@@ -361,6 +363,9 @@ func (t *translator) translateProjectedVolume(projectedVolume *corev1.ProjectedV
 			}
 		}
 		if projectedVolume.Sources[i].ServiceAccountToken != nil {
+			if !t.syncServiceAccountToken {
+				continue
+			}
 			serviceAccountName := "default"
 			if vPod.Spec.ServiceAccountName != "" {
 				serviceAccountName = vPod.Spec.ServiceAccountName


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

This allows users to configure the syncer to skip override of `serviceAccountToken` `projected` volumes. In effect, this will allow the host cluster to issue the service token to the physical pod rather than having vcluster be the issuer. This is important when the host cluster uses a customized auth mechanism like [OIDC](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens). 

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...
Add an option to prevent vcluster from issuing a `serviceAccountToken` for `projected` volumes in the host cluster.

**What else do we need to know?** 
Open to alternatives here! 