### PR TITLE
chore: bump loft-sh/utils to pick up new releases for all distros

### DIFF
--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -89,7 +89,6 @@ spec:
           - '--etcd-certfile=/run/config/pki/apiserver-etcd-client.crt'
           - '--etcd-keyfile=/run/config/pki/apiserver-etcd-client.key'
           - '--etcd-servers=https://{{ .Release.Name }}-etcd:2379'
-          - '--insecure-port=0'
           - '--kubelet-client-certificate=/run/config/pki/apiserver-kubelet-client.crt'
           - '--kubelet-client-key=/run/config/pki/apiserver-kubelet-client.key'
           - '--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname'

--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -85,7 +85,6 @@ spec:
           - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
           - '--horizontal-pod-autoscaler-sync-period=60s'
           - '--kubeconfig=/run/config/pki/controller-manager.conf'
-          - '--port=0'
           - '--profiling=false'
           {{- if .Values.serviceCIDR }}
           - '--service-cluster-ip-range={{ .Values.serviceCIDR }}'

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -146,7 +146,7 @@ syncer:
 
 # Etcd settings
 etcd:
-  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-4
+  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-24-3
   # The amount of replicas to run 
   replicas: 1
   # NodeSelector used
@@ -203,7 +203,7 @@ controller:
 
 # Kubernetes API Server settings
 api:
-  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.7-eks-1-23-4
+  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3"
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1
@@ -228,7 +228,7 @@ api:
 
 # Core DNS settings
 coredns:
-  image: public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-4
+  image: public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-3
   replicas: 1
   resources:
     limits:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -108,9 +108,9 @@ spec:
           - --status-socket=/run/k0s/status.sock
           {{- end }}
           {{- if not .Values.sync.nodes.enableScheduler }}
-          - --disable-components=konnectivity-server,kube-scheduler,csr-approver,default-psp,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config
+          - --disable-components=konnectivity-server,kube-scheduler,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config
           {{- else }}
