### PR TITLE
Allow templating with chart values inside the init-configmap

### DIFF
--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -33,9 +33,10 @@ data:
       {{- if .insecure }}
       insecure: true
       {{- end}}
-      {{- if .values }}
+      {{- if or .values .valuesTemplate }}
       values: |-
-        {{ .values | nindent 8 | trim }}
+        {{ (.values | default "") | nindent 8 | trim }}
+        {{ tpl (.valuesTemplate | default "") $ | nindent 8 | trim }}
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -33,9 +33,10 @@ data:
       {{- if .insecure }}
       insecure: true
       {{- end}}
-      {{- if .values }}
+      {{- if or .values .valuesTemplate }}
       values: |-
-        {{ .values | nindent 8 | trim }}
+        {{ (.values | default "") | nindent 8 | trim }}
+        {{ tpl (.valuesTemplate | default "") $ | nindent 8 | trim }}
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -37,9 +37,10 @@ data:
       {{- if .insecure }}
       insecure: true
       {{- end}}
-      {{- if .values }}
+      {{- if or .values .valuesTemplate }}
       values: |-
-        {{ .values | nindent 8 | trim }}
+        {{ (.values | default "") | nindent 8 | trim }}
+        {{ tpl (.valuesTemplate | default "") $ | nindent 8 | trim }}
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -33,9 +33,10 @@ data:
       {{- if .insecure }}
       insecure: true
       {{- end}}
-      {{- if .values }}
+      {{- if or .values .valuesTemplate }}
       values: |-
-        {{ .values | nindent 8 | trim }}
+        {{ (.values | default "") | nindent 8 | trim }}
+        {{ tpl (.valuesTemplate | default "") $ | nindent 8 | trim }}
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
This PR does not solve any issue, it is rather a suggestion. The goal is to allow the use of `vcluster` as a subchart by adding some templates to the Helm values. With this we can use the actual values to inject them into the Helm map that will be deployed when the vcluster is created.

**Please provide a short message that should be published in the vcluster release notes**
Allow templating with chart values inside the init-configmap
