### PR TITLE
allow setting clusterDomain in k0s helm chart

### DIFF
--- a/charts/k0s/templates/secret.yaml
+++ b/charts/k0s/templates/secret.yaml
@@ -36,6 +36,9 @@ stringData:
         serviceCIDR: CIDR_PLACEHOLDER
         {{- end }}
         provider: custom
+        {{- if .Values.vcluster.clusterDomain }}
+        clusterDomain: {{ .Values.vcluster.clusterDomain }}
+        {{- end}}
       controllerManager:
         extraArgs:
           {{- if not .Values.sync.nodes.enableScheduler }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -150,6 +150,7 @@ vcluster:
       cpu: 200m
       memory: 256Mi
   priorityClassName: ""
+  # clusterDomain: cluster.local
 
 # Storage settings for the vcluster
 storage:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** 
Partly resolves #397 . In comparison to k3s, the cluster domain cannot be passed as an argument to the [k0s controller](https://docs.k0sproject.io/v1.25.4+k0s.0/cli/k0s_controller/). instead it needs to be defined in the [k0s config](https://docs.k0sproject.io/v1.25.4+k0s.0/configuration/#specnetwork). This PR exposes the `spec.network.clusterDomain` configuration field as a helm value


**Please provide a short message that should be published in the vcluster release notes**
clusterDomain can be passed to k0s

**What else do we need to know?** 
In case coredns managed by vcluster, a custom coredns.yaml must still be provided as described in https://github.com/loft-sh/vcluster/issues/397