### PR TITLE
fix: disable k8s controller that reconciles default/kubernetes endpoints

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distribution: ["k3s", "k8s", "k0s"]
+        distribution: ["k3s", "k8s", "k0s", "eks"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -67,8 +67,13 @@ jobs:
     - name: Setup DevSpace
       uses: loft-sh/setup-devspace@main
 
+    # Note: keep the devspace render and devspace run commands in sync!
     - name: Deploy vcluster
-      run: devspace run deploy -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests -p sync-networkpolicies --skip-push
+      run: |
+          echo "Render what will get deployed"
+          devspace render -p deploy -n vcluster -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests -p sync-networkpolicies --skip-push --skip-build
+          echo "Deploy vcluster"
+          devspace run deploy -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests -p sync-networkpolicies --skip-push
 
     - name: Wait until vcluster is ready
       id: wait-until-vcluster-is-ready

--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -99,6 +99,7 @@ spec:
           - '--tls-cert-file=/run/config/pki/apiserver.crt'
           - '--tls-private-key-file=/run/config/pki/apiserver.key'
           - '--watch-cache=false'
+          - '--endpoint-reconciler-type=none'
           {{- range $f := .Values.api.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k0s/templates/secret.yaml
+++ b/charts/k0s/templates/secret.yaml
@@ -24,6 +24,7 @@ stringData:
         k0sApiPort: 9443
         extraArgs:
           enable-admission-plugins: NodeRestriction
+          endpoint-reconciler-type: none
       network:
         # Will be replaced automatically from the vcluster cli
         serviceCIDR: {{ .Values.serviceCIDR }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -89,8 +89,10 @@ spec:
           {{- if not .Values.sync.nodes.enableScheduler }}
             --disable-scheduler
             --kube-controller-manager-arg=controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle
+            --kube-apiserver-arg=endpoint-reconciler-type=none
           {{- else }}
             --kube-controller-manager-arg=controllers=*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle
+            --kube-apiserver-arg=endpoint-reconciler-type=none
             --kube-controller-manager-arg=node-monitor-grace-period=1h
             --kube-controller-manager-arg=node-monitor-period=1h
           {{- end }}

--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -94,6 +94,7 @@ spec:
           - '--tls-cert-file=/run/config/pki/apiserver.crt'
           - '--tls-private-key-file=/run/config/pki/apiserver.key'
           - '--watch-cache=false'
+          - '--endpoint-reconciler-type=none'
           {{- range $f := .Values.api.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -116,6 +116,11 @@ profiles:
       - op: replace
         path: deployments.name=vcluster.helm.chart.name
         value: ./charts/k8s
+  - name: eks
+    patches:
+      - op: replace
+        path: deployments.name=vcluster.helm.chart.name
+        value: ./charts/eks
   - name: kind-load
     patches:
       - op: add

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -5,6 +5,9 @@ COLOR_CYAN="\033[0;36m"
 COLOR_RESET="\033[0m"
 
 RUN_CMD="go run -mod vendor cmd/vcluster/main.go start"
+RUN_CMD_K8S="echo \"Run syncer with k8s flags\" && go run -mod vendor cmd/vcluster/main.go start --request-header-ca-cert=/pki/ca.crt --client-ca-cert=/pki/ca.crt --server-ca-cert=/pki/ca.crt --server-ca-key=/pki/ca.key --kube-config=/pki/admin.conf"
+RUN_CMD_K0S="echo \"Run syncer with k0s flags\" && go run -mod vendor cmd/vcluster/main.go start --request-header-ca-cert=/data/k0s/pki/ca.crt --client-ca-cert=/data/k0s/pki/ca.crt --server-ca-cert=/data/k0s/pki/ca.crt --server-ca-key=/data/k0s/pki/ca.key --kube-config=/data/k0s/pki/admin.conf"
+RUN_CMD_EKS="echo \"Run syncer with eks flags\" && go run -mod vendor cmd/vcluster/main.go start  --request-header-ca-cert=/pki/ca.crt --client-ca-cert=/pki/ca.crt --server-ca-cert=/pki/ca.crt --server-ca-key=/pki/ca.key --kube-config=/pki/admin.conf"
 DEBUG_CMD="dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- start"
 
 echo -e "${COLOR_CYAN}
@@ -33,9 +36,12 @@ ${COLOR_CYAN}TIP:${COLOR_RESET} hit an up arrow on your keyboard to find the com
 "
 # add useful commands to the history for convenience
 export HISTFILE=/tmp/.bash_history
+history -s $RUN_CMD_EKS
+history -s $RUN_CMD_K0S
+history -s $RUN_CMD_K8S
 history -s $DEBUG_CMD
 history -s $RUN_CMD
 history -a
 
-# hide "I have no name!" from the bash prompt
+# hide "I have no name!" from the bash prompt when running as non root
 bash --init-file <(echo "export PS1=\"\\H:\\W\\$ \"")

--- a/pkg/controllers/k8sdefaultendpoint/k8sdefaultendpoint.go
+++ b/pkg/controllers/k8sdefaultendpoint/k8sdefaultendpoint.go
@@ -2,17 +2,20 @@ package k8sdefaultendpoint
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/utils/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -56,16 +59,18 @@ func (e *K8SDefaultEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			builder.WithPredicates(pfuncs, predicate.ResourceVersionChangedPredicate{})).
 		Watches(source.NewKindWithCache(&corev1.Endpoints{}, e.VirtualManagerCache),
 			&handler.EnqueueRequestForObject{}, builder.WithPredicates(vfuncs)).
+		Watches(source.NewKindWithCache(&discovery.EndpointSlice{}, e.VirtualManagerCache),
+			&handler.EnqueueRequestForObject{}, builder.WithPredicates(vfuncs)).
 		Complete(e)
 }
 
 func syncKubernetesServiceEndpoints(ctx context.Context, virtualClient client.Client, localClient client.Client, serviceName, serviceNamespace string) error {
 	// get physical service endpoints
-	pObj := &corev1.Endpoints{}
+	pEndpoints := &corev1.Endpoints{}
 	err := localClient.Get(ctx, types.NamespacedName{
 		Namespace: serviceNamespace,
 		Name:      serviceName,
-	}, pObj)
+	}, pEndpoints)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil
@@ -74,51 +79,141 @@ func syncKubernetesServiceEndpoints(ctx context.Context, virtualClient client.Cl
 		return err
 	}
 
-	// get virtual service endpoints
-	vObj := &corev1.Endpoints{}
-	err = virtualClient.Get(ctx, types.NamespacedName{
-		Namespace: "default",
-		Name:      "kubernetes",
-	}, vObj)
+	vEndpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "kubernetes",
+		},
+	}
+
+	result, err := controllerutil.CreateOrPatch(ctx, virtualClient, vEndpoints, func() error {
+		if vEndpoints.Labels == nil {
+			vEndpoints.Labels = map[string]string{}
+		}
+		vEndpoints.Labels[discovery.LabelSkipMirror] = "true"
+
+		// build new subsets
+		newSubsets := pEndpoints.DeepCopy().Subsets
+		for i := range newSubsets {
+			for j := range newSubsets[i].Ports {
+				newSubsets[i].Ports[j].Name = "https"
+			}
+			for j := range pEndpoints.Subsets[i].Addresses {
+				newSubsets[i].Addresses[j].Hostname = ""
+				newSubsets[i].Addresses[j].NodeName = nil
+				newSubsets[i].Addresses[j].TargetRef = nil
+			}
+			for j := range pEndpoints.Subsets[i].NotReadyAddresses {
+				newSubsets[i].NotReadyAddresses[j].Hostname = ""
+				newSubsets[i].NotReadyAddresses[j].NodeName = nil
+				newSubsets[i].NotReadyAddresses[j].TargetRef = nil
+			}
+		}
+
+		vEndpoints.Subsets = newSubsets
+		return nil
+	})
 	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return nil
-		}
-
-		return err
-	}
-
-	// build new subsets
-	newSubsets := pObj.DeepCopy().Subsets
-	for i := range newSubsets {
-		for j := range newSubsets[i].Ports {
-			newSubsets[i].Ports[j].Name = "https"
-		}
-		for j := range pObj.Subsets[i].Addresses {
-			newSubsets[i].Addresses[j].Hostname = ""
-			newSubsets[i].Addresses[j].NodeName = nil
-			newSubsets[i].Addresses[j].TargetRef = nil
-		}
-		for j := range pObj.Subsets[i].NotReadyAddresses {
-			newSubsets[i].NotReadyAddresses[j].Hostname = ""
-			newSubsets[i].NotReadyAddresses[j].NodeName = nil
-			newSubsets[i].NotReadyAddresses[j].TargetRef = nil
-		}
-	}
-
-	oldJSON, err := json.Marshal(vObj.Subsets)
-	if err != nil {
-		return err
-	}
-	newJSON, err := json.Marshal(newSubsets)
-	if err != nil {
-		return err
-	}
-
-	if string(oldJSON) == string(newJSON) {
 		return nil
 	}
 
