### PR TITLE
[Helm K0s] Try to avoid leaving a status.sock around between restarts

### DIFF
--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
           - {{ $f | quote }}
           {{- end }}
           {{- if or .Values.securityContext.runAsUser .Values.securityContext.runAsNonRoot }}
-          - --status-socket=/data/k0s/status.sock
+          - --status-socket=/run/k0s/status.sock
           {{- end }}
           {{- if not .Values.sync.nodes.enableScheduler }}
           - --disable-components=konnectivity-server,kube-scheduler,csr-approver,default-psp,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
improves the situation for #678 - it doesn't fully resolve it, but it should actually be "fixable" with a restart of the pod with this change

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where a rootless install of the k0s vcluster chart could leave a socket in place, wedging the cluster until the socket is manually removed.

**What else do we need to know?** 
This will store the status socket for k0s in the emptyDir `/run/k0s`, which would mean that if an instance hits #678 then it should be enough to restart it to clear the collision.

A better fix would probably be to ensure that the socket file is removed on every startup, but I don't really want to start adding complex startup to a container that's just `k0s controller ...` at the moment