### PR TITLE
docs: add `ingressClassName` to the ingress example

### DIFF
--- a/docs/pages/operator/external-access.mdx
+++ b/docs/pages/operator/external-access.mdx
@@ -169,6 +169,7 @@ metadata:
   name: vcluster-ingress
   namespace: my-vcluster
 spec:
+  ingressClassName: nginx # use your ingress class name
   rules:
   - host: my-vcluster.example.com
     http:
@@ -233,6 +234,7 @@ metadata:
   name: vcluster-ingress
   namespace: my-vcluster
 spec:
+  ingressClassName: nginx # use your ingress class name
   rules:
   - host: my-vcluster.example.com
     http:


### PR DESCRIPTION
It was not clear to me as to why the ingress was not working even after setting up things as per the documentation, and it took a while to figure out that `ingressClassName` was missing from the example. 

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Add `ingressClassName` to the example to make it easier for the users who're new to Kubernetes

