### PR TITLE
fix: add envvar ETCD_UNSUPPORTED_ARCH=arm64 to run etcd on arm64

### DIFF
--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -114,6 +114,8 @@ spec:
           {{- if .Values.vcluster.env }}
 {{ toYaml .Values.vcluster.env | indent 10 }}
           {{- end }}
+          - name: ETCD_UNSUPPORTED_ARCH
+            value: arm64
           - name: CONFIG_READY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do?** 
It adds envvar ETCD_UNSUPPORTED_ARCH=arm64 to k0s statefulset.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster creation used to fail on arm64 machine for k0s distro because etcd does not fully support arm64 yet.

