### PR TITLE
Add Node Sync on Labels and Pod Workloads

### DIFF
--- a/docs/pages/architecture/nodes.mdx
+++ b/docs/pages/architecture/nodes.mdx
@@ -12,7 +12,7 @@ vcluster supports multiple modes to customize node syncing behaviour:
 - **Real Nodes** : vcluster will copy and sync real nodes information for each `spec.nodeName`. If there are no more pods on a node within vcluster, the virtual cluster node will be deleted. This mode requires helm value `.sync.nodes.enabled: true`, as described below.
 - **Real Nodes All** : vcluster will always sync all nodes from the host cluster to the vcluster, no matter where pods are running. This is useful if you want to use DaemonSets within the vcluster. This mode requires following helm values: `.sync.nodes.enabled: true` and `.sync.nodes.syncAllNodes: true`.
 - **Real Nodes Label Selector** vcluster will only sync nodes that match the given label selector. This mode requires following helm values: `.sync.nodes.enabled: true` and `.sync.nodes.nodeSelector: "label1=value1"`. You can also specify `--enforce-node-selector` to enforce scheduling only on these nodes. 
-
+- **Real Nodes + Label Selector** vcluster will sync nodes that match the given label selector as well as the real nodes information for each `spec.nodeName`. This mode requires following helm values: `.sync.nodes.enabled: true` and `.sync.nodes.nodeSelector: "label1=value1"` and the flag `--enforce-node-selector=false`.
 
 To set the `.sync.nodes.enabled: true` helm value add the following to your `values.yaml` file:
 ```

--- a/docs/pages/architecture/scheduling.mdx
+++ b/docs/pages/architecture/scheduling.mdx
@@ -68,6 +68,9 @@ This will pass the necessary flags to the "syncer" container and create or updat
 Vcluster allows you to limit on which nodes the pods synced by vcluster will run.
 You can achieve this by combining `--node-selector` and `--enforce-node-selector` syncer flags. 
 The `--enforce-node-selector` flag is enabled by default.
+When `--enforce-node-selector` flag is disabled, and a `--node-selector` is specified nodes will be synced based on the
+selector, as well as nodes running pod workloads.
+
 When using vcluster helm chart or CLI, there are two options for setting the `--node-selector` flag.
 
 This first option is recommended if you are not enabling node synchronization, and use [the fake nodes](./nodes), which are enabled by default. In such case, you would write a string representation of your node selector(e.g. "nodeLabel=labelValue") and set it as the value of `--node-selector` argument for syncer in your `values.yaml`:

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -291,7 +291,10 @@ func (s *nodeSyncer) shouldSync(ctx context.Context, pObj *corev1.Node) (bool, e
 			ls = labels.Set{}
 		}
 
-		return s.nodeSelector.Matches(ls), nil
+		if !s.nodeSelector.Matches(ls) {
+			return isNodeNeededByPod(ctx, s.virtualClient, s.physicalClient, pObj.Name)
+		}
+		return true, nil
 	}
 
 	return isNodeNeededByPod(ctx, s.virtualClient, s.physicalClient, pObj.Name)


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
Adds an enhancement to allow nodes to be synced based on the NodeSelector or the pod workloads being run. 


**Please provide a short message that should be published in the vcluster release notes**
Adds an enhancement to sync nodes with either the nodeSelector, or running pods. Previously if you supplied a nodeSelector it would ignore any nodes needed by a pod. 


**What else do we need to know?** 
The Test Suite should provide adequate coverage of the changes, but since I'm new to your project, it could require some modifications or additions. 