### PR TITLE
fix: fixed an issue with - ending hostname

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -208,7 +208,7 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 		// includes a '.', therefore we need to rewrite the hostname. This is really bad
 		// and wrong, but unfortunately there is currently no other solution as there is
 		// no other way to change the container's hostname.
-		pPod.Spec.Hostname = strings.Replace(pPod.Spec.Hostname, ".", "-", -1)
+		pPod.Spec.Hostname = strings.TrimSuffix(strings.Replace(pPod.Spec.Hostname, ".", "-", -1), "-")
 	}
 
 	// if spec.subdomain is set we have to translate the /etc/hosts


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #583


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster synced pods could end with an - in hostname
