### PR TITLE
feat: skip port-forwarding for local k8s distros

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,6 +70,9 @@ jobs:
     # Note: keep the devspace render and devspace run commands in sync!
     - name: Deploy vcluster
       run: |
+          docker ps
+          docker network ls
+        
           echo "Render what will get deployed"
           devspace render -p deploy -n vcluster -p ${{ matrix.distribution}} -p kind-load -p no-cpu-requests -p sync-networkpolicies --skip-push --skip-build
           echo "Deploy vcluster"

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -184,7 +184,7 @@ func ExecuteStart(options *context2.VirtualClusterOptions) error {
 	}
 
 	// Ensure that service CIDR range is written into the expected location
-	err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
 		err = ensureServiceCIDR(inClusterClient, currentNamespace, translate.Suffix)
 		if err != nil {
 			klog.Errorf("failed to ensure that service CIDR range is written into the expected location: %v", err)
@@ -198,7 +198,7 @@ func ExecuteStart(options *context2.VirtualClusterOptions) error {
 
 	// wait until kube config is available
 	var clientConfig clientcmd.ClientConfig
-	err = wait.Poll(time.Second, time.Hour, func() (bool, error) {
+	err = wait.PollImmediate(time.Second, time.Hour, func() (bool, error) {
 		out, err := ioutil.ReadFile(options.KubeConfig)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/vclusterctl/cmd/app/create/types.go
+++ b/cmd/vclusterctl/cmd/app/create/types.go
@@ -13,12 +13,14 @@ type CreateOptions struct {
 
 	KubernetesVersion string
 
-	CreateNamespace    bool
-	DisableIngressSync bool
-	CreateClusterRole  bool
-	Expose             bool
-	Connect            bool
-	Upgrade            bool
-	Isolate            bool
-	ReleaseValues      string
+	CreateNamespace      bool
+	DisableIngressSync   bool
+	CreateClusterRole    bool
+	Expose               bool
+	ExposeLocal          bool
+	ConnectUpdateCurrent bool
+	Connect              bool
+	Upgrade              bool
+	Isolate              bool
+	ReleaseValues        string
 }

--- a/cmd/vclusterctl/cmd/app/create/types.go
+++ b/cmd/vclusterctl/cmd/app/create/types.go
@@ -13,14 +13,13 @@ type CreateOptions struct {
 
 	KubernetesVersion string
 
-	CreateNamespace      bool
-	DisableIngressSync   bool
-	CreateClusterRole    bool
-	Expose               bool
-	ExposeLocal          bool
-	ConnectUpdateCurrent bool
-	Connect              bool
-	Upgrade              bool
-	Isolate              bool
-	ReleaseValues        string
+	CreateNamespace    bool
+	DisableIngressSync bool
+	CreateClusterRole  bool
+	Expose             bool
+	ExposeLocal        bool
+	Connect            bool
+	Upgrade            bool
+	Isolate            bool
+	ReleaseValues      string
 }

--- a/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
+++ b/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
@@ -1,0 +1,171 @@
+package localkubernetes
+
+import (
+	"context"
+	"fmt"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func ExposeLocal(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, log log.Logger) (string, error) {
+	clusterType := DetectClusterType(rawConfig)
+	switch clusterType {
+	case ClusterTypeDockerDesktop:
+		return directExposure(vRawConfig, service)
+	case ClusterTypeRancherDesktop:
+		return directExposure(vRawConfig, service)
+	case ClusterTypeKIND:
+		return kindProxy(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, log)
+	}
+
+	return "", nil
+}
+
+func CleanupLocal(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) error {
+	clusterType := DetectClusterType(rawConfig)
+	switch clusterType {
+	case ClusterTypeKIND:
+		return cleanupKindProxy(vClusterName, vClusterNamespace, rawConfig, log)
+	}
+
+	return nil
+}
+
+func cleanupKindProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) error {
+	// construct proxy name
+	proxyName := find.VClusterContextName(vClusterName, vClusterNamespace, rawConfig.CurrentContext)
+
+	// check if proxy container already exists
+	cmd := exec.Command(
+		"docker",
+		"stop",
+		proxyName,
+	)
+	log.Infof("Stopping kind proxy...")
+	_, _ = cmd.Output()
+	return nil
+}
+
+func kindProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, log log.Logger) (string, error) {
+	if len(service.Spec.Ports) != 1 {
+		return "", nil
+	}
+
+	// construct proxy name
+	proxyName := find.VClusterContextName(vClusterName, vClusterNamespace, rawConfig.CurrentContext)
+
+	// check if proxy container already exists
+	cmd := exec.Command(
+		"docker",
+		"inspect",
+		proxyName,
+		"-f",
+		fmt.Sprintf("{{ index (index (index .HostConfig.PortBindings \"%v/tcp\") 0) \"HostPort\" }}", service.Spec.Ports[0].NodePort),
+	)
+	out, err := cmd.Output()
+	if err == nil {
+		localPort, err = strconv.Atoi(strings.TrimSpace(string(out)))
+		if err == nil && localPort != 0 {
+			server := fmt.Sprintf("https://localhost:%v", localPort)
+			err = testConnectionWithServer(vRawConfig, server)
+			if err != nil {
+				return "", errors.Wrap(err, "test connection")
+			}
+
+			return server, nil
+		}
+	} else {
+		log.Debugf("Error running docker inspect: %v", err)
+
+		// in general, we need to run this statement to expose the correct port for this
+		// docker run -d -p LOCAL_PORT:NODE_PORT --rm -e "BACKEND_HOST=NAME-control-plane" -e "BACKEND_PORT=NODE_PORT" --network=kind ghcr.io/loft-sh/docker-tcp-proxy
+		controlPlane := strings.TrimPrefix(rawConfig.CurrentContext, "kind-")
+		cmd = exec.Command(
+			"docker",
+			"run",
+			"-d",
+			"-p",
+			fmt.Sprintf("%v:%v", localPort, service.Spec.Ports[0].NodePort),
+			"--rm",
+			fmt.Sprintf("--name=%s", proxyName),
+			"-e",
+			fmt.Sprintf("BACKEND_HOST=%s-control-plane", controlPlane),
+			"-e",
+			fmt.Sprintf("BACKEND_PORT=%v", service.Spec.Ports[0].NodePort),
+			"--network=kind",
+			"ghcr.io/loft-sh/docker-tcp-proxy",
+		)
+		log.Infof("Starting proxy container...")
+		out, err = cmd.Output()
+		if err != nil {
+			return "", errors.Errorf("error starting kind proxy: %s %v", string(out), err)
+		}
+	}
+
+	server := fmt.Sprintf("https://localhost:%v", localPort)
+	waitErr := wait.PollImmediate(time.Second, time.Second*20, func() (done bool, err error) {
+		err = testConnectionWithServer(vRawConfig, server)
+		if err != nil {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if waitErr != nil {
+		return "", fmt.Errorf("test connection: %v %v", waitErr, err)
+	}
+
+	return server, nil
+}
+
+func directExposure(vRawConfig *clientcmdapi.Config, service *corev1.Service) (string, error) {
+	if len(service.Spec.Ports) != 1 {
+		return "", nil
+	}
+
+	server := fmt.Sprintf("https://localhost:%v", service.Spec.Ports[0].NodePort)
+	err := testConnectionWithServer(vRawConfig, server)
+	if err != nil {
+		return "", err
+	}
+
+	return server, nil
+}
+
+func testConnectionWithServer(vRawConfig *clientcmdapi.Config, server string) error {
+	vRawConfig = vRawConfig.DeepCopy()
+	for k := range vRawConfig.Clusters {
+		vRawConfig.Clusters[k].Server = server
+	}
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(*vRawConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "retrieve default namespace")
+	}
+
+	return nil
+}

--- a/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
+++ b/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
@@ -18,6 +18,14 @@ import (
 	"time"
 )
 
+func (c ClusterType) NodePortSupported() bool {
+	return c == ClusterTypeDockerDesktop ||
+		c == ClusterTypeRancherDesktop ||
+		c == ClusterTypeKIND ||
+		c == ClusterTypeMinikube ||
+		c == ClusterTypeK3D
+}
+
 func ExposeLocal(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, log log.Logger) (string, error) {
 	clusterType := DetectClusterType(rawConfig)
 	switch clusterType {
@@ -27,6 +35,10 @@ func ExposeLocal(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi
 		return directExposure(vRawConfig, service)
 	case ClusterTypeKIND:
 		return kindProxy(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, log)
+	case ClusterTypeMinikube:
+		return minikubeProxy(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, log)
+	case ClusterTypeK3D:
+		return k3dProxy(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, log)
 	}
 
 	return "", nil
@@ -35,14 +47,63 @@ func ExposeLocal(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi
 func CleanupLocal(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) error {
 	clusterType := DetectClusterType(rawConfig)
 	switch clusterType {
+	case ClusterTypeMinikube:
+		if containerExists(rawConfig.CurrentContext) {
+			return cleanupProxy(vClusterName, vClusterNamespace, rawConfig, log)
+		}
+
+		return nil
 	case ClusterTypeKIND:
-		return cleanupKindProxy(vClusterName, vClusterNamespace, rawConfig, log)
+		return cleanupProxy(vClusterName, vClusterNamespace, rawConfig, log)
+	case ClusterTypeK3D:
+		return cleanupProxy(vClusterName, vClusterNamespace, rawConfig, log)
 	}
 
 	return nil
 }
 
-func cleanupKindProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) error {
+func k3dProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, log log.Logger) (string, error) {
+	if len(service.Spec.Ports) != 1 {
+		return "", nil
+	}
+
+	// see if we already have a proxy container running
+	server, err := getServerFromExistingProxyContainer(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, log)
+	if err != nil {
+		return "", err
+	} else if server != "" {
+		return server, nil
+	}
+
+	k3dName := strings.TrimPrefix(rawConfig.CurrentContext, "k3d-")
+	return createProxyContainer(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, "k3d-"+k3dName+"-server-0", "k3d-"+k3dName, log)
+}
+
+func minikubeProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, log log.Logger) (string, error) {
+	if len(service.Spec.Ports) != 1 {
+		return "", nil
+	}
+
+	// check if docker driver or vm
+	minikubeName := rawConfig.CurrentContext
+	if containerExists(minikubeName) {
+		// see if we already have a proxy container running
+		server, err := getServerFromExistingProxyContainer(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, log)
+		if err != nil {
+			return "", err
+		} else if server != "" {
+			return server, nil
+		}
+
+		// create proxy container if missing
+		return createProxyContainer(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, minikubeName, minikubeName, log)
+	}
+
+	// TODO: find out how to connect to the minikube vm directly
+	return "", nil
+}
+
+func cleanupProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) error {
 	// construct proxy name
 	proxyName := find.VClusterContextName(vClusterName, vClusterNamespace, rawConfig.CurrentContext)
 
@@ -52,7 +113,7 @@ func cleanupKindProxy(vClusterName, vClusterNamespace string, rawConfig *clientc
 		"stop",
 		proxyName,
 	)
-	log.Infof("Stopping kind proxy...")
+	log.Infof("Stopping docker proxy...")
 	_, _ = cmd.Output()
 	return nil
 }
@@ -62,59 +123,62 @@ func kindProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.C
 		return "", nil
 	}
 
+	// see if we already have a proxy container running
+	server, err := getServerFromExistingProxyContainer(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, log)
+	if err != nil {
+		return "", err
+	} else if server != "" {
+		return server, nil
+	}
+
+	// name is prefixed with kind- and suffixed with -control-plane
+	controlPlane := strings.TrimPrefix(rawConfig.CurrentContext, "kind-") + "-control-plane"
+	return createProxyContainer(vClusterName, vClusterNamespace, rawConfig, vRawConfig, service, localPort, controlPlane, "kind", log)
+}
+
+func directExposure(vRawConfig *clientcmdapi.Config, service *corev1.Service) (string, error) {
+	if len(service.Spec.Ports) != 1 {
+		return "", nil
+	}
+
+	server := fmt.Sprintf("https://127.0.0.1:%v", service.Spec.Ports[0].NodePort)
+	err := testConnectionWithServer(vRawConfig, server)
+	if err != nil {
+		return "", err
+	}
+
+	return server, nil
+}
+
+func createProxyContainer(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, backendHost, network string, log log.Logger) (string, error) {
 	// construct proxy name
 	proxyName := find.VClusterContextName(vClusterName, vClusterNamespace, rawConfig.CurrentContext)
 
-	// check if proxy container already exists
+	// in general, we need to run this statement to expose the correct port for this
+	// docker run -d -p LOCAL_PORT:NODE_PORT --rm -e "BACKEND_HOST=NAME-control-plane" -e "BACKEND_PORT=NODE_PORT" --network=NETWORK ghcr.io/loft-sh/docker-tcp-proxy
 	cmd := exec.Command(
 		"docker",
-		"inspect",
-		proxyName,
-		"-f",
-		fmt.Sprintf("{{ index (index (index .HostConfig.PortBindings \"%v/tcp\") 0) \"HostPort\" }}", service.Spec.Ports[0].NodePort),
+		"run",
+		"-d",
+		"-p",
+		fmt.Sprintf("%v:%v", localPort, service.Spec.Ports[0].NodePort),
+		"--rm",
+		fmt.Sprintf("--name=%s", proxyName),
+		"-e",
+		fmt.Sprintf("BACKEND_HOST=%s", backendHost),
+		"-e",
+		fmt.Sprintf("BACKEND_PORT=%v", service.Spec.Ports[0].NodePort),
+		fmt.Sprintf("--network=%s", network),
+		"ghcr.io/loft-sh/docker-tcp-proxy",
 	)
+	log.Infof("Starting proxy container...")
 	out, err := cmd.Output()
-	if err == nil {
-		localPort, err = strconv.Atoi(strings.TrimSpace(string(out)))
-		if err == nil && localPort != 0 {
-			server := fmt.Sprintf("https://localhost:%v", localPort)
-			err = testConnectionWithServer(vRawConfig, server)
-			if err != nil {
-				return "", errors.Wrap(err, "test connection")
-			}
-
-			return server, nil
-		}
-	} else {
-		log.Debugf("Error running docker inspect: %v", err)
-
-		// in general, we need to run this statement to expose the correct port for this
-		// docker run -d -p LOCAL_PORT:NODE_PORT --rm -e "BACKEND_HOST=NAME-control-plane" -e "BACKEND_PORT=NODE_PORT" --network=kind ghcr.io/loft-sh/docker-tcp-proxy
-		controlPlane := strings.TrimPrefix(rawConfig.CurrentContext, "kind-")
-		cmd = exec.Command(
-			"docker",
-			"run",
-			"-d",
-			"-p",
-			fmt.Sprintf("%v:%v", localPort, service.Spec.Ports[0].NodePort),
-			"--rm",
-			fmt.Sprintf("--name=%s", proxyName),
-			"-e",
-			fmt.Sprintf("BACKEND_HOST=%s-control-plane", controlPlane),
-			"-e",
-			fmt.Sprintf("BACKEND_PORT=%v", service.Spec.Ports[0].NodePort),
-			"--network=kind",
-			"ghcr.io/loft-sh/docker-tcp-proxy",
-		)
-		log.Infof("Starting proxy container...")
-		out, err = cmd.Output()
-		if err != nil {
-			return "", errors.Errorf("error starting kind proxy: %s %v", string(out), err)
-		}
+	if err != nil {
+		return "", errors.Errorf("error starting kind proxy: %s %v", string(out), err)
 	}
 
-	server := fmt.Sprintf("https://localhost:%v", localPort)
-	waitErr := wait.PollImmediate(time.Second, time.Second*20, func() (done bool, err error) {
+	server := fmt.Sprintf("https://127.0.0.1:%v", localPort)
+	waitErr := wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
 		err = testConnectionWithServer(vRawConfig, server)
 		if err != nil {
 			return false, nil
@@ -124,20 +188,6 @@ func kindProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.C
 	})
 	if waitErr != nil {
 		return "", fmt.Errorf("test connection: %v %v", waitErr, err)
-	}
-
-	return server, nil
-}
-
-func directExposure(vRawConfig *clientcmdapi.Config, service *corev1.Service) (string, error) {
-	if len(service.Spec.Ports) != 1 {
-		return "", nil
-	}
-
-	server := fmt.Sprintf("https://localhost:%v", service.Spec.Ports[0].NodePort)
-	err := testConnectionWithServer(vRawConfig, server)
-	if err != nil {
-		return "", err
 	}
 
 	return server, nil
@@ -168,4 +218,62 @@ func testConnectionWithServer(vRawConfig *clientcmdapi.Config, server string) er
 	}
 
 	return nil
+}
+
+func getServerFromExistingProxyContainer(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, log log.Logger) (string, error) {
+	// construct proxy name
+	proxyName := find.VClusterContextName(vClusterName, vClusterNamespace, rawConfig.CurrentContext)
+
+	// check if proxy container already exists
+	cmd := exec.Command(
+		"docker",
+		"inspect",
+		proxyName,
+		"-f",
+		fmt.Sprintf("{{ index (index (index .HostConfig.PortBindings \"%v/tcp\") 0) \"HostPort\" }}", service.Spec.Ports[0].NodePort),
+	)
+	out, err := cmd.Output()
+	if err == nil {
+		localPort, err := strconv.Atoi(strings.TrimSpace(string(out)))
+		if err == nil && localPort != 0 {
+			server := fmt.Sprintf("https://127.0.0.1:%v", localPort)
+			waitErr := wait.PollImmediate(time.Second, time.Second*5, func() (bool, error) {
+				err = testConnectionWithServer(vRawConfig, server)
+				if err != nil {
+					return false, nil
+				}
+
+				return true, nil
+			})
+			if waitErr != nil {
+				// return err here as waitErr is only timed out
+				return "", errors.Wrap(err, "test connection")
+			}
+
+			return server, nil
+		}
+	} else {
+		log.Debugf("Error running docker inspect with go template: %v", err)
+	}
+
+	// check if container exists
+	found := containerExists(proxyName)
+	if found {
+		err := cleanupProxy(vClusterName, vClusterNamespace, rawConfig, log)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return "", nil
+}
+
+func containerExists(containerName string) bool {
+	cmd := exec.Command(
+		"docker",
+		"inspect",
+		containerName,
+	)
+	_, err := cmd.Output()
+	return err == nil
 }

--- a/cmd/vclusterctl/cmd/app/localkubernetes/localkubernetes.go
+++ b/cmd/vclusterctl/cmd/app/localkubernetes/localkubernetes.go
@@ -26,14 +26,6 @@ const (
 	ClusterTypeColima         ClusterType = "colima"
 )
 
-func (c ClusterType) NodePortSupported() bool {
-	return c == ClusterTypeDockerDesktop ||
-		c == ClusterTypeRancherDesktop ||
-		c == ClusterTypeKIND ||
-		c == ClusterTypeMinikube ||
-		c == ClusterTypeK3D
-}
-
 // DetectClusterType detects the k8s distro locally.
 // Mostly taken from github.com/tilt-dev/clusterid, with some adjustments for vcluster
 func DetectClusterType(config *clientcmdapi.Config) ClusterType {

--- a/cmd/vclusterctl/cmd/app/localkubernetes/localkubernetes.go
+++ b/cmd/vclusterctl/cmd/app/localkubernetes/localkubernetes.go
@@ -1,0 +1,99 @@
+package localkubernetes
+
+import (
+	"path/filepath"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type ClusterType string
+
+func (c ClusterType) String() string { return string(c) }
+
+const (
+	ClusterTypeUnknown        ClusterType = "unknown"
+	ClusterTypeVCluster       ClusterType = "vcluster"
+	ClusterTypeMinikube       ClusterType = "minikube"
+	ClusterTypeDockerDesktop  ClusterType = "docker-desktop"
+	ClusterTypeMicroK8s       ClusterType = "microk8s"
+	ClusterTypeCRC            ClusterType = "crc"
+	ClusterTypeKrucible       ClusterType = "krucible"
+	ClusterTypeKIND           ClusterType = "kind"
+	ClusterTypeK3D            ClusterType = "k3d"
+	ClusterTypeRancherDesktop ClusterType = "rancher-desktop"
+	ClusterTypeColima         ClusterType = "colima"
+)
+
+func (c ClusterType) NodePortSupported() bool {
+	return c == ClusterTypeDockerDesktop ||
+		c == ClusterTypeRancherDesktop ||
+		c == ClusterTypeKIND ||
+		c == ClusterTypeMinikube ||
+		c == ClusterTypeK3D
+}
+
+// DetectClusterType detects the k8s distro locally.
+// Mostly taken from github.com/tilt-dev/clusterid, with some adjustments for vcluster
+func DetectClusterType(config *clientcmdapi.Config) ClusterType {
+	if config == nil || config.Contexts == nil || config.Clusters == nil {
+		return ClusterTypeUnknown
+	}
+
+	c := config.Contexts[config.CurrentContext]
+	if c == nil {
+		return ClusterTypeUnknown
+	}
+
+	cl := config.Clusters[c.Cluster]
+	if cl == nil {
+		return ClusterTypeUnknown
+	}
+
+	cn := c.Cluster
+	if strings.HasPrefix(cn, string(ClusterTypeVCluster)+"_") {
+		return ClusterTypeVCluster
+	} else if strings.HasPrefix(cn, string(ClusterTypeMinikube)) {
+		return ClusterTypeMinikube
+	} else if strings.HasPrefix(cn, "docker-for-desktop-cluster") || strings.HasPrefix(cn, "docker-desktop") {
+		return ClusterTypeDockerDesktop
+	} else if cn == "kind" {
+		return ClusterTypeKIND
+	} else if strings.HasPrefix(cn, "kind-") {
+		// As of KinD 0.6.0, KinD uses a context name prefix
+		// https://github.com/kubernetes-sigs/kind/issues/1060
+		return ClusterTypeKIND
+	} else if strings.HasPrefix(cn, "microk8s-cluster") {
+		return ClusterTypeMicroK8s
+	} else if strings.HasPrefix(cn, "api-crc-testing") {
+		return ClusterTypeCRC
+	} else if strings.HasPrefix(cn, "krucible-") {
+		return ClusterTypeKrucible
+	} else if strings.HasPrefix(cn, "k3d-") {
+		return ClusterTypeK3D
+	} else if strings.HasPrefix(cn, "rancher-desktop") {
+		return ClusterTypeRancherDesktop
+	} else if strings.HasPrefix(cn, "colima") {
+		return ClusterTypeColima
+	}
+
+	loc := c.LocationOfOrigin
+	homedir, err := homedir.Dir()
+	if err != nil {
+		return ClusterTypeUnknown
+	}
+
+	k3dDir := filepath.Join(homedir, ".config", "k3d")
+	if strings.HasPrefix(loc, k3dDir+string(filepath.Separator)) {
+		return ClusterTypeK3D
+	}
+
+	minikubeDir := filepath.Join(homedir, ".minikube")
+	if cl != nil && cl.CertificateAuthority != "" &&
+		strings.HasPrefix(cl.CertificateAuthority, minikubeDir+string(filepath.Separator)) {
+		return ClusterTypeMinikube
+	}
+
+	return ClusterTypeUnknown
+}

--- a/cmd/vclusterctl/cmd/app/podprinter/podprinter.go
+++ b/cmd/vclusterctl/cmd/app/podprinter/podprinter.go
@@ -1,0 +1,116 @@
+package podprinter
+
+import (
+	"context"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
+	"github.com/loft-sh/vcluster/pkg/util/stringutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sort"
+	"sync"
+	"time"
+)
+
+type PodInfoPrinter struct {
+	lastMutex   sync.Mutex
+	LastWarning time.Time
+
+	shownEvents           []string
+	printedInitContainers []string
+}
+
+func (u *PodInfoPrinter) PrintPodInfo(ctx context.Context, client *kubernetes.Clientset, pod *corev1.Pod, log log.Logger) {
+	u.lastMutex.Lock()
+	defer u.lastMutex.Unlock()
+
+	if time.Since(u.LastWarning) > time.Second*10 {
+		status := find.GetPodStatus(pod)
+		u.shownEvents = displayWarnings(ctx, relevantObjectsFromPod(pod), pod.Namespace, client, u.shownEvents, log)
+		if status != "Running" {
+			log.Warnf("vcluster is waiting, because vcluster pod %s has status: %s", pod.Name, status)
+		}
+		u.LastWarning = time.Now()
+	}
+}
+
+func (u *PodInfoPrinter) PrintPodWarning(pod *corev1.Pod, log log.Logger) {
+	u.lastMutex.Lock()
+	defer u.lastMutex.Unlock()
+
+	if time.Since(u.LastWarning) > time.Second*10 {
+		status := find.GetPodStatus(pod)
+		log.Warnf("Pod %s has critical status: %s. vcluster will continue waiting, but this operation might timeout", pod.Name, status)
+		u.LastWarning = time.Now()
+	}
+}
+
+type relevantObject struct {
+	Kind string
+	Name string
+	UID  string
+}
+
+func displayWarnings(ctx context.Context, relevantObjects []relevantObject, namespace string, client *kubernetes.Clientset, filter []string, log log.Logger) []string {
+	events, err := client.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Debugf("Error retrieving pod events: %v", err)
+		return nil
+	}
+
+	sort.Slice(events.Items, func(i, j int) bool {
+		return events.Items[i].CreationTimestamp.Unix() > events.Items[j].CreationTimestamp.Unix()
+	})
+	for _, event := range events.Items {
+		if event.Type != "Warning" {
+			continue
+		} else if stringutil.Contains(filter, event.Name) {
+			continue
+		} else if !eventMatches(&event, relevantObjects) {
+			continue
+		}
+
+		log.Warnf("%s %s: %s (%s)", event.InvolvedObject.Kind, event.InvolvedObject.Name, event.Message, event.Reason)
+		filter = append(filter, event.Name)
+	}
+
+	return filter
+}
+
+func relevantObjectsFromPod(pod *corev1.Pod) []relevantObject {
+	// search for persistent volume claims
+	objects := []relevantObject{
+		{
+			Kind: "Pod",
+			Name: pod.Name,
+			UID:  string(pod.UID),
+		},
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil {
+			objects = append(objects, relevantObject{
+				Kind: "PersistentVolumeClaim",
+				Name: v.PersistentVolumeClaim.ClaimName,
+			})
+		}
+
+	}
+	return objects
+}
+
+func eventMatches(event *corev1.Event, objects []relevantObject) bool {
+	for _, o := range objects {
+		if o.Name != "" && event.InvolvedObject.Name != o.Name {
+			continue
+		} else if o.Kind != "" && event.InvolvedObject.Kind != o.Kind {
+			continue
+		} else if o.UID != "" && string(event.InvolvedObject.UID) != o.UID {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -3,6 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/localkubernetes"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -14,17 +19,18 @@ import (
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
 	"github.com/loft-sh/vcluster/pkg/helm"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
-// DeleteCmd holds the login cmd flags
+// DeleteCmd holds the delete cmd flags
 type DeleteCmd struct {
 	*flags.GlobalFlags
 
 	KeepPVC         bool
 	DeleteNamespace bool
 
-	log log.Logger
+	rawConfig  *clientcmdapi.Config
+	restConfig *rest.Config
+	log        log.Logger
 }
 
 // NewDeleteCmd creates a new command
@@ -54,7 +60,7 @@ vcluster delete test --namespace test
 	}
 
 	cobraCmd.Flags().BoolVar(&cmd.KeepPVC, "keep-pvc", false, "If enabled, vcluster will not delete the persistent volume claim of the vcluster")
-	cobraCmd.Flags().BoolVar(&cmd.DeleteNamespace, "delete-namespace", false, "If enabled, vcluster will delete the namespace of the vcluster")
+	cobraCmd.Flags().BoolVar(&cmd.DeleteNamespace, "delete-namespace", true, "If enabled, vcluster will delete the namespace of the vcluster")
 	return cobraCmd
 }
 
@@ -71,81 +77,138 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		return fmt.Errorf("seems like there are issues with your helm client: \n\n%s", output)
 	}
 
-	// first load the kube config
-	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
-		CurrentContext: cmd.Context,
-	})
-
-	// load the raw config
-	rawConfig, err := kubeClientConfig.RawConfig()
-	if err != nil {
-		return fmt.Errorf("there is an error loading your current kube config (%v), please make sure you have access to a kubernetes cluster and the command `kubectl get namespaces` is working", err)
-	}
-	if cmd.Context != "" {
-		rawConfig.CurrentContext = cmd.Context
-	}
-
-	namespace, _, err := kubeClientConfig.Namespace()
+	// prepare client
+	err = cmd.prepare(args[0])
 	if err != nil {
 		return err
-	} else if namespace == "" {
-		namespace = "default"
-	}
-	if cmd.Namespace != "" {
-		namespace = cmd.Namespace
 	}
 
 	// we have to delete the chart
-	err = helm.NewClient(&rawConfig, cmd.log).Delete(args[0], namespace)
+	err = helm.NewClient(cmd.rawConfig, cmd.log).Delete(args[0], cmd.Namespace)
 	if err != nil {
 		return err
 	}
-	cmd.log.Donef("Successfully deleted virtual cluster %s in namespace %s", args[0], namespace)
+	cmd.log.Donef("Successfully deleted virtual cluster %s in namespace %s", args[0], cmd.Namespace)
 
 	// try to delete the pvc
 	if !cmd.KeepPVC {
 		pvcName := fmt.Sprintf("data-%s-0", args[0])
-		restConfig, err := kubeClientConfig.ClientConfig()
+		client, err := kubernetes.NewForConfig(cmd.restConfig)
 		if err != nil {
 			return err
 		}
 
-		client, err := kubernetes.NewForConfig(restConfig)
-		if err != nil {
-			return err
-		}
-
-		err = client.CoreV1().PersistentVolumeClaims(namespace).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
+		err = client.CoreV1().PersistentVolumeClaims(cmd.Namespace).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
 		if err != nil {
 			if !kerrors.IsNotFound(err) {
 				return errors.Wrap(err, "delete pvc")
 			}
 		} else {
-			cmd.log.Donef("Successfully deleted virtual cluster pvc %s in namespace %s", pvcName, namespace)
+			cmd.log.Donef("Successfully deleted virtual cluster pvc %s in namespace %s", pvcName, cmd.Namespace)
 		}
 	}
 
 	// try to delete the namespace
 	if cmd.DeleteNamespace {
-		restConfig, err := kubeClientConfig.ClientConfig()
+		client, err := kubernetes.NewForConfig(cmd.restConfig)
 		if err != nil {
 			return err
 		}
 
-		client, err := kubernetes.NewForConfig(restConfig)
-		if err != nil {
-			return err
-		}
-
-		err = client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+		err = client.CoreV1().Namespaces().Delete(context.Background(), cmd.Namespace, metav1.DeleteOptions{})
 		if err != nil {
 			if !kerrors.IsNotFound(err) {
 				return errors.Wrap(err, "delete namespace")
 			}
 		} else {
-			cmd.log.Donef("Successfully deleted virtual cluster namespace %s", namespace)
+			cmd.log.Donef("Successfully deleted virtual cluster namespace %s", cmd.Namespace)
 		}
 	}
 
 	return nil
+}
+
+func (cmd *DeleteCmd) prepare(vClusterName string) error {
+	vCluster, err := find.GetVCluster(cmd.Context, vClusterName, cmd.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// load the raw config
+	rawConfig, err := vCluster.ClientFactory.RawConfig()
+	if err != nil {
+		return fmt.Errorf("there is an error loading your current kube config (%v), please make sure you have access to a kubernetes cluster and the command `kubectl get namespaces` is working", err)
+	}
+	err = deleteContext(&rawConfig, find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context), vCluster.Context)
+	if err != nil {
+		return errors.Wrap(err, "delete kube context")
+	}
+
+	rawConfig.CurrentContext = vCluster.Context
+	restConfig, err := vCluster.ClientFactory.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	err = localkubernetes.CleanupLocal(vClusterName, vCluster.Namespace, &rawConfig, cmd.log)
+	if err != nil {
+		cmd.log.Warnf("error cleaning up: %v", err)
+	}
+
+	cmd.Namespace = vCluster.Namespace
+	cmd.rawConfig = &rawConfig
+	cmd.restConfig = restConfig
+	return nil
+}
+
+func deleteContext(kubeConfig *clientcmdapi.Config, kubeContext string, otherContext string) error {
+	// Get context
+	contextRaw, ok := kubeConfig.Contexts[kubeContext]
+	if !ok {
+		return nil
+	}
+
+	// Remove context
+	delete(kubeConfig.Contexts, kubeContext)
+
+	removeAuthInfo := true
+	removeCluster := true
+
+	// Check if AuthInfo or Cluster is used by any other context
+	for name, ctx := range kubeConfig.Contexts {
+		if name != kubeContext && ctx.AuthInfo == contextRaw.AuthInfo {
+			removeAuthInfo = false
+		}
+
+		if name != kubeContext && ctx.Cluster == contextRaw.Cluster {
+			removeCluster = false
+		}
+	}
+
+	// Remove AuthInfo if not used by any other context
+	if removeAuthInfo {
+		delete(kubeConfig.AuthInfos, contextRaw.AuthInfo)
+	}
+
+	// Remove Cluster if not used by any other context
+	if removeCluster {
+		delete(kubeConfig.Clusters, contextRaw.Cluster)
+	}
+
+	if kubeConfig.CurrentContext == kubeContext {
+		kubeConfig.CurrentContext = ""
+
+		if otherContext != "" {
+			kubeConfig.CurrentContext = otherContext
+		} else if len(kubeConfig.Contexts) > 0 {
+			for contextName, contextObj := range kubeConfig.Contexts {
+				if contextObj != nil {
+					kubeConfig.CurrentContext = contextName
+					break
+				}
+			}
+		}
+	}
+
+	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), *kubeConfig, false)
 }

--- a/cmd/vclusterctl/cmd/disconnect.go
+++ b/cmd/vclusterctl/cmd/disconnect.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// DisconnectCmd holds the disconnect cmd flags
+type DisconnectCmd struct {
+	*flags.GlobalFlags
+
+	rawConfig  *clientcmdapi.Config
+	restConfig *rest.Config
+	log        log.Logger
+}
+
+// NewDisconnectCmd creates a new command
+func NewDisconnectCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &DisconnectCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "disconnect",
+		Short: "Disconnects from a virtual cluster",
+		Long: `
+#######################################################
+################# vcluster disconnect #################
+#######################################################
+Disconnect switches back the kube context if
+vcluster connect --update-current was used
+
+Example:
+vcluster connect --update-current
+vcluster disconnect
+#######################################################
+	`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(cobraCmd, args)
+		},
+	}
+
+	return cobraCmd
+}
+
+// Run executes the functionality
+func (cmd *DisconnectCmd) Run(cobraCmd *cobra.Command, args []string) error {
+	if cmd.Context == "" {
+		rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
+		if err != nil {
+			return err
+		}
+
+		cmd.Context = rawConfig.CurrentContext
+	}
+
+	// get vcluster info from context
+	vClusterName, vClusterNamespace, _ := find.VClusterFromContext(cmd.Context)
+	if vClusterName == "" {
+		return fmt.Errorf("current selected context is not a vcluster context")
+	}
+
+	// disconnect
+	err := cmd.disconnect(vClusterName, vClusterNamespace)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cmd *DisconnectCmd) disconnect(vClusterName, vClusterNamespace string) error {
+	vCluster, err := find.GetVCluster(cmd.Context, vClusterName, vClusterNamespace)
+	if err != nil {
+		return err
+	}
+
+	// load the raw config
+	rawConfig, err := vCluster.ClientFactory.RawConfig()
+	if err != nil {
+		return fmt.Errorf("there is an error loading your current kube config (%v), please make sure you have access to a kubernetes cluster and the command `kubectl get namespaces` is working", err)
+	}
+	err = switchContext(&rawConfig, vCluster.Context)
+	if err != nil {
+		return errors.Wrap(err, "delete kube context")
+	}
+
+	rawConfig.CurrentContext = vCluster.Context
+	restConfig, err := vCluster.ClientFactory.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	cmd.Namespace = vCluster.Namespace
+	cmd.rawConfig = &rawConfig
+	cmd.restConfig = restConfig
+	return nil
+}
+
+func switchContext(kubeConfig *clientcmdapi.Config, otherContext string) error {
+	kubeConfig.CurrentContext = otherContext
+	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), *kubeConfig, false)
+}

