### PR TITLE
Add translation support for the dataSourceRef field in PersistentVolumeClaim Spec

### DIFF
--- a/pkg/controllers/resources/persistentvolumeclaims/translate.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/translate.go
@@ -24,12 +24,17 @@ func (s *persistentVolumeClaimSyncer) translate(ctx *synccontext.SyncContext, vP
 	if err != nil {
 		return nil, err
 	}
-	if newPvc.Spec.DataSource != nil && vPvc.Annotations[constants.SkipTranslationAnnotation] != "true" &&
-		(newPvc.Spec.DataSource.Kind == "PersistentVolumeClaim" || newPvc.Spec.DataSource.Kind == "VolumeSnapshot") {
-		newPvc.Spec.DataSource.Name = translate.Default.PhysicalName(newPvc.Spec.DataSource.Name, vPvc.Namespace)
+
+	if vPvc.Annotations[constants.SkipTranslationAnnotation] != "true" {
+		if newPvc.Spec.DataSource != nil {
+			newPvc.Spec.DataSource.Name = translate.Default.PhysicalName(newPvc.Spec.DataSource.Name, vPvc.Namespace)
+		}
+
+		if newPvc.Spec.DataSourceRef != nil {
+			newPvc.Spec.DataSourceRef.Name = translate.Default.PhysicalName(newPvc.Spec.DataSourceRef.Name, vPvc.Namespace)
+		}
 	}
 
-	//TODO: add support for the .Spec.DataSourceRef field
 	return newPvc, nil
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Added translation for the dataSourceRef field in PersistentVolumeClaim Spec

**What else do we need to know?** 
In Kubernetes v1.22, if the `AnyVolumeDataSource` feature gate is enabled, the `dataSourceRef` field is added, which behaves similarly to the dataSource field except that it allows arbitrary objects to be specified. The API server ensures that the two fields always have the same contents, and neither of them are mutable. The differences is that at creation time dataSource allows only PVCs or VolumeSnapshots, and ignores all other values, while dataSourceRef allows most types of objects, and in the few cases it doesn't allow an object (core objects other than PVCs) a validation error occurs.

With Kubernetes v1.24 and onwards, this feature gate is enabled by default and this adds the dataSourceRef field automatically (with the exact same content as dataSource field) under the PVC Spec and also ensures that the content in these two fields should be exactly the same. Currently, when syncing a PVC to the host, we are only translating dataSource.Name field. Hence,the contents of the dataSource and dataSourceRef fields differ and the Host API server rejects it.

With this PR, we are adding the translation for the dataSourceRef field which was required, and so after translation the contents match and the PVC is accepted by the Host API server.

