### PR TITLE
fix(tooling): install Helm for build of Dockerfile.cli

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -4,6 +4,9 @@ WORKDIR /vcluster-dev
 ARG TARGETOS
 ARG TARGETARCH
 
+# Install helm binary
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && chmod 700 get_helm.sh && ./get_helm.sh
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes:
```
> [linux/amd64 builder 10/12] RUN go generate ./...:
#41 2.840 ../../../hack/embed-charts.sh: line 15: helm: command not found
#41 2.841 cmd/vclusterctl/cmd/create.go:43: running "../../../hack/embed-charts.sh": exit status 127
```

**Please provide a short message that should be published in the vcluster release notes**
N/A