### PR TITLE
fix: return non-zero exit code on failing command

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -573,8 +573,9 @@ func (cmd *ConnectCmd) executeCommand(vKubeConfig api.Config, command []string) 
 
 		return errors.Wrap(err, "error port-forwarding")
 	case err := <-commandErrChan:
-		if _, ok := err.(*exec.ExitError); ok {
-			return errors.Wrap(err, "error execute command")
+		if exitError, ok := err.(*exec.ExitError); ok {
+			cmd.Log.Errorf("Error executing command: %v", err)
+			os.Exit(exitError.ExitCode())
 		}
 
 		return err

--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -87,7 +87,7 @@ Connect to a virtual cluster
 Example:
 vcluster connect test --namespace test
 # Open a new bash with the vcluster KUBECONFIG defined
-vcluster connect test -n test -- bash 
+vcluster connect test -n test -- bash
 vcluster connect test -n test -- kubectl get ns
 #######################################################
 	`,
@@ -574,9 +574,7 @@ func (cmd *ConnectCmd) executeCommand(vKubeConfig api.Config, command []string) 
 		return errors.Wrap(err, "error port-forwarding")
 	case err := <-commandErrChan:
 		if _, ok := err.(*exec.ExitError); ok {
-			// we ignore exit errors as the stderr was printed to the console already
-			// anyways
-			return nil
+			return errors.Wrap(err, "error execute command")
 		}
 
 		return err


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
running command under vcluster kube context doesn't provide the right exit code when commands fail:
```console
$ vcluster connect vcluster -- kubectl get ns nonexistent
Error from server (NotFound): namespaces "nonexistent" not found
$ echo $?
0
```
so it's much harder to exit the ci/cd pipeline


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster connect doesn't return non-zero exit code of failing command

