### PR TITLE
Updated Disconnect to display the message on exit

### DIFF
--- a/cmd/vclusterctl/cmd/disconnect.go
+++ b/cmd/vclusterctl/cmd/disconnect.go
@@ -76,6 +76,7 @@ func (cmd *DisconnectCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "switch kube context")
 	}
 
+	cmd.log.Infof("Successfully disconnected from vcluster: %s and switched back to the original context: %s", vClusterName, otherContext)
 	return nil
 }
 


### PR DESCRIPTION
on vcluster disconnect, it shows a message saying it successfully disconnected and switched back to original context

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #677 

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where on vcluster disconnect, it shows a message saying it successfully disconnected and switched back to original context
screenshot below

![Screenshot 2022-08-23 at 5 42 17 PM](https://user-images.githubusercontent.com/741952/186159652-653392d2-63a2-4a8c-aa6c-a5ed03d8abc4.png)

**What else do we need to know?** 