--- a/cmd/vclusterctl/cmd/find/find.go
+++ b/cmd/vclusterctl/cmd/find/find.go
@@ -1,0 +1,331 @@
+package find
+
+import (
+	"context"
+	"fmt"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
+)
+
+const VirtualClusterSelector = "app=vcluster"
+
+type VCluster struct {
+	Name      string
+	Namespace string
+
+	Status        Status
+	Created       time.Time
+	Context       string
+	ClientFactory clientcmd.ClientConfig `json:"-"`
+}
+
+type Status string
+
+const (
+	StatusRunning Status = "Running"
+	StatusPaused  Status = "Paused"
+	StatusUnknown Status = "Unknown"
+)
+
+func GetVCluster(context, name, namespace string) (*VCluster, error) {
+	if name == "" {
+		return nil, fmt.Errorf("please specify a name")
+	}
+
+	vclusters, err := ListVClusters(context, name, namespace)
+	if err != nil {
+		return nil, err
+	} else if len(vclusters) == 0 {
+		return nil, fmt.Errorf("couldn't find vcluster %s", name)
+	} else if len(vclusters) == 1 {
+		return &vclusters[0], nil
+	}
+
+	return nil, fmt.Errorf("multiple vclusters with name %s found, please specify a namespace via -n", name)
+}
+
+func ListVClusters(context, name, namespace string) ([]VCluster, error) {
+	if context == "" {
+		rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		context = rawConfig.CurrentContext
+	}
+
+	vClusterName, _, vClusterContext := VClusterFromContext(context)
+	vclusters, err := findInContext(context, name, namespace)
+	if err != nil && vClusterName == "" {
+		return nil, errors.Wrap(err, "find vcluster")
+	}
+
+	if vClusterName != "" {
+		parentContextVclusters, err := findInContext(vClusterContext, name, namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "find vcluster")
+		}
+
+		vclusters = append(vclusters, parentContextVclusters...)
+	}
+
+	return vclusters, nil
+}
+
+func VClusterContextName(vClusterName string, vClusterNamespace string, currentContext string) string {
+	return "vcluster_" + vClusterName + "_" + vClusterNamespace + "_" + currentContext
+}
+
+func VClusterFromContext(originalContext string) (name string, namespace string, context string) {
+	if strings.HasPrefix(originalContext, "vcluster_") == false {
+		return "", "", ""
+	}
+
+	splitted := strings.Split(originalContext, "_")
+	if len(splitted) < 4 {
+		return "", "", ""
+	}
+
+	return splitted[1], splitted[2], strings.Join(splitted[3:], "_")
+}
+
+func findInContext(context, name, namespace string) ([]VCluster, error) {
+	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
+		CurrentContext: context,
+	})
+	restConfig, err := kubeClientConfig.ClientConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "load kube config")
+	}
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "create kube client")
+	}
+
+	// statefulset based vclusters
+	vclusters := []VCluster{}
+	statefulSets, err := getStatefulSets(client, namespace, kubeClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range statefulSets.Items {
+		if release, ok := p.Labels["release"]; ok {
+			if name != "" && name != release {
+				continue
+			}
+
+			vCluster, err := getVCluster(&p, context, release, client, kubeClientConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			vclusters = append(vclusters, vCluster)
+		}
+	}
+
+	// deployment based vclusters
+	deployments, err := getDeployments(client, namespace, kubeClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range deployments.Items {
+		if release, ok := p.Labels["release"]; ok {
+			if name != "" && name != release {
+				continue
+			}
+
+			vCluster, err := getVCluster(&p, context, release, client, kubeClientConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			vclusters = append(vclusters, vCluster)
+		}
+	}
+
+	return vclusters, nil
+}
+
+func getVCluster(object client.Object, context, release string, client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig) (VCluster, error) {
+	namespace := object.GetNamespace()
+	created := object.GetCreationTimestamp().Time
+	releaseName := ""
+	status := ""
+	if object.GetAnnotations() != nil && object.GetAnnotations()[constants.PausedAnnotation] == "true" {
+		status = string(StatusPaused)
+	} else {
+		releaseName = "release=" + release
+	}
+
+	if status == "" {
+		pods, err := getPods(client, kubeClientConfig, namespace, releaseName)
+		if err != nil {
+			return VCluster{}, err
+		}
+		for _, pod := range pods.Items {
+			status = GetPodStatus(&pod)
+		}
+	}
+	if status == "" {
+		status = string(StatusUnknown)
+	}
+
+	return VCluster{
+		Name:          release,
+		Namespace:     namespace,
+		Status:        Status(status),
+		Created:       created,
+		Context:       context,
+		ClientFactory: kubeClientConfig,
+	}, nil
+}
+
+func getPods(client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig, namespace, podSelector string) (*corev1.PodList, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	podList, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: VirtualClusterSelector + "," + podSelector,
+	})
+	if err != nil {
+		if kerrors.IsForbidden(err) {
+			// try the current namespace instead
+			if namespace, err = getAccessibleNS(kubeClientConfig); err != nil {
+				return nil, err
+			}
+			return client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: VirtualClusterSelector,
+			})
+		}
+		return nil, err
+	}
+	return podList, nil
+}
+
+func getDeployments(client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig) (*appsv1.DeploymentList, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	deploymentList, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: VirtualClusterSelector,
+	})
+	if err != nil {
+		if kerrors.IsForbidden(err) {
+			// try the current namespace instead
+			if namespace, err = getAccessibleNS(kubeClientConfig); err != nil {
+				return nil, err
+			}
+			return client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: VirtualClusterSelector,
+			})
+		}
+		return nil, err
+	}
+	return deploymentList, nil
+}
+
+func getStatefulSets(client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig) (*appsv1.StatefulSetList, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	statefulSetList, err := client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: VirtualClusterSelector,
+	})
+	if err != nil {
+		if kerrors.IsForbidden(err) {
+			if namespace, err = getAccessibleNS(kubeClientConfig); err != nil {
+				return nil, err
+			}
+			return client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: VirtualClusterSelector,
+			})
+		}
+		return nil, err
+	}
+	return statefulSetList, nil
+}
+
+func getAccessibleNS(kubeClientConfig clientcmd.ClientConfig) (string, error) {
+	// try the current namespace instead
+	namespace, _, err := kubeClientConfig.Namespace()
+	if err != nil {
+		return "", err
+	} else if namespace == "" {
+		namespace = "default"
+	}
+	return namespace, nil
+}
+
+// GetPodStatus returns the pod status as a string
+// Taken from https://github.com/kubernetes/kubernetes/pkg/printers/internalversion/printers.go
+func GetPodStatus(pod *corev1.Pod) string {
+	reason := string(pod.Status.Phase)
+	if pod.Status.Reason != "" {
+		reason = pod.Status.Reason
+	}
+	initializing := false
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		switch {
+		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case container.State.Terminated != nil:
+			// initialization is failed
+			if len(container.State.Terminated.Reason) == 0 {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else {
+				reason = "Init:" + container.State.Terminated.Reason
+			}
+			initializing = true
+		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + container.State.Waiting.Reason
+			initializing = true
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+			initializing = true
+		}
+		break
+	}
+	if !initializing {
+		hasRunning := false
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			container := pod.Status.ContainerStatuses[i]
+			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
+				reason = container.State.Waiting.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
+				reason = container.State.Terminated.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else if container.Ready && container.State.Running != nil {
+				hasRunning = true
+			}
+		}
+		// change pod status back to "Running" if there is at least one container still reporting as "Running" status
+		if reason == "Completed" && hasRunning {
+			reason = "Running"
+		}
+	}
+	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
+		reason = "Unknown"
+	} else if pod.DeletionTimestamp != nil {
+		reason = "Terminating"
+	}
+	return reason
+}

