### PR TITLE
Reapply kube config secret & fix multiple bind

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -122,6 +122,7 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, pObj client.
 		if err != nil {
 			ctx.Log.Debugf("error parsing %s: %v", LockPersistentVolume, err)
 		} else if t.Add(time.Minute).After(time.Now()) {
+			ctx.Log.Debugf("requeue because persistent volume %s is locked", vPersistentVolume.Name)
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 	}

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -3,20 +3,18 @@ package kubeconfig
 import (
 	"context"
 	"fmt"
-	"github.com/ghodss/yaml"
-	"github.com/loft-sh/vcluster/pkg/util/applier"
-	"io/ioutil"
-	"k8s.io/client-go/rest"
-	"os"
-
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
+	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -27,7 +25,7 @@ const (
 	CertificateKeySecretKey = "client-key"
 )
 
-func WriteKubeConfig(currentNamespaceConfig *rest.Config, secretName, secretNamespace string, config *api.Config) error {
+func WriteKubeConfig(ctx context.Context, currentNamespaceClient client.Client, secretName, secretNamespace string, config *api.Config) error {
 	out, err := clientcmd.Write(*config)
 	if err != nil {
 		return err
@@ -39,7 +37,7 @@ func WriteKubeConfig(currentNamespaceConfig *rest.Config, secretName, secretName
 	if err == nil {
 		err = ioutil.WriteFile("/root/.kube/config", out, 0666)
 		if err != nil {
-			klog.Infof("Failed wrtie /root/.kube/config file: %v ; This error might be expected if you are running as non-root user or securityContext.readOnlyRootFilesystem = true", err)
+			klog.Infof("Failed writing /root/.kube/config file: %v ; This error might be expected if you are running as non-root user or securityContext.readOnlyRootFilesystem = true", err)
 		}
 	} else {
 		klog.Infof("Failed to create /root/.kube folder for writing kube config: %v ; This error might be expected if you are running as non-root user or securityContext.readOnlyRootFilesystem = true", err)
@@ -57,36 +55,31 @@ func WriteKubeConfig(currentNamespaceConfig *rest.Config, secretName, secretName
 		key := clientConfig.KeyData
 
 		kubeConfigSecret := &corev1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: secretNamespace,
 			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				KubeconfigSecretKey:     out,
-				CADataSecretKey:         caData,
-				CertificateSecretKey:    cert,
-				CertificateKeySecretKey: key,
-			},
 		}
+		result, err := controllerutil.CreateOrPatch(ctx, currentNamespaceClient, kubeConfigSecret, func() error {
+			kubeConfigSecret.Type = corev1.SecretTypeOpaque
+			if kubeConfigSecret.Data == nil {
+				kubeConfigSecret.Data = map[string][]byte{}
+			}
+			kubeConfigSecret.Data[KubeconfigSecretKey] = out
+			kubeConfigSecret.Data[CADataSecretKey] = caData
+			kubeConfigSecret.Data[CertificateSecretKey] = cert
+			kubeConfigSecret.Data[CertificateKeySecretKey] = key
 
-		// set owner reference
-		if translate.Owner != nil && translate.Owner.GetNamespace() == kubeConfigSecret.Namespace {
-			kubeConfigSecret.OwnerReferences = translate.GetOwnerReference(nil)
-		}
-
-		out, err := yaml.Marshal(kubeConfigSecret)
-		if err != nil {
-			return err
-		}
-
-		err = applier.ApplyManifest(currentNamespaceConfig, out)
+			// set owner reference
+			if translate.Owner != nil && translate.Owner.GetNamespace() == kubeConfigSecret.Namespace {
+				kubeConfigSecret.OwnerReferences = translate.GetOwnerReference(nil)
+			}
+			return nil
+		})
 		if err != nil {
 			return errors.Wrap(err, "apply generated kube config secret")
+		} else if result != controllerutil.OperationResultNone {
+			klog.Infof("Applied kube config secret %s/%s", kubeConfigSecret.Namespace, kubeConfigSecret.Name)
 		}
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
- vcluster will now try to reapply the kube config secret periodically
- Fixed an issue where vcluster would try to bind a virtual pod multiple times to a node