### PR TITLE
Add podAnnotations key for api, controller, syncer and etcd's pod template

### DIFF
--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.api.podAnnotations }}
+      annotations:
+{{ toYaml .Values.api.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-api
         release: {{ .Release.Name }}

--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.controller.podAnnotations }}
+      annotations:
+{{ toYaml .Values.controller.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-controller
         release: {{ .Release.Name }}

--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -42,6 +42,10 @@ spec:
   {{- end }}
   template:
     metadata:
+  {{- if .Values.etcd.podAnnotations }}
+      annotations:
+{{ toYaml .Values.etcd.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-etcd
         release: {{ .Release.Name }}

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -32,6 +32,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.syncer.podAnnotations }}
+      annotations:
+{{ toYaml .Values.syncer.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster
         release: {{ .Release.Name }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -129,6 +129,7 @@ syncer:
   labels: {}
   # Extra Annotations for the syncer deployment
   annotations: {}
+  podAnnotations: {}
   priorityClassName: ""
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
@@ -149,6 +150,7 @@ etcd:
   labels: {}
   # Extra Annotations
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 20m
@@ -180,6 +182,7 @@ controller:
   labels: {}
   # Extra Annotations
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 15m
@@ -201,6 +204,7 @@ api:
   labels: {}
   # Extra Annotations for the syncer deployment
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 40m

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -40,6 +40,10 @@ spec:
   {{- end }}
   template:
     metadata:
+  {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster
         release: {{ .Release.Name }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -201,6 +201,7 @@ labels: {}
 
 # Extra Annotations for the stateful set
 annotations: {}
+podAnnotations: {}
 
 # Service configurations
 service:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -40,6 +40,10 @@ spec:
   {{- end }}
   template:
     metadata:
+  {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster
         release: {{ .Release.Name }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -207,6 +207,7 @@ labels: {}
 
 # Extra Annotations for the stateful set
 annotations: {}
+podAnnotations: {}
 
 # Service configurations
 service:

--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.api.podAnnotations }}
+      annotations:
+{{ toYaml .Values.api.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-api
         release: {{ .Release.Name }}

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.controller.podAnnotations }}
+      annotations:
+{{ toYaml .Values.controller.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-controller
         release: {{ .Release.Name }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -42,6 +42,10 @@ spec:
   {{- end }}
   template:
     metadata:
+  {{- if .Values.etcd.podAnnotations }}
+      annotations:
+{{ toYaml .Values.etcd.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-etcd
         release: {{ .Release.Name }}

--- a/charts/k8s/templates/scheduler-deployment.yaml
+++ b/charts/k8s/templates/scheduler-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.scheduler.podAnnotations }}
+      annotations:
+{{ toYaml .Values.scheduler.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster-scheduler
         release: {{ .Release.Name }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -32,6 +32,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+  {{- if .Values.syncer.podAnnotations }}
+      annotations:
+{{ toYaml .Values.syncer.podAnnotations | indent 8 }}
+  {{- end }}
       labels:
         app: vcluster
         release: {{ .Release.Name }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -131,6 +131,7 @@ syncer:
   labels: {}
   # Extra Annotations for the syncer deployment
   annotations: {}
+  podAnnotations: {}
   priorityClassName: ""
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
@@ -151,6 +152,7 @@ etcd:
   labels: {}
   # Extra Annotations
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 20m
@@ -182,6 +184,7 @@ controller:
   labels: {}
   # Extra Annotations
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 15m
@@ -202,6 +205,7 @@ scheduler:
   labels: {}
   # Extra Annotations
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 10m
@@ -223,6 +227,7 @@ api:
   labels: {}
   # Extra Annotations for the syncer deployment
   annotations: {}
+  podAnnotations: {}
   resources:
     requests:
       cpu: 40m


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #711 


**Please provide a short message that should be published in the vcluster release notes**
The **podAnnotations** key now controls annotations of pod template in api, controller, syncer and etcd. 

**What else do we need to know?** 
