### PR TITLE
Add option for simpler target namespace configuration

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -134,6 +134,8 @@ jobs:
         kind load image-archive vcluster_syncer
 
         chmod +x vcluster && sudo mv vcluster /usr/bin
+
+        kubectl create namespace vcluster-workload
         
         vcluster create ${{ env.VCLUSTER_SUFFIX }} -n ${{ env.VCLUSTER_NAMESPACE }} \
         --create-namespace \

--- a/charts/eks/templates/limitrange.yaml
+++ b/charts/eks/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/eks/templates/networkpolicy.yaml
+++ b/charts/eks/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/eks/templates/rbac/target-ns-role.yaml
+++ b/charts/eks/templates/rbac/target-ns-role.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if or .Values.sync.pods.status .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.pods.ephemeralContainers .Values.rbac.role.extended }}
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["patch", "update"]
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create", "delete", "patch", "update"]
+  {{- end }}
+  {{- if or .Values.enableHA .Values.rbac.role.extended }}
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["endpoints", "events", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  {{- if or .Values.sync.networkpolicies.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.volumesnapshots.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.openshift.enable }}
+  {{- if .Values.sync.endpoints.enabled }}
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"]
+    verbs: ["create"]
+  {{- end }}
+  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
+{{- end }}

--- a/charts/eks/templates/rbac/target-ns-rolebinding.yaml
+++ b/charts/eks/templates/rbac/target-ns-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: vc-{{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/eks/templates/resourcequota.yaml
+++ b/charts/eks/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -138,6 +138,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.syncer.targetNamespace }}
+          - --target-namespace={{ .Values.syncer.targetNamespace }}
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/eks/templates/syncer-service-headless.yaml
+++ b/charts/eks/templates/syncer-service-headless.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.syncer.targetNamespace }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/eks/templates/workloadserviceaccount.yaml
+++ b/charts/eks/templates/workloadserviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vc-workload-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -135,6 +135,7 @@ syncer:
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
   securityContext: {}
+  targetNamespace: null
 
 # Etcd settings
 etcd:
@@ -327,7 +328,6 @@ init:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  namespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k0s/templates/rbac/target-ns-role.yaml
+++ b/charts/k0s/templates/rbac/target-ns-role.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if or .Values.sync.pods.status .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.pods.ephemeralContainers .Values.rbac.role.extended }}
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["patch", "update"]
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create", "delete", "patch", "update"]
+  {{- end }}
+  {{- if or .Values.enableHA .Values.rbac.role.extended }}
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["endpoints", "events", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  {{- if or .Values.sync.networkpolicies.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.volumesnapshots.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.openshift.enable }}
+  {{- if .Values.sync.endpoints.enabled }}
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"]
+    verbs: ["create"]
+  {{- end }}
+  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
+{{- end }}

--- a/charts/k0s/templates/rbac/target-ns-rolebinding.yaml
+++ b/charts/k0s/templates/rbac/target-ns-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: vc-{{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k0s/templates/service-headless.yaml
+++ b/charts/k0s/templates/service-headless.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.syncer.targetNamespace }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -191,6 +191,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.syncer.targetNamespace }}
+          - --target-namespace={{ .Values.syncer.targetNamespace }}
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k0s/templates/workloadserviceaccount.yaml
+++ b/charts/k0s/templates/workloadserviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vc-workload-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -114,6 +114,7 @@ syncer:
       cpu: 10m
       memory: 64Mi
   kubeConfigContextName: "my-vcluster"
+  targetNamespace: null
 
 # Virtual Cluster (k0s) configuration
 vcluster:
@@ -300,7 +301,6 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  namespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:
 {{ toYaml .Values.globalAnnotations | indent 4 }}

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:
 {{ toYaml .Values.globalAnnotations | indent 4 }}

