### PR TITLE
refactor: improve secret usage detection

### DIFF
--- a/pkg/constants/indices.go
+++ b/pkg/constants/indices.go
@@ -5,6 +5,7 @@ const (
 	IndexByAssigned      = "IndexByAssigned"
 	IndexByStorageClass  = "IndexByStorageClass"
 	IndexByIngressSecret = "IndexByIngressSecret"
+	IndexByPodSecret     = "IndexByPodSecret"
 	IndexByConfigMap     = "IndexByConfigMap"
 	IndexByClusterIP     = "IndexByClusterIP"
 )


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


Uses an index to remember what secrets belong to which pod. This should greatly improve perforamance for large vclusters as not every secrets needs to reiterate over every pod.
