### PR TITLE
feat: support 1.25 version with k8s distro

### DIFF
--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -138,7 +138,7 @@ syncer:
 
 # Etcd settings
 etcd:
-  image: k8s.gcr.io/etcd:3.5.1-0
+  image: k8s.gcr.io/etcd:3.5.4-0
   # The amount of replicas to run 
   replicas: 1
   # NodeSelector used
@@ -169,7 +169,7 @@ etcd:
 
 # Kubernetes Controller Manager settings
 controller:
-  image: k8s.gcr.io/kube-controller-manager:v1.24.3
+  image: k8s.gcr.io/kube-controller-manager:v1.25.0
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used 
@@ -189,7 +189,7 @@ controller:
 
 # Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
 scheduler:
-  image: k8s.gcr.io/kube-scheduler:v1.24.3
+  image: k8s.gcr.io/kube-scheduler:v1.25.0
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -209,7 +209,7 @@ scheduler:
 
 # Kubernetes API Server settings
 api:
-  image: k8s.gcr.io/kube-apiserver:v1.24.3
+  image: k8s.gcr.io/kube-apiserver:v1.25.0
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1

--- a/pkg/helm/values/k8s.go
+++ b/pkg/helm/values/k8s.go
@@ -8,6 +8,7 @@ import (
 )
 
 var K8SAPIVersionMap = map[string]string{
+	"1.25": "k8s.gcr.io/kube-apiserver:v1.25.0",
 	"1.24": "k8s.gcr.io/kube-apiserver:v1.24.3",
 	"1.23": "k8s.gcr.io/kube-apiserver:v1.23.9",
 	"1.22": "k8s.gcr.io/kube-apiserver:v1.22.12",
@@ -16,6 +17,7 @@ var K8SAPIVersionMap = map[string]string{
 }
 
 var K8SControllerVersionMap = map[string]string{
+	"1.25": "k8s.gcr.io/kube-controller-manager:v1.25.0",
 	"1.24": "k8s.gcr.io/kube-controller-manager:v1.24.3",
 	"1.23": "k8s.gcr.io/kube-controller-manager:v1.23.9",
 	"1.22": "k8s.gcr.io/kube-controller-manager:v1.22.12",
@@ -24,6 +26,7 @@ var K8SControllerVersionMap = map[string]string{
 }
 
 var K8SSchedulerVersionMap = map[string]string{
+	"1.25": "k8s.gcr.io/kube-scheduler:v1.25.0",
 	"1.24": "k8s.gcr.io/kube-scheduler:v1.24.3",
 	"1.23": "k8s.gcr.io/kube-scheduler:v1.23.9",
 	"1.22": "k8s.gcr.io/kube-scheduler:v1.22.12",
@@ -32,6 +35,7 @@ var K8SSchedulerVersionMap = map[string]string{
 }
 
 var K8SEtcdVersionMap = map[string]string{
+	"1.25": "k8s.gcr.io/etcd:3.5.4-0",
 	"1.24": "k8s.gcr.io/etcd:3.5.1-0",
 	"1.23": "k8s.gcr.io/etcd:3.5.1-0",
 	"1.22": "k8s.gcr.io/etcd:3.5.1-0",
@@ -51,12 +55,12 @@ func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	schedulerImage := K8SSchedulerVersionMap[serverVersionString]
 	etcdImage, ok := K8SEtcdVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 24 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-			apiImage = K8SAPIVersionMap["1.24"]
-			controllerImage = K8SControllerVersionMap["1.24"]
-			schedulerImage = K8SSchedulerVersionMap["1.24"]
-			etcdImage = K8SEtcdVersionMap["1.24"]
+		if serverMinorInt > 25 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+			apiImage = K8SAPIVersionMap["1.25"]
+			controllerImage = K8SControllerVersionMap["1.25"]
+			schedulerImage = K8SSchedulerVersionMap["1.25"]
+			etcdImage = K8SEtcdVersionMap["1.25"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = K8SAPIVersionMap["1.20"]


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Adds support for Kubernetes 1.25 when using k8s distro of vcluster.


**What else do we need to know?** 
I am also running v1.25 conformance tests with this change.
If the tests finish successfully before this is merged, I'll add a commit with results too.