### PR TITLE
Allow setting the loadBalancerSourceRanges when the Service type is LoadBalancer

### DIFF
--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -18,3 +18,11 @@ spec:
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $f := .Values.service.loadBalancerSourceRanges }}
+    - "{{ $f }}"
+    {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -234,7 +234,9 @@ rbac:
 # Service configurations
 service:
   type: ClusterIP
-  
+  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+  loadBalancerSourceRanges: []
+
 # job configuration
 job:
   enabled: true

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -19,6 +19,12 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $f := .Values.service.loadBalancerSourceRanges }}
+    - "{{ $f }}"
+    {{- end }}
+  {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:
     {{- range $f := .Values.service.externalIPs }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -204,6 +204,8 @@ service:
   # Configuration for LoadBalancer service type
   externalIPs: []
   externalTrafficPolicy: ""
+  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+  loadBalancerSourceRanges: []
 
 # Configure the ingress resource that allows you to access the vcluster
 ingress:

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -19,6 +19,12 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $f := .Values.service.loadBalancerSourceRanges }}
+    - "{{ $f }}"
+    {{- end }}
+  {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:
     {{- range $f := .Values.service.externalIPs }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -209,7 +209,9 @@ service:
   # Configuration for LoadBalancer service type
   externalIPs: []
   externalTrafficPolicy: ""
-  
+  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+  loadBalancerSourceRanges: []
+
 # Configure the ingress resource that allows you to access the vcluster
 ingress:
   # Enable ingress record generation

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -19,6 +19,12 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $f := .Values.service.loadBalancerSourceRanges }}
+    - "{{ $f }}"
+    {{- end }}
+  {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:
     {{- range $f := .Values.service.externalIPs }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -253,6 +253,8 @@ service:
   # Configuration for LoadBalancer service type
   externalIPs: []
   externalTrafficPolicy: ""
+  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+  loadBalancerSourceRanges: []
 
 # job configuration
 job:


### PR DESCRIPTION
Allow setting the loadBalancerSourceRanges when the Service type is LoadBalancer

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves https://github.com/loft-sh/vcluster/issues/606
relates to https://github.com/loft-sh/cluster-api-provider-vcluster/issues/15


**Please provide a short message that should be published in the vcluster release notes**
Allow setting the loadBalancerSourceRanges when the Service type is LoadBalancer in the Helm charts


**What else do we need to know?** 
