### PR TITLE
feature: add fsGroup setting for persistent data

### DIFF
--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -76,6 +76,10 @@ spec:
       {{- if .Values.etcd.priorityClassName }}
       priorityClassName: {{ .Values.etcd.priorityClassName }}
       {{- end }}
+      {{- if .Values.etcd.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.etcd.fsGroup }}
+      {{- end }}
       containers:
       - name: etcd
         image: "{{ .Values.defaultImageRegistry }}{{ .Values.etcd.image }}"

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -75,6 +75,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.fsGroup }}
+      {{- end }}
       containers:
       {{- if not .Values.vcluster.disabled }}
       - image: {{ .Values.defaultImageRegistry }}{{ .Values.vcluster.image }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -72,6 +72,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.fsGroup }}
+      {{- end }}
       containers:
       {{- if not .Values.vcluster.disabled }}
       - image: {{ .Values.defaultImageRegistry }}{{ .Values.vcluster.image }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -81,6 +81,10 @@ spec:
       {{- if .Values.etcd.priorityClassName }}
       priorityClassName: {{ .Values.etcd.priorityClassName }}
       {{- end }}
+      {{- if .Values.etcd.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.etcd.fsGroup }}
+      {{- end }}
       containers:
       - name: etcd
         image: "{{ .Values.defaultImageRegistry }}{{ .Values.etcd.image }}"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #314

**Please provide a short message that should be published in the vcluster release notes**
Fixes issue where Kubernetes running as non-root cannot store persistent data because folder is owned by root.

**What else do we need to know?** 
Related to #564 as K8s/EKS rootless mode cannot be fully tested other why.