### PR TITLE
Add kube-config-context-name flag for vcluster create and syncer

### DIFF
--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -104,6 +104,9 @@ spec:
           {{- if .Values.defaultImageRegistry }}
           - --default-image-registry={{ .Values.defaultImageRegistry }}
           {{- end }}
+          {{- if .Values.syncer.kubeConfigContextName }}
+          - --kube-config-context-name={{ .Values.syncer.kubeConfigContextName }}
+          {{- end }}
           {{- if .Values.enableHA }}
           - --leader-elect=true
           {{- else }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -128,6 +128,7 @@ syncer:
   # Extra Annotations for the syncer deployment
   annotations: {}
   priorityClassName: ""
+  kubeConfigContextName: "my-vcluster"
 
 # Etcd settings
 etcd:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -149,6 +149,9 @@ spec:
           {{- if .Values.defaultImageRegistry }}
           - --default-image-registry={{ .Values.defaultImageRegistry }}
           {{- end }}
+          {{- if .Values.syncer.kubeConfigContextName }}
+          - --kube-config-context-name={{ .Values.syncer.kubeConfigContextName }}
+          {{- end }}
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}
           {{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -111,6 +111,7 @@ syncer:
     requests:
       cpu: 100m
       memory: 128Mi
+  kubeConfigContextName: "my-vcluster"
 
 # Virtual Cluster (k0s) configuration
 vcluster:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -157,6 +157,9 @@ spec:
           {{- if .Values.defaultImageRegistry }}
           - --default-image-registry={{ .Values.defaultImageRegistry }}
           {{- end }}
+          {{- if .Values.syncer.kubeConfigContextName }}
+          - --kube-config-context-name={{ .Values.syncer.kubeConfigContextName }}
+          {{- end }}
           {{- if .Values.ingress.enabled }}
           - --tls-san={{ .Values.ingress.host }}
           {{- end }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -111,6 +111,7 @@ syncer:
     requests:
       cpu: 100m
       memory: 128Mi
+  kubeConfigContextName: "my-vcluster"
 
 # Virtual Cluster (k3s) configuration
 vcluster:

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -109,6 +109,9 @@ spec:
           {{- if .Values.defaultImageRegistry }}
           - --default-image-registry={{ .Values.defaultImageRegistry }}
           {{- end }}
+          {{- if .Values.syncer.kubeConfigContextName }}
+          - --kube-config-context-name={{ .Values.syncer.kubeConfigContextName }}
+          {{- end }}
           {{- if .Values.enableHA }}
           - --leader-elect=true
           {{- else }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -130,6 +130,7 @@ syncer:
   # Extra Annotations for the syncer deployment
   annotations: {}
   priorityClassName: ""
+  kubeConfigContextName: "my-vcluster"
 
 # Etcd settings
 etcd:

--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -22,6 +22,7 @@ type VirtualClusterOptions struct {
 	ClientCaCert        string   `json:"clientCaCert,omitempty"`
 	KubeConfig          string   `json:"kubeConfig,omitempty"`
 
+	KubeConfigContextName     string   `json:"kubeConfigContextName,omitempty"`
 	KubeConfigSecret          string   `json:"kubeConfigSecret,omitempty"`
 	KubeConfigSecretNamespace string   `json:"kubeConfigSecretNamespace,omitempty"`
 	KubeConfigServer          string   `json:"kubeConfigServer,omitempty"`

--- a/cmd/vclusterctl/cmd/app/create/types.go
+++ b/cmd/vclusterctl/cmd/app/create/types.go
@@ -16,9 +16,9 @@ type CreateOptions struct {
 	CreateNamespace    bool
 	DisableIngressSync bool
 	CreateClusterRole  bool
-
-	Expose      bool
-	ExposeLocal bool
+	UpdateCurrent      bool
+	Expose             bool
+	ExposeLocal        bool
 
 	Connect       bool
 	Upgrade       bool

--- a/cmd/vclusterctl/cmd/app/create/types.go
+++ b/cmd/vclusterctl/cmd/app/create/types.go
@@ -2,14 +2,15 @@ package create
 
 // CreateOptions holds the create cmd options
 type CreateOptions struct {
-	ChartVersion  string
-	ChartName     string
-	ChartRepo     string
-	LocalChartDir string
-	K3SImage      string
-	Distro        string
-	CIDR          string
-	ExtraValues   []string
+	KubeConfigContextName string
+	ChartVersion          string
+	ChartName             string
+	ChartRepo             string
+	LocalChartDir         string
+	K3SImage              string
+	Distro                string
+	CIDR                  string
+	ExtraValues           []string
 
 	KubernetesVersion string
 

--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -100,7 +100,7 @@ vcluster connect test -n test -- kubectl get ns
 		},
 	}
 
-	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "kube-config-context-name to be set")
+	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
 	cobraCmd.Flags().StringVar(&cmd.KubeConfig, "kube-config", "./kubeconfig.yaml", "Writes the created kube config to this file")
 	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
 	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "When enabled prints the context to stdout")

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -87,6 +87,7 @@ vcluster create test --namespace test
 		},
 	}
 
+	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "kube-config-context-name to be set")
 	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
 	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
 	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", LoftChartRepo, "The virtual cluster chart repo to use")
