### PR TITLE
Allow setting the LoadBalancerClass if using an external LoadBalancer controller

### DIFF
--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -30,6 +30,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -285,6 +285,8 @@ service:
   loadBalancerIP: ""
   # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
+  # Set the loadBalancerClass if using an external load balancer controller
+  loadBalancerClass: ""
 
 # job configuration
 job:

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -30,6 +30,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -225,6 +225,8 @@ service:
   loadBalancerIP: ""
   # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
+  # Set the loadBalancerClass if using an external load balancer controller
+  loadBalancerClass: ""
 
 # Configure the ingress resource that allows you to access the vcluster
 ingress:

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -34,6 +34,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -237,6 +237,8 @@ service:
   loadBalancerIP: ""
   # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
+  # Set the loadBalancerClass if using an external load balancer controller
+  loadBalancerClass: ""
 
 # Configure the ingress resource that allows you to access the vcluster
 ingress:

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -30,6 +30,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range $f := .Values.service.loadBalancerSourceRanges }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -289,6 +289,8 @@ service:
   loadBalancerIP: ""
   # CIDR block(s) for the service allowlist
   loadBalancerSourceRanges: []
+  # Set the loadBalancerClass if using an external load balancer controller
+  loadBalancerClass: ""
 
 # job configuration
 job:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**Please provide a short message that should be published in the vcluster release notes**
Allow setting the `LoadBalancerClass` if using an external LoadBalancer controller and running Kubernetes 1.22+ (stable in 1.24)