### PR TITLE
fix: excessive node updates when syncing real nodes with ttl != 0

### DIFF
--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -75,7 +75,7 @@ spec:
           - '--cluster-name=kubernetes'
           - '--cluster-signing-cert-file=/run/config/pki/ca.crt'
           - '--cluster-signing-key-file=/run/config/pki/ca.key'
-          - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle'
+          - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
           - '--horizontal-pod-autoscaler-sync-period=60s'
           - '--kubeconfig=/run/config/pki/controller-manager.conf'
           - '--port=0'

--- a/charts/k0s/templates/secret.yaml
+++ b/charts/k0s/templates/secret.yaml
@@ -39,9 +39,9 @@ stringData:
       controllerManager:
         extraArgs:
           {{- if not .Values.sync.nodes.enableScheduler }}
-          controllers: '*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle'
+          controllers: '*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
           {{- else }}
-          controllers: '*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle'
+          controllers: '*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
           node-monitor-grace-period: 1h
           node-monitor-period: 1h
           {{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -103,10 +103,10 @@ spec:
           {{- end }}
           {{- if not .Values.sync.nodes.enableScheduler }}
             --disable-scheduler
-            --kube-controller-manager-arg=controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle
+            --kube-controller-manager-arg=controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl
             --kube-apiserver-arg=endpoint-reconciler-type=none
           {{- else }}
-            --kube-controller-manager-arg=controllers=*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle
+            --kube-controller-manager-arg=controllers=*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl
             --kube-apiserver-arg=endpoint-reconciler-type=none
             --kube-controller-manager-arg=node-monitor-grace-period=1h
             --kube-controller-manager-arg=node-monitor-period=1h

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -113,9 +113,9 @@ spec:
           - '--cluster-signing-cert-file=/run/config/pki/ca.crt'
           - '--cluster-signing-key-file=/run/config/pki/ca.key'
           {{- if not .Values.sync.nodes.enableScheduler }}
-          - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle'
+          - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
           {{- else }}
-          - '--controllers=*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle'
+          - '--controllers=*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
           - '--node-monitor-grace-period=1h'
           - '--node-monitor-period=1h'
           {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
When the "node.alpha.kubernetes.io/ttl" annotation on the host node is not equal to "0", and sync of the real nodes is enabled, the "ttl" controller will be resetting the value of the annotation, and the syncer will keep updating it.
The issue is fixed by disabling Kubernetes "ttl" controller.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where in specific scenarios vcluster was updating the nodes excessively.


**What else do we need to know?** 
Here is an explanation of what the "ttl" controller does - https://github.com/kubernetes/kubernetes/blob/cba0dcecc9ca6d5e884a3b3d1bf99ef7f20b3d37/pkg/controller/ttl/ttl_controller.go#L17-L25
and about the annotation that is mentioned above - https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/annotation_key_constants.go#L59-L62
TLDR: we don't use kubelet - we don't need to enable this controller
