### PR TITLE
fix(chart): wrong condition for volumeClaimTemplates

### DIFF
--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -24,8 +24,10 @@ spec:
     matchLabels:
       app: vcluster-etcd
       release: {{ .Release.Name }}
-  {{- if .Values.etcd.storage.persistence }}
-  {{- if not .Values.etcd.storage.volumeClaimTemplates }}
+  {{- if (hasKey .Values.etcd "volumeClaimTemplates") }}
+  volumeClaimTemplates:
+{{ toYaml .Values.etcd.volumeClaimTemplates | indent 4 }}
+  {{- else if .Values.etcd.storage.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -35,10 +37,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.etcd.storage.size }}
-  {{- else }}
-  volumeClaimTemplates:
-{{ toYaml .Values.etcd.volumeClaimTemplates | indent 4 }}
-  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -22,8 +22,10 @@ spec:
     matchLabels:
       app: vcluster
       release: {{ .Release.Name }}
-  {{- if .Values.storage.persistence }}
-  {{- if not .Values.storage.volumeClaimTemplates }}
+  {{- if (hasKey .Values "volumeClaimTemplates") }}
+  volumeClaimTemplates:
+{{ toYaml .Values.volumeClaimTemplates | indent 4 }}
+  {{- else if .Values.storage.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -33,10 +35,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.size }}
-  {{- else }}
-  volumeClaimTemplates:
-{{ toYaml .Values.volumeClaimTemplates | indent 4 }}
-  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -23,8 +23,10 @@ spec:
     matchLabels:
       app: vcluster
       release: {{ .Release.Name }}
-  {{- if .Values.storage.persistence }}
-  {{- if not .Values.storage.volumeClaimTemplates }}
+  {{- if (hasKey .Values "volumeClaimTemplates") }}
+  volumeClaimTemplates:
+{{ toYaml .Values.volumeClaimTemplates | indent 4 }}
+  {{- else if .Values.storage.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -34,10 +36,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.size }}
-  {{- else }}
-  volumeClaimTemplates:
-{{ toYaml .Values.volumeClaimTemplates | indent 4 }}
-  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -24,8 +24,10 @@ spec:
     matchLabels:
       app: vcluster-etcd
       release: {{ .Release.Name }}
-  {{- if .Values.etcd.storage.persistence }}
-  {{- if not .Values.etcd.storage.volumeClaimTemplates }}
+  {{- if (hasKey .Values.etcd "volumeClaimTemplates") }}
+  volumeClaimTemplates:
+{{ toYaml .Values.etcd.volumeClaimTemplates | indent 4 }}
+  {{- else if .Values.etcd.storage.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -35,10 +37,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.etcd.storage.size }}
-  {{- else }}
-  volumeClaimTemplates:
-{{ toYaml .Values.etcd.volumeClaimTemplates | indent 4 }}
-  {{- end }}
   {{- end }}
   template:
     metadata:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
The helm chart was checking wrong value in a condition for user-defined volumeClaimTemplates.
New condition use `hasKey` function in order to allow setting no volumeClaimTemplates.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster chart was ignoring the `volumeClaimTemplates` (or `etcd.volumeClaimTemplates`) helm value. The `storage.volumeClaimTemplates` helm value is no longer needed.


**What else do we need to know?** 
