### PR TITLE
fix(chart): do not override affinity in k8s

### DIFF
--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -87,8 +87,6 @@ spec:
       {{- end }}
       nodeSelector:
 {{ toYaml .Values.api.nodeSelector | indent 8 }}
-      affinity:
-{{ toYaml .Values.api.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.api.tolerations | indent 8 }}
       automountServiceAccountToken: false

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -87,8 +87,6 @@ spec:
       {{- end }}
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
-      affinity:
-{{ toYaml .Values.controller.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.controller.tolerations | indent 8 }}
       automountServiceAccountToken: false

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -94,8 +94,6 @@ spec:
       {{- end }}
       nodeSelector:
 {{ toYaml .Values.etcd.nodeSelector | indent 8 }}
-      affinity:
-{{ toYaml .Values.etcd.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.etcd.tolerations | indent 8 }}
       automountServiceAccountToken: false

--- a/charts/k8s/templates/scheduler-deployment.yaml
+++ b/charts/k8s/templates/scheduler-deployment.yaml
@@ -87,8 +87,6 @@ spec:
       {{- end }}
       nodeSelector:
 {{ toYaml .Values.scheduler.nodeSelector | indent 8 }}
-      affinity:
-{{ toYaml .Values.scheduler.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.scheduler.tolerations | indent 8 }}
       automountServiceAccountToken: false

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -86,8 +86,6 @@ spec:
       {{- end }}
       nodeSelector:
 {{ toYaml .Values.syncer.nodeSelector | indent 8 }}
-      affinity:
-{{ toYaml .Values.syncer.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.syncer.tolerations | indent 8 }}
       {{- if .Values.serviceAccount.name }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes default podAntiAffinity for k8s HA. The k8s chart currently sets affinity twice and basicly overrides the default affinity set if HA mode is enabled (last one wins). This PR removes the duplicate affinity definition. Affinity is already set (if not empty) a few lines above. If it's empty the default affinity is used.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster didn't apply a default podAntiAffinity when using k8s in HA mode


**What else do we need to know?** 
