### PR TITLE
support 1.26 version with k8s distro

### DIFF
--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -151,7 +151,7 @@ syncer:
 
 # Etcd settings
 etcd:
-  image: registry.k8s.io/etcd:3.5.5-0
+  image: registry.k8s.io/etcd:3.5.6-0
   # The amount of replicas to run 
   replicas: 1
   # NodeSelector used
@@ -184,7 +184,7 @@ etcd:
   securityContext: {}
 # Kubernetes Controller Manager settings
 controller:
-  image: registry.k8s.io/kube-controller-manager:v1.25.4
+  image: registry.k8s.io/kube-controller-manager:v1.26.0
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used 
@@ -206,7 +206,7 @@ controller:
   securityContext: {}
 # Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
 scheduler:
-  image: registry.k8s.io/kube-scheduler:v1.25.4
+  image: registry.k8s.io/kube-scheduler:v1.26.0
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -228,7 +228,7 @@ scheduler:
 
 # Kubernetes API Server settings
 api:
-  image: registry.k8s.io/kube-apiserver:v1.25.4
+  image: registry.k8s.io/kube-apiserver:v1.26.0
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
-	github.com/loft-sh/utils v0.0.12-alpha
+	github.com/loft-sh/utils v0.0.13-alpha
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyP
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
-github.com/loft-sh/utils v0.0.12-alpha h1:RjiWWCL5St7FDWB3P+K9KKByk7fL9+D9LX2y0/9zsPU=
-github.com/loft-sh/utils v0.0.12-alpha/go.mod h1:n2L3X4i7d8kb2NF+q5duKa41N+N6fBde6XY2AolgSBI=
+github.com/loft-sh/utils v0.0.13-alpha h1:dlOH45azXkoe/CV6U9QUl+Da9H9bKWjIfcCAqekBnlw=
+github.com/loft-sh/utils v0.0.13-alpha/go.mod h1:n2L3X4i7d8kb2NF+q5duKa41N+N6fBde6XY2AolgSBI=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
@@ -8,6 +8,7 @@ import (
 )
 
 var K8SAPIVersionMap = map[string]string{
+	"1.26": "registry.k8s.io/kube-apiserver:v1.26.0",
 	"1.25": "registry.k8s.io/kube-apiserver:v1.25.4",
 	"1.24": "registry.k8s.io/kube-apiserver:v1.24.8",
 	"1.23": "registry.k8s.io/kube-apiserver:v1.23.14",
@@ -17,6 +18,7 @@ var K8SAPIVersionMap = map[string]string{
 }
 
 var K8SControllerVersionMap = map[string]string{
+	"1.26": "registry.k8s.io/kube-controller-manager:v1.26.0",
 	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.4",
 	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.8",
 	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.14",
@@ -26,6 +28,7 @@ var K8SControllerVersionMap = map[string]string{
 }
 
 var K8SSchedulerVersionMap = map[string]string{
+	"1.26": "registry.k8s.io/kube-scheduler:v1.26.0",
 	"1.25": "registry.k8s.io/kube-scheduler:v1.25.4",
 	"1.24": "registry.k8s.io/kube-scheduler:v1.24.8",
 	"1.23": "registry.k8s.io/kube-scheduler:v1.23.14",
@@ -35,6 +38,7 @@ var K8SSchedulerVersionMap = map[string]string{
 }
 
 var K8SEtcdVersionMap = map[string]string{
+	"1.26": "registry.k8s.io/etcd:3.5.6-0",
 	"1.25": "registry.k8s.io/etcd:3.5.5-0",
 	"1.24": "registry.k8s.io/etcd:3.5.1-0",
 	"1.23": "registry.k8s.io/etcd:3.5.1-0",
@@ -55,12 +59,12 @@ func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	schedulerImage := K8SSchedulerVersionMap[serverVersionString]
 	etcdImage, ok := K8SEtcdVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 25 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
-			apiImage = K8SAPIVersionMap["1.25"]
-			controllerImage = K8SControllerVersionMap["1.25"]
-			schedulerImage = K8SSchedulerVersionMap["1.25"]
-			etcdImage = K8SEtcdVersionMap["1.25"]
+		if serverMinorInt > 26 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
+			apiImage = K8SAPIVersionMap["1.26"]
+			controllerImage = K8SControllerVersionMap["1.26"]
+			schedulerImage = K8SSchedulerVersionMap["1.26"]
+			etcdImage = K8SEtcdVersionMap["1.26"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = K8SAPIVersionMap["1.20"]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -239,7 +239,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/utils v0.0.12-alpha
+# github.com/loft-sh/utils v0.0.13-alpha
 ## explicit; go 1.19
 github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Adds support for Kubernetes 1.26 when using k8s distro of vcluster.


**What else do we need to know?** 
I have run the conformance tests for this version and there are no failures.

![image](https://user-images.githubusercontent.com/87601990/207243580-487d3523-02fb-4f6c-ba44-b456a1e94460.png)

Fixes ENG-754
