### PR TITLE
refactor: add validation for storage class sync

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -156,6 +156,11 @@ func NewControllerContext(currentNamespace string, localManager ctrl.Manager, vi
 		return nil, fmt.Errorf("you cannot use --sync-all-nodes and --enable-scheduler without enabling nodes sync")
 	}
 
+	// check if storage classes and legacy storage classes are enabled at the same time
+	if controllers["storageclasses"] && controllers["legacy-storageclasses"] {
+		return nil, fmt.Errorf("you cannot sync storage classes and legacy storage classes at the same time. Choose only one of them")
+	}
+
 	return &ControllerContext{
 		Context:        ctx,
 		Controllers:    controllers,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
vcluster will now fail to start if storage classes sync and legacy storage classes sync are enabled at the same time
