### PR TITLE
fix: vcluster create error - illegal base64 data at input byte x

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/localkubernetes"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log/survey"
@@ -11,11 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/create"
 	"github.com/loft-sh/vcluster/pkg/helm/values"
@@ -169,12 +170,10 @@ func (cmd *CreateCmd) Run(args []string) error {
 	var newExtraValues []string
 	for _, value := range cmd.ExtraValues {
 		decodedString, err := getBase64DecodedString(value)
+		// ignore decoding errors and treat it as non-base64 string
 		if err != nil {
-			if strings.Contains(err.Error(), "illegal base64 data at input byte 0") {
-				newExtraValues = append(newExtraValues, value)
-				continue
-			}
-			return err
+			newExtraValues = append(newExtraValues, value)
+			continue
 		}
 
 		// write a temporary values file


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Solves this error:
```
$ vcluster create vcluster -n vcluster -f values_1.25.yaml
info   Detected local kubernetes cluster minikube. Will deploy vcluster with a NodePort & sync real nodes
info   officially unsupported host server version 1.25, will fallback to virtual cluster version v1.24
fatal  illegal base64 data at input byte 6
```


**Please provide a short message that should be published in the vcluster release notes**
N/A - this was a regression from the last beta build, I don't think it's necessary to mention a fix for an issue which was not present in the previous GA build.