--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -1,22 +1,17 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"k8s.io/client-go/tools/clientcmd"
+	"strings"
 	"time"
 
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // VCluster holds information about a cluster
@@ -27,8 +22,6 @@ type VCluster struct {
 	AgeSeconds int
 	Status     string
 }
-
-const VirtualClusterSelector = "app=vcluster"
 
 // ListCmd holds the login cmd flags
 type ListCmd struct {
@@ -73,241 +66,55 @@ vcluster list --namespace test
 
 // Run executes the functionality
 func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
-	// first load the kube config
-	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
-		CurrentContext: cmd.Context,
-	})
+	if cmd.Context == "" {
+		rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
+		if err != nil {
+			return err
+		}
+
+		cmd.Context = rawConfig.CurrentContext
+	}
+
 	namespace := metav1.NamespaceAll
 	if cmd.Namespace != "" {
 		namespace = cmd.Namespace
 	}
 
-	// get all statefulsets with the label app=vcluster
-	restConfig, err := kubeClientConfig.ClientConfig()
+	vClusters, err := find.ListVClusters(cmd.Context, "", namespace)
 	if err != nil {
 		return err
-	}
-	client, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-
-	vclusters := []VCluster{}
-
-	// statefulset based vclusters
-	statefulSets, err := getStatefulSets(client, namespace, kubeClientConfig)
-	if err != nil {
-		return err
-	}
-	for _, p := range statefulSets.Items {
-		if v, ok := p.Labels["release"]; ok {
-			vCluster, err := getVCluster(&p, v, client, kubeClientConfig)
-			if err != nil {
-				return err
-			}
-			vclusters = append(vclusters, vCluster)
-		}
-	}
-
-	// deployment based vclusters
-	deployments, err := getDeployments(client, namespace, kubeClientConfig)
-	if err != nil {
-		return err
-	}
-	for _, p := range deployments.Items {
-		if v, ok := p.Labels["release"]; ok {
-			vCluster, err := getVCluster(&p, v, client, kubeClientConfig)
-			if err != nil {
-				return err
-			}
-			vclusters = append(vclusters, vCluster)
-		}
 	}
 
 	if cmd.output == "json" {
-		bytes, err := json.MarshalIndent(&vclusters, "", "    ")
+		bytes, err := json.MarshalIndent(&vClusters, "", "    ")
 		if err != nil {
 			return errors.Wrap(err, "json marshal vclusters")
 		}
 		cmd.log.WriteString(string(bytes) + "\n")
 	} else {
-		header := []string{"NAME", "NAMESPACE", "STATUS", "CREATED", "AGE"}
+		header := []string{"NAME", "NAMESPACE", "STATUS", "CONNECTED", "CREATED", "AGE"}
 		values := [][]string{}
-		for _, vcluster := range vclusters {
+		for _, vcluster := range vClusters {
+			connected := ""
+			if cmd.Context == find.VClusterContextName(vcluster.Name, vcluster.Namespace, vcluster.Context) {
+				connected = "True"
+			}
+
 			values = append(values, []string{
 				vcluster.Name,
 				vcluster.Namespace,
-				vcluster.Status,
+				string(vcluster.Status),
+				connected,
 				vcluster.Created.String(),
 				time.Since(vcluster.Created).Round(1 * time.Second).String(),
 			})
 		}
 
 		log.PrintTable(cmd.log, header, values)
+		if strings.HasPrefix(cmd.Context, "vcluster_") {
+			cmd.log.Infof("Run `vcluster disconnect` to switch the current context back")
+		}
 	}
 
 	return nil
-}
-
-func getVCluster(object client.Object, v string, client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig) (VCluster, error) {
-	namespace := object.GetNamespace()
-	created := object.GetCreationTimestamp().Time
-	var releaseName string
-	var status string
-	if object.GetAnnotations() != nil && object.GetAnnotations()[PausedAnnotation] == "true" {
-		status = "Paused"
-	} else {
-		releaseName = "release=" + v
-	}
-	if len(status) < 1 {
-		pods, err := getPods(client, kubeClientConfig, namespace, releaseName)
-		if err != nil {
-			return VCluster{}, err
-		}
-		for _, pod := range pods.Items {
-			status = GetPodStatus(&pod)
-		}
-	}
-	if len(status) < 1 {
-		status = "Unknown"
-	}
-	return VCluster{
-		Name:       v,
-		Namespace:  namespace,
-		Created:    created,
-		AgeSeconds: int(time.Since(created).Seconds()),
-		Status:     status,
-	}, nil
-}
-
-func getPods(client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig, namespace, podSelector string) (*corev1.PodList, error) {
-	podList, err := client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: VirtualClusterSelector + "," + podSelector,
-	})
-	if err != nil {
-		if kerrors.IsForbidden(err) {
-			// try the current namespace instead
-			if namespace, err = getAccessibleNS(kubeClientConfig); err != nil {
-				return nil, err
-			}
-			return client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
-				LabelSelector: VirtualClusterSelector,
-			})
-		}
-		return nil, err
-	}
-	return podList, nil
-}
-
-func getDeployments(client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig) (*appsv1.DeploymentList, error) {
-	deploymentList, err := client.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: VirtualClusterSelector,
-	})
-	if err != nil {
-		if kerrors.IsForbidden(err) {
-			// try the current namespace instead
-			if namespace, err = getAccessibleNS(kubeClientConfig); err != nil {
-				return nil, err
-			}
-			return client.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{
-				LabelSelector: VirtualClusterSelector,
-			})
-		}
-		return nil, err
-	}
-	return deploymentList, nil
-}
-
-func getStatefulSets(client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig) (*appsv1.StatefulSetList, error) {
-	statefulSetList, err := client.AppsV1().StatefulSets(namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: VirtualClusterSelector,
-	})
-	if err != nil {
-		if kerrors.IsForbidden(err) {
-			if namespace, err = getAccessibleNS(kubeClientConfig); err != nil {
-				return nil, err
-			}
-			return client.AppsV1().StatefulSets(namespace).List(context.Background(), metav1.ListOptions{
-				LabelSelector: VirtualClusterSelector,
-			})
-		}
-		return nil, err
-	}
-	return statefulSetList, nil
-}
-
-func getAccessibleNS(kubeClientConfig clientcmd.ClientConfig) (string, error) {
-	// try the current namespace instead
-	namespace, _, err := kubeClientConfig.Namespace()
-	if err != nil {
-		return "", err
-	} else if namespace == "" {
-		namespace = "default"
-	}
-	return namespace, nil
-}
-
-// GetPodStatus returns the pod status as a string
-// Taken from https://github.com/kubernetes/kubernetes/pkg/printers/internalversion/printers.go
-func GetPodStatus(pod *corev1.Pod) string {
-	reason := string(pod.Status.Phase)
-	if pod.Status.Reason != "" {
-		reason = pod.Status.Reason
-	}
-	initializing := false
-	for i := range pod.Status.InitContainerStatuses {
-		container := pod.Status.InitContainerStatuses[i]
-		switch {
-		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
-			continue
-		case container.State.Terminated != nil:
-			// initialization is failed
-			if len(container.State.Terminated.Reason) == 0 {
-				if container.State.Terminated.Signal != 0 {
-					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
-				} else {
-					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
-				}
-			} else {
-				reason = "Init:" + container.State.Terminated.Reason
-			}
-			initializing = true
-		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
-			reason = "Init:" + container.State.Waiting.Reason
-			initializing = true
-		default:
-			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
-			initializing = true
-		}
-		break
-	}
-	if !initializing {
-		hasRunning := false
-		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
-			container := pod.Status.ContainerStatuses[i]
-			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
-				reason = container.State.Waiting.Reason
-			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
-				reason = container.State.Terminated.Reason
-			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
-				if container.State.Terminated.Signal != 0 {
-					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
-				} else {
-					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
-				}
-			} else if container.Ready && container.State.Running != nil {
-				hasRunning = true
-			}
-		}
-		// change pod status back to "Running" if there is at least one container still reporting as "Running" status
-		if reason == "Completed" && hasRunning {
-			reason = "Running"
-		}
-	}
-	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
-		reason = "Unknown"
-	} else if pod.DeletionTimestamp != nil {
-		reason = "Terminating"
-	}
-	return reason
 }

