### PR TITLE
add namespace to coredns configmap

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: custom-deployments
+  namespace: {{ .Release.Namespace }}
 data:
   coredns.yaml: |-
     apiVersion: v1

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
+  namespace: {{ .Release.Namespace }}
 data:
   coredns.yaml: |-
     apiVersion: v1

--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
+  namespace: {{ .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
@@ -43,6 +44,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-control-plane
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
+  namespace: {{ .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
+  namespace: {{ .Release.Namespace }}
 data:
   coredns.yaml: |-
     apiVersion: v1

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
+  namespace: {{ .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
@@ -43,6 +44,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-control-plane
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
+  namespace: {{ .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
+  namespace: {{ .Release.Namespace }}
 data:
   coredns.yaml: |-
     apiVersion: v1

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
+  namespace: {{ .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
@@ -43,6 +44,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-control-plane
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
+  namespace: {{ .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
The chart has not set the namespace of the configmap coredns.  If the user runs the command `helm template my-vcluster vcluster --repo https://charts.loft.sh --set serviceCIDR=10.96.0.0/12 -n host-namespace-1 | kubectl apply -f -`. kubectl will create the configmap coredns in the default(which is dependent on the context of kubeconfig) namespace. Then the `syncer-deployment` will not start because of a lack of  coredns config in namespace host-namespace-1.

```
  Warning  FailedMount  34s (x32 over 111m)  kubelet  Unable to attach or mount volumes: unmounted volumes=[coredns], unattached volumes=[data vc-my-vcluster-token-v5sxt coredns]: timed out waiting for the condition
```

**What else do we need to know?** 
