### PR TITLE
Releases the cloud provider volume when a dynamically provisioned PV with a reclaim policy of 'Delete', is deleted.

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -127,17 +127,19 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, pObj client.
 		}
 	}
 
-	// check if objects are getting deleted
-	if vObj.GetDeletionTimestamp() != nil {
-		if pObj.GetDeletionTimestamp() == nil {
-			ctx.Log.Infof("delete physical persistent volume %s, because virtual persistent volume is terminating", pObj.GetName())
-			err := ctx.PhysicalClient.Delete(ctx.Context, pObj)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
+	// check if virtual persistent volume is deleted
+	if vPersistentVolume.GetDeletionTimestamp() != nil && len(vPersistentVolume.GetFinalizers()) > 0 {
+		if vPersistentVolume.Spec.ClaimRef != nil && vPersistentVolume.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
+			// executes when dynamically provisioned PV with a delete reclaim policy gets deleted
+			// it also releases the cloud provider volume.
+			vPersistentVolume.SetFinalizers(nil)
+			ctx.Log.Infof("remove virtual persistent volume %s finalizers, because virtual persistent volume is terminating", vPersistentVolume.GetName())
+			return ctrl.Result{}, ctx.VirtualClient.Update(ctx.Context, vPersistentVolume)
+		} else {
+			// executes when a Retained PV in Released status is manually deleted and when statically provisioned PVs are deleted
+			ctx.Log.Infof("remove physical persistent volume %s, because virtual persistent volume is deleted", pPersistentVolume.GetName())
+			return ctrl.Result{}, ctx.PhysicalClient.Delete(ctx.Context, pPersistentVolume)
 		}
-
-		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	// check if the persistent volume should get synced
@@ -220,6 +222,10 @@ func (s *persistentVolumeSyncer) SyncUp(ctx *synccontext.SyncContext, pObj clien
 	} else if translate.IsManagedCluster(ctx.TargetNamespace, pObj) {
 		ctx.Log.Infof("delete physical persistent volume %s, because it is not needed anymore", pPersistentVolume.Name)
 		return syncer.DeleteObject(ctx, pObj)
+	} else if pPersistentVolume.GetDeletionTimestamp() != nil {
+		// executes after the sync when a Retained PV in Released status is manually deleted
+		ctx.Log.Infof("deleting physical persistent volume %s", pPersistentVolume.Name)
+		return ctrl.Result{}, nil
 	} else if sync {
 		// create the persistent volume
 		vObj := s.translateBackwards(pPersistentVolume, vPvc)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This fixes the "issue 2" of the issue #600. With this fix, when the PV is dynamically provisioned and its reclaim policy is Delete, we now wait for the physical PV to be deleted and in-turn the CSI to delete the cloud provider volume naturally. Once the physical PV gets deleted, the existing code takes care of clearing the finalizers on the virtual PV and the same gets deleted eventually.

**Please provide a short message that should be published in the vcluster release notes**
Releases the cloud provider volume when a dynamically provisioned PV with a reclaim policy of 'Delete', is deleted.