### PR TITLE
add chart status tracking via annotations

### DIFF
--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -12,53 +12,35 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+  {{- if .Values.init.helm }}
+  charts: |-
+  {{- range .Values.init.helm }}
+  {{- /* only render this chart entry if either of chart or bundle is defined */}}
+  {{- if or .chart .bundle }}
+    - name: {{ .chart.name }}
+      repo: {{ .chart.repo }}
+      version: {{ .chart.version }}
+      {{- if .chart.username }}
+      username: {{ .chart.username }}
+      {{- end }}
+      {{- if .chart.password }}
+      password: {{ .chart.password }}
+      {{- end }}
+      {{- else if .bundle }}
+      bundle: {{ .bundle }}
+      {{- end }}
+      {{- if .values }}
+      values: |-
+        {{ .values | nindent 4 | trim }}
+      {{- end}}
+      {{- if .release }}
+      timeout: {{ .timeout | default "120s" | quote }}
+      releaseName: {{ .release.name }}
+      releaseNamespace: {{ .release.namespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 ---
-
-{{- if .Values.init.helm }}
-{{- range .Values.init.helm }}
-{{- /* only render this chart entry if either of chart or bundle is defined */}}
-{{- if or .chart .bundle }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm-{{ $.Release.Name }}-chart{{ if .chart }}-{{ .chart.name }}{{ end }}{{ if .release }}-{{ .release.name }}{{ end }}
-  labels:
-    app: vcluster
-    {{- if .chart }}
-    chart: {{ .chart.name }}-{{ .chart.version }}
-    {{- else }}
-    chart: {{ .release.name }}
-    {{- end }}
-    release: {{ $.Release.Name }}
-    heritage: {{ $.Release.Service }}
-    context: vcluster-helm-chart
-data:
-  {{- if .chart }}
-  name: {{ .chart.name }}
-  repo: {{ .chart.repo }}
-  version: {{ .chart.version }}
-  {{- if .chart.username }}
-  username: {{ .chart.username }}
-  {{- end }}
-  {{- if .chart.password }}
-  password: {{ .chart.password }}
-  {{- end }}
-  {{- else if .bundle }}
-  bundle: {{ .bundle }}
-  {{- end }}
-  {{- if .values }}
-  values: |-
-    {{ .values | nindent 4 | trim }}
-  {{- end}}
-  {{- if .release }}
-  timeout: {{ .timeout | default "120s" | quote }}
-  releaseName: {{ .release.name }}
-  releaseNamespace: {{ .release.namespace }}
-  {{- end }}
-{{- end }}
----
-{{- end }}
-{{- end }}

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -30,6 +30,9 @@ data:
       {{- else if .bundle }}
       bundle: {{ .bundle }}
       {{- end }}
+      {{- if .insecure }}
+      insecure: true
+      {{- end}}
       {{- if .values }}
       values: |-
         {{ .values | nindent 4 | trim }}
@@ -42,5 +45,3 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
-
----

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
-  annotations:
-    vcluster.loft.sh/init-ready: |
-      ready: false
-      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
@@ -14,7 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  initmanifests.yaml: |-
+  manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
     {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
+  annotations:
+    vcluster.loft.sh/init-ready: |
+      ready: false
+      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -12,53 +12,35 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+  {{- if .Values.init.helm }}
+  charts: |-
+  {{- range .Values.init.helm }}
+  {{- /* only render this chart entry if either of chart or bundle is defined */}}
+  {{- if or .chart .bundle }}
+    - name: {{ .chart.name }}
+      repo: {{ .chart.repo }}
+      version: {{ .chart.version }}
+      {{- if .chart.username }}
+      username: {{ .chart.username }}
+      {{- end }}
+      {{- if .chart.password }}
+      password: {{ .chart.password }}
+      {{- end }}
+      {{- else if .bundle }}
+      bundle: {{ .bundle }}
+      {{- end }}
+      {{- if .values }}
+      values: |-
+        {{ .values | nindent 4 | trim }}
+      {{- end}}
+      {{- if .release }}
+      timeout: {{ .timeout | default "120s" | quote }}
+      releaseName: {{ .release.name }}
+      releaseNamespace: {{ .release.namespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 ---
-
-{{- if .Values.init.helm }}
-{{- range .Values.init.helm }}
-{{- /* only render this chart entry if either of chart or bundle is defined */}}
-{{- if or .chart .bundle }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm-{{ $.Release.Name }}-chart{{ if .chart }}-{{ .chart.name }}{{ end }}{{ if .release }}-{{ .release.name }}{{ end }}
-  labels:
-    app: vcluster
-    {{- if .chart }}
-    chart: {{ .chart.name }}-{{ .chart.version }}
-    {{- else }}
-    chart: {{ .release.name }}
-    {{- end }}
-    release: {{ $.Release.Name }}
-    heritage: {{ $.Release.Service }}
-    context: vcluster-helm-chart
-data:
-  {{- if .chart }}
-  name: {{ .chart.name }}
-  repo: {{ .chart.repo }}
-  version: {{ .chart.version }}
-  {{- if .chart.username }}
-  username: {{ .chart.username }}
-  {{- end }}
-  {{- if .chart.password }}
-  password: {{ .chart.password }}
-  {{- end }}
-  {{- else if .bundle }}
-  bundle: {{ .bundle }}
-  {{- end }}
-  {{- if .values }}
-  values: |-
-    {{ .values | nindent 4 | trim }}
-  {{- end}}
-  {{- if .release }}
-  timeout: {{ .timeout | default "120s" | quote }}
-  releaseName: {{ .release.name }}
-  releaseNamespace: {{ .release.namespace }}
-  {{- end }}
-{{- end }}
----
-{{- end }}
-{{- end }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -30,6 +30,9 @@ data:
       {{- else if .bundle }}
       bundle: {{ .bundle }}
       {{- end }}
+      {{- if .insecure }}
+      insecure: true
+      {{- end}}
       {{- if .values }}
       values: |-
         {{ .values | nindent 4 | trim }}
@@ -42,5 +45,3 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
-
----

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
-  annotations:
-    vcluster.loft.sh/init-ready: |
-      ready: false
-      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
@@ -14,7 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  initmanifests.yaml: |-
+  manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
     {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
+  annotations:
+    vcluster.loft.sh/init-ready: |
+      ready: false
+      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -12,53 +12,35 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+  {{- if .Values.init.helm }}
+  charts: |-
+  {{- range .Values.init.helm }}
+  {{- /* only render this chart entry if either of chart or bundle is defined */}}
+  {{- if or .chart .bundle }}
+    - name: {{ .chart.name }}
+      repo: {{ .chart.repo }}
+      version: {{ .chart.version }}
+      {{- if .chart.username }}
+      username: {{ .chart.username }}
+      {{- end }}
+      {{- if .chart.password }}
+      password: {{ .chart.password }}
+      {{- end }}
+      {{- else if .bundle }}
+      bundle: {{ .bundle }}
+      {{- end }}
+      {{- if .values }}
+      values: |-
+        {{ .values | nindent 4 | trim }}
+      {{- end}}
+      {{- if .release }}
+      timeout: {{ .timeout | default "120s" | quote }}
+      releaseName: {{ .release.name }}
+      releaseNamespace: {{ .release.namespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 ---
-
-{{- if .Values.init.helm }}
-{{- range .Values.init.helm }}
-{{- /* only render this chart entry if either of chart or bundle is defined */}}
-{{- if or .chart .bundle }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm-{{ $.Release.Name }}-chart{{ if .chart }}-{{ .chart.name }}{{ end }}{{ if .release }}-{{ .release.name }}{{ end }}
-  labels:
-    app: vcluster
-    {{- if .chart }}
-    chart: {{ .chart.name }}-{{ .chart.version }}
-    {{- else }}
-    chart: {{ .release.name }}
-    {{- end }}
-    release: {{ $.Release.Name }}
-    heritage: {{ $.Release.Service }}
-    context: vcluster-helm-chart
-data:
-  {{- if .chart }}
-  name: {{ .chart.name }}
-  repo: {{ .chart.repo }}
-  version: {{ .chart.version }}
-  {{- if .chart.username }}
-  username: {{ .chart.username }}
-  {{- end }}
-  {{- if .chart.password }}
-  password: {{ .chart.password }}
-  {{- end }}
-  {{- else if .bundle }}
-  bundle: {{ .bundle }}
-  {{- end }}
-  {{- if .values }}
-  values: |-
-    {{ .values | nindent 4 | trim }}
-  {{- end}}
-  {{- if .release }}
-  timeout: {{ .timeout | default "120s" | quote }}
-  releaseName: {{ .release.name }}
-  releaseNamespace: {{ .release.namespace }}
-  {{- end }}
-{{- end }}
----
-{{- end }}
-{{- end }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -30,6 +30,9 @@ data:
       {{- else if .bundle }}
       bundle: {{ .bundle }}
       {{- end }}
+      {{- if .insecure }}
+      insecure: true
+      {{- end}}
       {{- if .values }}
       values: |-
         {{ .values | nindent 4 | trim }}
@@ -42,5 +45,3 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
-
----

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
-  annotations:
-    vcluster.loft.sh/init-ready: |
-      ready: false
-      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
@@ -14,7 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  initmanifests.yaml: |-
+  manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
     {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
+  annotations:
+    vcluster.loft.sh/init-ready: |
+      ready: false
+      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -12,53 +12,35 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+  {{- if .Values.init.helm }}
+  charts: |-
+  {{- range .Values.init.helm }}
+  {{- /* only render this chart entry if either of chart or bundle is defined */}}
+  {{- if or .chart .bundle }}
+    - name: {{ .chart.name }}
+      repo: {{ .chart.repo }}
+      version: {{ .chart.version }}
+      {{- if .chart.username }}
+      username: {{ .chart.username }}
+      {{- end }}
+      {{- if .chart.password }}
+      password: {{ .chart.password }}
+      {{- end }}
+      {{- else if .bundle }}
+      bundle: {{ .bundle }}
+      {{- end }}
+      {{- if .values }}
+      values: |-
+        {{ .values | nindent 4 | trim }}
+      {{- end}}
+      {{- if .release }}
+      timeout: {{ .timeout | default "120s" | quote }}
+      releaseName: {{ .release.name }}
+      releaseNamespace: {{ .release.namespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 ---
-
-{{- if .Values.init.helm }}
-{{- range .Values.init.helm }}
-{{- /* only render this chart entry if either of chart or bundle is defined */}}
-{{- if or .chart .bundle }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm-{{ $.Release.Name }}-chart{{ if .chart }}-{{ .chart.name }}{{ end }}{{ if .release }}-{{ .release.name }}{{ end }}
-  labels:
-    app: vcluster
-    {{- if .chart }}
-    chart: {{ .chart.name }}-{{ .chart.version }}
-    {{- else }}
-    chart: {{ .release.name }}
-    {{- end }}
-    release: {{ $.Release.Name }}
-    heritage: {{ $.Release.Service }}
-    context: vcluster-helm-chart
-data:
-  {{- if .chart }}
-  name: {{ .chart.name }}
-  repo: {{ .chart.repo }}
-  version: {{ .chart.version }}
-  {{- if .chart.username }}
-  username: {{ .chart.username }}
-  {{- end }}
-  {{- if .chart.password }}
-  password: {{ .chart.password }}
-  {{- end }}
-  {{- else if .bundle }}
-  bundle: {{ .bundle }}
-  {{- end }}
-  {{- if .values }}
-  values: |-
-    {{ .values | nindent 4 | trim }}
-  {{- end}}
-  {{- if .release }}
-  timeout: {{ .timeout | default "120s" | quote }}
-  releaseName: {{ .release.name }}
-  releaseNamespace: {{ .release.namespace }}
-  {{- end }}
-{{- end }}
----
-{{- end }}
-{{- end }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -30,6 +30,9 @@ data:
       {{- else if .bundle }}
       bundle: {{ .bundle }}
       {{- end }}
+      {{- if .insecure }}
+      insecure: true
+      {{- end}}
       {{- if .values }}
       values: |-
         {{ .values | nindent 4 | trim }}
@@ -42,5 +45,3 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
-
----

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
-  annotations:
-    vcluster.loft.sh/init-ready: |
-      ready: false
-      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
@@ -14,7 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  initmanifests.yaml: |-
+  manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
     {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-init-manifests
+  annotations:
+    vcluster.loft.sh/init-ready: |
+      ready: false
+      phase: pending
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/pkg/controllers/manifests/types.go
+++ b/pkg/controllers/manifests/types.go
@@ -1,0 +1,21 @@
+package manifests
+
+type Chart struct {
+	Name             string `json:"name,omitempty"`
+	Repo             string `json:"repo,omitempty"`
+	Version          string `json:"version,omitempty"`
+	Username         string `json:"username,omitempty"`
+	Password         string `json:"password,omitempty"`
+	Values           string `json:"values,omitempty"`
+	Timeout          string `json:"timeout,omitempty"`
+	ReleaseName      string `json:"releaseName,omitempty"`
+	ReleaseNamespace string `json:"releaseNamespace,omitempty"`
+	Bundle           string `json:"bundle,omitempty"`
+}
+
+type ChartStatus struct {
+	Name    string `json:"name,omitempty"`
+	Phase   string `json:"phase,omitempty"`
+	Message string `json:"message,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}

--- a/pkg/controllers/manifests/types.go
+++ b/pkg/controllers/manifests/types.go
@@ -25,16 +25,10 @@ type ChartStatus struct {
 	LastAppliedChartConfigHash string `json:"lastAppliedChartConfigHash,omitempty"`
 }
 
-type Ready struct {
-	Ready   bool   `json:"ready,omitempty"`
-	Phase   string `json:"phase,omitempty"`
-	Reason  string `json:"reason,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
 type Chart struct {
 	Name             string `json:"name,omitempty"`
 	Repo             string `json:"repo,omitempty"`
+	Insecure         bool   `json:"insecure,omitempty"`
 	Version          string `json:"version,omitempty"`
 	Username         string `json:"username,omitempty"`
 	Password         string `json:"password,omitempty"`

--- a/pkg/controllers/manifests/types.go
+++ b/pkg/controllers/manifests/types.go
@@ -20,3 +20,9 @@ type ChartStatus struct {
 	Message   string `json:"message,omitempty"`
 	Reason    string `json:"reason,omitempty"`
 }
+
+type Ready struct {
+	Ready  bool   `json:"ready,omitempty"`
+	Phase  string `json:"phase,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}

--- a/pkg/controllers/manifests/types.go
+++ b/pkg/controllers/manifests/types.go
@@ -14,8 +14,9 @@ type Chart struct {
 }
 
 type ChartStatus struct {
-	Name    string `json:"name,omitempty"`
-	Phase   string `json:"phase,omitempty"`
-	Message string `json:"message,omitempty"`
-	Reason  string `json:"reason,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Phase     string `json:"phase,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Reason    string `json:"reason,omitempty"`
 }

--- a/pkg/controllers/manifests/types.go
+++ b/pkg/controllers/manifests/types.go
@@ -1,5 +1,37 @@
 package manifests
 
+type Status struct {
+	Phase   string `json:"phase,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+
+	Charts    []ChartStatus   `json:"charts,omitempty"`
+	Manifests ManifestsStatus `json:"manifests,omitempty"`
+}
+
+type ManifestsStatus struct {
+	Phase                string `json:"phase,omitempty"`
+	Reason               string `json:"reason,omitempty"`
+	Message              string `json:"message,omitempty"`
+	LastAppliedManifests string `json:"lastAppliedManifests,omitempty"`
+}
+
+type ChartStatus struct {
+	Name                       string `json:"name,omitempty"`
+	Namespace                  string `json:"namespace,omitempty"`
+	Phase                      string `json:"phase,omitempty"`
+	Reason                     string `json:"reason,omitempty"`
+	Message                    string `json:"message,omitempty"`
+	LastAppliedChartConfigHash string `json:"lastAppliedChartConfigHash,omitempty"`
+}
+
+type Ready struct {
+	Ready   bool   `json:"ready,omitempty"`
+	Phase   string `json:"phase,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
 type Chart struct {
 	Name             string `json:"name,omitempty"`
 	Repo             string `json:"repo,omitempty"`
@@ -8,21 +40,7 @@ type Chart struct {
 	Password         string `json:"password,omitempty"`
 	Values           string `json:"values,omitempty"`
 	Timeout          string `json:"timeout,omitempty"`
+	Bundle           string `json:"bundle,omitempty"`
 	ReleaseName      string `json:"releaseName,omitempty"`
 	ReleaseNamespace string `json:"releaseNamespace,omitempty"`
-	Bundle           string `json:"bundle,omitempty"`
-}
-
-type ChartStatus struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Phase     string `json:"phase,omitempty"`
-	Message   string `json:"message,omitempty"`
-	Reason    string `json:"reason,omitempty"`
-}
-
-type Ready struct {
-	Ready  bool   `json:"ready,omitempty"`
-	Phase  string `json:"phase,omitempty"`
-	Reason string `json:"reason,omitempty"`
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -35,8 +35,9 @@ type UpgradeOptions struct {
 	Password string
 	WorkDir  string
 
-	Atomic bool
-	Force  bool
+	Insecure bool
+	Atomic   bool
+	Force    bool
 }
 
 // Client defines the interface how to interact with helm
@@ -111,6 +112,9 @@ func (c *client) run(ctx context.Context, name, namespace string, options Upgrad
 
 	if options.CreateNamespace {
 		args = append(args, "--create-namespace")
+	}
+	if options.Insecure {
+		args = append(args, "--insecure-skip-tls-verify")
 	}
 
 	args = append(args, "--kubeconfig", kubeConfig, "--namespace", namespace)
@@ -195,11 +199,11 @@ func (c *client) run(ctx context.Context, name, namespace string, options Upgrad
 
 	c.log.Info("execute command: helm " + strings.Join(args, " "))
 	output, err := cmd.CombinedOutput()
+	c.log.Info("DONE COMMAND")
 
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("error executing helm %s: operation timedout", command)
+		return fmt.Errorf("error executing helm %s: %s operation timedout", string(output), command)
 	}
-
 	if err != nil {
 		return fmt.Errorf("error executing helm %s: %s", strings.Join(args, " "), string(output))
 	}

--- a/pkg/util/applier/direct.go
+++ b/pkg/util/applier/direct.go
@@ -48,7 +48,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 	}
 
 	f := cmdutil.NewFactory(restClientGetter)
-	res := resource.NewBuilder(restClientGetter).Unstructured().Stream(ioReader, "manifestString").Do()
+	res := resource.NewBuilder(restClientGetter).Unstructured().Stream(ioReader, "manifests").Do()
 	infos, resErr := res.Infos()
 
 	// Populate the namespace on any namespace-scoped objects

--- a/test/e2e/manifests/chart.go
+++ b/test/e2e/manifests/chart.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("Chart ingress-nginx is synced and applied as expected",
 
 	ginkgo.JustBeforeEach(func() {
 		f = framework.DefaultFramework
-		hostConfigMapName = fmt.Sprintf("cm-%s-chart-%s-%s", f.VclusterNamespace, ChartName, ChartRelease)
+		hostConfigMapName = fmt.Sprintf("%s-%s", f.VclusterNamespace, InitConfigmapSuffix)
 	})
 
 	ginkgo.It("Test if configmap for the chart is created as expected", func() {
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("Chart ingress-nginx is synced and applied as expected",
 				return false, err
 			}
 
-			_, ok := cm.ObjectMeta.Annotations[LastAppliedChartConfigAnnotationName]
+			_, ok := cm.ObjectMeta.Annotations[LastAppliedChartConfigAnnotationName+"-"+ChartName+"-"+ChartNamespace]
 			if !ok {
 				return false, nil
 			}

--- a/test/e2e/manifests/chart.go
+++ b/test/e2e/manifests/chart.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	"fmt"
+	"github.com/loft-sh/vcluster/pkg/controllers/manifests"
 	"time"
 
 	"github.com/loft-sh/vcluster/test/framework"
@@ -16,8 +17,6 @@ const (
 	ChartName      = "ingress-nginx"
 	ChartRelease   = "ingress-nginx"
 	ChartNamespace = "ingress-nginx"
-
-	LastAppliedChartConfigAnnotationName = "vcluster.loft.sh/last-applied-chart-config"
 )
 
 var _ = ginkgo.Describe("Chart ingress-nginx is synced and applied as expected", func() {
@@ -54,12 +53,8 @@ var _ = ginkgo.Describe("Chart ingress-nginx is synced and applied as expected",
 				return false, err
 			}
 
-			_, ok := cm.ObjectMeta.Annotations[LastAppliedChartConfigAnnotationName+"-"+ChartName+"-"+ChartNamespace]
-			if !ok {
-				return false, nil
-			}
-
-			return true, nil
+			status := manifests.ParseStatus(cm)
+			return status.Phase == string(manifests.StatusSuccess) && len(status.Charts) == 1 && status.Charts[0].Phase == string(manifests.StatusSuccess), nil
 		})
 
 		framework.ExpectNoError(err)

--- a/test/e2e/manifests/init.go
+++ b/test/e2e/manifests/init.go
@@ -14,7 +14,7 @@ const (
 	TestManifestName      = "test-configmap"
 	TestManifestNamespace = "default"
 
-	InitManifestConfigmapSuffix = "init-manifests"
+	InitConfigmapSuffix = "init-manifests"
 )
 
 var _ = ginkgo.Describe("Init manifests are synced and applied as expected", func() {
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe("Init manifests are synced and applied as expected", fun
 		initmanifests, err := f.HostClient.
 			CoreV1().
 			ConfigMaps(f.VclusterNamespace).
-			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitManifestConfigmapSuffix), metav1.GetOptions{})
+			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitConfigmapSuffix), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		initmanifests.Data["initmanifests.yaml"] = "---"
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("Init manifests are synced and applied as expected", fun
 		initmanifests, err := f.HostClient.
 			CoreV1().
 			ConfigMaps(f.VclusterNamespace).
-			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitManifestConfigmapSuffix), metav1.GetOptions{})
+			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitConfigmapSuffix), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		framework.ExpectEqual(initmanifests.Data["initmanifests.yaml"], "---")
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("Init manifests are synced and applied as expected", fun
 		initmanifests, err := f.HostClient.
 			CoreV1().
 			ConfigMaps(f.VclusterNamespace).
-			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitManifestConfigmapSuffix), metav1.GetOptions{})
+			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitConfigmapSuffix), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		testManifest := fmt.Sprintf(`apiVersion: v1

--- a/test/e2e/manifests/init.go
+++ b/test/e2e/manifests/init.go
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe("Init manifests are synced and applied as expected", fun
 			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitConfigmapSuffix), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		initmanifests.Data["initmanifests.yaml"] = "---"
+		initmanifests.Data["manifests"] = "---"
 		_, err = f.HostClient.CoreV1().ConfigMaps(f.VclusterNamespace).Update(f.Context, initmanifests, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 	})
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe("Init manifests are synced and applied as expected", fun
 			Get(f.Context, fmt.Sprintf("%s-%s", f.VclusterNamespace, InitConfigmapSuffix), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		framework.ExpectEqual(initmanifests.Data["initmanifests.yaml"], "---")
+		framework.ExpectEqual(initmanifests.Data["manifests"], "---")
 	})
 
 	ginkgo.It("Test if manifest is synced with the vcluster", func() {
@@ -77,7 +77,7 @@ data:
   foo: bar
 `, TestManifestName)
 
-		initmanifests.Data["initmanifests.yaml"] = testManifest
+		initmanifests.Data["manifests"] = testManifest
 		_, err = f.HostClient.CoreV1().ConfigMaps(f.VclusterNamespace).Update(f.Context, initmanifests, metav1.UpdateOptions{})
 		framework.ExpectNoError(err)
 


### PR DESCRIPTION
Signed-off-by: Ishan Khare <me@ishankhare.dev>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Add status annotations with error meassages where applicable to init manifests and charts.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster init chart upgrade would fail/get stuck due to namespace mismatch


**What else do we need to know?** 
