### PR TITLE
docs: clarify order of init manifests/charts

### DIFF
--- a/docs/pages/operator/init-manifests.mdx
+++ b/docs/pages/operator/init-manifests.mdx
@@ -4,7 +4,7 @@ sidebar_label: Applying manifests and charts on init
 ---
 
 ## Applying manifests on initialization
-Starting in version 0.8.0, vcluster allows users to apply manifests as soon as a virtual cluster is started. This can be useful for users configuring internal vcluster resources.
+Starting in version 0.8.0, vcluster allows users to apply manifests as soon as a virtual cluster is started. This can be useful for users configuring internal vcluster resources. These manifests are applied before applying the helm charts.
 
 This can be configured via `helm` values:
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves [a question from Slack](https://loft-sh.slack.com/archives/C01N273CF4P/p1669187153875849)
Clarifies the order in which the syncer applies the init manifests(first) and init charts.

**Please provide a short message that should be published in the vcluster release notes**
N/A