### PR TITLE
refactor: add daemon set annotation

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -29,15 +29,16 @@ import (
 )
 
 const (
-	OwnerSetKind                  = "vcluster.loft.sh/owner-set-kind"
-	NamespaceAnnotation           = "vcluster.loft.sh/namespace"
-	NameAnnotation                = "vcluster.loft.sh/name"
-	LabelsAnnotation              = "vcluster.loft.sh/labels"
-	NamespaceLabelPrefix          = "vcluster.loft.sh/ns-label"
-	UIDAnnotation                 = "vcluster.loft.sh/uid"
-	ClusterAutoScalerAnnotation   = "cluster-autoscaler.kubernetes.io/safe-to-evict"
-	ServiceAccountNameAnnotation  = "vcluster.loft.sh/service-account-name"
-	ServiceAccountTokenAnnotation = "vcluster.loft.sh/token-"
+	OwnerSetKind                         = "vcluster.loft.sh/owner-set-kind"
+	NamespaceAnnotation                  = "vcluster.loft.sh/namespace"
+	NameAnnotation                       = "vcluster.loft.sh/name"
+	LabelsAnnotation                     = "vcluster.loft.sh/labels"
+	NamespaceLabelPrefix                 = "vcluster.loft.sh/ns-label"
+	UIDAnnotation                        = "vcluster.loft.sh/uid"
+	ClusterAutoScalerAnnotation          = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
+	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
+	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
 )
 
 var (
@@ -171,6 +172,9 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 		controller := metav1.GetControllerOf(vPod)
 		isEvictable := controller != nil
 		pPod.Annotations[ClusterAutoScalerAnnotation] = strconv.FormatBool(isEvictable)
+		if controller != nil && controller.Kind == "DaemonSet" {
+			pPod.Annotations[ClusterAutoScalerDaemonSetAnnotation] = "true"
+		}
 	}
 
 	// Add Namespace labels


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now set the annotation `cluster-autoscaler.kubernetes.io/daemonset-pod` on pods that belong to a daemon set inside the virtual cluster
