### PR TITLE
fix: validate helm's binary version

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -132,7 +132,10 @@ func (cmd *CreateCmd) Run(args []string) error {
 		return err
 	}
 
-	_, err = exec.Command(helmBinaryPath, "version").CombinedOutput()
+	output, err := exec.Command(helmBinaryPath, "version", "--client").CombinedOutput()
+	if errHelm := CheckHelmVersion(string(output)); errHelm != nil {
+		return errHelm
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -77,7 +77,10 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output, err := exec.Command(helmBinaryPath, "version").CombinedOutput()
+	output, err := exec.Command(helmBinaryPath, "version", "--client").CombinedOutput()
+	if errHelm := CheckHelmVersion(string(output)); errHelm != nil {
+		return errHelm
+	}
 	if err != nil {
 		return fmt.Errorf("seems like there are issues with your helm client: \n\n%s", output)
 	}

--- a/cmd/vclusterctl/cmd/util.go
+++ b/cmd/vclusterctl/cmd/util.go
@@ -112,6 +112,14 @@ func HasPodProblem(pod *corev1.Pod) bool {
 	return CriticalStatus[status]
 }
 
+func CheckHelmVersion(output string) error {
+	if !(strings.Contains(output, "Version:\"v3.")) {
+		return errors.New("Please ensure that the \"helm\" binary in your PATH is valid. Only Helm v3 is supported")
+	}
+
+	return nil
+}
+
 func updateKubeConfig(contextName string, cluster *api.Cluster, authInfo *api.AuthInfo, setActive bool) error {
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
 	if err != nil {


### PR DESCRIPTION
As a prerequisite helm v2 is not currently supported and must be validated beforehand. Also, the version command for helm v2 without the '--client' flag will force the validation of a remote tiller deployment which could lead to a potential 'exit 1' error.

Issue: #803

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #803


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster allowed non-supported helm v2 binary to be used


**What else do we need to know?** 