### PR TITLE
feat: add serviceCIDR to values only when provided

### DIFF
--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -92,8 +92,11 @@ securityContext:
 }
 
 func addCommonReleaseValues(values string, chartOptions *helm.ChartOptions) (string, error) {
-	values += `
+	if chartOptions.CIDR != "" {
+		values += `
 serviceCIDR: ##CIDR##`
+		values = strings.ReplaceAll(values, "##CIDR##", chartOptions.CIDR)
+	}
 
 	if chartOptions.DisableIngressSync {
 		values += `
@@ -131,7 +134,6 @@ isolation:
   enabled: true`
 	}
 
-	values = strings.ReplaceAll(values, "##CIDR##", chartOptions.CIDR)
 	values = strings.TrimSpace(values)
 	return values, nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
The `addCommonReleaseValues` is used in cluster-api-provider-vcluster, where we will no longer be setting the CIDR value upfront. This produces an unnecessary entry in the generated values:
```
serviceCIDR: null
```
which won't be present after this change.


**Please provide a short message that should be published in the vcluster release notes**
N/A