### PR TITLE
feat: remove the "kubernetes.io/ingress.class" Ingress annotation

### DIFF
--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -253,7 +253,6 @@ ingress:
   ingressClassName: ""
   host: vcluster.local
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -215,7 +215,6 @@ ingress:
   ingressClassName: ""
   host: vcluster.local
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -220,7 +220,6 @@ ingress:
   ingressClassName: ""
   host: vcluster.local
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -272,7 +272,6 @@ ingress:
   ingressClassName: ""
   host: vcluster.local
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/docs/pages/operator/external-access.mdx
+++ b/docs/pages/operator/external-access.mdx
@@ -159,7 +159,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     # We need the ingress to pass through ssl traffic to the vcluster
     # This only works for the nginx-ingress (enable via --enable-ssl-passthrough
     # https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough )
@@ -229,7 +228,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   name: vcluster-ingress


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This was a request raised in the community Slack - https://loft-sh.slack.com/archives/C01N273CF4P/p1657916368544929 


**Please provide a short message that should be published in the vcluster release notes**
**Breaking change:** Removed the "kubernetes.io/ingress.class" annotation from the Ingress created by the vcluster chart.


**What else do we need to know?** 
The "kubernetes.io/ingress.class" Ingress [annotation is "deprecated"](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation), and .spec.ingressClassName field should be used instead.