### PR TITLE
refactor: add plugin name as env to plugin container

### DIFF
--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -193,6 +193,8 @@ spec:
         env:
           - name: VCLUSTER_PLUGIN_ADDRESS
             value: "localhost:{{ add 14000 $counter }}"
+          - name: VCLUSTER_PLUGIN_NAME
+            value: "{{ $key }}"
         {{- if $container.env }}
 {{ toYaml $container.env | indent 10 }}
         {{- end }}

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -242,6 +242,8 @@ spec:
         env:
           - name: VCLUSTER_PLUGIN_ADDRESS
             value: "localhost:{{ add 14000 $counter }}"
+          - name: VCLUSTER_PLUGIN_NAME
+            value: "{{ $key }}"
         {{- if $container.env }}
 {{ toYaml $container.env | indent 10 }}
         {{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -252,6 +252,8 @@ spec:
         env:
           - name: VCLUSTER_PLUGIN_ADDRESS
             value: "localhost:{{ add 14000 $counter }}"
+          - name: VCLUSTER_PLUGIN_NAME
+            value: "{{ $key }}"
         {{- if $container.env }}
 {{ toYaml $container.env | indent 10 }}
         {{- end }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -206,6 +206,8 @@ spec:
         env:
           - name: VCLUSTER_PLUGIN_ADDRESS
             value: "localhost:{{ add 14000 $counter }}"
+          - name: VCLUSTER_PLUGIN_NAME
+            value: "{{ $key }}"
         {{- if $container.env }}
 {{ toYaml $container.env | indent 10 }}
         {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Adds the plugin name from the `plugin.yaml` to the environment of the plugin container. This allows us in the plugin sdk to get rid of the name inside the code.