### PR TITLE
feat: Support CoreDNS service type configuration

### DIFF
--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -218,6 +218,9 @@ data:
       annotations:
         prometheus.io/port: "9153"
         prometheus.io/scrape: "true"
+        {{- if .Values.coredns.service.annotations }}
+{{ toYaml .Values.coredns.service.annotations | indent 8 }}
+        {{- end }}
       labels:
         k8s-app: kube-dns
         kubernetes.io/cluster-service: "true"
@@ -225,6 +228,18 @@ data:
     spec:
       selector:
         k8s-app: kube-dns
+      type: {{ .Values.coredns.service.type }}
+      {{- if (eq (.Values.coredns.service.type) "LoadBalancer") }}
+      {{- if .Values.coredns.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.coredns.service.externalTrafficPolicy }}
+      {{- end }}
+      {{- if .Values.coredns.service.externalIPs }}
+      externalIPs:
+        {{- range $f := .Values.coredns.service.externalIPs }}
+        - {{ $f }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
       ports:
         - name: dns
           port: 53

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -238,6 +238,14 @@ coredns:
   # config: |-
   #   .:1053 {
   #      ...
+  # CoreDNS service configurations
+  service:
+    type: ClusterIP
+    # Configuration for LoadBalancer service type
+    externalIPs: []
+    externalTrafficPolicy: ""
+    # Extra Annotations
+    annotations: {}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -218,6 +218,9 @@ data:
       annotations:
         prometheus.io/port: "9153"
         prometheus.io/scrape: "true"
+        {{- if .Values.coredns.service.annotations }}
+{{ toYaml .Values.coredns.service.annotations | indent 8 }}
+        {{- end }}
       labels:
         k8s-app: kube-dns
         kubernetes.io/cluster-service: "true"
@@ -225,6 +228,18 @@ data:
     spec:
       selector:
         k8s-app: kube-dns
+      type: {{ .Values.coredns.service.type }}
+      {{- if (eq (.Values.coredns.service.type) "LoadBalancer") }}
+      {{- if .Values.coredns.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.coredns.service.externalTrafficPolicy }}
+      {{- end }}
+      {{- if .Values.coredns.service.externalIPs }}
+      externalIPs:
+        {{- range $f := .Values.coredns.service.externalIPs }}
+        - {{ $f }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
       ports:
         - name: dns
           port: 53

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -240,6 +240,14 @@ coredns:
   # config: |-
   #   .:1053 {
   #      ...
+  # CoreDNS service configurations
+  service:
+    type: ClusterIP
+    # Configuration for LoadBalancer service type
+    externalIPs: []
+    externalTrafficPolicy: ""
+    # Extra Annotations
+    annotations: {}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -218,6 +218,9 @@ data:
       annotations:
         prometheus.io/port: "9153"
         prometheus.io/scrape: "true"
+        {{- if .Values.coredns.service.annotations }}
+{{ toYaml .Values.coredns.service.annotations | indent 8 }}
+        {{- end }}
       labels:
         k8s-app: kube-dns
         kubernetes.io/cluster-service: "true"
@@ -225,6 +228,18 @@ data:
     spec:
       selector:
         k8s-app: kube-dns
+      type: {{ .Values.coredns.service.type }}
+      {{- if (eq (.Values.coredns.service.type) "LoadBalancer") }}
+      {{- if .Values.coredns.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.coredns.service.externalTrafficPolicy }}
+      {{- end }}
+      {{- if .Values.coredns.service.externalIPs }}
+      externalIPs:
+        {{- range $f := .Values.coredns.service.externalIPs }}
+        - {{ $f }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
       ports:
         - name: dns
           port: 53

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -269,6 +269,14 @@ coredns:
   # config: |-
   #   .:1053 {
   #      ...
+  # CoreDNS service configurations
+  service:
+    type: ClusterIP
+    # Configuration for LoadBalancer service type
+    externalIPs: []
+    externalTrafficPolicy: ""
+    # Extra Annotations
+    annotations: {}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind feature

**What does this pull request do? Which issues does it resolve?**
Allow publish CoreDNS as load balancer service.

**Please provide a short message that should be published in the vcluster release notes**
chart: coredns is service type and external IP can be now easily overridden through helm values

**What else do we need to know?** 
Here is full on prem example where both syncer and coredns are configured to use DNS domain `dev.local` instead of default `cluster.local`, CoreDNS is published as LoadBalancer service (so external systems can use it as forwarder for this DNS domain), Metal LB is instructed to use [address pool ip-pool](https://metallb.universe.tf/usage/#requesting-specific-ips) and Calico to do [service BGP advertisement with /32 mask](https://projectcalico.docs.tigera.io/networking/advertise-service-ips#advertising-service-ips-quick-glance)
```yaml
syncer:
  replicas: 1
  extraArgs:
    - --cluster-domain=dev.local

coredns:
  enabled: true
  replicas: 1
  config: |-
    .:1053 {
        errors
        health
        ready
        kubernetes dev.local in-addr.arpa ip6.arpa {
          pods insecure
          fallthrough in-addr.arpa ip6.arpa
        }
        hosts /etc/coredns/NodeHosts {
          ttl 60
          reload 15s
          fallthrough
        }
        prometheus :9153
        forward . /etc/resolv.conf
        cache 30
        loop
        reload
        loadbalance
    }
  service:
    type: LoadBalancer
    externalTrafficPolicy: "Local"
    annotations:
      metallb.universe.tf/address-pool: ip-pool
```