### PR TITLE
refactor: improve helm chart notes

### DIFF
--- a/charts/eks/templates/NOTES.txt
+++ b/charts/eks/templates/NOTES.txt
@@ -1,8 +1,10 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing vcluster.
 
-Your release is named {{ .Release.Name }}.
+Your vcluster is named {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 
-To learn more about the release, try:
+To connect to the vcluster, use vcluster CLI (https://www.vcluster.com/docs/getting-started/setup):
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }} -- kubectl get ns
 
-  $ helm status {{ .Release.Name }}
-  $ helm get all {{ .Release.Name }}
+
+For more information, please take a look at the vcluster docs at https://www.vcluster.com/docs

--- a/charts/k0s/templates/NOTES.txt
+++ b/charts/k0s/templates/NOTES.txt
@@ -1,8 +1,10 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing vcluster.
 
-Your release is named {{ .Release.Name }}.
+Your vcluster is named {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 
-To learn more about the release, try:
+To connect to the vcluster, use vcluster CLI (https://www.vcluster.com/docs/getting-started/setup):
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }} -- kubectl get ns
 
-  $ helm status {{ .Release.Name }}
-  $ helm get all {{ .Release.Name }}
+
+For more information, please take a look at the vcluster docs at https://www.vcluster.com/docs

--- a/charts/k3s/templates/NOTES.txt
+++ b/charts/k3s/templates/NOTES.txt
@@ -1,8 +1,10 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing vcluster.
 
-Your release is named {{ .Release.Name }}.
+Your vcluster is named {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 
-To learn more about the release, try:
+To connect to the vcluster, use vcluster CLI (https://www.vcluster.com/docs/getting-started/setup):
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }} -- kubectl get ns
 
-  $ helm status {{ .Release.Name }}
-  $ helm get all {{ .Release.Name }}
+
+For more information, please take a look at the vcluster docs at https://www.vcluster.com/docs

--- a/charts/k8s/templates/NOTES.txt
+++ b/charts/k8s/templates/NOTES.txt
@@ -1,8 +1,10 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing vcluster.
 
