### PR TITLE
Allow annotation of all objects created by the eks,8s and k0s charts

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: custom-deployments
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-

--- a/charts/eks/templates/ingress.yaml
+++ b/charts/eks/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+{{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/eks/templates/limitrange.yaml
+++ b/charts/eks/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 rules:
   {{- if or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: [""]

--- a/charts/eks/templates/rbac/clusterrolebinding.yaml
+++ b/charts/eks/templates/rbac/clusterrolebinding.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/eks/templates/rbac/role.yaml
+++ b/charts/eks/templates/rbac/role.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]

--- a/charts/eks/templates/rbac/rolebinding.yaml
+++ b/charts/eks/templates/rbac/rolebinding.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/eks/templates/resourcequota.yaml
+++ b/charts/eks/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/eks/templates/serviceaccount.yaml
+++ b/charts/eks/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/eks/templates/workloadserviceaccount.yaml
+++ b/charts/eks/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -1,3 +1,6 @@
+# These annotations will be applied to all objects created in this chart
+globalAnnotations: {}
+
 # DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-

--- a/charts/k0s/templates/ingress.yaml
+++ b/charts/k0s/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+{{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/k0s/templates/rbac/clusterrole.yaml
+++ b/charts/k0s/templates/rbac/clusterrole.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 rules:
   {{- if or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: [""]

--- a/charts/k0s/templates/rbac/clusterrolebinding.yaml
+++ b/charts/k0s/templates/rbac/clusterrolebinding.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]

--- a/charts/k0s/templates/rbac/rolebinding.yaml
+++ b/charts/k0s/templates/rbac/rolebinding.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/k0s/templates/serviceaccount.yaml
+++ b/charts/k0s/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k0s/templates/statefulset-service.yaml
+++ b/charts/k0s/templates/statefulset-service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: https

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -11,9 +11,10 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.annotations }}
+{{- $annotations := merge .Values.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-headless

--- a/charts/k0s/templates/workloadserviceaccount.yaml
+++ b/charts/k0s/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -1,3 +1,6 @@
+# These annotations will be applied to all objects created in this chart
+globalAnnotations: {}
+
 # DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-

--- a/charts/k8s/templates/ingress.yaml
+++ b/charts/k8s/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+  {{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/k8s/templates/rbac/clusterrole.yaml
+++ b/charts/k8s/templates/rbac/clusterrole.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 rules:
   {{- if or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create }}
   - apiGroups: [""]

--- a/charts/k8s/templates/rbac/clusterrolebinding.yaml
+++ b/charts/k8s/templates/rbac/clusterrolebinding.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]

--- a/charts/k8s/templates/rbac/rolebinding.yaml
+++ b/charts/k8s/templates/rbac/rolebinding.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     {{- if .Values.serviceAccount.name }}

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k8s/templates/serviceaccount.yaml
+++ b/charts/k8s/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/k8s/templates/workloadserviceaccount.yaml
+++ b/charts/k8s/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -1,3 +1,6 @@
+# These annotations will be applied to all objects created in this chart
+globalAnnotations: {}
+
 # DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""


### PR DESCRIPTION
Signed-off-by: Ab-hishek <abhishek.agarwal1@nutanix.com>

**What issue type does this pull request address?**
/kind enhancement

**What does this pull request do? Which issues does it resolve?** 
resolves #714


**Please provide a short message that should be published in the vcluster release notes**
Added helm value "global.annotations" to eke, k8s and k0s charts that will add its annotations to all objects created in the chart. Annotations for specific objects have precedence over global ones.

**What else do we need to know?** 
