### PR TITLE
introduce isolation.targetNamespace in k0s, k3s, k8s chart values

### DIFF
--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -30,13 +30,11 @@ spec:
             matchLabels:
               vcluster.loft.sh/managed-by: {{ .Release.Name }}
         - ipBlock:
-            cidr: 0.0.0.0/0
+            cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
-              - 100.64.0.0/10
-              - 127.0.0.0/8
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
+              {{- range .Values.isolation.networkPolicy.outgoingConnections.ipBlock.except }}
+              - {{ . }}
+              {{- end }}
   policyTypes:
     - Egress
 ---

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -243,6 +243,7 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
+  targetNamespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -243,7 +243,7 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  targetNamespace: null
+  namespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -282,3 +282,12 @@ isolation:
 
   networkPolicy:
     enabled: true
+    outgoingConnections:
+      ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+          - 100.64.0.0/10
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -30,13 +30,11 @@ spec:
             matchLabels:
               vcluster.loft.sh/managed-by: {{ .Release.Name }}
         - ipBlock:
-            cidr: 0.0.0.0/0
+            cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
-              - 100.64.0.0/10
-              - 127.0.0.0/8
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
+              {{- range .Values.isolation.networkPolicy.outgoingConnections.ipBlock.except }}
+              - {{ . }}
+              {{- end }}
   policyTypes:
     - Egress
 ---

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -245,6 +245,7 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
+  targetNamespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -284,3 +284,12 @@ isolation:
 
   networkPolicy:
     enabled: true
+    outgoingConnections:
+      ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+          - 100.64.0.0/10
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -245,7 +245,7 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  targetNamespace: null
+  namespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -30,13 +30,11 @@ spec:
             matchLabels:
               vcluster.loft.sh/managed-by: {{ .Release.Name }}
         - ipBlock:
-            cidr: 0.0.0.0/0
+            cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
-              - 100.64.0.0/10
-              - 127.0.0.0/8
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
+              {{- range .Values.isolation.networkPolicy.outgoingConnections.ipBlock.except }}
+              - {{ . }}
+              {{- end }}
   policyTypes:
     - Egress
 ---

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.targetNamespace | default .Release.Namespace }}
+  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -274,7 +274,7 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  targetNamespace: null
+  namespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -274,6 +274,7 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
+  targetNamespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -313,3 +313,12 @@ isolation:
 
   networkPolicy:
     enabled: true
+    outgoingConnections:
+      ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+          - 100.64.0.0/10
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16


### PR DESCRIPTION
also fix their usage in the chart templates
fixes #425

Signed-off-by: Ishan Khare <me@ishankhare.dev>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #425 


**Please provide a short message that should be published in the vcluster release notes**
fix `isolation.targetNamespace` usage in the chart templates


**What else do we need to know?** 