-	vObj.Subsets = newSubsets
-	return virtualClient.Update(ctx, vObj)
+	if result == controllerutil.OperationResultCreated || result == controllerutil.OperationResultUpdated {
+		vSlices := &discovery.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "kubernetes",
+			},
+		}
+		_, err = controllerutil.CreateOrPatch(ctx, virtualClient, vSlices, func() error {
+			newSlice := endpointSliceFromEndpoints(vEndpoints)
+			vSlices.Labels = newSlice.Labels
+			vSlices.AddressType = newSlice.AddressType
+			vSlices.Endpoints = newSlice.Endpoints
+			return nil
+		})
+		return err
+	}
+
+	return err
+}
+
+// endpointSliceFromEndpoints generates an EndpointSlice from an Endpoints
+// resource.
+// From: https://github.com/kubernetes/kubernetes/blob/7380fc735aca591325ae1fabf8dab194b40367de/pkg/controlplane/reconcilers/endpointsadapter.go#L121-L151
+func endpointSliceFromEndpoints(endpoints *corev1.Endpoints) *discovery.EndpointSlice {
+	endpointSlice := &discovery.EndpointSlice{}
+	endpointSlice.Name = endpoints.Name
+	endpointSlice.Labels = map[string]string{discovery.LabelServiceName: endpoints.Name}
+
+	// TODO: Add support for dual stack here (and in the rest of
+	// EndpointsAdapter).
+	endpointSlice.AddressType = discovery.AddressTypeIPv4
+
+	if len(endpoints.Subsets) > 0 {
+		subset := endpoints.Subsets[0]
+		for i := range subset.Ports {
+			endpointSlice.Ports = append(endpointSlice.Ports, discovery.EndpointPort{
+				Port:     &subset.Ports[i].Port,
+				Name:     &subset.Ports[i].Name,
+				Protocol: &subset.Ports[i].Protocol,
+			})
+		}
+
+		if allAddressesIPv6(append(subset.Addresses, subset.NotReadyAddresses...)) {
+			endpointSlice.AddressType = discovery.AddressTypeIPv6
+		}
+
+		endpointSlice.Endpoints = append(endpointSlice.Endpoints, getEndpointsFromAddresses(subset.Addresses, endpointSlice.AddressType, true)...)
+		endpointSlice.Endpoints = append(endpointSlice.Endpoints, getEndpointsFromAddresses(subset.NotReadyAddresses, endpointSlice.AddressType, false)...)
+	}
+
+	return endpointSlice
+}
+
+// getEndpointsFromAddresses returns a list of Endpoints from addresses that
+// match the provided address type.
+// From: https://github.com/kubernetes/kubernetes/blob/7380fc735aca591325ae1fabf8dab194b40367de/pkg/controlplane/reconcilers/endpointsadapter.go#L153-L166
+func getEndpointsFromAddresses(addresses []corev1.EndpointAddress, addressType discovery.AddressType, ready bool) []discovery.Endpoint {
+	endpoints := []discovery.Endpoint{}
+	isIPv6AddressType := addressType == discovery.AddressTypeIPv6
+
+	for _, address := range addresses {
+		if utilnet.IsIPv6String(address.IP) == isIPv6AddressType {
+			endpoints = append(endpoints, endpointFromAddress(address, ready))
+		}
+	}
+
+	return endpoints
+}
+
+// endpointFromAddress generates an Endpoint from an EndpointAddress resource.
+// From: https://github.com/kubernetes/kubernetes/blob/7380fc735aca591325ae1fabf8dab194b40367de/pkg/controlplane/reconcilers/endpointsadapter.go#L168-L181
+func endpointFromAddress(address corev1.EndpointAddress, ready bool) discovery.Endpoint {
+	ep := discovery.Endpoint{
+		Addresses:  []string{address.IP},
+		Conditions: discovery.EndpointConditions{Ready: &ready},
+		TargetRef:  address.TargetRef,
+	}
+
+	if address.NodeName != nil {
+		ep.NodeName = address.NodeName
+	}
+
+	return ep
+}
+
+// allAddressesIPv6 returns true if all provided addresses are IPv6.
+// From: https://github.com/kubernetes/kubernetes/blob/7380fc735aca591325ae1fabf8dab194b40367de/pkg/controlplane/reconcilers/endpointsadapter.go#L183-L196
+func allAddressesIPv6(addresses []corev1.EndpointAddress) bool {
+	if len(addresses) == 0 {
+		return false
+	}
+
+	for _, address := range addresses {
+		if !utilnet.IsIPv6String(address.IP) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
In this change, I disable the controller("EndpointsReconciler") in the kube-controller-manager which is updating the `default/kubernetes` Endpoints resource because it was updating it to an incorrect value.
Also, to ensure the expected outcome, the vclusters k8sdefaultendpoint controller has been updated to mimic the behavior of the original k8s "EndpointsReconciler" controller.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #433 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `default/kubernetes` Endpoints object was referencing incorrect IPs in k8s and eks flavors.
