### PR TITLE
Add Flag to clear node images from node status

### DIFF
--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -35,11 +35,11 @@ type VirtualClusterOptions struct {
 
 	SetOwner bool `json:"setOwner,omitempty"`
 
-	SyncAllNodes        bool `json:"syncAllNodes,omitempty"`
-	EnableScheduler     bool `json:"enableScheduler,omitempty"`
-	DisableFakeKubelets bool `json:"disableFakeKubelets,omitempty"`
-
-	TranslateImages []string `json:"translateImages,omitempty"`
+	SyncAllNodes        bool     `json:"syncAllNodes,omitempty"`
+	EnableScheduler     bool     `json:"enableScheduler,omitempty"`
+	DisableFakeKubelets bool     `json:"disableFakeKubelets,omitempty"`
+	ClearNodeImages     bool     `json:"clearNodeImages,omitempty"`
+	TranslateImages     []string `json:"translateImages,omitempty"`
 
 	NodeSelector        string `json:"nodeSelector,omitempty"`
 	EnforceNodeSelector bool   `json:"enforceNodeSelector,omitempty"`

--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -114,6 +114,7 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 	flags.BoolVar(&options.SyncAllNodes, "sync-all-nodes", false, "If enabled and --fake-nodes is false, the virtual cluster will sync all nodes instead of only the needed ones")
 	flags.BoolVar(&options.EnableScheduler, "enable-scheduler", false, "If enabled, will expect a scheduler running in the virtual cluster")
 	flags.BoolVar(&options.DisableFakeKubelets, "disable-fake-kubelets", false, "If disabled, the virtual cluster will not create fake kubelet endpoints to support metrics-servers")
+	flags.BoolVar(&options.ClearNodeImages, "node-clear-image-status", false, "If enabled, when syncing real nodes, the status.images data will be removed from the vcluster nodes")
 
 	flags.StringSliceVar(&options.TranslateImages, "translate-image", []string{}, "Translates image names from the virtual pod to the physical pod (e.g. coredns/coredns=mirror.io/coredns/coredns)")
 	flags.BoolVar(&options.EnforceNodeSelector, "enforce-node-selector", true, "If enabled and --node-selector is set then the virtual cluster will ensure that no pods are scheduled outside of the node selector")

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -58,6 +58,7 @@ func NewSyncer(ctx *synccontext.RegisterContext, nodeService nodeservice.NodeSer
 		enforceNodeSelector: ctx.Options.EnforceNodeSelector,
 		nodeServiceProvider: nodeService,
 		nodeSelector:        nodeSelector,
+		clearImages:         ctx.Options.ClearNodeImages,
 		useFakeKubelets:     !ctx.Options.DisableFakeKubelets,
 
 		targetNamespace:     ctx.Options.TargetNamespace,
@@ -69,6 +70,8 @@ func NewSyncer(ctx *synccontext.RegisterContext, nodeService nodeservice.NodeSer
 
 type nodeSyncer struct {
 	enableScheduler bool
+
+	clearImages bool
 
 	enforceNodeSelector bool
 	nodeSelector        labels.Selector

--- a/pkg/controllers/resources/nodes/syncer_test.go
+++ b/pkg/controllers/resources/nodes/syncer_test.go
@@ -424,17 +424,11 @@ func TestSync(t *testing.T) {
 			},
 		},
 	})
+
 	baseName = types.NamespacedName{
 		Name: "mynode",
 	}
-	basePod = &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mypod",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: baseName.Name,
-		},
-	}
+
 	baseNode = &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: baseName.Name,

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -236,6 +236,10 @@ func (s *nodeSyncer) translateUpdateStatus(ctx *synccontext.SyncContext, pNode *
 		}
 	}
 
+	if s.clearImages {
+		translatedStatus.Images = make([]corev1.ContainerImage, 0)
+	}
+
 	// check if the status has changed
 	if !equality.Semantic.DeepEqual(vNode.Status, *translatedStatus) {
 		newNode := vNode.DeepCopy()


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
This PR adds the capability to clear node images from the physical nodes when syncing down to the virtual node. 


**Please provide a short message that should be published in the vcluster release notes**
Enabling `node-clear-image-status` clears all `status.images` from the node when it is synced to the virtual cluster. Images can leak information about a node when running in a multi-tenant environment where customers share the nodes they run on. Enabling this flag helps prevent information leaking.
