### PR TITLE
fix: panic in PV syncer when ClaimRef is nil

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -67,8 +67,10 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 		isStorageClassCreatedOnVirtual = equality.Semantic.DeepEqual(storageClassPhysicalName, translatedSpec.StorageClassName)
 
 		// check if claim was created on virtual
-		claimRefPhysicalName := translate.PhysicalName(vPv.Spec.ClaimRef.Name, vPv.Spec.ClaimRef.Namespace)
-		isClaimRefCreatedOnVirtual = equality.Semantic.DeepEqual(claimRefPhysicalName, translatedSpec.ClaimRef.Name)
+		if vPv.Spec.ClaimRef != nil && translatedSpec.ClaimRef != nil {
+			claimRefPhysicalName := translate.PhysicalName(vPv.Spec.ClaimRef.Name, vPv.Spec.ClaimRef.Namespace)
+			isClaimRefCreatedOnVirtual = equality.Semantic.DeepEqual(claimRefPhysicalName, translatedSpec.ClaimRef.Name)
+		}
 	}
 
 	// check storage class. Do not copy the name, if it was created on virtual.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #708 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster syncer container would panic when PersistentVolume sync is enabled and a PV without the .spec.claimRef is updated.