### PR TITLE
Add OwnerSetKind annotation to Job pods

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -257,9 +257,9 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 		return nil, err
 	}
 
-	// we add an annotation if the pod has a replica set or statefulset owner
+	// add an owner-set-kind annotation to each pod with an owner
 	for _, ownerReference := range vPod.OwnerReferences {
-		if ownerReference.APIVersion == appsv1.SchemeGroupVersion.String() && (ownerReference.Kind == "StatefulSet" || ownerReference.Kind == "ReplicaSet" || ownerReference.Kind == "DaemonSet") {
+		if ownerReference.APIVersion == appsv1.SchemeGroupVersion.String() && canAnnotateOwnerSetKind(ownerReference.Kind) {
 			if pPod.Annotations == nil {
 				pPod.Annotations = map[string]string{}
 			}
@@ -294,6 +294,10 @@ func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dns
 	}
 
 	return pPod, nil
+}
+
+func canAnnotateOwnerSetKind(kind string) bool {
+	return kind == "DaemonSet" || kind == "Job" || kind == "ReplicaSet" || kind == "StatefulSet"
 }
 
 func translateLabelsAnnotation(obj client.Object) string {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves inability to distinguish pods without owners from pods spawned by jobs from within the host cluster.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was not setting the OwnerSetKind annotation on host-level pods translated from vcluster pods owned by a Job.

**What else do we need to know?** 
Nothing?