### PR TITLE
docs: corrected typo on the storage documentation page

### DIFF
--- a/docs/pages/architecture/storage.mdx
+++ b/docs/pages/architecture/storage.mdx
@@ -8,7 +8,7 @@ sidebar_label: Storage
   <figcaption>vcluster - Persistent Volume Provisioning</figcaption>
 </figure>
 
-Since the vcluster's syncer synchronizes pods to the underlying host cluster to schedule them, vcluster users can use the storage classes of the underlying host cluster to create persistent volume claims and to mount persistent volumes. By default, a host storage classe can be used without the need to create it in the vcluster, but this can be configured by [enabling sync of "storageclasses" or "legacy-storageclasses"](./synced-resources.mdx).
+Since the vcluster's syncer synchronizes pods to the underlying host cluster to schedule them, vcluster users can use the storage classes of the underlying host cluster to create persistent volume claims and to mount persistent volumes. By default, the host's storage classes can be used without the need to create it in the vcluster, but this can be configured by [enabling sync of "storageclasses" or "legacy-storageclasses"](./synced-resources.mdx).
 
 
 vcluster provides helm values to adjust this behavior during vcluster installation or upgrade. Find out more below. 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**Please provide a short message that should be published in the vcluster release notes**
Fixed a typo on the storage page of the main documentation website. Link to the page [here](https://www.vcluster.com/docs/architecture/storage).

