### PR TITLE
include seccompProfile to pre-install jobs if isolation mode is enabled

### DIFF
--- a/charts/eks/templates/pre-install-hook-job.yaml
+++ b/charts/eks/templates/pre-install-hook-job.yaml
@@ -25,6 +25,11 @@ spec:
       {{- if .Values.job.priorityClassName }}
       priorityClassName: {{ .Values.job.priorityClassName }}
       {{- end }}
+      {{- if .Values.isolation.enabled }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       containers:
         - name: certs
           {{- if .Values.syncer.image }}

--- a/charts/k8s/templates/pre-install-hook-job.yaml
+++ b/charts/k8s/templates/pre-install-hook-job.yaml
@@ -25,6 +25,11 @@ spec:
       {{- if .Values.job.priorityClassName }}
       priorityClassName: {{ .Values.job.priorityClassName }}
       {{- end }}
+      {{- if .Values.isolation.enabled }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       containers:
         - name: certs
           {{- if .Values.syncer.image }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where pre-install job was not able to run in namespace where *Restricted* Pod Security Standard is enforced because of missing seccompProfile.

**What else do we need to know?** 
Related to #564 as I'm testing how tight we can harden vcluster environments.