### PR TITLE
refactor: allow node ports during service create

### DIFF
--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -210,7 +210,6 @@ func createService(req *http.Request, decoder encoding.Decoder, localClient clie
 	}
 	newService.Annotations[services.ServiceBlockDeletion] = "true"
 	services.RewriteSelector(newService, vService)
-	services.StripNodePorts(newService)
 	err = localClient.Create(req.Context(), newService)
 	if err != nil {
 		klog.Infof("Error creating service in physical cluster: %v", err)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #593


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now sync the specific node ports of a service during creation.
