### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish-cli:
     if: startsWith(github.ref, 'refs/tags/v') == true
-    runs-on: macos-latest
+    runs-on: macos-12
     permissions:
       id-token: write
       contents: write
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19
+      - name: Install Helm
+        run: brew install helm
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - uses: sigstore/cosign-installer@main
@@ -41,7 +43,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   publish-vcluster-image:
     if: startsWith(github.ref, 'refs/tags/v') == true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write   # This is the key for OIDC!
     steps:
@@ -85,7 +87,7 @@ jobs:
           COSIGN_EXPERIMENTAL=1 cosign sign --force loftsh/vcluster@${{ steps.docker_build.outputs.digest }}
   publish-vcluster-cli-image:
     if: startsWith(github.ref, 'refs/tags/v') == true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write   # This is the key for OIDC!
     steps:
@@ -130,7 +132,7 @@ jobs:
   publish-chart:
     if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [publish-vcluster-image, publish-vcluster-cli-image]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -152,7 +154,7 @@ jobs:
   publish-release:
     if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [publish-chart]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/hack/embed-charts.sh
+++ b/hack/embed-charts.sh
@@ -4,8 +4,7 @@
 
 set -eu
 
-
-VCLUSTER_ROOT="$(realpath $(dirname ${0})/..)"
+VCLUSTER_ROOT="$(pwd)/$(dirname ${0})/.."
 RELEASE_VERSION="${RELEASE_VERSION:-0.0.1}"
 EMBED_DIR="${VCLUSTER_ROOT}/cmd/vclusterctl/cmd/charts"
 
@@ -15,4 +14,3 @@ for CHART in k3s k8s k0s eks;
 do
     helm package --version "${RELEASE_VERSION}" "${VCLUSTER_ROOT}/charts/${CHART}" -d "${EMBED_DIR}";
 done
-


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes problems in the MacOS runner - `../../../hack/embed-charts.sh: line 8: realpath: command not found`

Updating to new runners:
The ubuntu-18.04 runner [is deprecated](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/), and ubuntu-latest will move to ubuntu-22.04 on Dec 1st, so I am bumping to that.
Currently macos-latest = macos-11, but it will change to macos-12 on Dec 1st. [According to Readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md) the macos-12 runner doesn't have Helm, so this action would break if we just keep macos-latest. I am taking a pro-active step to update to new macos version now and solve the missing Helm in advance.


**Please provide a short message that should be published in the vcluster release notes**
N/A