### PR TITLE
Provide service creation rights to the service account for correct service-cidr retrieval on vcluster-eks chart

### DIFF
--- a/charts/eks/templates/pre-install-hook-job-role.yaml
+++ b/charts/eks/templates/pre-install-hook-job-role.yaml
@@ -10,6 +10,6 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded    
 rules:
   - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
+    resources: ["secrets", "configmaps","services"]
     verbs: ["create", "get", "list"]
 {{- end }}

--- a/charts/k8s/templates/pre-install-hook-job-role.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-role.yaml
@@ -10,6 +10,6 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
+    resources: ["secrets", "configmaps","services"]
     verbs: ["create", "get", "list"]
 {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves #704 
While using Helm deployment, a job runs which tries to create a fake service, an error occurs and we extract the correct service CIDR from this error message. This service CIDR gets assigned to the service-cidr configmap. Currently, the assigned value is incorrect because the service account being used did not have the rights to create the service. This causes the default CIDR value to be set to the configmap.

With this fix, the service creation rights is given to the service-account used by the job that allows the init container to get the correct CIDR.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the service-account was provided with the service resource creation rights to retrieve the correct CIDR on vcluster-eks.