### PR TITLE
Add 6443 port to controle plane egress NetworkPolicy

### DIFF
--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -49,11 +49,12 @@ spec:
       release: {{ .Release.Name }}
   egress:
     # Allows outgoing connections to all pods with
-    # port 443 or 8443. This is needed for host Kubernetes
+    # port 443, 8443 or 6443. This is needed for host Kubernetes
     # access
     - ports:
         - port: 443
         - port: 8443
+        - port: 6443
     # Allows outgoing connections to all vcluster workloads
     # or kube system dns server
     - to:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -49,11 +49,12 @@ spec:
       release: {{ .Release.Name }}
   egress:
     # Allows outgoing connections to all pods with
-    # port 443 or 8443. This is needed for host Kubernetes
+    # port 443, 8443 or 6443. This is needed for host Kubernetes
     # access
     - ports:
         - port: 443
         - port: 8443
+        - port: 6443
     # Allows outgoing connections to all vcluster workloads
     # or kube system dns server
     - to:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -49,11 +49,12 @@ spec:
       release: {{ .Release.Name }}
   egress:
     # Allows outgoing connections to all pods with
-    # port 443 or 8443. This is needed for host Kubernetes
+    # port 443, 8443 or 6443. This is needed for host Kubernetes
     # access
     - ports:
         - port: 443
         - port: 8443
+        - port: 6443
     # Allows outgoing connections to all vcluster workloads
     # or kube system dns server
     - to:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #475

**Please provide a short message that should be published in the vcluster release notes**
Allows vcluster isolation NetworkPolicy to be used in a host cluster that uses 6443 port for the API server.

**What else do we need to know?** 
I decided to go with a minimal fix - adding a new port to the list, so as not to go crazy with customizations in the helm chart. If more modifications of the NetworkPolicy are required, the user can always create it separately and disable the creation via our helm chart.