### PR TITLE
add custom clusterDomain to coredns

### DIFF
--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -74,7 +74,7 @@ data:
             health
             ready
             rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-            kubernetes cluster.local in-addr.arpa ip6.arpa {
+            kubernetes {{- if .Values.vcluster.clusterDomain }} {{ .Values.vcluster.clusterDomain }} {{- end }} cluster.local in-addr.arpa ip6.arpa {
               pods insecure
               fallthrough in-addr.arpa ip6.arpa
             }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves https://github.com/loft-sh/vcluster/issues/397 for k0s 

**Please provide a short message that should be published in the vcluster release notes**
custom clusterDomain is added to coredns config for k0s clusters

**What else do we need to know?** 
This builds upon https://github.com/loft-sh/vcluster/pull/867 to additionally add the custom clusterDomain to the coredns config. There's no [workaround to build a custom coredns config](https://github.com/loft-sh/vcluster/issues/397#issuecomment-1062870644) necessary any more. Affects only k0s