### PR TITLE
fix: ommit nodeSelector when using scheduler

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -276,11 +276,15 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 	}
 
 	// translate node selector
-	for k, v := range vPod.Spec.NodeSelector {
-		if pPod.Spec.NodeSelector == nil {
-			pPod.Spec.NodeSelector = map[string]string{}
+	if t.enableScheduler {
+		pPod.Spec.NodeSelector = nil
+	} else {
+		for k, v := range vPod.Spec.NodeSelector {
+			if pPod.Spec.NodeSelector == nil {
+				pPod.Spec.NodeSelector = map[string]string{}
+			}
+			pPod.Spec.NodeSelector[k] = v
 		}
-		pPod.Spec.NodeSelector[k] = v
 	}
 
 	return pPod, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Syncer should not set pods nodeSelector when the scheduler is used.

Fixes:
```
[Fail] [sig-apps] Daemon set [Serial] [It] should run and stop complex daemon [Conformance] 
/workspace/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:212
```