-          - --disable-components=konnectivity-server,csr-approver,default-psp,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config
+          - --disable-components=konnectivity-server,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config
           {{- end }}
           {{- range $f := .Values.vcluster.extraArgs }}
           - {{ $f | quote }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -126,7 +126,7 @@ syncer:
 # Virtual Cluster (k0s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: k0sproject/k0s:v1.24.3-k0s.0
+  image: k0sproject/k0s:v1.25.3-k0s.0
   command:
     - k0s
   baseArgs:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -136,7 +136,7 @@ syncer:
 # Virtual Cluster (k3s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: rancher/k3s:v1.25.0-k3s1
+  image: rancher/k3s:v1.25.3-k3s1
   command:
     - /bin/k3s
   baseArgs:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -151,7 +151,7 @@ syncer:
 
 # Etcd settings
 etcd:
-  image: registry.k8s.io/etcd:3.5.4-0
+  image: registry.k8s.io/etcd:3.5.5-0
   # The amount of replicas to run 
   replicas: 1
   # NodeSelector used
@@ -184,7 +184,7 @@ etcd:
   securityContext: {}
 # Kubernetes Controller Manager settings
 controller:
-  image: registry.k8s.io/kube-controller-manager:v1.25.0
+  image: registry.k8s.io/kube-controller-manager:v1.25.4
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used 
@@ -206,7 +206,7 @@ controller:
   securityContext: {}
 # Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
 scheduler:
-  image: registry.k8s.io/kube-scheduler:v1.25.0
+  image: registry.k8s.io/kube-scheduler:v1.25.4
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -228,7 +228,7 @@ scheduler:
 
 # Kubernetes API Server settings
 api:
-  image: registry.k8s.io/kube-apiserver:v1.25.0
+  image: registry.k8s.io/kube-apiserver:v1.25.4
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
-	github.com/loft-sh/utils v0.0.10-alpha
+	github.com/loft-sh/utils v0.0.11-alpha
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/loft-sh/utils v0.0.10-alpha h1:cZwtDAe7SwypV0B4+hnfQd2ZXG/4iQ7GjC5TxFUfZoM=
 github.com/loft-sh/utils v0.0.10-alpha/go.mod h1:Salfu/n63q7qKiWmnEs3ioRPGe8HSG1HFKBebH6Eh68=
+github.com/loft-sh/utils v0.0.11-alpha h1:mhHr0DUO0a07wa5pQuBU7ojtDDNYOxcg1WoMBm1n0Ho=
+github.com/loft-sh/utils v0.0.11-alpha/go.mod h1:Salfu/n63q7qKiWmnEs3ioRPGe8HSG1HFKBebH6Eh68=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1173,6 +1175,8 @@ k8s.io/kubectl v0.25.2 h1:2993lTeVimxKSWx/7z2PiJxUILygRa3tmC4QhFaeioA=
 k8s.io/kubectl v0.25.2/go.mod h1:eoBGJtKUj7x38KXelz+dqVtbtbKwCqyKzJWmBHU0prg=
 k8s.io/kubelet v0.25.2 h1:L0PXLc2kTfIf6bm+wv4/1dIWwgXWDRTxTErxqFR4nqc=
 k8s.io/kubelet v0.25.2/go.mod h1:/ASc/pglUA3TeRMG4hRKSjTa7arT0D6yqLzwqSxwMlY=
+k8s.io/kubernetes v1.15.0-alpha.0 h1:gIwzzIgt0BX8fznDZRxdZv2837cEmVetI54aUfzkPk8=
+k8s.io/kubernetes v1.15.0-alpha.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/kubernetes v1.25.3 h1:Ljx/Ew9+dt7rN9ob3V+N/aoDy7nDSbmr35IbYGRTyqE=
 k8s.io/kubernetes v1.25.3/go.mod h1:lvEY+3iJhh+sGIK1LorGkI56rW0eLGsfalnp68wQwYU=
 k8s.io/pod-security-admission v0.25.2 h1:sR3cU0fkfPQIXYIZllukBjLu8iElRl8R0Bskxsi15EU=

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
@@ -8,27 +8,35 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.7-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.13-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.20.15-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.13-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.15-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.14-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.20.15-eks-1-20-22",
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.13-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.20.15-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.13-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.15-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.14-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.20.15-eks-1-20-22",
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.18-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.18-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-24-3",
+	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-20-22",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-3",
+	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-20-22",
 }
 
 func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {
@@ -43,12 +51,12 @@ func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	etcdImage := EKSEtcdVersionMap[serverVersionString]
 	corednsImage, ok := EKSCoreDNSVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 23 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
-			apiImage = EKSAPIVersionMap["1.23"]
-			controllerImage = EKSControllerVersionMap["1.23"]
-			etcdImage = EKSEtcdVersionMap["1.23"]
-			corednsImage = EKSCoreDNSVersionMap["1.23"]
+		if serverMinorInt > 24 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
+			apiImage = EKSAPIVersionMap["1.24"]
+			controllerImage = EKSControllerVersionMap["1.24"]
+			etcdImage = EKSEtcdVersionMap["1.24"]
+			corednsImage = EKSCoreDNSVersionMap["1.24"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = EKSAPIVersionMap["1.20"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
@@ -8,9 +8,10 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.24": "k0sproject/k0s:v1.24.3-k0s.0",
-	"1.23": "k0sproject/k0s:v1.23.9-k0s.0",
-	"1.22": "k0sproject/k0s:v1.22.12-k0s.0",
+	"1.25": "k0sproject/k0s:v1.25.3-k0s.0",
+	"1.24": "k0sproject/k0s:v1.24.7-k0s.0",
+	"1.23": "k0sproject/k0s:v1.23.13-k0s.0",
+	"1.22": "k0sproject/k0s:v1.22.15-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {
@@ -22,9 +23,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 24 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-			image = K0SVersionMap["1.24"]
+		if serverMinorInt > 25 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+			image = K0SVersionMap["1.25"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			image = K0SVersionMap["1.22"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
@@ -12,9 +12,10 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.24": "rancher/k3s:v1.24.3-k3s1",
-	"1.23": "rancher/k3s:v1.23.9-k3s1",
-	"1.22": "rancher/k3s:v1.22.12-k3s1",
+	"1.25": "rancher/k3s:v1.25.3-k3s1",
+	"1.24": "rancher/k3s:v1.24.7-k3s1",
+	"1.23": "rancher/k3s:v1.23.13-k3s1",
+	"1.22": "rancher/k3s:v1.22.15-k3s1",
 	"1.21": "rancher/k3s:v1.21.14-k3s1",
 	"1.20": "rancher/k3s:v1.20.15-k3s1",
 	"1.19": "rancher/k3s:v1.19.16-k3s1",
@@ -58,10 +59,10 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 24 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-				image = K3SVersionMap["1.24"]
-				serverVersionString = "1.24"
+			if serverMinorInt > 25 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+				image = K3SVersionMap["1.25"]
+				serverVersionString = "1.25"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
@@ -8,30 +8,34 @@ import (
 )
 
 var K8SAPIVersionMap = map[string]string{
-	"1.24": "registry.k8s.io/kube-apiserver:v1.24.3",
-	"1.23": "registry.k8s.io/kube-apiserver:v1.23.9",
-	"1.22": "registry.k8s.io/kube-apiserver:v1.22.12",
+	"1.25": "registry.k8s.io/kube-apiserver:v1.25.4",
+	"1.24": "registry.k8s.io/kube-apiserver:v1.24.8",
+	"1.23": "registry.k8s.io/kube-apiserver:v1.23.14",
+	"1.22": "registry.k8s.io/kube-apiserver:v1.22.16",
 	"1.21": "registry.k8s.io/kube-apiserver:v1.21.14",
 	"1.20": "registry.k8s.io/kube-apiserver:v1.20.15",
 }
 
 var K8SControllerVersionMap = map[string]string{
-	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.3",
-	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.9",
-	"1.22": "registry.k8s.io/kube-controller-manager:v1.22.12",
+	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.4",
+	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.8",
+	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.14",
+	"1.22": "registry.k8s.io/kube-controller-manager:v1.22.16",
 	"1.21": "registry.k8s.io/kube-controller-manager:v1.21.14",
 	"1.20": "registry.k8s.io/kube-controller-manager:v1.20.15",
 }
 
 var K8SSchedulerVersionMap = map[string]string{
-	"1.24": "registry.k8s.io/kube-scheduler:v1.24.3",
-	"1.23": "registry.k8s.io/kube-scheduler:v1.23.9",
-	"1.22": "registry.k8s.io/kube-scheduler:v1.22.12",
+	"1.25": "registry.k8s.io/kube-scheduler:v1.25.4",
+	"1.24": "registry.k8s.io/kube-scheduler:v1.24.8",
+	"1.23": "registry.k8s.io/kube-scheduler:v1.23.14",
+	"1.22": "registry.k8s.io/kube-scheduler:v1.22.16",
 	"1.21": "registry.k8s.io/kube-scheduler:v1.21.14",
 	"1.20": "registry.k8s.io/kube-scheduler:v1.20.15",
 }
 
 var K8SEtcdVersionMap = map[string]string{
+	"1.25": "registry.k8s.io/etcd:3.5.5-0",
 	"1.24": "registry.k8s.io/etcd:3.5.1-0",
 	"1.23": "registry.k8s.io/etcd:3.5.1-0",
 	"1.22": "registry.k8s.io/etcd:3.5.1-0",
@@ -51,12 +55,12 @@ func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	schedulerImage := K8SSchedulerVersionMap[serverVersionString]
 	etcdImage, ok := K8SEtcdVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 24 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-			apiImage = K8SAPIVersionMap["1.24"]
-			controllerImage = K8SControllerVersionMap["1.24"]
-			schedulerImage = K8SSchedulerVersionMap["1.24"]
-			etcdImage = K8SEtcdVersionMap["1.24"]
+		if serverMinorInt > 25 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+			apiImage = K8SAPIVersionMap["1.25"]
+			controllerImage = K8SControllerVersionMap["1.25"]
+			schedulerImage = K8SSchedulerVersionMap["1.25"]
+			etcdImage = K8SEtcdVersionMap["1.25"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = K8SAPIVersionMap["1.20"]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -239,7 +239,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/utils v0.0.10-alpha
+# github.com/loft-sh/utils v0.0.11-alpha
 ## explicit; go 1.19
 github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Bump loft-sh/utils dependency to pick up new releases for all distros.


**Please provide a short message that should be published in the vcluster release notes**
Include support for Kubernetes 1.25 for the k3s(default), k0s, and k8s distros of vcluster. 
Include support for Kubernetes 1.24 for the EKS distro of vcluster. 
Update images used across all distros and all minor versions to the latest stable versions.