### PR TITLE
Fix init-manifest merge issue on Configmap

### DIFF
--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}
   charts: |-
   {{- range .Values.init.helm }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}
   charts: |-
   {{- range .Values.init.helm }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -16,7 +16,7 @@ metadata:
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}
   charts: |-
   {{- range .Values.init.helm }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}
-    {{- tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
+    {{ tpl .Values.init.manifestsTemplate $ | nindent 4 | trim }}
   {{- if .Values.init.helm }}
   charts: |-
   {{- range .Values.init.helm }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Currently, we can't "easily" use the `init.manifestsTemplate` value because there is no carriage return between `init.manifest` and `init.manifestsTemplate` (because of the `trim` + `-` just before templating `init.manifestsTemplate`).  
I didn't create an issue because it's a short quick fix, but I can create a new one if needed.


**Please provide a short message that should be published in the vcluster release notes**
Fixed merging issue between `manifest` and `manifestsTemplate` on the Helm chart


**What else do we need to know?**
Here is an example with the following values:
```yaml
init:
  manifests: |
    ---
  manifestsTemplate: |
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
```

##### Before fix
  ```yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: test-init-manifests
    namespace: default
    labels:
      app: vcluster
      chart: "vcluster-0.12.1"
      release: "test"
      heritage: "Helm"
  data:
    manifests: |-
      ---apiVersion: storage.k8s.io/v1
      kind: StorageClass
  ```

##### After fix
  ```yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: test-init-manifests
    namespace: default
    labels:
      app: vcluster
      chart: "vcluster-0.12.1"
      release: "test"
      heritage: "Helm"
  data:
    manifests: |-
      ---
      apiVersion: storage.k8s.io/v1
      kind: StorageClass
  ```
