### PR TITLE
Allow context name as a flag to connect command for generated config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 profile.out
 *.swp
+/vcluster


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #523 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ... connect command has flag to pass on the context-name which will overwrite the default context


**What else do we need to know?** 