-Your release is named {{ .Release.Name }}.
+Your vcluster is named {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 
-To learn more about the release, try:
+To connect to the vcluster, use vcluster CLI (https://www.vcluster.com/docs/getting-started/setup):
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ vcluster connect {{ .Release.Name }} -n {{ .Release.Namespace }} -- kubectl get ns
 
-  $ helm status {{ .Release.Name }}
-  $ helm get all {{ .Release.Name }}
+
+For more information, please take a look at the vcluster docs at https://www.vcluster.com/docs

--- a/pkg/constants/annotation.go
+++ b/pkg/constants/annotation.go
@@ -2,6 +2,5 @@ package constants
 
 const (
 	SkipTranslationAnnotation = "vcluster.loft.sh/skip-translate"
-	SkipSyncAnnotation        = "vcluster.loft.sh/skip-sync"
 	SyncResourceAnnotation    = "vcluster.loft.sh/force-sync"
 )

--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -2,9 +2,9 @@ package servicesync
 
 import (
 	"context"
-	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,8 +114,8 @@ func (e *ServiceSyncer) syncServiceWithSelector(ctx context.Context, fromService
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      to.Name,
 				Namespace: to.Namespace,
-				Annotations: map[string]string{
-					constants.SkipSyncAnnotation: "true",
+				Labels: map[string]string{
+					translate.ControllerLabel: "vcluster",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -125,7 +125,7 @@ func (e *ServiceSyncer) syncServiceWithSelector(ctx context.Context, fromService
 		services.RewriteSelector(toService, fromService)
 		e.Log.Infof("Create target service %s/%s because it is missing", to.Namespace, to.Name)
 		return ctrl.Result{}, e.To.GetClient().Create(ctx, toService)
-	} else if toService.Annotations == nil || toService.Annotations[constants.SkipSyncAnnotation] != "true" {
+	} else if toService.Labels == nil || toService.Labels[translate.ControllerLabel] != "vcluster" {
 		// skip as it seems the service was user created
 		return ctrl.Result{}, nil
 	}
@@ -179,8 +179,8 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      to.Name,
 				Namespace: to.Namespace,
-				Annotations: map[string]string{
-					constants.SkipSyncAnnotation: "true",
+				Labels: map[string]string{
+					translate.ControllerLabel: "vcluster",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -190,7 +190,7 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 		}
 		e.Log.Infof("Create target service %s/%s because it is missing", to.Namespace, to.Name)
 		return ctrl.Result{}, e.To.GetClient().Create(ctx, toService)
-	} else if toService.Annotations == nil || toService.Annotations[constants.SkipSyncAnnotation] != "true" {
+	} else if toService.Labels == nil || toService.Labels[translate.ControllerLabel] != "vcluster" {
 		// skip as it seems the service was user created
 		return ctrl.Result{}, nil
 	}
@@ -215,8 +215,8 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      to.Name,
 				Namespace: to.Namespace,
-				Annotations: map[string]string{
-					constants.SkipSyncAnnotation: "true",
+				Labels: map[string]string{
+					translate.ControllerLabel: "vcluster",
 				},
 			},
 			Subsets: []corev1.EndpointSubset{

--- a/pkg/controllers/syncer/fake_syncer.go
+++ b/pkg/controllers/syncer/fake_syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
@@ -71,6 +72,11 @@ func (r *fakeSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		return r.syncer.FakeSyncUp(syncContext, req.NamespacedName)
+	}
+
+	// check if we should skip resource
+	if vObj != nil && vObj.GetLabels() != nil && vObj.GetLabels()[translate.ControllerLabel] != "" {
+		return ctrl.Result{}, nil
 	}
 
 	// update object

--- a/pkg/controllers/syncer/syncer.go
+++ b/pkg/controllers/syncer/syncer.go
@@ -2,7 +2,7 @@ package syncer
 
 import (
 	"context"
-	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
@@ -82,7 +82,7 @@ func (r *syncerController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// check if we should skip resource
-	if vObj != nil && vObj.GetAnnotations() != nil && vObj.GetAnnotations()[constants.SkipSyncAnnotation] == "true" {
+	if vObj != nil && vObj.GetLabels() != nil && vObj.GetLabels()[translate.ControllerLabel] != "" {
 		return ctrl.Result{}, nil
 	}
 
@@ -95,6 +95,11 @@ func (r *syncerController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		pObj = nil
+	}
+
+	// check if we should skip resource
+	if pObj != nil && pObj.GetLabels() != nil && pObj.GetLabels()[translate.ControllerLabel] != "" {
+		return ctrl.Result{}, nil
 	}
 
 	// check what function we should call

--- a/pkg/controllers/syncer/translator/namespaced_translator.go
+++ b/pkg/controllers/syncer/translator/namespaced_translator.go
@@ -147,7 +147,7 @@ func TranslateMetadata(physicalNamespace string, vObj client.Object, syncedLabel
 		return nil
 	}
 
-	pObj.SetLabels(translateLabels(vObj, syncedLabels))
+	pObj.SetLabels(translateLabels(vObj, nil, syncedLabels))
 	pObj.SetAnnotations(translateAnnotations(vObj, nil, excludedAnnotations))
 	return pObj
 }
@@ -158,7 +158,7 @@ func (n *namespacedTranslator) TranslateMetadataUpdate(vObj client.Object, pObj 
 
 func TranslateMetadataUpdate(vObj client.Object, pObj client.Object, syncedLabels []string, excludedAnnotations ...string) (bool, map[string]string, map[string]string) {
 	updatedAnnotations := translateAnnotations(vObj, pObj, excludedAnnotations)
-	updatedLabels := translateLabels(vObj, syncedLabels)
+	updatedLabels := translateLabels(vObj, pObj, syncedLabels)
 	return !equality.Semantic.DeepEqual(updatedAnnotations, pObj.GetAnnotations()) || !equality.Semantic.DeepEqual(updatedLabels, pObj.GetLabels()), updatedAnnotations, updatedLabels
 }
 
@@ -216,7 +216,7 @@ func translateAnnotations(vObj client.Object, pObj client.Object, excluded []str
 	return retMap
 }
 
-func translateLabels(vObj client.Object, syncedLabels []string) map[string]string {
+func translateLabels(vObj client.Object, pObj client.Object, syncedLabels []string) map[string]string {
 	newLabels := map[string]string{}
 	vObjLabels := vObj.GetLabels()
 	for k, v := range vObjLabels {
@@ -232,6 +232,12 @@ func translateLabels(vObj client.Object, syncedLabels []string) map[string]strin
 			if value, ok := vObjLabels[k]; ok {
 				newLabels[k] = value
 			}
+		}
+	}
+	if pObj != nil {
+		pObjLabels := pObj.GetLabels()
+		if pObjLabels != nil && pObjLabels[translate.ControllerLabel] != "" {
+			newLabels[translate.ControllerLabel] = pObjLabels[translate.ControllerLabel]
 		}
 	}
 

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	NamespaceLabel = "vcluster.loft.sh/namespace"
-	MarkerLabel    = "vcluster.loft.sh/managed-by"
-	Suffix         = "suffix"
+	NamespaceLabel  = "vcluster.loft.sh/namespace"
+	MarkerLabel     = "vcluster.loft.sh/managed-by"
+	ControllerLabel = "vcluster.loft.sh/controlled-by"
+	Suffix          = "suffix"
 )
 
 var Owner client.Object
@@ -36,17 +37,6 @@ func SafeConcatName(name ...string) string {
 		return strings.Replace(fullPath[0:52]+"-"+hex.EncodeToString(digest[0:])[0:10], ".-", "-", -1)
 	}
 	return fullPath
-}
-
-func IsManaged(obj runtime.Object) bool {
-	metaAccessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false
-	} else if metaAccessor.GetLabels() == nil {
-		return false
-	}
-
-	return metaAccessor.GetLabels()[MarkerLabel] == Suffix
 }
 
 func GetOwnerReference(object client.Object) []metav1.OwnerReference {
@@ -73,6 +63,17 @@ func GetOwnerReference(object client.Object) []metav1.OwnerReference {
 			Controller: &isController,
 		},
 	}
+}
+
+func IsManaged(obj runtime.Object) bool {
+	metaAccessor, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	} else if metaAccessor.GetLabels() == nil {
+		return false
+	}
+
+	return metaAccessor.GetLabels()[MarkerLabel] == Suffix
 }
 
 func IsManagedCluster(physicalNamespace string, obj runtime.Object) bool {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation
/kind feature

**Release Notes**
- **syncer**: vcluster now supports a label `vcluster.loft.sh/controlled-by` that if set to a non empty value will omit syncing. This can be set either on the host cluster object or on the virtual cluster object and is very useful for writing plugins that want to handle their own objects.