### PR TITLE
fix: version format for the embeded chart

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -278,7 +278,7 @@ func (cmd *CreateCmd) deployChart(vClusterName, chartValues, helmExecutablePath 
 	if cmd.LocalChartDir == "" {
 		chartEmbedded := false
 		if cmd.ChartVersion == upgrade.GetVersion() { // use embedded chart if default version
-			embeddedChartName := fmt.Sprintf("%s-v%s.tgz", cmd.ChartName, upgrade.GetVersion())
+			embeddedChartName := fmt.Sprintf("%s-%s.tgz", cmd.ChartName, upgrade.GetVersion())
 			// not using filepath.Join because the embed.FS separator is not OS specific
 			embeddedChartPath := fmt.Sprintf("charts/%s", embeddedChartName)
 

--- a/hack/embed-charts.sh
+++ b/hack/embed-charts.sh
@@ -5,7 +5,8 @@
 set -eu
 
 VCLUSTER_ROOT="$(dirname ${0})/.."
-RELEASE_VERSION="${RELEASE_VERSION:-v0.0.1}"
+RELEASE_VERSION="${RELEASE_VERSION:-0.0.1}"
+RELEASE_VERSION="${RELEASE_VERSION#"v"}" # remove "v" prefix
 EMBED_DIR="${VCLUSTER_ROOT}/cmd/vclusterctl/cmd/charts"
 
 rm -rfv "${EMBED_DIR}"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
A different approach to fix the same problem that we tried to fix with #819
The charts that we usually create with the release pipeline don't have the `v` prefix for the chart version. The chart version is used internally for the syncer image tag. Using the version with the `v` prefix caused ImagePullBackOff errors.

**Please provide a short message that should be published in the vcluster release notes**
N/A