### PR TITLE
feat(cli): add dynamic shell completion for vcluster_name and namespaces

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -3,12 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/localkubernetes"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
-	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"io"
-	authenticationv1 "k8s.io/api/authentication/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -17,6 +12,12 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/localkubernetes"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/loft-sh/vcluster/pkg/upgrade"
 	"github.com/loft-sh/vcluster/pkg/util/portforward"
@@ -76,7 +77,7 @@ func NewConnectCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	cobraCmd := &cobra.Command{
-		Use:   "connect",
+		Use:   "connect [flags] vcluster_name",
 		Short: "Connect to a virtual cluster",
 		Long: `
 #######################################################
@@ -91,7 +92,8 @@ vcluster connect test -n test -- bash
 vcluster connect test -n test -- kubectl get ns
 #######################################################
 	`,
-		Args: cobra.MinimumNArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Check for newer version
 			upgrade.PrintNewerVersionWarning()

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os/exec"
+
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/app/localkubernetes"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"os/exec"
 
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,7 +44,7 @@ func NewDeleteCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	cobraCmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [flags] vcluster_name",
 		Short: "Deletes a virtual cluster",
 		Long: `
 #######################################################
@@ -55,7 +56,8 @@ Example:
 vcluster delete test --namespace test
 #######################################################
 	`,
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd, args)
 		},

--- a/cmd/vclusterctl/cmd/get/get.go
+++ b/cmd/vclusterctl/cmd/get/get.go
@@ -8,7 +8,7 @@ import (
 func NewGetCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:   "get",
-		Short: "gets cluster related information",
+		Short: "Gets cluster related information",
 		Long: `
 #######################################################
 #################### vcluster get #####################

--- a/cmd/vclusterctl/cmd/pause.go
+++ b/cmd/vclusterctl/cmd/pause.go
@@ -3,14 +3,15 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"time"
 
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
@@ -38,7 +39,7 @@ func NewPauseCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	cobraCmd := &cobra.Command{
-		Use:   "pause",
+		Use:   "pause [flags] vcluster_name",
 		Short: "Pauses a virtual cluster",
 		Long: `
 #######################################################
@@ -56,7 +57,8 @@ Example:
 vcluster pause test --namespace test
 #######################################################
 	`,
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(args)
 		},

--- a/cmd/vclusterctl/cmd/resume.go
+++ b/cmd/vclusterctl/cmd/resume.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
@@ -12,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 // ResumeCmd holds the cmd flags
@@ -31,7 +32,7 @@ func NewResumeCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	cobraCmd := &cobra.Command{
-		Use:   "resume",
+		Use:   "resume [flags] vcluster_name",
 		Short: "Resumes a virtual cluster",
 		Long: `
 #######################################################
@@ -45,7 +46,8 @@ Example:
 vcluster resume test --namespace test
 #######################################################
 	`,
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(args)
 		},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind feature


**What does this pull request do?**
resolves #673


**Please provide a short message that should be published in the vcluster release notes**
Shell completion now suggests vcluster and namespace completions based on the running vclusters and existing namespaces.


**What else do we need to know?** 
- Commands with vcluster_name positional argument(connect, delete, pause, resume) now get autocompleted.
```
source <(vcluster completion bash)
 $ vcluster connect #tab,tab
cluster1 cluster2
```
- Specifying the namespace flag also narrows down the cluster results
- Namespaces also get similarly autocompleted (kube-system is left out)
- The usage line for each now shows the positional argument
```
Usage:
  vcluster connect [flags] vcluster_name
```


Removed the existing completion generation command [which automatically moves us to cobra's V2 of completions](https://github.com/spf13/cobra/blob/main/shell_completions.md). 
This means that the completions from the root command that show all the verbs will have help text like this:
```
$ vcluster 
completion  (Generate the autocompletion script for the specified shell)
connect     (Connect to a virtual cluster)
create      (Create a new virtual cluster)
delete      (Deletes a virtual cluster)
disconnect  (Disconnects from a virtual cluster)
get         (Gets cluster related information)
help        (Help about any command)
list        (Lists all virtual clusters)
pause       (Pauses a virtual cluster)
resume      (Resumes a virtual cluster)
upgrade     (Upgrade the vcluster CLI to the newest version)
version     (Print the version number of vcluster)
```

Adding @ygshvr as coauthor on a couple commits because he made PR #701 to add this feature initially.