### PR TITLE
Add support for k3s v1.25

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -99,7 +99,7 @@ jobs:
       uses: engineerd/setup-kind@v0.5.0
       with:
         version: "v0.14.0"
-        image: kindest/node:v1.24.2
+        image: kindest/node:v1.25.0
     
     - name: Testing kind cluster set-up
       run: |

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -124,7 +124,7 @@ syncer:
 # Virtual Cluster (k3s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: rancher/k3s:v1.24.3-k3s1
+  image: rancher/k3s:v1.25.0-k3s1
   command:
     - /bin/k3s
   baseArgs:

--- a/pkg/constants/coredns.go
+++ b/pkg/constants/coredns.go
@@ -1,6 +1,7 @@
 package constants
 
 var CoreDNSVersionMap = map[string]string{
+	"1.25": "coredns/coredns:1.9.3",
 	"1.24": "coredns/coredns:1.8.7",
 	"1.23": "coredns/coredns:1.8.6",
 	"1.22": "coredns/coredns:1.8.4",

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -12,6 +12,7 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
+	"1.25": "rancher/k3s:v1.25.0-k3s1",
 	"1.24": "rancher/k3s:v1.24.3-k3s1",
 	"1.23": "rancher/k3s:v1.23.9-k3s1",
 	"1.22": "rancher/k3s:v1.22.12-k3s1",
@@ -58,10 +59,10 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 24 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-				image = K3SVersionMap["1.24"]
-				serverVersionString = "1.24"
+			if serverMinorInt > 25 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+				image = K3SVersionMap["1.25"]
+				serverVersionString = "1.25"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Adding support for k3s v1.25 
Bump the k8s version of the KinD cluster used for e2e to v1.25.0


**Please provide a short message that should be published in the vcluster release notes**
Adding support for k3s v1.25
