### PR TITLE
 Aliases for list/delete commands #389

### DIFF
--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -57,6 +57,7 @@ vcluster delete test --namespace test
 #######################################################
 	`,
 		Args:              cobra.ExactArgs(1),
+		Aliases:           []string{"del"},
 		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd, args)

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -57,7 +57,7 @@ vcluster delete test --namespace test
 #######################################################
 	`,
 		Args:              cobra.ExactArgs(1),
-		Aliases:           []string{"del"},
+		Aliases:           []string{"rm"},
 		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd, args)

--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
-	"k8s.io/client-go/tools/clientcmd"
 	"strings"
 	"time"
+
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
@@ -53,7 +54,8 @@ vcluster list --output json
 vcluster list --namespace test
 #######################################################
 	`,
-		Args: cobra.NoArgs,
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd, args)
 		},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #389 


**Please provide a short message that should be published in the vcluster release notes**
add aliases. `rm` for delete and `ls` for list.


**What else do we need to know?** 

I also briefly considered adding an alias for other commands. In all cases, however, one would have saved only 1 letter and there I thought, rather less aliases and for it a more comprehensible cli.

However, if anyone can think of a good alias for other commands, I'd be happy to add them.
