### PR TITLE
Allow setting imagePullSecrets for coredns

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -10,6 +10,10 @@ data:
     metadata:
       name: coredns
       namespace: kube-system
+{{- if and .Values.coredns.serviceAccount .Values.coredns.serviceAccount.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.coredns.serviceAccount.imagePullSecrets | indent 6 }}
+{{- end }}
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -187,6 +187,8 @@ api:
 # Core DNS settings
 coredns:
   image: public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-8
+  # serviceAccount:
+  #   imagePullSecrets: []
 
 # Service account that should be used by the vcluster
 serviceAccount:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -11,6 +11,10 @@ data:
     metadata:
       name: coredns
       namespace: kube-system
+{{- if and .Values.coredns.serviceAccount .Values.coredns.serviceAccount.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.coredns.serviceAccount.imagePullSecrets | indent 6 }}
+{{- end }}
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -237,6 +237,8 @@ coredns:
   # config: |-
   #   .:1053 {
   #      ...
+  # serviceAccount:
+  #   imagePullSecrets: []
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -11,6 +11,10 @@ data:
     metadata:
       name: coredns
       namespace: kube-system
+{{- if and .Values.coredns.serviceAccount .Values.coredns.serviceAccount.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.coredns.serviceAccount.imagePullSecrets | indent 6 }}
+{{- end }}
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -239,6 +239,8 @@ coredns:
   # config: |-
   #   .:1053 {
   #      ...
+  # serviceAccount:
+  #   imagePullSecrets: []
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -11,6 +11,10 @@ data:
     metadata:
       name: coredns
       namespace: kube-system
+{{- if and .Values.coredns.serviceAccount .Values.coredns.serviceAccount.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.coredns.serviceAccount.imagePullSecrets | indent 6 }}
+{{- end }}
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -268,6 +268,8 @@ coredns:
   # config: |-
   #   .:1053 {
   #      ...
+  # serviceAccount:
+  #   imagePullSecrets: []
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

Allows setting imagePullSecrets for the coredns ServiceAccount when using a private repository via the `defaultImageRegistry` value.

**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where coredns wouldn't start due to missing imagePullSecrets when using a private repository


**What else do we need to know?** 
