### PR TITLE
feat(chart): helm values to set labels on vclusters pods

### DIFF
--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         app: vcluster-api
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.api.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.api.affinity }}

--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         app: vcluster-controller
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.controller.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.controller.affinity }}

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -119,6 +119,9 @@ data:
   {{- end }}
           labels:
             k8s-app: kube-dns
+          {{- range $k, $v := .Values.coredns.podLabels }}
+            {{ $k }}: {{ $v | quote }}
+          {{- end }}
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: coredns

--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -49,6 +49,9 @@ spec:
       labels:
         app: vcluster-etcd
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.etcd.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.etcd.affinity }}

--- a/charts/eks/templates/pre-install-hook-job.yaml
+++ b/charts/eks/templates/pre-install-hook-job.yaml
@@ -13,6 +13,14 @@ spec:
   template:
     metadata:
       name: {{ .Release.Name }}-job
+      {{- if .Values.job.podAnnotations }}
+      annotations:
+{{ toYaml .Values.job.podAnnotations | indent 8 }}
+      {{- end }}
+      {{- if .Values.job.podLabels }}
+      labels:
+{{ toYaml .Values.job.podLabels | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-job
       restartPolicy: OnFailure

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -39,6 +39,9 @@ spec:
       labels:
         app: vcluster
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.syncer.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.syncer.affinity }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -130,6 +130,7 @@ syncer:
   # Extra Annotations for the syncer deployment
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   priorityClassName: ""
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
@@ -151,6 +152,7 @@ etcd:
   # Extra Annotations
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 20m
@@ -184,6 +186,7 @@ controller:
   # Extra Annotations
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 15m
@@ -207,6 +210,7 @@ api:
   # Extra Annotations for the syncer deployment
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 40m
@@ -230,6 +234,7 @@ coredns:
 #    apiVersion: ...
 #    ...
   podAnnotations: {}
+  podLabels: {}
 
 # Service account that should be used by the vcluster
 serviceAccount:
@@ -284,6 +289,8 @@ job:
   affinity: {}
   tolerations: []
   resources: {}
+  podAnnotations: {}
+  podLabels: {}
 
 # Configure the ingress resource that allows you to access the vcluster
 ingress:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -125,6 +125,9 @@ data:
   {{- end }}
           labels:
             k8s-app: kube-dns
+          {{- range $k, $v := .Values.coredns.podLabels }}
+            {{ $k }}: {{ $v | quote }}
+          {{- end }}
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: coredns

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -47,6 +47,9 @@ spec:
       labels:
         app: vcluster
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       nodeSelector:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -198,6 +198,7 @@ tolerations: []
 
 # Extra Labels for the stateful set
 labels: {}
+podLabels: {}
 
 # Extra Annotations for the stateful set
 annotations: {}
@@ -291,6 +292,7 @@ coredns:
 #    apiVersion: ...
 #    ...
   podAnnotations: {}
+  podLabels: {}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -129,6 +129,9 @@ data:
   {{- end }}
           labels:
             k8s-app: kube-dns
+          {{- range $k, $v := .Values.coredns.podLabels }}
+            {{ $k }}: {{ $v | quote }}
+          {{- end }}
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: coredns

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -48,6 +48,9 @@ spec:
       labels:
         app: vcluster
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       nodeSelector:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -207,6 +207,7 @@ tolerations: []
 
 # Extra Labels for the stateful set
 labels: {}
+podLabels: {}
 
 # Extra Annotations for the stateful set
 annotations: {}
@@ -295,6 +296,7 @@ coredns:
 #    apiVersion: ...
 #    ...
   podAnnotations: {}
+  podLabels: {}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         app: vcluster-api
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.api.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.api.affinity }}

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         app: vcluster-controller
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.controller.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.controller.affinity }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -125,6 +125,9 @@ data:
   {{- end }}
           labels:
             k8s-app: kube-dns
+          {{- range $k, $v := .Values.coredns.podLabels }}
+            {{ $k }}: {{ $v | quote }}
+          {{- end }}
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: coredns

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -49,6 +49,9 @@ spec:
       labels:
         app: vcluster-etcd
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.etcd.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.etcd.affinity }}

--- a/charts/k8s/templates/pre-install-hook-job.yaml
+++ b/charts/k8s/templates/pre-install-hook-job.yaml
@@ -13,6 +13,14 @@ spec:
   template:
     metadata:
       name: {{ .Release.Name }}-job
+      {{- if .Values.job.podAnnotations }}
+      annotations:
+{{ toYaml .Values.job.podAnnotations | indent 8 }}
+      {{- end }}
+      {{- if .Values.job.podLabels }}
+      labels:
+{{ toYaml .Values.job.podLabels | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-job
       restartPolicy: OnFailure

--- a/charts/k8s/templates/scheduler-deployment.yaml
+++ b/charts/k8s/templates/scheduler-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         app: vcluster-scheduler
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.scheduler.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.scheduler.affinity }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -39,6 +39,9 @@ spec:
       labels:
         app: vcluster
         release: {{ .Release.Name }}
+      {{- range $k, $v := .Values.syncer.podLabels }}
+        {{ $k }}: {{ $v | quote }}
+      {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.syncer.affinity }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -132,6 +132,7 @@ syncer:
   # Extra Annotations for the syncer deployment
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   priorityClassName: ""
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
@@ -153,6 +154,7 @@ etcd:
   # Extra Annotations
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 20m
@@ -185,6 +187,7 @@ controller:
   # Extra Annotations
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 15m
@@ -206,6 +209,7 @@ scheduler:
   # Extra Annotations
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 10m
@@ -228,6 +232,7 @@ api:
   # Extra Annotations for the syncer deployment
   annotations: {}
   podAnnotations: {}
+  podLabels: {}
   resources:
     requests:
       cpu: 40m
@@ -287,6 +292,8 @@ job:
   affinity: {}
   tolerations: []
   resources: {}
+  podAnnotations: {}
+  podLabels: {}
 
 # Configure the ingress resource that allows you to access the vcluster
 ingress:
@@ -336,6 +343,7 @@ coredns:
 #    apiVersion: ...
 #    ...
   podAnnotations: {}
+  podLabels: {}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This allows users to set labels on the pods that are created from the helm chart, including the coredns pod (subject to the usual translation unless `--sync-labels` syncer flag is used).
This is useful for example when Istio sidecar injection is enabled in the namespace where vcluster is installed. Then the user can disable it on the vcluster pods with the `sidecar.istio.io/inject: "false"` label.


**Please provide a short message that should be published in the vcluster release notes**
chart: Added a helm value to set labels on the vcluster pods.