### PR TITLE
tooling: improve debug config for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
           "type": "go",
           "request": "attach",
           "mode": "remote",
+          "debugAdapter": "dlv-dap", // already a default for local debug, it improves e.g. inspection of the maps of interfaces
           "port": 2346,
           "host": "localhost",
           "substitutePath": [


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
Tooling improvement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Solves some tooling errors which were preventing inspection of the maps that contain interface{} while debugging remotely.


**Please provide a short message that should be published in the vcluster release notes**
N/A