### PR TITLE
fix: resolves duplicate vclusters in list when using devspace

### DIFF
--- a/cmd/vclusterctl/cmd/find/find.go
+++ b/cmd/vclusterctl/cmd/find/find.go
@@ -137,6 +137,15 @@ func findInContext(context, name, namespace string, timeout time.Duration) ([]VC
 				continue
 			}
 
+			if p.Spec.Replicas != nil && *p.Spec.Replicas == 0 {
+				// if the stateful set has been scaled down we'll ignore it -- this happens when
+				// using devspace to do vcluster plugin dev for example, devspace scales down the
+				// vcluster stateful set and re-creates a deployment for "dev mode" so we end up
+				// with a duplicate vcluster in the list, one for the statefulset and one for the
+				// deployment
+				continue
+			}
+
 			vCluster, err := getVCluster(&p, context, release, client, kubeClientConfig)
 			if err != nil {
 				return nil, err

--- a/cmd/vclusterctl/cmd/find/find.go
+++ b/cmd/vclusterctl/cmd/find/find.go
@@ -139,8 +139,9 @@ func findInContext(context, name, namespace string, timeout time.Duration) ([]VC
 
 			var paused string
 
-			paused, _ = p.Annotations[constants.PausedAnnotation]
-
+			if p.Annotations != nil {
+				paused, _ = p.Annotations[constants.PausedAnnotation]
+			}
 			if p.Spec.Replicas != nil && *p.Spec.Replicas == 0 && paused != "true" {
 				// if the stateful set has been scaled down we'll ignore it -- this happens when
 				// using devspace to do vcluster plugin dev for example, devspace scales down the

--- a/cmd/vclusterctl/cmd/find/find.go
+++ b/cmd/vclusterctl/cmd/find/find.go
@@ -137,12 +137,18 @@ func findInContext(context, name, namespace string, timeout time.Duration) ([]VC
 				continue
 			}
 
-			if p.Spec.Replicas != nil && *p.Spec.Replicas == 0 {
+			var paused string
+
+			paused, _ = p.Annotations[constants.PausedAnnotation]
+
+			if p.Spec.Replicas != nil && *p.Spec.Replicas == 0 && paused != "true" {
 				// if the stateful set has been scaled down we'll ignore it -- this happens when
 				// using devspace to do vcluster plugin dev for example, devspace scales down the
 				// vcluster stateful set and re-creates a deployment for "dev mode" so we end up
 				// with a duplicate vcluster in the list, one for the statefulset and one for the
-				// deployment
+				// deployment. Of course if the vcluster is paused (via `vcluster pause`), we *do*
+				// still need to care about it even if replicas == 0.
+
 				continue
 			}
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
resolves N/A

When using devspace to work on vcluster/plugins and replacing one of the images in the statefulset with a dev image, devspace will scale the statefulset to zero and replace it with a devspace managed deployment. this causes there to be a statefulset *and* a deployment with the vcluster release label causing vcluster to report a duplicate of the same vcluster when using vcluster list.

example:

```
 ➜ vcluster list

 NAME       NAMESPACE             STATUS    CONNECTED   CREATED                         AGE
 vcluster   vcluster-plugin-dev   Running               2022-07-13 15:21:55 -0700 PDT   3m57s
 vcluster   vcluster-plugin-dev   Running               2022-07-13 15:21:55 -0700 PDT   3m57s
```

```
 ➜ k get statefulset,deploy -l release=vcluster
NAME                        READY   AGE
statefulset.apps/vcluster   0/0     15m

NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/vcluster-devspace   1/1     1            1           15m
```

This is unfortunately not just cosmetic though as we then are unable to connect to the vcluster since vcluster doesn't know (and cant tell) which one we want to connect to.

```
 ➜ vcluster connect vcluster -n vcluster-plugin-dev
fatal  multiple vclusters with name vcluster found, please specify a namespace via -n
```

This PR eliminates the duplicate entries by checking if the replicas are 0, and if so ignoring it (unless the paused annotation is set to true).

```
 ➜ ./vc list

 NAME       NAMESPACE             STATUS    CONNECTED   CREATED                         AGE
 vcluster   vcluster-plugin-dev   Running               2022-07-13 15:21:55 -0700 PDT   19m27s
```

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster list reports at the same vcluster multiple times when using devspace to develop vcluster/plugins.


**What else do we need to know?** 
I think this is only a devspace 6.x issue. 