### PR TITLE
refactor: use vcluster service for fake nodes

### DIFF
--- a/pkg/controllers/resources/nodes/register.go
+++ b/pkg/controllers/resources/nodes/register.go
@@ -16,10 +16,10 @@ func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 		return nil, err
 	}
 
-	nodeService := nodeservice.NewNodeServiceProvider(ctx.CurrentNamespace, ctx.CurrentNamespaceClient, ctx.VirtualManager.GetClient(), uncachedVirtualClient)
-
+	nodeService := nodeservice.NewNodeServiceProvider(ctx.Options.ServiceName, ctx.CurrentNamespace, ctx.CurrentNamespaceClient, ctx.VirtualManager.GetClient(), uncachedVirtualClient)
 	if !ctx.Controllers["nodes"] {
 		return NewFakeSyncer(ctx, nodeService)
 	}
+
 	return NewSyncer(ctx, nodeService)
 }

--- a/pkg/util/clienthelper/helper.go
+++ b/pkg/util/clienthelper/helper.go
@@ -118,15 +118,6 @@ func GVKFrom(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKin
 	return gvks[0], nil
 }
 
-func CurrentPodName() (string, error) {
-	podNameEnv := os.Getenv("POD_NAME")
-	if podNameEnv != "" {
-		return podNameEnv, nil
-	}
-
-	return os.Hostname()
-}
-
 func NewImpersonatingClient(config *rest.Config, mapper meta.RESTMapper, user user.Info, scheme *runtime.Scheme) (client.Client, error) {
 	// Impersonate user
 	restConfig := rest.CopyConfig(config)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Use the vcluster service label selector for creating a fake kubelet service instead of finding out the pod label selector
