### PR TITLE
[Helm K3s] Add CoreDNS placement options as well as Service annotations / labels

### DIFF
--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -121,6 +121,12 @@ data:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: coredns
           nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 12 }}
+          affinity:
+{{ toYaml .Values.affinity | indent 12 }}
+          tolerations:
+{{ toYaml .Values.tolerations | indent 12 }}
+          nodeSelector:
             kubernetes.io/os: linux
           topologySpreadConstraints:
             - maxSkew: 1

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -8,6 +8,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -194,6 +194,10 @@ service:
   # Configuration for LoadBalancer service type
   externalIPs: []
   externalTrafficPolicy: ""
+  # Extra Labels for the service
+  labels: {}
+  # Extra Annotations for the service
+  annotations: {}
 
 # Configure the ingress resource that allows you to access the vcluster
 ingress:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
- Adds nodeSelector / affinity / toleration for CoreDns
- Adds ability to set label and annotation on the APIServer Service



**Please provide a short message that should be published in the vcluster release notes**
CoreDNS will inherit the same nodeSelectors as the API Server
Labels and Annotations can now be set on the API Server service via values


**What else do we need to know?** 
It might make sense to let CoreDNs have it's own affinities, under the `coredns` section instead of inheriting the global ones. Went with global since they were not scoped under `vcluster`.