### PR TITLE
feat(charts): add helm templated init manifest

### DIFF
--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
 {{- end }}
 
 ---

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -271,8 +271,7 @@ init:
     ---
   # The contents of manifests-template will be templated using helm
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
-  manifestsTemplate: |-
-    ---
+  manifestsTemplate: ''
   helm: []
 
 # If enabled will deploy vcluster in an isolated mode with pod security

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -269,6 +269,11 @@ openshift:
 init:
   manifests: |-
     ---
+  # The contents of manifests-template will be templated using helm
+  # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
+  manifestsTemplate: |-
+    ---
+  helm: []
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas
@@ -322,5 +327,3 @@ isolation:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-  helm: []
-  helm: []

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
 {{- end }}
 
 ---

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -323,4 +323,8 @@ isolation:
 init:
   manifests: |-
     ---
+  # The contents of manifests-template will be templated using helm
+  # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
+  manifestsTemplate: |-
+    ---
   helm: []

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -325,6 +325,5 @@ init:
     ---
   # The contents of manifests-template will be templated using helm
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
-  manifestsTemplate: |-
-    ---
+  manifestsTemplate: ''
   helm: []

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
 {{- end }}
 
 ---

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -323,4 +323,8 @@ isolation:
 init:
   manifests: |-
     ---
+  # The contents of manifests-template will be templated using helm
+  # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
+  manifestsTemplate: |-
+    ---
   helm: []

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -325,6 +325,5 @@ init:
     ---
   # The contents of manifests-template will be templated using helm
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
-  manifestsTemplate: |-
-    ---
+  manifestsTemplate: ''
   helm: []

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   initmanifests.yaml: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
 {{- end }}
 
 ---

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -361,6 +361,5 @@ init:
     ---
   # The contents of manifests-template will be templated using helm
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
-  manifestsTemplate: |-
-    ---
+  manifestsTemplate: ''
   helm: []

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -359,4 +359,8 @@ isolation:
 init:
   manifests: |-
     ---
+  # The contents of manifests-template will be templated using helm
+  # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
+  manifestsTemplate: |-
+    ---
   helm: []


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Slack thread - https://loft-sh.slack.com/archives/C01NP55P8F6/p1658489200272449
vcluster user would like to be able to pass vcluster name inside of the cluster


**Please provide a short message that should be published in the vcluster release notes**
feat(charts): add init.manifestsTemplate field to values, which can be used to create a helm templated manifest which can use helm values passed to vcluster chart, for example vcluster name - "{{ .Release.Name }}".


**What else do we need to know?** 
This is just an idea, I open to suggestions how to implement this better, or to arguments why we shouldn't add this at all.
Also, if we are going to add this, I feel like it would be nice to add templated values for init helm charts.
