### PR TITLE
Allow annotation of all objects created by the chart

### DIFF
--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 data:
 {{- if .Values.coredns.resources }}
   coredns.yaml: |-

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -4,9 +4,9 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 data:
 {{- if .Values.coredns.resources }}

--- a/charts/k3s/templates/ingress.yaml
+++ b/charts/k3s/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+{{- $annotations := merge .Values.ingress.annotations .Values.global.annotations }}
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/k3s/templates/ingress.yaml
+++ b/charts/k3s/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-{{- $annotations := merge .Values.ingress.annotations .Values.global.annotations }}
+{{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
   {{- if $annotations }}
   annotations:
   {{- toYaml $annotations | nindent 4 }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 data:
   manifests: |-

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -4,9 +4,9 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 spec:
   limits:

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -4,6 +4,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -4,9 +4,9 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 spec:
   podSelector:

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 rules:
   {{- if or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: [""]

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 rules:
   {{- if or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create }}

--- a/charts/k3s/templates/rbac/clusterrolebinding.yaml
+++ b/charts/k3s/templates/rbac/clusterrolebinding.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 subjects:
   - kind: ServiceAccount

--- a/charts/k3s/templates/rbac/clusterrolebinding.yaml
+++ b/charts/k3s/templates/rbac/clusterrolebinding.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 rules:
   - apiGroups: [""]

--- a/charts/k3s/templates/rbac/rolebinding.yaml
+++ b/charts/k3s/templates/rbac/rolebinding.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 subjects:
   - kind: ServiceAccount

--- a/charts/k3s/templates/rbac/rolebinding.yaml
+++ b/charts/k3s/templates/rbac/rolebinding.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -4,9 +4,9 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 spec:
   hard:

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/k3s/templates/serviceaccount.yaml
+++ b/charts/k3s/templates/serviceaccount.yaml
@@ -9,9 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k3s/templates/serviceaccount.yaml
+++ b/charts/k3s/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k3s/templates/statefulset-service.yaml
+++ b/charts/k3s/templates/statefulset-service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: https

--- a/charts/k3s/templates/statefulset-service.yaml
+++ b/charts/k3s/templates/statefulset-service.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 spec:
   ports:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -11,9 +11,10 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.annotations }}
+{{- $annotations := merge .Values.annotations .Values.global.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-headless
@@ -221,7 +222,7 @@ spec:
         {{- end }}
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
-        env:          
+        env:
           {{- if .Values.syncer.env }}
 {{ toYaml .Values.syncer.env | indent 10 }}
           {{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-{{- $annotations := merge .Values.annotations .Values.global.annotations }}
+{{- $annotations := merge .Values.annotations .Values.globalAnnotations }}
   {{- if $annotations }}
   annotations:
 {{ toYaml $annotations | indent 4 }}

--- a/charts/k3s/templates/workloadserviceaccount.yaml
+++ b/charts/k3s/templates/workloadserviceaccount.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.global.annotations }}
+  {{- if .Values.globalAnnotations }}
   annotations:
-{{ toYaml .Values.global.annotations | indent 4 }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k3s/templates/workloadserviceaccount.yaml
+++ b/charts/k3s/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.global.annotations }}
+  annotations:
+{{ toYaml .Values.global.annotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -1,6 +1,5 @@
-global:
-  # These annotations will be applied to all objects created in this chart
-  annotations: {}
+# These annotations will be applied to all objects created in this chart
+globalAnnotations: {}
 
 # DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
 # images within the vcluster will not be rewritten.

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # These annotations will be applied to all objects created in this chart
+  annotations: {}
+
 # DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Added helm value "global.annotations" to k3s chart that will add its annotations to all objects created in the chart. Annotations for specific objects have precedence over global ones.

**What else do we need to know?** 
I have a case where I want to add an annotation to all objects created in the vcluster release. I'm not super happy with using a `global` value because of its special meaning in helm, but I think if still kind of makes sense and I did not want to touch the existing top-level `annotations` value, as it's only used for the stateful set.