### PR TITLE
fix: only set securityContext if isolation mode is disabled

### DIFF
--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -128,9 +128,11 @@ data:
               labelSelector:
                 matchLabels:
                   k8s-app: kube-dns
+          {{- if .Values.isolation.enabled }}
           securityContext:
             seccompProfile:
               type: RuntimeDefault
+          {{- end }}
           containers:
             - name: coredns
               {{- if .Values.coredns.image }}

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -128,9 +128,11 @@ data:
               labelSelector:
                 matchLabels:
                   k8s-app: kube-dns
+          {{- if .Values.isolation.enabled }}
           securityContext:
             seccompProfile:
               type: RuntimeDefault
+          {{- end }}
           containers:
             - name: coredns
               {{- if .Values.coredns.image }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -128,9 +128,11 @@ data:
               labelSelector:
                 matchLabels:
                   k8s-app: kube-dns
+          {{- if .Values.isolation.enabled }}
           securityContext:
             seccompProfile:
               type: RuntimeDefault
+          {{- end }}
           containers:
             - name: coredns
               {{- if .Values.coredns.image }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would use a securityContext for coredns that would cause problems for specific systems