--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -112,7 +112,7 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
 
 		log.PrintTable(cmd.log, header, values)
 		if strings.HasPrefix(cmd.Context, "vcluster_") {
-			cmd.log.Infof("Run `vcluster disconnect` to switch the current context back")
+			cmd.log.Infof("Run `vcluster disconnect` to switch back to the parent context")
 		}
 	}
 

--- a/cmd/vclusterctl/cmd/pause.go
+++ b/cmd/vclusterctl/cmd/pause.go
@@ -130,6 +130,19 @@ func (cmd *PauseCmd) prepare(vClusterName string) error {
 		return err
 	}
 
+	currentContext, currentRawConfig, err := find.CurrentContext()
+	if err != nil {
+		return err
+	}
+
+	vClusterName, vClusterNamespace, vClusterContext := find.VClusterFromContext(currentContext)
+	if vClusterName == vCluster.Name && vClusterNamespace == vCluster.Namespace && vClusterContext == vCluster.Context {
+		err = switchContext(currentRawConfig, vCluster.Context)
+		if err != nil {
+			return err
+		}
+	}
+
 	cmd.Namespace = vCluster.Namespace
 	cmd.kubeClient = kubeClient
 	return nil

--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -19,6 +19,10 @@ func NewRootCmd(log log.Logger) *cobra.Command {
 		PersistentPreRun: func(cobraCmd *cobra.Command, args []string) {
 			if globalFlags.Silent {
 				log.SetLevel(logrus.FatalLevel)
+			} else if globalFlags.Debug {
+				log.SetLevel(logrus.DebugLevel)
+			} else {
+				log.SetLevel(logrus.InfoLevel)
 			}
 		},
 		Long: `vcluster root command`,
@@ -60,6 +64,7 @@ func BuildRoot(log log.Logger) *cobra.Command {
 	rootCmd.AddCommand(NewDeleteCmd(globalFlags))
 	rootCmd.AddCommand(NewPauseCmd(globalFlags))
 	rootCmd.AddCommand(NewResumeCmd(globalFlags))
+	rootCmd.AddCommand(NewDisconnectCmd(globalFlags))
 	rootCmd.AddCommand(NewUpgradeCmd())
 	rootCmd.AddCommand(NewCompletionCmd())
 	rootCmd.AddCommand(get.NewGetCmd(globalFlags))

--- a/cmd/vclusterctl/cmd/util.go
+++ b/cmd/vclusterctl/cmd/util.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"context"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/podprinter"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
+	"github.com/loft-sh/vcluster/pkg/util/kubeconfig"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"math/rand"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CriticalStatus container status
+var CriticalStatus = map[string]bool{
+	"Error":                      true,
+	"Unknown":                    true,
+	"ImagePullBackOff":           true,
+	"CrashLoopBackOff":           true,
+	"RunContainerError":          true,
+	"ErrImagePull":               true,
+	"CreateContainerConfigError": true,
+	"InvalidImageName":           true,
+}
+
+var SortPodsByNewest = func(pods []corev1.Pod, i, j int) bool {
+	return pods[i].CreationTimestamp.Unix() > pods[j].CreationTimestamp.Unix()
+}
+
+// GetKubeConfig attempts to read the kubeconfig from the default Secret and
+// falls back to reading from filesystem if the Secret is not read successfully.
+// Reading from filesystem is implemented for the backward compatibility and
+// can be eventually removed in the future.
+//
+// This is retried until the kube config is successfully retrieve, or until 10 minute timeout is reached.
+func GetKubeConfig(ctx context.Context, kubeClient *kubernetes.Clientset, vclusterName string, namespace string, log log.Logger) (*api.Config, error) {
+	var kubeConfig *api.Config
+
+	printedWaiting := false
+	podInfoPrinter := podprinter.PodInfoPrinter{LastWarning: time.Now().Add(time.Second * 6)}
+	err := wait.PollImmediate(time.Second, time.Minute*10, func() (done bool, err error) {
+		podList, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=vcluster,release=" + vclusterName,
+		})
+		if err != nil {
+			return false, err
+		} else if len(podList.Items) > 0 {
+			sort.Slice(podList.Items, func(i, j int) bool {
+				return SortPodsByNewest(podList.Items, i, j)
+			})
+			if HasPodProblem(&podList.Items[0]) {
+				if !printedWaiting {
+					log.Infof("Waiting for vcluster to come up...")
+					printedWaiting = true
+				}
+
+				podInfoPrinter.PrintPodWarning(&podList.Items[0], log)
+				return false, nil
+			} else if !allContainersReady(&podList.Items[0]) {
+				if !printedWaiting {
+					log.Infof("Waiting for vcluster to come up...")
+					printedWaiting = true
+				}
+
+				if find.GetPodStatus(&podList.Items[0]) != "Running" {
+					podInfoPrinter.PrintPodInfo(ctx, kubeClient, &podList.Items[0], log)
+				}
+				return false, nil
+			}
+		}
+
+		kubeConfig, err = kubeconfig.ReadKubeConfig(ctx, kubeClient, vclusterName, namespace)
+		if err != nil {
+			if !printedWaiting {
+				log.Infof("Waiting for vcluster to come up...")
+				printedWaiting = true
+			}
+
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "wait for vcluster")
+	}
+
+	return kubeConfig, nil
+}
+
+func allContainersReady(pod *corev1.Pod) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready || cs.State.Running == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func HasPodProblem(pod *corev1.Pod) bool {
+	status := find.GetPodStatus(pod)
+	status = strings.TrimPrefix(status, "Init:")
+	return CriticalStatus[status]
+}
+
+func updateKubeConfig(contextName string, cluster *api.Cluster, authInfo *api.AuthInfo, setActive bool) error {
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
+	if err != nil {
+		return err
+	}
+
+	config.Clusters[contextName] = cluster
+	config.AuthInfos[contextName] = authInfo
+
+	// Update kube context
+	context := api.NewContext()
+	context.Cluster = contextName
+	context.AuthInfo = contextName
+
+	config.Contexts[contextName] = context
+	if setActive {
+		config.CurrentContext = contextName
+	}
+
+	// Save the config
+	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), config, false)
+}
+
+func randomPort() int {
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 10; i++ {
+		port := 10000 + rand.Intn(3000)
+		s, err := checkPort(port)
+		if s && err == nil {
+			return port
+		}
+	}
+
+	// just try another port
+	return 10000 + rand.Intn(3000)
+}
+
+func checkPort(port int) (status bool, err error) {
+	// Concatenate a colon and the port
+	host := "localhost:" + strconv.Itoa(port)
+
+	// Try to create a server with the port
+	server, err := net.Listen("tcp", host)
+
+	// if it fails then the port is likely taken
+	if err != nil {
+		return false, err
+	}
+
+	// close the server
+	_ = server.Close()
+
+	// we successfully used and closed the port
+	// so it's now available to be used again
+	return true, nil
+}

