### PR TITLE
Update docs for synced resources to reflect change in default sync setting for ingresses since v0.12.0

### DIFF
--- a/docs/pages/architecture/synced-resources.mdx
+++ b/docs/pages/architecture/synced-resources.mdx
@@ -14,9 +14,9 @@ This section lists all resources that can be synced or mirrored by vcluster curr
 | events                 | Syncs events from host cluster to virtual cluster                                                                                                                                                                                                                                                 | Yes             |
 | pods                   | Mirrors pods between host and virtual cluster                                                                                                                                                                                                                                                     | Yes             |
 | persistentvolumeclaims | Mirrors persistent volume claims between host and virtual cluster                                                                                                                                                                                                                                 | Yes             |
-| ingresses              | Mirrors ingresses between host and virtual cluster. Automatically tries to detect the supported ingress version (networking.k8s.io/v1 or networking.k8s.io/v1beta1)                                                                                                                               | Yes             |
 | fake-nodes             | Creates fake nodes based on spec.nodeName fields of synced pods. Requires no cluster role                                                                                                                                                                                                         | Yes             |
 | fake-persistentvolumes | Creates fake persistent volumes based on spec.volumeName of persistent volume claims. Requires no cluster role                                                                                                                                                                                    | Yes             |
+| ingresses              | Mirrors ingresses between host and virtual cluster. Automatically tries to detect the supported ingress version (networking.k8s.io/v1 or networking.k8s.io/v1beta1)                                                                                                                               | No            |
 | nodes                  | Syncs real nodes from host cluster to virtual cluster. If enabled, implies that fake-nodes is disabled. For more information see [nodes](./nodes.mdx).                                                                                                                                            | No              |
 | persistentvolumes      | Mirrors persistent volumes from vcluster to host cluster and dynamically created persistent volumes from host cluster to virtual cluster. If enabled, implies that fake-persistentvolumes is disabled. For more information see [storage](./storage.mdx).                                         | No              |
 | storageclasses         | Syncs created storage classes from virtual cluster to host cluster                                                                                                                                                                                                                                | No              |
@@ -43,10 +43,10 @@ then create or upgrade the vcluster with:
 vcluster create my-vcluster --upgrade -f values.yaml
 ```
 
-To disable a resource that is synced by default, for example if you don't want to sync ingresses, set the following in your `values.yaml`: 
+To disable a resource that is synced by default, for example if you don't want to sync services, set the following in your `values.yaml`: 
 ```
 sync:
-  ingresses:
+  services:
     enabled: false
 ```
 then create or upgrade the vcluster with:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

Starting with v0.12.0, vcluster will by default now not sync ingresses anymore. Updating the documentation to reflect this along with the inline example.

**Please provide a short message that should be published in the vcluster release notes**
Update docs for synced resources to reflect change in default sync setting for ingresses

