### PR TITLE
Add loadBalancerIP; fix externalTrafficPolicy & externalIPs logic

### DIFF
--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -15,10 +15,21 @@ spec:
       port: 443
       targetPort: 8443
       protocol: TCP
-  selector:
-    app: vcluster
-    release: {{ .Release.Name }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+    {{- range $f := .Values.service.externalIPs }}
+    - {{ $f }}
+    {{- end }}
+  {{- end }}
+  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- end }}
   {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}
@@ -26,3 +37,6 @@ spec:
     {{- end }}
   {{- end }}
   {{- end }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -238,10 +238,23 @@ rbac:
     # Support for this value will be removed in a future version of the vcluster
     extended: false
 
-# Service configurations
+# Syncer service configurations
 service:
   type: ClusterIP
-  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+
+  # Optional configuration
+  # A list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+  # These IPs are not managed by Kubernetes; e.g., an external load balancer.
+  externalIPs: []
+
+  # Optional configuration for LoadBalancer & NodePort service types
+  # Route external traffic to node-local or cluster-wide endpoints [ Local | Cluster ]
+  externalTrafficPolicy: ""
+
+  # Optional configuration for LoadBalancer service type
+  # Specify IP of load balancer to be created
+  loadBalancerIP: ""
+  # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
 
 # job configuration

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -15,20 +15,25 @@ spec:
       port: 443
       targetPort: 8443
       protocol: TCP
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+    {{- range $f := .Values.service.externalIPs }}
+    - {{ $f }}
+    {{- end }}
+  {{- end }}
+  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}
     - "{{ $f }}"
-    {{- end }}
-  {{- end }}
-  {{- if .Values.service.externalIPs }}
-  externalIPs:
-    {{- range $f := .Values.service.externalIPs }}
-    - {{ $f }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -205,10 +205,20 @@ annotations: {}
 # Service configurations
 service:
   type: ClusterIP
-  # Configuration for LoadBalancer service type
+
+  # Optional configuration
+  # A list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+  # These IPs are not managed by Kubernetes; e.g., an external load balancer.
   externalIPs: []
+
+  # Optional configuration for LoadBalancer & NodePort service types
+  # Route external traffic to node-local or cluster-wide endpoints [ Local | Cluster ]
   externalTrafficPolicy: ""
-  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+
+  # Optional configuration for LoadBalancer service type
+  # Specify IP of load balancer to be created
+  loadBalancerIP: ""
+  # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
 
 # Configure the ingress resource that allows you to access the vcluster

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -15,20 +15,25 @@ spec:
       port: 443
       targetPort: 8443
       protocol: TCP
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+    {{- range $f := .Values.service.externalIPs }}
+    - {{ $f }}
+    {{- end }}
+  {{- end }}
+  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}
     - "{{ $f }}"
-    {{- end }}
-  {{- end }}
-  {{- if .Values.service.externalIPs }}
-  externalIPs:
-    {{- range $f := .Values.service.externalIPs }}
-    - {{ $f }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -211,10 +211,20 @@ annotations: {}
 # Service configurations
 service:
   type: ClusterIP
-  # Configuration for LoadBalancer service type
+
+  # Optional configuration
+  # A list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+  # These IPs are not managed by Kubernetes; e.g., an external load balancer.
   externalIPs: []
+
+  # Optional configuration for LoadBalancer & NodePort service types
+  # Route external traffic to node-local or cluster-wide endpoints [ Local | Cluster ]
   externalTrafficPolicy: ""
-  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+
+  # Optional configuration for LoadBalancer service type
+  # Specify IP of load balancer to be created
+  loadBalancerIP: ""
+  # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
 
 # Configure the ingress resource that allows you to access the vcluster

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -15,20 +15,25 @@ spec:
       port: 443
       targetPort: 8443
       protocol: TCP
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+    {{- range $f := .Values.service.externalIPs }}
+    - {{ $f }}
+    {{- end }}
+  {{- end }}
+  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}
     - "{{ $f }}"
-    {{- end }}
-  {{- end }}
-  {{- if .Values.service.externalIPs }}
-  externalIPs:
-    {{- range $f := .Values.service.externalIPs }}
-    - {{ $f }}
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -254,13 +254,24 @@ rbac:
     # Necessary extended roles are created based on the enabled syncers (.sync.*.enabled)
     # Support for this value will be removed in a future version of the vcluster
     extended: false
-# Service configurations
+
+# Syncer service configurations
 service:
   type: ClusterIP
-  # Configuration for LoadBalancer service type
+
+  # Optional configuration
+  # A list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+  # These IPs are not managed by Kubernetes; e.g., an external load balancer.
   externalIPs: []
+
+  # Optional configuration for LoadBalancer & NodePort service types
+  # Route external traffic to node-local or cluster-wide endpoints [ Local | Cluster ]
   externalTrafficPolicy: ""
-  # CIDR block(s) for the service allowlist; only used when the Service type is LoadBalancer
+
+  # Optional configuration for LoadBalancer service type
+  # Specify IP of load balancer to be created
+  loadBalancerIP: ""
+  # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
 
 # job configuration


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
- Adds support for configuring `loadbalancerIP`
- Fixes `externalTrafficPolicy` logic (should be included in NodePort & LoadBalancer cases)
- Fixes `externalIPs` logic. This field should not be tightly bound with the LoadBalancer case. [External IPs](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) are [typically specified in conjunction with ClusterIP services](https://medium.com/swlh/kubernetes-external-ip-service-type-5e5e9ad62fcd).

**Please provide a short message that should be published in the vcluster release notes**
Enhanced correctness & flexibility of vcluster service configuration

**What else do we need to know?**
N/A
