### PR TITLE
Fix wrong namespace name in getting-started docs

### DIFF
--- a/docs/pages/getting-started/connect.mdx
+++ b/docs/pages/getting-started/connect.mdx
@@ -61,7 +61,7 @@ So, let's check to see if our deployment `nginx-deployment` has made it to the u
 kubectl get deployments -n vcluster-my-vcluster
 ```
 ```bash
-No resources found in host-namespace-1 namespace.
+No resources found in vcluster-my-vcluster namespace.
 ```
 
 You will see that there is **no deployment `nginx-deployment`** because it also just lives inside the virtual cluster.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

It mentioned `host-namespace-1` instead of `vcluster-my-vcluster`

