### PR TITLE
docs: fixed typos in operator/init-manifests and operator/restricted-hosts documentation pages

### DIFF
--- a/docs/pages/operator/init-manifests.mdx
+++ b/docs/pages/operator/init-manifests.mdx
@@ -54,7 +54,7 @@ init:
 ```
 
 ### Chart Bundle Mode
-If you're interested in applying a local chart directory, or a chart pulled from a repo that exists locally as a `tar` archive, then bundle mode can come handy. Let's say we have a chart named `my-chart.tar.gz` in the current directoy, we can use the bundle mode to deploy it during vcluster initialization as follows:
+If you're interested in applying a local chart directory, or a chart pulled from a repo that exists locally as a `tar` archive, then bundle mode can come handy. Let's say we have a chart named `my-chart.tar.gz` in the current directory, we can use the bundle mode to deploy it during vcluster initialization as follows:
 ```
 # copy the chart to your clipboard
 cat my-chart.tar.gz | base64 | pbcopy

--- a/docs/pages/operator/restricted-hosts.mdx
+++ b/docs/pages/operator/restricted-hosts.mdx
@@ -28,7 +28,7 @@ vcluster doesn't currently provide a migration path from an instance that was ru
 :::
 
 ## Running on OpenShift
-By default, OpenShift doesn't allow running containers with the root user, but it assings a random UID from the allowed range automatically, which means that you can skip the steps described in the [Running as non-root user](#running-as-non-root-user) section of this document and your vcluster should run as non-root user by default.
+By default, OpenShift doesn't allow running containers with the root user, but it assigns a random UID from the allowed range automatically, which means that you can skip the steps described in the [Running as non-root user](#running-as-non-root-user) section of this document and your vcluster should run as non-root user by default.
 
 OpenShift also imposes some restrictions that are not common to other Kubernetes distributions.  
 When deploying vcluster to OpenShift you will need to follow these additional steps:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation


**Please provide a short message that should be published in the vcluster release notes**
fixed typos in operator/init-manifests and operator/restricted-hosts documentation pages



