### PR TITLE
Fix Chart generation experience for: `devspace dev` and macos 

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -100,6 +100,7 @@ dev:
     - excludePaths:
         - '**'
         - '!/pkg'
+        - 'cmd/vclusterctl/cmd/charts'
         - '!/cmd'
         - '!/vendor'
         - '!/hack'

--- a/hack/embed-charts.sh
+++ b/hack/embed-charts.sh
@@ -4,7 +4,7 @@
 
 set -eu
 
-VCLUSTER_ROOT="$(pwd)/$(dirname ${0})/.."
+VCLUSTER_ROOT="$(dirname ${0})/.."
 RELEASE_VERSION="${RELEASE_VERSION:-0.0.1}"
 EMBED_DIR="${VCLUSTER_ROOT}/cmd/vclusterctl/cmd/charts"
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix




**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue whereL

- You needed to run `go generate ./...` within the devspace syncer
- hack/embed-charts depended on realpath (not available by default on MacOS)


**What else do we need to know?** 
