### PR TITLE
fix: set more realistic resource requests

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -139,8 +139,8 @@ data:
                 cpu: 1000m
                 memory: 170Mi
               requests:
-                cpu: 100m
-                memory: 70Mi
+                cpu: 3m
+                memory: 16Mi
             args: [ "-conf", "/etc/coredns/Corefile" ]
             volumeMounts:
             - name: config-volume

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -111,8 +111,8 @@ syncer:
     limits:
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 64Mi
   # Extra volumes 
   volumes: []
   # The amount of replicas to run the deployment with
@@ -147,8 +147,8 @@ etcd:
   annotations: {}
   resources:
     requests:
-      cpu: 100m
-      memory: 100Mi
+      cpu: 20m
+      memory: 150Mi
   # Storage settings for the etcd
   storage:
     # If this is disabled, vcluster will use an emptyDir instead
@@ -178,7 +178,7 @@ controller:
   annotations: {}
   resources:
     requests:
-      cpu: 200m
+      cpu: 15m
   priorityClassName: ""
 
 # Kubernetes API Server settings
@@ -199,7 +199,8 @@ api:
   annotations: {}
   resources:
     requests:
-      cpu: 200m
+      cpu: 40m
+      memory: 300Mi
   priorityClassName: ""
 
 # Core DNS settings

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -151,8 +151,8 @@ data:
                   cpu: 1000m
                   memory: 170Mi
                 requests:
-                  cpu: 100m
-                  memory: 70Mi
+                  cpu: 3m
+                  memory: 16Mi
               args: [ "-conf", "/etc/coredns/Corefile" ]
               volumeMounts:
                 - name: config-volume

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -109,8 +109,8 @@ syncer:
     limits:
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 64Mi
   kubeConfigContextName: "my-vcluster"
 
 # Virtual Cluster (k0s) configuration

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -151,8 +151,8 @@ data:
                   cpu: 1000m
                   memory: 170Mi
                 requests:
-                  cpu: 100m
-                  memory: 70Mi
+                  cpu: 3m
+                  memory: 16Mi
               args: [ "-conf", "/etc/coredns/Corefile" ]
               volumeMounts:
                 - name: config-volume

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -109,8 +109,8 @@ syncer:
     limits:
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 64Mi
   kubeConfigContextName: "my-vcluster"
 
 # Virtual Cluster (k3s) configuration

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -151,8 +151,8 @@ data:
                   cpu: 1000m
                   memory: 170Mi
                 requests:
-                  cpu: 100m
-                  memory: 70Mi
+                  cpu: 3m
+                  memory: 16Mi
               args: [ "-conf", "/etc/coredns/Corefile" ]
               volumeMounts:
                 - name: config-volume

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -113,8 +113,8 @@ syncer:
     limits:
       memory: 1Gi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 10m
+      memory: 64Mi
   # Extra volumes 
   volumes: []
   # The amount of replicas to run the deployment with
@@ -149,8 +149,8 @@ etcd:
   annotations: {}
   resources:
     requests:
-      cpu: 100m
-      memory: 100Mi
+      cpu: 20m
+      memory: 150Mi
   # Storage settings for the etcd
   storage:
     # If this is disabled, vcluster will use an emptyDir instead
@@ -180,7 +180,7 @@ controller:
   annotations: {}
   resources:
     requests:
-      cpu: 200m
+      cpu: 15m
   priorityClassName: ""
 
 # Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
@@ -200,7 +200,7 @@ scheduler:
   annotations: {}
   resources:
     requests:
-      cpu: 100m
+      cpu: 10m
   priorityClassName: ""
 
 # Kubernetes API Server settings
@@ -221,7 +221,8 @@ api:
   annotations: {}
   resources:
     requests:
-      cpu: 200m
+      cpu: 40m
+      memory: 300Mi
   priorityClassName: ""
 
 # Service account that should be used by the vcluster


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster reserves a lot more resources that it actually needs.

**What else do we need to know?** 
I noticed that when deployed a lot of K8s based vclusters on top of same host cluster it stopped from scheduling pods with error "Insufficient cpu" when all nodes CPU usage was still under 30% (and I have not even enabled HA mode for those yet which would tribe number of those pods).

New values are based on fact that on multiple environments which I checked:
* syncer cpu was 6-8m and memory 46-52Mi
* api-server cpu was 28-32m and memory 249-282Mi
* controller cpu was 8-10m and memory 37-45Mi
* etcd cpu was 9-12m and memory 62-156Mi
* coredns cpu was 2m and memory 13-14Mi

Because Kubernetes does not use swap it is more critical to have buffer on memory than on CPU side.

Scheduler I don't use so there I'm just guessing. For same reason I didn't touched to k0s, k3s or eks other resources.

EDIT: Found now also very interesting article about topic https://sysdig.com/blog/kubernetes-resource-limits/