### PR TITLE
fix: refresh managed endpoints

### DIFF
--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,15 +42,39 @@ func (s *endpointsSyncer) ReconcileStart(ctx *synccontext.SyncContext, req ctrl.
 		Namespace: req.Namespace,
 		Name:      req.Name,
 	}, svc)
-
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return true, nil
 		}
-		return true, err
-	}
 
-	if svc.Spec.Selector != nil {
+		return true, err
+	} else if svc.Spec.Selector != nil {
+		// check if it was a managed endpoints object before and delete it
+		endpoints := &corev1.Endpoints{}
+		err := ctx.PhysicalClient.Get(ctx.Context, s.NamespacedTranslator.VirtualToPhysical(req.NamespacedName, nil), endpoints)
+		if err != nil {
+			if !kerrors.IsNotFound(err) {
+				klog.Infof("Error retrieving endpoints: %v", err)
+			}
+
+			return true, nil
+		}
+
+		// check if endpoints were created by us
+		if endpoints.Annotations != nil && endpoints.Annotations[translator.NameAnnotation] != "" {
+			// Deleting the endpoints is necessary here as some clusters would not correctly maintain
+			// the endpoints if they were managed by us previously and now should be managed by Kubernetes.
+			// In the worst case we would end up in a state where we have multiple endpoint slices pointing
+			// to the same endpoints resulting in wrong DNS and cluster networking. Hence deleting the previously
+			// managed endpoints signals the Kubernetes controller to recreate the endpoints from the selector.
+			klog.Infof("Refresh endpoints in physical cluster because they shouldn't be managed by vcluster anymore")
+			err = ctx.PhysicalClient.Delete(ctx.Context, endpoints)
+			if err != nil {
+				klog.Infof("Error deleting endpoints %s/%s: %v", endpoints.Namespace, endpoints.Name, err)
+				return true, err
+			}
+		}
+
 		return true, nil
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not migrate managed endpoints to Kubernetes managed endpoints correctly.
