### PR TITLE
Allow multiple-vcluster-creation in a single namespace

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -148,16 +148,6 @@ func (cmd *CreateCmd) Run(args []string) error {
 		return err
 	}
 
-	vclusterExistsInNamespace, err := cmd.vclusterExistsInNamespace()
-	if err != nil {
-		cmd.log.Errorf("error while listing clusters to check if the vcluster is already present in the namespace : %s", err)
-		return err
-	}
-	if !cmd.Upgrade && vclusterExistsInNamespace {
-		cmd.log.Errorf("another vcluster is already present in %s namespace, please try another namespace.", cmd.Namespace)
-		return nil
-	}
-
 	// load the default values
 	chartOptions, err := cmd.ToChartOptions(kubernetesVersion)
 	if err != nil {
@@ -516,17 +506,4 @@ func (cmd *CreateCmd) getKubernetesVersion() (*version.Info, error) {
 	}
 
 	return kubernetesVersion, nil
-}
-
-func (cmd *CreateCmd) vclusterExistsInNamespace() (bool, error) {
-	vClusters, err := find.ListVClusters(cmd.Context, "", cmd.Namespace)
-	if err != nil {
-		return false, err
-	}
-	for _, cluster := range vClusters {
-		if cluster.Namespace == cmd.Namespace {
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -129,8 +129,8 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(vClusters) > 1 {
-		// set to false if there are more than 1 virtual clusters in the same namespace
+	if len(vClusters) > 0 {
+		// set to false if there are any virtual clusters running in the same namespace. The vcluster supposed to be deleted by the command has been deleted by now and hence the check should be greater than 0
 		cmd.DeleteNamespace = false
 	}
 


### PR DESCRIPTION
and corrected existing check to prevent namespace deletion incase another vcluster is running in the same namespace.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves # Regression of earlier fix


**Please provide a short message that should be published in the vcluster release notes**
Allow multiple-vcluster-creation in a single namespace. If a vcluster is deleted and another vcluster is running in the same namespace, namespace won't be deleted.


**What else do we need to know?** 
