### PR TITLE
refactor: deploy vcluster with node sync on local k8s

### DIFF
--- a/cmd/vclusterctl/cmd/app/create/types.go
+++ b/cmd/vclusterctl/cmd/app/create/types.go
@@ -16,10 +16,12 @@ type CreateOptions struct {
 	CreateNamespace    bool
 	DisableIngressSync bool
 	CreateClusterRole  bool
-	Expose             bool
-	ExposeLocal        bool
-	Connect            bool
-	Upgrade            bool
-	Isolate            bool
-	ReleaseValues      string
+
+	Expose      bool
+	ExposeLocal bool
+
+	Connect       bool
+	Upgrade       bool
+	Isolate       bool
+	ReleaseValues string
 }

--- a/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
+++ b/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
@@ -20,7 +20,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-func (c ClusterType) NodePortSupported() bool {
+func (c ClusterType) LocalKubernetes() bool {
 	return c == ClusterTypeDockerDesktop ||
 		c == ClusterTypeRancherDesktop ||
 		c == ClusterTypeKIND ||

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -247,8 +247,8 @@ func (cmd *CreateCmd) ToChartOptions(kubernetesVersion *version.Info) (*helm.Cha
 
 	// check if we should create with node port
 	clusterType := localkubernetes.DetectClusterType(&cmd.rawConfig)
-	if cmd.ExposeLocal && clusterType.NodePortSupported() {
-		cmd.log.Infof("Detected local kubernetes cluster %s. Will deploy vcluster with a NodePort", clusterType)
+	if cmd.ExposeLocal && clusterType.LocalKubernetes() {
+		cmd.log.Infof("Detected local kubernetes cluster %s. Will deploy vcluster with a NodePort & sync real nodes", clusterType)
 		cmd.localCluster = true
 	}
 
@@ -260,7 +260,8 @@ func (cmd *CreateCmd) ToChartOptions(kubernetesVersion *version.Info) (*helm.Cha
 		CreateClusterRole:  cmd.CreateClusterRole,
 		DisableIngressSync: cmd.DisableIngressSync,
 		Expose:             cmd.Expose,
-		NodePort:           cmd.ExposeLocal && clusterType.NodePortSupported(),
+		SyncNodes:          cmd.localCluster,
+		NodePort:           cmd.localCluster,
 		K3SImage:           cmd.K3SImage,
 		Isolate:            cmd.Isolate,
 		KubernetesVersion:  kubernetesVersion,

--- a/pkg/helm/types.go
+++ b/pkg/helm/types.go
@@ -19,6 +19,7 @@ type ChartOptions struct {
 	DisableIngressSync bool
 	Expose             bool
 	NodePort           bool
+	SyncNodes          bool
 	K3SImage           string
 	Isolate            bool
 	KubernetesVersion  *version.Info

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -12,7 +12,7 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.24": "rancher/k3s:v1.24.1-rc1-k3s1",
+	"1.24": "rancher/k3s:v1.24.1-k3s1",
 	"1.23": "rancher/k3s:v1.23.6-k3s1",
 	"1.22": "rancher/k3s:v1.22.9-k3s1",
 	"1.21": "rancher/k3s:v1.21.12-k3s1",
@@ -116,6 +116,13 @@ service:
 		values += `
 service:
   type: NodePort`
+	}
+
+	if chartOptions.SyncNodes {
+		values += `
+sync:
+  nodes:
+    enabled: true`
 	}
 
 	if chartOptions.Isolate {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
vcluster cli will now deploy vcluster with enabled node sync on local k8s distributions.