--- a/charts/k3s/templates/rbac/target-ns-role.yaml
+++ b/charts/k3s/templates/rbac/target-ns-role.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if or .Values.sync.pods.status .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.pods.ephemeralContainers .Values.rbac.role.extended }}
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["patch", "update"]
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create", "delete", "patch", "update"]
+  {{- end }}
+  {{- if or .Values.enableHA .Values.rbac.role.extended }}
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["endpoints", "events", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  {{- if or .Values.sync.networkpolicies.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.volumesnapshots.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.openshift.enable }}
+  {{- if .Values.sync.endpoints.enabled }}
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"]
+    verbs: ["create"]
+  {{- end }}
+  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
+{{- end }}

--- a/charts/k3s/templates/rbac/target-ns-rolebinding.yaml
+++ b/charts/k3s/templates/rbac/target-ns-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: vc-{{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:
 {{ toYaml .Values.globalAnnotations | indent 4 }}

--- a/charts/k3s/templates/service-headless.yaml
+++ b/charts/k3s/templates/service-headless.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.syncer.targetNamespace }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -193,6 +193,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.syncer.targetNamespace }}
+          - --target-namespace={{ .Values.syncer.targetNamespace }}
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k3s/templates/workloadserviceaccount.yaml
+++ b/charts/k3s/templates/workloadserviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vc-workload-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -120,6 +120,7 @@ syncer:
       cpu: 20m
       memory: 64Mi
   kubeConfigContextName: "my-vcluster"
+  targetNamespace: null
 
 # Virtual Cluster (k3s) configuration
 vcluster:
@@ -305,7 +306,6 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  namespace: null
 
   podSecurityStandard: baseline
 

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   limits:
   - default:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k8s/templates/rbac/target-ns-role.yaml
+++ b/charts/k8s/templates/rbac/target-ns-role.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- if or .Values.sync.pods.status .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.pods.ephemeralContainers .Values.rbac.role.extended }}
+  {{- if ge (.Capabilities.KubeVersion.Minor | int) 23 }}
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["patch", "update"]
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create", "delete", "patch", "update"]
+  {{- end }}
+  {{- if or .Values.enableHA .Values.rbac.role.extended }}
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["endpoints", "events", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  {{- if or .Values.sync.networkpolicies.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.volumesnapshots.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.serviceaccounts.enabled .Values.rbac.role.extended }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if or .Values.sync.poddisruptionbudgets.enabled .Values.rbac.role.extended }}
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
+  {{- if .Values.openshift.enable }}
+  {{- if .Values.sync.endpoints.enabled }}
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"]
+    verbs: ["create"]
+  {{- end }}
+  {{- end }}
+  {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
+{{- end }}

--- a/charts/k8s/templates/rbac/target-ns-rolebinding.yaml
+++ b/charts/k8s/templates/rbac/target-ns-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.syncer.targetNamespace }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: vc-{{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
-  namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -175,6 +175,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.syncer.targetNamespace }}
+          - --target-namespace={{ .Values.syncer.targetNamespace }}
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k8s/templates/syncer-service-headless.yaml
+++ b/charts/k8s/templates/syncer-service-headless.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.syncer.targetNamespace }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.syncer.targetNamespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/k8s/templates/workloadserviceaccount.yaml
+++ b/charts/k8s/templates/workloadserviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vc-workload-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.syncer.targetNamespace | default .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -140,6 +140,7 @@ syncer:
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
   securityContext: {}
+  targetNamespace: null
 
 # Etcd settings
 etcd:
@@ -352,7 +353,6 @@ coredns:
 # standards, limit ranges and resource quotas
 isolation:
   enabled: false
-  namespace: null
 
   podSecurityStandard: baseline
 

