### PR TITLE
fix: delete missing physical pods & plugin hooks registration

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -183,7 +183,7 @@ func (m *manager) Start(
 func (m *manager) waitForPlugins(options *context2.VirtualClusterOptions) error {
 	for _, plugin := range options.Plugins {
 		klog.Infof("Waiting for plugin %s to register...", plugin)
-		err := wait.PollImmediate(time.Millisecond*100, time.Minute*3, func() (done bool, err error) {
+		err := wait.PollImmediate(time.Millisecond*100, time.Minute*10, func() (done bool, err error) {
 			m.pluginMutex.Lock()
 			defer m.pluginMutex.Unlock()
 
@@ -235,7 +235,7 @@ func (m *manager) RegisterPlugin(ctx context.Context, info *remote.RegisterPlugi
 		newPlugins[info.Name] = info
 
 		// regenerate client hooks
-		newClientHooks, err := regenerateClientHooks(m.pluginVersions)
+		newClientHooks, err := regenerateClientHooks(newPlugins)
 		if err != nil {
 			klog.Infof("Error regenerating client hooks for plugin %s: %v", info.Name, err)
 			return nil, errors.Wrap(err, "generate client hooks")


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
- If vcluster loses track of a physical pod (for example if vcluster was paused and restarted) and that physical pod was deleted, vcluster will also delete it upon restart
- Fixed an issue where plugin hooks wouldn't be registered correctly initially