### PR TITLE
docs: remove vcluster binary after installing it

### DIFF
--- a/docs/pages/fragments/install/cli.mdx
+++ b/docs/pages/fragments/install/cli.mdx
@@ -16,28 +16,28 @@ import TabItem from '@theme/TabItem'
 <TabItem value="mac">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-darwin-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-darwin-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 </TabItem>
 <TabItem value="mac-arm">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-darwin-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-darwin-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 </TabItem>
 <TabItem value="linux">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 </TabItem>
 <TabItem value="linux-arm">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 </TabItem>


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This decreases chances of user having problems with helm when installing from the same folder where vcluster binary is still present. It would help avoid one of these two problems:

> vcluster create my-vcluster
> fatal  aborting vcluster creation. Current working directory contains a file or a directory with the name equal to the vcluster chart name - "vcluster". Please execute vcluster create command from a directory that doesn't contain a file or directory named "vcluster"

or 
> helm upgrade --install my-vcluster vcluster ...
> Release "my-vcluster" does not exist. Installing it now.
> Error: file '/root/vcluster' does not appear to be a gzipped archive; got 'application/octet-stream'


**Please provide a short message that should be published in the vcluster release notes**
N/A