### PR TITLE
add flag to enable hostpath mapping

### DIFF
--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -138,6 +138,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.hostpathMapper.enabled }}
+          - --rewrite-host-paths=true
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -191,6 +191,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.hostpathMapper.enabled }}
+          - --rewrite-host-paths=true
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -255,6 +255,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.hostpathMapper.enabled }}
+          - --rewrite-host-paths=true
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -173,6 +173,9 @@ spec:
           {{- if .Values.sync.nodes.nodeSelector }}
           - --node-selector={{ .Values.sync.nodes.nodeSelector }}
           {{- end }}
+          {{- if .Values.hostpathMapper.enabled }}
+          - --rewrite-host-paths=true
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -69,6 +69,7 @@ type VirtualClusterOptions struct {
 	SyncLabels []string `json:"syncLabels,omitempty"`
 
 	// hostpath mapper options
+	RewriteHostPaths         bool `json:"rewriteHostPaths,omitempty"`
 	VirtualLogsPath          string
 	VirtualPodLogsPath       string
 	VirtualContainerLogsPath string
@@ -145,6 +146,8 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 
 	flags.StringVar(&options.HostMetricsBindAddress, "host-metrics-bind-address", "0", "If set, metrics for the controller manager for the resources managed in the host cluster will be exposed at this address")
 	flags.StringVar(&options.VirtualMetricsBindAddress, "virtual-metrics-bind-address", "0", "If set, metrics for the controller manager for the resources managed in the virtual cluster will be exposed at this address")
+
+	flags.BoolVar(&options.RewriteHostPaths, "rewrite-host-paths", false, "If enabled, syncer with rewite hostpaths in synced pod volumes")
 
 	// Deprecated Flags
 	flags.BoolVar(&options.DeprecatedSyncNodeChanges, "sync-node-changes", false, "If enabled and --fake-nodes is false, the virtual cluster will proxy node updates from the virtual cluster to the host cluster. This is not recommended and should only be used if you know what you are doing.")

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -89,9 +89,10 @@ func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder record.EventR
 		enableScheduler:        ctx.Options.EnableScheduler,
 		syncedLabels:           ctx.Options.SyncLabels,
 
-		virtualLogsPath:       virtualLogsPath,
-		virtualPodLogsPath:    filepath.Join(virtualLogsPath, "pods"),
-		virtualKubeletPodPath: filepath.Join(virtualKubeletPath, "pods"),
+		rewriteVirtualHostPaths: ctx.Options.RewriteHostPaths,
+		virtualLogsPath:         virtualLogsPath,
+		virtualPodLogsPath:      filepath.Join(virtualLogsPath, "pods"),
+		virtualKubeletPodPath:   filepath.Join(virtualKubeletPath, "pods"),
 	}, nil
 }
 
@@ -113,9 +114,10 @@ type translator struct {
 	enableScheduler        bool
 	syncedLabels           []string
 
-	virtualLogsPath       string
-	virtualPodLogsPath    string
-	virtualKubeletPodPath string
+	rewriteVirtualHostPaths bool
+	virtualLogsPath         string
+	virtualPodLogsPath      string
+	virtualKubeletPodPath   string
 }
 
 func (t *translator) Translate(vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string) (*corev1.Pod, error) {
@@ -399,7 +401,9 @@ func (t *translator) translateVolumes(pPod *corev1.Pod, vPod *corev1.Pod) error 
 	}
 
 	// rewrite host paths if enabled
-	t.rewriteHostPaths(pPod)
+	if t.rewriteVirtualHostPaths {
+		t.rewriteHostPaths(pPod)
+	}
 
 	return nil
 }


### PR DESCRIPTION
this is wrt the syncer component

Signed-off-by: Ishan Khare <me@ishankhare.dev>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves an issue where the hostpaths in pod volumes and volume mounts were being rewritten even when the hestpath mapper component was not enabled from the helm charts.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the hostpaths in pod volumes and volume mounts were being rewritten even when the hestpath mapper component was not enabled from the helm charts.


**What else do we need to know?** 
