### PR TITLE
fix: increase minimum coredns resource requests

### DIFF
--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -221,10 +221,12 @@ coredns:
   resources:
     limits:
       cpu: 1000m
-      memory: 170Mi
+      memory: 512Mi
     requests:
-      cpu: 3m
-      memory: 16Mi
+      # ensure that cpu/memory requests are high enough.
+      # for example gke wants minimum 10m/32Mi here!
+      cpu: 20m
+      memory: 64Mi
 # if below option is configured, it will override the coredns manifests with the following string
 #  manifests: |-
 #    apiVersion: ...

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -282,10 +282,12 @@ coredns:
   resources:
     limits:
       cpu: 1000m
-      memory: 170Mi
+      memory: 512Mi
     requests:
-      cpu: 3m
-      memory: 16Mi
+      # ensure that cpu/memory requests are high enough.
+      # for example gke wants minimum 10m/32Mi here!
+      cpu: 20m
+      memory: 64Mi
 # if below option is configured, it will override the coredns manifests with the following string
 #  manifests: |-
 #    apiVersion: ...

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -112,9 +112,12 @@ syncer:
       readOnly: true
   resources:
     limits:
-      memory: 1Gi
+      cpu: 1000m
+      memory: 512Mi
     requests:
-      cpu: 10m
+      # ensure that cpu/memory requests are high enough.
+      # for example gke wants minimum 10m/32Mi here!
+      cpu: 20m
       memory: 64Mi
   kubeConfigContextName: "my-vcluster"
 

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -113,9 +113,12 @@ syncer:
     enabled: true
   resources:
     limits:
-      memory: 1Gi
+      cpu: 1000m
+      memory: 512Mi
     requests:
-      cpu: 10m
+      # ensure that cpu/memory requests are high enough.
+      # for example gke wants minimum 10m/32Mi here!
+      cpu: 20m
       memory: 64Mi
   # Extra volumes 
   volumes: []


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves N/A


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster resource limits for coredns were too low.


**What else do we need to know?** 

In GKE we encountered an error `Error syncing to physical cluster: pods "coredns-749456dcbf-8d729-x-kube-system-x-vc-cm-123" is forbidden: [minimum cpu usage per Container is 10m, but request is 3m, minimum memory usage per Container is 32Mi, but request is 16Mi]` which caused coredns pod to never get deployed.