@@ -155,10 +156,11 @@ func (cmd *CreateCmd) Run(args []string) error {
 		} else if release != nil && release.Chart != nil && release.Chart.Metadata != nil && (release.Chart.Metadata.Name == "vcluster" || release.Chart.Metadata.Name == "vcluster-k0s" || release.Chart.Metadata.Name == "vcluster-k8s") {
 			if cmd.Connect {
 				connectCmd := &ConnectCmd{
-					GlobalFlags:   cmd.GlobalFlags,
-					UpdateCurrent: cmd.UpdateCurrent,
-					KubeConfig:    "./kubeconfig.yaml",
-					Log:           cmd.log,
+					GlobalFlags:           cmd.GlobalFlags,
+					UpdateCurrent:         cmd.UpdateCurrent,
+					KubeConfigContextName: cmd.KubeConfigContextName,
+					KubeConfig:            "./kubeconfig.yaml",
+					Log:                   cmd.log,
 				}
 
 				return connectCmd.Connect(args[0], nil)
@@ -178,10 +180,11 @@ func (cmd *CreateCmd) Run(args []string) error {
 	if cmd.Connect {
 		cmd.log.Donef("Successfully created virtual cluster %s in namespace %s", args[0], cmd.Namespace)
 		connectCmd := &ConnectCmd{
-			GlobalFlags:   cmd.GlobalFlags,
-			UpdateCurrent: cmd.UpdateCurrent,
-			KubeConfig:    "./kubeconfig.yaml",
-			Log:           cmd.log,
+			GlobalFlags:           cmd.GlobalFlags,
+			UpdateCurrent:         cmd.UpdateCurrent,
+			KubeConfigContextName: cmd.KubeConfigContextName,
+			KubeConfig:            "./kubeconfig.yaml",
+			Log:                   cmd.log,
 		}
 
 		return connectCmd.Connect(args[0], nil)

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -98,6 +98,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringSliceVarP(&cmd.ExtraValues, "extra-values", "f", []string{}, "Path where to load extra helm values from")
 	cobraCmd.Flags().BoolVar(&cmd.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")
 	cobraCmd.Flags().BoolVar(&cmd.DisableIngressSync, "disable-ingress-sync", false, "If true the virtual cluster will not sync any ingresses")
+	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", false, "If true updates the current kube config")
 	cobraCmd.Flags().BoolVar(&cmd.CreateClusterRole, "create-cluster-role", false, "DEPRECATED: cluster role is now automatically created if it is required by one of the resource syncers that are enabled by the .sync.RESOURCE.enabled=true helm value, which is set in a file that is passed via --extra-values argument.")
 	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
 	cobraCmd.Flags().BoolVar(&cmd.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service")
@@ -155,7 +156,7 @@ func (cmd *CreateCmd) Run(args []string) error {
 			if cmd.Connect {
 				connectCmd := &ConnectCmd{
 					GlobalFlags:   cmd.GlobalFlags,
-					UpdateCurrent: true,
+					UpdateCurrent: cmd.UpdateCurrent,
 					KubeConfig:    "./kubeconfig.yaml",
 					Log:           cmd.log,
 				}
@@ -178,7 +179,7 @@ func (cmd *CreateCmd) Run(args []string) error {
 		cmd.log.Donef("Successfully created virtual cluster %s in namespace %s", args[0], cmd.Namespace)
 		connectCmd := &ConnectCmd{
 			GlobalFlags:   cmd.GlobalFlags,
-			UpdateCurrent: true,
+			UpdateCurrent: cmd.UpdateCurrent,
 			KubeConfig:    "./kubeconfig.yaml",
 			Log:           cmd.log,
 		}

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -87,7 +87,7 @@ vcluster create test --namespace test
 		},
 	}
 
-	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "kube-config-context-name to be set")
+	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
 	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
 	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
 	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", LoftChartRepo, "The virtual cluster chart repo to use")
@@ -99,7 +99,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringSliceVarP(&cmd.ExtraValues, "extra-values", "f", []string{}, "Path where to load extra helm values from")
 	cobraCmd.Flags().BoolVar(&cmd.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")
 	cobraCmd.Flags().BoolVar(&cmd.DisableIngressSync, "disable-ingress-sync", false, "If true the virtual cluster will not sync any ingresses")
-	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", false, "If true updates the current kube config")
+	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
 	cobraCmd.Flags().BoolVar(&cmd.CreateClusterRole, "create-cluster-role", false, "DEPRECATED: cluster role is now automatically created if it is required by one of the resource syncers that are enabled by the .sync.RESOURCE.enabled=true helm value, which is set in a file that is passed via --extra-values argument.")
 	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
 	cobraCmd.Flags().BoolVar(&cmd.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service")

--- a/cmd/vclusterctl/cmd/util.go
+++ b/cmd/vclusterctl/cmd/util.go
@@ -122,11 +122,11 @@ func updateKubeConfig(contextName string, cluster *api.Cluster, authInfo *api.Au
 	config.AuthInfos[contextName] = authInfo
 
 	// Update kube context
-	context := api.NewContext()
-	context.Cluster = contextName
-	context.AuthInfo = contextName
+	newContext := api.NewContext()
+	newContext.Cluster = contextName
+	newContext.AuthInfo = contextName
 
-	config.Contexts[contextName] = context
+	config.Contexts[contextName] = newContext
 	if setActive {
 		config.CurrentContext = contextName
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #561 and #554 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...  kube-config-context-name flag is available for create command as well as syncer deployment


**What else do we need to know?** UpdateCurrent in create command is also set through flag now.
