### PR TITLE
Fix 3 conformance tests - Service type change + default/kubernetes EndpointSlices

### DIFF
--- a/pkg/controllers/k8sdefaultendpoint/k8sdefaultendpoint.go
+++ b/pkg/controllers/k8sdefaultendpoint/k8sdefaultendpoint.go
@@ -129,6 +129,7 @@ func syncKubernetesServiceEndpoints(ctx context.Context, virtualClient client.Cl
 			vSlices.Labels = newSlice.Labels
 			vSlices.AddressType = newSlice.AddressType
 			vSlices.Endpoints = newSlice.Endpoints
+			vSlices.Ports = newSlice.Ports
 			return nil
 		})
 		return err

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -152,6 +152,7 @@ func updateService(req *http.Request, decoder encoding.Decoder, localClient clie
 	// we try to patch the service as this has the best chances to go through
 	originalPService := pService.DeepCopy()
 	pService.Spec.Type = newVService.Spec.Type
+	pService.Spec.Ports = newVService.Spec.Ports
 	pService.Spec.ClusterIP = ""
 	err = localClient.Patch(ctx, pService, client.MergeFrom(originalPService))
 	if err != nil {

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -161,6 +161,10 @@ func updateService(req *http.Request, decoder encoding.Decoder, localClient clie
 
 	// now we have the cluster ip that we can apply to the new service
 	newVService.Spec.ClusterIP = pService.Spec.ClusterIP
+	// also we need to apply newly allocated node ports
+	newVService.Spec.HealthCheckNodePort = pService.Spec.HealthCheckNodePort
+	newVService.Spec.Ports = pService.Spec.Ports
+
 	err = virtualClient.Update(ctx, newVService)
 	if err != nil {
 		// this is actually worst case that can happen, as we have somehow now a really strange


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes following conformance tests:
```
[sig-network] DNS [It] should provide DNS for ExternalName services
[sig-network] Services [It] should be able to change the type from ExternalName to ClusterIP
[sig-network] Services [It] should be able to change the type from ExternalName to NodePort
[sig-network] EndpointSlice [It] should have Endpoints and EndpointSlices pointing to API Server
```


**Please provide a short message that should be published in the vcluster release notes**
fix: Service type change from ExternalName type to other types
fix: default/kubernetes EndpointSlices content should match default/kubernetes Endpoints - add the missing ports

**What else do we need to know?** 
Added unit tests are not related to the fix because originally I thought that the problem is elsewhere, but I decided to keep them anyway.
