### PR TITLE
fix(charts): add ephemeralcontainers permission only on k8s 1.23+

### DIFF
--- a/charts/eks/templates/rbac/role.yaml
+++ b/charts/eks/templates/rbac/role.yaml
@@ -11,8 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/ephemeralcontainers", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if .Values.sync.endpoints.enabled }}
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -11,8 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/ephemeralcontainers", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if .Values.sync.endpoints.enabled }}
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -11,8 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/ephemeralcontainers", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if .Values.sync.endpoints.enabled }}
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -11,8 +11,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/ephemeralcontainers", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/status", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- if .Values.sync.endpoints.enabled }}
   - apiGroups: [""]
     resources: ["endpoints"]


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
https://loft-sh.slack.com/archives/C01N273CF4P/p1659972352151499


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would request `pods/ephemeralcontainers` RBAC permissions on Kubernetes host clusters that do not support this feature(v1.22 and earlier).
