### PR TITLE
feat: serve pprof info on port 6060

### DIFF
--- a/cmd/vcluster/main.go
+++ b/cmd/vcluster/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd"
 	"github.com/loft-sh/vcluster/pkg/util/log"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
+
 	// "go.uber.org/zap/zapcore"
 	// zappkg "go.uber.org/zap"
 

--- a/pkg/server/filters/pprof.go
+++ b/pkg/server/filters/pprof.go
@@ -1,0 +1,31 @@
+package filters
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"strings"
+)
+
+func WithPprof(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		prefix := "/debug/pprof/"
+		if strings.HasPrefix(req.URL.Path, prefix) {
+			switch req.URL.Path {
+			case fmt.Sprintf("%scmdline", prefix):
+				pprof.Cmdline(w, req)
+			case fmt.Sprintf("%sprofile", prefix):
+				pprof.Profile(w, req)
+			case fmt.Sprintf("%strace", prefix):
+				pprof.Trace(w, req)
+			case fmt.Sprintf("%ssymbol", prefix):
+				pprof.Symbol(w, req)
+			default:
+				pprof.Index(w, req)
+			}
+			return
+		}
+
+		h.ServeHTTP(w, req)
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"context"
-	"github.com/loft-sh/vcluster/pkg/util/pluginhookclient"
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -22,6 +22,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/server/filters"
 	"github.com/loft-sh/vcluster/pkg/server/handler"
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
+	"github.com/loft-sh/vcluster/pkg/util/pluginhookclient"
 	"github.com/loft-sh/vcluster/pkg/util/serverhelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
@@ -179,6 +180,11 @@ func NewServer(ctx *context2.ControllerContext, requestHeaderCaFile, clientCaFil
 		h = filters.WithNodeChanges(h, uncachedLocalClient, uncachedVirtualClient, virtualConfig)
 	}
 	h = filters.WithFakeKubelet(h, localConfig, cachedVirtualClient, ctx.Options.TargetNamespace)
+
+	if os.Getenv("DEBUG") == "true" {
+		h = filters.WithPprof(h)
+	}
+
 	serverhelper.HandleRoute(s.handler, "/", h)
 
 	return s, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
When DEBUG env var is true, syncer profiling information will be served via built-in API server on the /debug/pprof/ path.

**What else do we need to know?** 
To consume the information first start a port forward command in a separate terminal:
`kubectl port-forward -n vcluster-namespace $(kubectl get pods -o name -l app=vcluster -n vcluster-namespace | head -n 1) 6060:8443`

To acquire a 10s sample run:
`curl -k -o timer.prof http://localhost:6060/debug/pprof/profile?seconds=10`
it will override the previous `timer.prof` file if one exists

To view the collected data run
`go tool pprof -http=:8888 timer.prof 2>/dev/null`
and open the http://localhost:8888 URL in your browser