--- a/test/e2e_target_namespace/targetNamespace.go
+++ b/test/e2e_target_namespace/targetNamespace.go
@@ -6,7 +6,6 @@ import (
 	"github.com/loft-sh/vcluster/test/framework"
 	"github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -14,76 +13,6 @@ import (
 var _ = ginkgo.Describe("Target Namespace", func() {
 	f := framework.DefaultFramework
 	ginkgo.It("Create vcluster with target namespace", func() {
-		ginkgo.By("Create target namespace")
-		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "vcluster-workload",
-			},
-		}
-		_, err := f.HostClient.CoreV1().Namespaces().Create(f.Context, ns, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		err = wait.Poll(time.Second, time.Minute*1, func() (done bool, err error) {
-			namespace, _ := f.HostClient.CoreV1().Namespaces().Get(f.Context, ns.Name, metav1.GetOptions{})
-			if namespace.Status.Phase == corev1.NamespaceActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Create service account, role and role binding in target namespace")
-		workloadSaName := "vc-workload-" + f.VclusterName
-		sa := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      workloadSaName,
-				Namespace: ns.Name,
-			},
-		}
-		_, err = f.HostClient.CoreV1().ServiceAccounts(ns.Name).Create(f.Context, sa, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		role := &rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vcluster-workload",
-				Namespace: ns.Name,
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"", "networking.k8s.io"},
-					Resources: []string{"*"},
-					Verbs:     []string{"*"},
-				},
-			},
-		}
-		_, err = f.HostClient.RbacV1().Roles(ns.Name).Create(f.Context, role, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
-		vcSaName := "vc-" + f.VclusterName
-		rb := &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vcluster-workload",
-				Namespace: ns.Name,
-				Labels: map[string]string{
-					"app": "vcluster-nginxa-app",
-				},
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      vcSaName,
-					Namespace: f.VclusterNamespace,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     role.Name,
-			},
-		}
-		_, err = f.HostClient.RbacV1().RoleBindings(ns.Name).Create(f.Context, rb, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-
 		ginkgo.By("Create workload in vcluster and verify if it's running in targeted namespace")
 		pod := &corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
@@ -103,7 +32,7 @@ var _ = ginkgo.Describe("Target Namespace", func() {
 			},
 		}
 
-		_, err = f.VclusterClient.CoreV1().Pods("default").Create(f.Context, pod, metav1.CreateOptions{})
+		_, err := f.VclusterClient.CoreV1().Pods("default").Create(f.Context, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 
 		err = wait.Poll(time.Second, time.Minute*2, func() (bool, error) {
@@ -115,10 +44,25 @@ var _ = ginkgo.Describe("Target Namespace", func() {
 		})
 		framework.ExpectNoError(err)
 
-		p, err := f.HostClient.CoreV1().Pods(ns.Name).List(f.Context, metav1.ListOptions{
+		p, err := f.HostClient.CoreV1().Pods("vcluster-workload").List(f.Context, metav1.ListOptions{
 			LabelSelector: "vcluster.loft.sh/managed-by=" + f.VclusterName,
 		})
 		framework.ExpectNoError(err)
-		framework.ExpectEqual(true, len(p.Items) > 0)
+		framework.ExpectEqual(true, len(p.Items) > 1)
+
+		ginkgo.By("Check if OwnerReferences is set to pod")
+		framework.ExpectEqual(*p.Items[0].OwnerReferences[0].Controller, true)
+
+		ginkgo.By("Check if networkpolicy is created to target namespace")
+		_, err = f.HostClient.NetworkingV1().NetworkPolicies("vcluster-workload").Get(f.Context, "vcluster-workloads", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Check if resourcequota is created to target namespace")
+		_, err = f.HostClient.CoreV1().ResourceQuotas("vcluster-workload").Get(f.Context, "vcluster-quota", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Check if limitrange is created to target namespace")
+		_, err = f.HostClient.CoreV1().LimitRanges("vcluster-workload").Get(f.Context, "vcluster-limit-range", metav1.GetOptions{})
+		framework.ExpectNoError(err)
 	})
 })

--- a/test/e2e_target_namespace/values.yaml
+++ b/test/e2e_target_namespace/values.yaml
@@ -1,3 +1,4 @@
 syncer:
-  extraArgs:
-  - --target-namespace=vcluster-workload
+  targetNamespace: vcluster-workload
+isolation:
+  enabled: true


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind feature

**What does this pull request do? Which issues does it resolve?** 
resolves #659

**Please provide a short message that should be published in the vcluster release notes**
Add option `syncer.targetNamespace` for simpler target namespace configuration.

**What else do we need to know?** 
I did find out that Longhorn [has logic](https://github.com/longhorn/longhorn-manager/blob/93063e1b3df7ca3716afef45ecb9c5ed258ce983/controller/kubernetes_pod_controller.go#L284-L303) to remove pods which are failing because of volume mounting issues (which happens example during Longhorn upgrade) but it only works if pods has `ownerReferences` configured which is not case when `--target-namespace` is used.

That why I added logic which create headless service to target namespace which is used as owner for pods.

Additionally `isolation.namespace` setting was deprecated and replaced by `syncer.targetNamespace` (breaking chage) and e2e tests updated to cover these scenarios.

FYI @ishankhare07 because you added `isolation.namespace` in #435 and @pratikjagrut because you added target namespace tests in #626