### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/cmd/vcluster/cmd/certs.go
+++ b/cmd/vcluster/cmd/certs.go
@@ -80,17 +80,17 @@ var certMap = map[string]string{
 	certs.ServiceAccountPrivateKeyName: certs.ServiceAccountPrivateKeyName,
 	certs.ServiceAccountPublicKeyName:  certs.ServiceAccountPublicKeyName,
 
-	certs.EtcdCACertName: strings.Replace(certs.EtcdCACertName, "/", "-", -1),
-	certs.EtcdCAKeyName:  strings.Replace(certs.EtcdCAKeyName, "/", "-", -1),
+	certs.EtcdCACertName: strings.ReplaceAll(certs.EtcdCACertName, "/", "-"),
+	certs.EtcdCAKeyName:  strings.ReplaceAll(certs.EtcdCAKeyName, "/", "-"),
 
-	certs.EtcdHealthcheckClientCertName: strings.Replace(certs.EtcdHealthcheckClientCertName, "/", "-", -1),
-	certs.EtcdHealthcheckClientKeyName:  strings.Replace(certs.EtcdHealthcheckClientKeyName, "/", "-", -1),
+	certs.EtcdHealthcheckClientCertName: strings.ReplaceAll(certs.EtcdHealthcheckClientCertName, "/", "-"),
+	certs.EtcdHealthcheckClientKeyName:  strings.ReplaceAll(certs.EtcdHealthcheckClientKeyName, "/", "-"),
 
-	certs.EtcdPeerCertName: strings.Replace(certs.EtcdPeerCertName, "/", "-", -1),
-	certs.EtcdPeerKeyName:  strings.Replace(certs.EtcdPeerKeyName, "/", "-", -1),
+	certs.EtcdPeerCertName: strings.ReplaceAll(certs.EtcdPeerCertName, "/", "-"),
+	certs.EtcdPeerKeyName:  strings.ReplaceAll(certs.EtcdPeerKeyName, "/", "-"),
 
-	certs.EtcdServerCertName: strings.Replace(certs.EtcdServerCertName, "/", "-", -1),
-	certs.EtcdServerKeyName:  strings.Replace(certs.EtcdServerKeyName, "/", "-", -1),
+	certs.EtcdServerCertName: strings.ReplaceAll(certs.EtcdServerCertName, "/", "-"),
+	certs.EtcdServerKeyName:  strings.ReplaceAll(certs.EtcdServerKeyName, "/", "-"),
 }
 
 func ExecuteCerts(options *CertsCmd) error {

--- a/pkg/controllers/resources/nodes/nodeservice/node_service.go
+++ b/pkg/controllers/resources/nodes/nodeservice/node_service.go
@@ -123,7 +123,7 @@ func (n *nodeServiceProvider) Unlock() {
 }
 
 func (n *nodeServiceProvider) GetNodeIP(ctx context.Context, name types.NamespacedName) (string, error) {
-	serviceName := translate.SafeConcatName(translate.Suffix, "node", strings.Replace(name.Name, ".", "-", -1))
+	serviceName := translate.SafeConcatName(translate.Suffix, "node", strings.ReplaceAll(name.Name, ".", "-"))
 
 	service := &corev1.Service{}
 	err := n.currentNamespaceClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: n.currentNamespace}, service)

--- a/pkg/controllers/resources/pods/translate/envvars.go
+++ b/pkg/controllers/resources/pods/translate/envvars.go
@@ -44,7 +44,7 @@ func buildEnvironmentVariables(services []*v1.Service) []v1.EnvVar {
 }
 
 func serviceNameToEnv(str string) string {
-	return strings.ToUpper(strings.Replace(str, "-", "_", -1))
+	return strings.ToUpper(strings.ReplaceAll(str, "-", "_"))
 }
 
 func makeLinkVariables(service *v1.Service) []v1.EnvVar {

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -208,7 +208,7 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 		// includes a '.', therefore we need to rewrite the hostname. This is really bad
 		// and wrong, but unfortunately there is currently no other solution as there is
 		// no other way to change the container's hostname.
-		pPod.Spec.Hostname = strings.Replace(pPod.Spec.Hostname, ".", "-", -1)
+		pPod.Spec.Hostname = strings.ReplaceAll(pPod.Spec.Hostname, ".", "-")
 	}
 
 	// if spec.subdomain is set we have to translate the /etc/hosts

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -29,7 +29,7 @@ func SafeConcatGenerateName(name ...string) string {
 	fullPath := strings.Join(name, "-")
 	if len(fullPath) > 53 {
 		digest := sha256.Sum256([]byte(fullPath))
-		return strings.Replace(fullPath[0:42]+"-"+hex.EncodeToString(digest[0:])[0:10], ".-", "-", -1)
+		return strings.ReplaceAll(fullPath[0:42]+"-"+hex.EncodeToString(digest[0:])[0:10], ".-", "-")
 	}
 	return fullPath
 }
@@ -38,7 +38,7 @@ func SafeConcatName(name ...string) string {
 	fullPath := strings.Join(name, "-")
 	if len(fullPath) > 63 {
 		digest := sha256.Sum256([]byte(fullPath))
-		return strings.Replace(fullPath[0:52]+"-"+hex.EncodeToString(digest[0:])[0:10], ".-", "-", -1)
+		return strings.ReplaceAll(fullPath[0:52]+"-"+hex.EncodeToString(digest[0:])[0:10], ".-", "-")
 	}
 	return fullPath
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.


**Please provide a short message that should be published in the vcluster release notes**
N/A, this is not a user-facing change


**What else do we need to know?** 
