### PR TITLE
fix: vcluster connect edge case - deploying proxy for minikube when minikube VM is used

### DIFF
--- a/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
+++ b/cmd/vclusterctl/cmd/app/localkubernetes/configure.go
@@ -313,6 +313,7 @@ func containerExists(containerName string) bool {
 	cmd := exec.Command(
 		"docker",
 		"inspect",
+		"--type=container",
 		containerName,
 	)
 	_, err := cmd.Output()


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes the use of port forwarding in connect command when direct connection is possible.
Before:
```
$ vcluster connect vcluster -n vcluster
info   Starting proxy container...
warn   Error exposing local vcluster, will fallback to port-forwarding: test connection: timed out waiting for the condition retrieve default namespace: Get "https://127.0.0.1:11436/api/v1/namespaces/default": dial tcp 127.0.0.1:11436: connect: connection refused
done √ Switched active kube context to vcluster_vcluster_vcluster_minikube
warn   Since you are using port-forwarding to connect, you will need to leave this terminal open
- Use CTRL+C to return to your previous kube context
- Use `kubectl get namespaces` in another terminal to access the vcluster
Forwarding from 127.0.0.1:11436 -> 8443
Forwarding from [::1]:11436 -> 8443
```
After:
```
$ /tmp/vcluster connect vcluster -n vcluster
done √ Switched active kube context to vcluster_vcluster_vcluster_minikube
- Use `vcluster disconnect` to return to your previous kube context
- Use `kubectl get namespaces` to access the vcluster
``` 

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster connect` was trying to deploy a proxy pod even though a minikube VM driver was used.

**What else do we need to know?** 
`containerExists` function was returning true when container with minikubename did not exist, but a volume with this name did exist