### PR TITLE
fix(syncer): stop syncing "field.cattle.io/publicEndpoints" Service annotation

### DIFF
--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -22,7 +22,10 @@ var ServiceBlockDeletion = "vcluster.loft.sh/block-deletion"
 
 func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 	return &serviceSyncer{
-		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "service", &corev1.Service{}),
+		// exclude "field.cattle.io/publicEndpoints" annotation used by Rancher,
+		// because if it is also installed in the host cluster, it will be
+		// overriding it, which would cause endless updates back and forth.
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "service", &corev1.Service{}, "field.cattle.io/publicEndpoints"),
 
 		serviceName: ctx.Options.ServiceName,
 	}, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves an issue where the Service syncer continuously updates a Service in the host cluster because the host cluster and vcluster both have Rancher controller installed. 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was updating a Service excessively. The "field.cattle.io/publicEndpoints" annotation will no longer be synced to Services that vcluster creates in the host cluster.


**What else do we need to know?** 
Example of the annotation on the host Service how vcluster updates it:
```
kind: Service
metadata:
  annotations:
    field.cattle.io/publicEndpoints: '
[{"addresses":["abc.elb.us-east-1.amazonaws.com"],"port":80,"protocol":"TCP",
"serviceName":"kong:kong-kong-proxy","allNodes":false},
{"addresses":["abc.elb.us-east-1.amazonaws.com"],"port":443,"protocol":"TCP",
"serviceName":"kong:kong-kong-proxy","allNodes":false}]'
```
and how it is updated by the controller in the host cluster:
```
kind: Service
metadata:
  annotations:
    field.cattle.io/publicEndpoints: '
[{"addresses":["abc-7fbc04d0d82ed653.elb.us-east-1.amazonaws.com"],"port":80,"protocol":"TCP",
"serviceName":"vcluster-qlik:kong-kong-proxy-x-kong-x-qlik","allNodes":false},
{"addresses":["abc-7fbc04d0d82ed653.elb.us-east-1.amazonaws.com"],"port":443,"protocol":"TCP",
"serviceName":"vcluster-qlik:kong-kong-proxy-x-kong-x-qlik","allNodes":false}]'
```
Notice the difference in the "serviceName".