--- a/cmd/vclusterctl/log/stdout_logger.go
+++ b/cmd/vclusterctl/log/stdout_logger.go
@@ -36,49 +36,49 @@ type fnTypeInformation struct {
 
 var fnTypeInformationMap = map[logFunctionType]*fnTypeInformation{
 	debugFn: {
-		tag:      "[debug]  ",
+		tag:      "debug  ",
 		color:    "green+b",
 		logLevel: logrus.DebugLevel,
 		stream:   stdout,
 	},
 	infoFn: {
-		tag:      "[info]   ",
+		tag:      "info   ",
 		color:    "cyan+b",
 		logLevel: logrus.InfoLevel,
 		stream:   stdout,
 	},
 	warnFn: {
-		tag:      "[warn]   ",
+		tag:      "warn   ",
 		color:    "red+b",
 		logLevel: logrus.WarnLevel,
 		stream:   stdout,
 	},
 	errorFn: {
-		tag:      "[error]  ",
+		tag:      "error  ",
 		color:    "red+b",
 		logLevel: logrus.ErrorLevel,
 		stream:   stdout,
 	},
 	fatalFn: {
-		tag:      "[fatal]  ",
+		tag:      "fatal  ",
 		color:    "red+b",
 		logLevel: logrus.FatalLevel,
 		stream:   stdout,
 	},
 	panicFn: {
-		tag:      "[panic]  ",
+		tag:      "panic  ",
 		color:    "red+b",
 		logLevel: logrus.PanicLevel,
 		stream:   stderr,
 	},
 	doneFn: {
-		tag:      "[done] √ ",
+		tag:      "done √ ",
 		color:    "green+b",
 		logLevel: logrus.InfoLevel,
 		stream:   stdout,
 	},
 	failFn: {
-		tag:      "[fail] X ",
+		tag:      "fail X ",
 		color:    "red+b",
 		logLevel: logrus.ErrorLevel,
 		stream:   stdout,

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -18,6 +18,8 @@ deployments:
       chart:
         name: ./charts/k3s
       values:
+        service:
+          type: NodePort
         serviceCIDR: $([ $1 == "dev" ] && vcluster get service-cidr || echo "null")
         mapServices:
           fromVirtual:

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -128,18 +128,15 @@ func CreateFramework(ctx context.Context, scheme *runtime.Scheme) error {
 		Log: l,
 		GlobalFlags: &flags.GlobalFlags{
 			Namespace: ns,
+			Debug:     true,
 		},
 		KubeConfig: vKubeconfigFile.Name(),
-		LocalPort:  8440,        // choosing a port that usually should be unused
-		Address:    "127.0.0.1", // setting only ipv4 address may reduce a number of errors, see comments on kubernetes#74551
+		LocalPort:  14550, // choosing a port that usually should be unused
 	}
-	go func() {
-		//TODO: perhaps forward stdout/stderr to debug level logs?
-		err = connectCmd.Connect(name, nil)
-		if err != nil {
-			l.Fatalf("failed to connect to the vcluster: %v", err)
-		}
-	}()
+	err = connectCmd.Connect(name, nil)
+	if err != nil {
+		l.Fatalf("failed to connect to the vcluster: %v", err)
+	}
 
 	var vclusterConfig *rest.Config
 	var vclusterClient *kubernetes.Clientset

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,7 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=

--- a/pkg/constants/annotation.go
+++ b/pkg/constants/annotation.go
@@ -3,4 +3,6 @@ package constants
 const (
 	SkipTranslationAnnotation = "vcluster.loft.sh/skip-translate"
 	SyncResourceAnnotation    = "vcluster.loft.sh/force-sync"
+
+	PausedAnnotation = "loft.sh/paused"
 )

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -168,7 +168,7 @@ func (c *client) run(name, namespace string, options UpgradeOptions, command str
 		args = append(args, "--atomic")
 	}
 
-	c.log.Info("execute command: helm " + strings.Join(args, " "))
+	c.log.Debug("execute command: helm " + strings.Join(args, " "))
 	output, err := exec.Command(c.helmPath, args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error executing helm %s: %s", strings.Join(args, " "), string(output))
@@ -186,7 +186,7 @@ func (c *client) Delete(name, namespace string) error {
 
 	args := []string{"delete", name, "--namespace", namespace, "--kubeconfig", kubeConfig, "--repository-config=''"}
 
-	c.log.Info("Delete helm chart with helm " + strings.Join(args, " "))
+	c.log.Debug("Delete helm chart with helm " + strings.Join(args, " "))
 	output, err := exec.Command(c.helmPath, args...).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "release: not found") {

--- a/pkg/helm/types.go
+++ b/pkg/helm/types.go
@@ -18,6 +18,7 @@ type ChartOptions struct {
 	CreateClusterRole  bool
 	DisableIngressSync bool
 	Expose             bool
+	NodePort           bool
 	K3SImage           string
 	Isolate            bool
 	KubernetesVersion  *version.Info

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -112,6 +112,10 @@ rbac:
 		values += `
 service:
   type: LoadBalancer`
+	} else if chartOptions.NodePort {
+		values += `
+service:
+  type: NodePort`
 	}
 
 	if chartOptions.Isolate {

--- a/vendor/github.com/mitchellh/go-homedir/LICENSE
+++ b/vendor/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-homedir/README.md
+++ b/vendor/github.com/mitchellh/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/vendor/github.com/mitchellh/go-homedir/homedir.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,167 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+// Reset clears the cache, forcing the next call to Dir to re-detect
+// the home directory. This generally never has to be called, but can be
+// useful in tests if you're modifying the home directory via the HOME
+// env var or something.
+func Reset() {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	homedirCache = ""
+}
+
+func dirUnix() (string, error) {
+	homeEnv := "HOME"
+	if runtime.GOOS == "plan9" {
+		// On plan9, env vars are lowercase.
+		homeEnv = "home"
+	}
+
+	// First prefer the HOME environmental variable
+	if home := os.Getenv(homeEnv); home != "" {
+		return home, nil
+	}
+
+	var stdout bytes.Buffer
+
+	// If that fails, try OS specific commands
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err == nil {
+			result := strings.TrimSpace(stdout.String())
+			if result != "" {
+				return result, nil
+			}
+		}
+	} else {
+		cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err != nil {
+			// If the error is ErrNotFound, we ignore it. Otherwise, return it.
+			if err != exec.ErrNotFound {
+				return "", err
+			}
+		} else {
+			if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+				// username:password:uid:gid:gecos:home:shell
+				passwdParts := strings.SplitN(passwd, ":", 7)
+				if len(passwdParts) > 5 {
+					return passwdParts[5], nil
+				}
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd := exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// Prefer standard environment variable USERPROFILE
+	if home := os.Getenv("USERPROFILE"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, or USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,6 +250,9 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 ## explicit
 github.com/mgutz/ansi
+# github.com/mitchellh/go-homedir v1.1.0
+## explicit
+github.com/mitchellh/go-homedir
 # github.com/mitchellh/go-wordwrap v1.0.0
 ## explicit
 github.com/mitchellh/go-wordwrap


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #528

**BREAKING CHANGES**
- `vcluster create` now automatically does a connect. Can be disabled via `vcluster create --connect=false`
- `vcluster connect` now by default switches the current kube context to the vcluster context. Can be disabled via `vcluster connect --update-current=false`
- `vcluster delete` now by default deletes the namespace of the vcluster if it was created by vcluster before. Can be disabled via `vcluster delete --auto-delete-namespace=false`

**Please provide a short message that should be published in the vcluster release notes**
- Refactored `vcluster create` and `vcluster connect` that will now create a nodeport service for local k8s distros such as docker-desktop & rancher-desktop, that does not need port-forwarding. 
- Refactored `vcluster` commands to work even if the current context points to a vcluster. This allows easier management of vclusters with:
```
vcluster connect cluster-1
vcluster connect cluster-2 # <- Works even though current context points to cluster-1
```
- New `vcluster disconnect` to switch back to the parent cluster context. 

