### PR TITLE
fix(syncer): allocatable pods calculation

### DIFF
--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/util/stringutil"
@@ -163,7 +164,8 @@ func (s *nodeSyncer) translateUpdateStatus(ctx *synccontext.SyncContext, pNode *
 					continue
 				}
 				if s.enableScheduler {
-					if pod.Namespace != ctx.TargetNamespace {
+					if !translate.IsManaged(&pod) {
+						// count pods that are not synced by this vcluster
 						nonVClusterPods++
 					}
 				}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Allocatable pods were calculated incorrectly. Calculation assumed that all pods in the targetNamespace were from vcluster, so the result was always off but at least 1 pod(vcluster itself).


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where nodes status would show an incorrect number of allocatable pods, which could cause scheduling problems.
