### PR TITLE
fix: look for charts with 'v' version prefix

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -265,8 +265,6 @@ func getBase64DecodedString(values string) (string, error) {
 	return string(strDecoded), nil
 }
 
-// func
-
 func (cmd *CreateCmd) deployChart(vClusterName, chartValues, helmExecutablePath string) error {
 	// check if there is a vcluster directory already
 	workDir, err := os.Getwd()
@@ -280,7 +278,7 @@ func (cmd *CreateCmd) deployChart(vClusterName, chartValues, helmExecutablePath 
 	if cmd.LocalChartDir == "" {
 		chartEmbedded := false
 		if cmd.ChartVersion == upgrade.GetVersion() { // use embedded chart if default version
-			embeddedChartName := fmt.Sprintf("%s-%s.tgz", cmd.ChartName, upgrade.GetVersion())
+			embeddedChartName := fmt.Sprintf("%s-v%s.tgz", cmd.ChartName, upgrade.GetVersion())
 			// not using filepath.Join because the embed.FS separator is not OS specific
 			embeddedChartPath := fmt.Sprintf("charts/%s", embeddedChartName)
 

--- a/hack/embed-charts.sh
+++ b/hack/embed-charts.sh
@@ -5,7 +5,7 @@
 set -eu
 
 VCLUSTER_ROOT="$(dirname ${0})/.."
-RELEASE_VERSION="${RELEASE_VERSION:-0.0.1}"
+RELEASE_VERSION="${RELEASE_VERSION:-v0.0.1}"
 EMBED_DIR="${VCLUSTER_ROOT}/cmd/vclusterctl/cmd/charts"
 
 rm -rfv "${EMBED_DIR}"


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohan.joseph@loft.sh>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

The release pipeline sets RELEASE_VERSION to vx.y.z for cli, but to x.y.z in other places, the current code assumes the helm chart is bundled at x.y.z instead of vx.y.z.

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
