### PR TITLE
use run-k0s only when in rootless mode

### DIFF
--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -57,8 +57,10 @@ spec:
       serviceAccountName: vc-{{ .Release.Name }}
       {{- end }}
       volumes:
+        {{- if or .Values.securityContext.runAsUser .Values.securityContext.runAsNonRoot }}
         - name: run-k0s
           emptyDir: {}
+        {{- end }}
         - name: k0s-config
           secret:
             secretName: vc-{{ .Release.Name }}-config
@@ -113,8 +115,10 @@ spec:
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
         volumeMounts:
+          {{- if or .Values.securityContext.runAsUser .Values.securityContext.runAsNonRoot }}
           - name: run-k0s
             mountPath: /run/k0s
+          {{- end }}
 {{ toYaml .Values.vcluster.volumeMounts | indent 10 }}
         resources:
 {{ toYaml .Values.vcluster.resources | indent 10 }}


### PR DESCRIPTION
fixes #648

Signed-off-by: Ishan Khare <me@ishankhare.dev>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #648 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster with the k0s distro would fail to create / upgrade to version `0.11.0` because of additional volume `/run/k0s`. We now only create this when rootless mode is enabled


**What else do we need to know?** 
