### PR TITLE
Generics for syncer 'newIfNil' function

### DIFF
--- a/docs/pages/plugins/tutorial.mdx
+++ b/docs/pages/plugins/tutorial.mdx
@@ -109,28 +109,21 @@ func (s *configMapSyncer) translateUpdate(pObj, vObj *corev1.ConfigMap) *corev1.
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	// check if the data has changed
 	if !equality.Semantic.DeepEqual(vObj.Data, pObj.Data) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Data = vObj.Data
 	}
 
 	// check if the binary data has changed
 	if !equality.Semantic.DeepEqual(vObj.BinaryData, pObj.BinaryData) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.BinaryData = vObj.BinaryData
-	}
-	return updated
-}
-
-func newIfNil(updated *corev1.ConfigMap, pObj *corev1.ConfigMap) *corev1.ConfigMap {
-	if updated == nil {
-		return pObj.DeepCopy()
 	}
 	return updated
 }

--- a/pkg/controllers/resources/configmaps/translate.go
+++ b/pkg/controllers/resources/configmaps/translate.go
@@ -1,6 +1,7 @@
 package configmaps
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,29 +17,22 @@ func (s *configMapSyncer) translateUpdate(pObj, vObj *corev1.ConfigMap) *corev1.
 	// check annotations & labels
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	// check data
 	if !equality.Semantic.DeepEqual(vObj.Data, pObj.Data) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Data = vObj.Data
 	}
 
 	// check binary data
 	if !equality.Semantic.DeepEqual(vObj.BinaryData, pObj.BinaryData) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.BinaryData = vObj.BinaryData
 	}
 
-	return updated
-}
-
-func newIfNil(updated *corev1.ConfigMap, pObj *corev1.ConfigMap) *corev1.ConfigMap {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/csidrivers/translate.go
+++ b/pkg/controllers/resources/csidrivers/translate.go
@@ -1,6 +1,7 @@
 package csidrivers
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -14,22 +15,15 @@ func (s *csidriverSyncer) translateUpdateBackwards(pObj, vObj *storagev1.CSIDriv
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Spec, pObj.Spec) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		pObj.Spec.DeepCopyInto(&updated.Spec)
 	}
 
-	return updated
-}
-
-func newIfNil(updated *storagev1.CSIDriver, obj *storagev1.CSIDriver) *storagev1.CSIDriver {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/csinodes/translate.go
+++ b/pkg/controllers/resources/csinodes/translate.go
@@ -1,6 +1,7 @@
 package csinodes
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -14,22 +15,15 @@ func (s *csinodeSyncer) translateUpdateBackwards(pObj, vObj *storagev1.CSINode) 
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Spec, pObj.Spec) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		pObj.Spec.DeepCopyInto(&updated.Spec)
 	}
 
-	return updated
-}
-
-func newIfNil(updated *storagev1.CSINode, obj *storagev1.CSINode) *storagev1.CSINode {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/csistoragecapacities/translate.go
+++ b/pkg/controllers/resources/csistoragecapacities/translate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/loft-sh/vcluster/pkg/constants"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -86,38 +87,31 @@ func (s *csistoragecapacitySyncer) translateUpdateBackwards(ctx *synccontext.Syn
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if scName != vObj.StorageClassName {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.StorageClassName = scName
 
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.NodeTopology, pObj.NodeTopology) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.NodeTopology = pObj.NodeTopology
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Capacity, pObj.Capacity) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Capacity = pObj.Capacity
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.MaximumVolumeSize, pObj.MaximumVolumeSize) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.MaximumVolumeSize = pObj.MaximumVolumeSize
 	}
 
 	return updated, false, nil
-}
-
-func newIfNil(updated *storagev1.CSIStorageCapacity, obj *storagev1.CSIStorageCapacity) *storagev1.CSIStorageCapacity {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
-	return updated
 }

--- a/pkg/controllers/resources/endpoints/translate.go
+++ b/pkg/controllers/resources/endpoints/translate.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -53,7 +54,7 @@ func (s *endpointsSyncer) translateUpdate(pObj, vObj *corev1.Endpoints) *corev1.
 	translated := vObj.DeepCopy()
 	s.translateSpec(translated)
 	if !equality.Semantic.DeepEqual(translated.Subsets, pObj.Subsets) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Subsets = translated.Subsets
 	}
 
@@ -61,17 +62,10 @@ func (s *endpointsSyncer) translateUpdate(pObj, vObj *corev1.Endpoints) *corev1.
 	_, annotations, labels := s.TranslateMetadataUpdate(vObj, pObj)
 	delete(annotations, "control-plane.alpha.kubernetes.io/leader")
 	if !equality.Semantic.DeepEqual(annotations, pObj.Annotations) || !equality.Semantic.DeepEqual(labels, pObj.Labels) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = annotations
 		updated.Labels = labels
 	}
 
-	return updated
-}
-
-func newIfNil(updated *corev1.Endpoints, pObj *corev1.Endpoints) *corev1.Endpoints {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/ingressclasses/translate.go
+++ b/pkg/controllers/resources/ingressclasses/translate.go
@@ -1,6 +1,7 @@
 package ingressclasses
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -14,27 +15,19 @@ func (i *ingressClassSyncer) translateUpdateBackwards(pObj, vObj *networkingv1.I
 
 	changed, updatedAnnotations, updatedLabels := i.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Spec.Controller, pObj.Spec.Controller) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Spec.Controller = pObj.Spec.Controller
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Spec.Parameters, pObj.Spec.Parameters) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Spec.Parameters = pObj.Spec.Parameters
-	}
-
-	return updated
-}
-
-func newIfNil(updated, obj *networkingv1.IngressClass) *networkingv1.IngressClass {
-	if updated == nil {
-		return obj.DeepCopy()
 	}
 
 	return updated

--- a/pkg/controllers/resources/ingresses/legacy/translate.go
+++ b/pkg/controllers/resources/ingresses/legacy/translate.go
@@ -2,6 +2,7 @@ package legacy
 
 import (
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/ingresses/util"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -27,13 +28,13 @@ func (s *ingressSyncer) translateUpdate(pObj, vObj *networkingv1beta1.Ingress) *
 
 	translatedSpec := *translateSpec(vObj.Namespace, &vObj.Spec)
 	if !equality.Semantic.DeepEqual(translatedSpec, pObj.Spec) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Spec = translatedSpec
 	}
 
 	changed, translatedAnnotations, translatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = translatedAnnotations
 		updated.Labels = translatedLabels
 	}
@@ -45,7 +46,7 @@ func (s *ingressSyncer) translateUpdateBackwards(pObj, vObj *networkingv1beta1.I
 	var updated *networkingv1beta1.Ingress
 
 	if vObj.Spec.IngressClassName == nil && pObj.Spec.IngressClassName != nil {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Spec.IngressClassName = pObj.Spec.IngressClassName
 	}
 
@@ -83,11 +84,4 @@ func translateSpec(namespace string, vIngressSpec *networkingv1beta1.IngressSpec
 	}
 
 	return retSpec
-}
-
-func newIfNil(updated *networkingv1beta1.Ingress, pObj *networkingv1beta1.Ingress) *networkingv1beta1.Ingress {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
-	return updated
 }

--- a/pkg/controllers/resources/ingresses/translate.go
+++ b/pkg/controllers/resources/ingresses/translate.go
@@ -2,6 +2,7 @@ package ingresses
 
 import (
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/ingresses/util"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -28,14 +29,14 @@ func (s *ingressSyncer) translateUpdate(pObj, vObj *networkingv1.Ingress) *netwo
 
 	translatedSpec := *translateSpec(vObj.Namespace, &vObj.Spec)
 	if !equality.Semantic.DeepEqual(translatedSpec, pObj.Spec) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Spec = translatedSpec
 	}
 
 	_, translatedAnnotations, translatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	translatedAnnotations, _ = translateIngressAnnotations(translatedAnnotations, vObj.Namespace)
 	if !equality.Semantic.DeepEqual(translatedAnnotations, pObj.GetAnnotations()) || !equality.Semantic.DeepEqual(translatedLabels, pObj.GetLabels()) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = translatedAnnotations
 		updated.Labels = translatedLabels
 	}
@@ -47,7 +48,7 @@ func (s *ingressSyncer) translateUpdateBackwards(pObj, vObj *networkingv1.Ingres
 	var updated *networkingv1.Ingress
 
 	if vObj.Spec.IngressClassName == nil && pObj.Spec.IngressClassName != nil {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Spec.IngressClassName = pObj.Spec.IngressClassName
 	}
 
@@ -85,11 +86,4 @@ func translateSpec(namespace string, vIngressSpec *networkingv1.IngressSpec) *ne
 	}
 
 	return retSpec
-}
-
-func newIfNil(updated *networkingv1.Ingress, pObj *networkingv1.Ingress) *networkingv1.Ingress {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
-	return updated
 }

--- a/pkg/controllers/resources/namespaces/translate.go
+++ b/pkg/controllers/resources/namespaces/translate.go
@@ -1,6 +1,7 @@
 package namespaces
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -14,17 +15,10 @@ func (s *namespaceSyncer) translateUpdate(pObj, vObj *corev1.Namespace) *corev1.
 	var updated *corev1.Namespace
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels
 	}
 
-	return updated
-}
-
-func newIfNil(updated *corev1.Namespace, obj *corev1.Namespace) *corev1.Namespace {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/networkpolicies/translate.go
+++ b/pkg/controllers/resources/networkpolicies/translate.go
@@ -2,6 +2,7 @@ package networkpolicies
 
 import (
 	podstranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -18,13 +19,13 @@ func (s *networkPolicySyncer) translateUpdate(pObj, vObj *networkingv1.NetworkPo
 
 	translatedSpec := *translateSpec(&vObj.Spec, vObj.GetNamespace())
 	if !equality.Semantic.DeepEqual(translatedSpec, pObj.Spec) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Spec = translatedSpec
 	}
 
 	changed, translatedAnnotations, translatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Labels = translatedLabels
 		updated.Annotations = translatedAnnotations
 	}
@@ -103,11 +104,4 @@ func translateNetworkPolicyPeers(peers []networkingv1.NetworkPolicyPeer, namespa
 		out = append(out, newPeer)
 	}
 	return out
-}
-
-func newIfNil(updated *networkingv1.NetworkPolicy, pObj *networkingv1.NetworkPolicy) *networkingv1.NetworkPolicy {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
-	return updated
 }

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"fmt"
+
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -10,6 +11,7 @@ import (
 	podtranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
@@ -107,7 +109,7 @@ func (r *fakeNodeSyncer) updateNeeded(node *corev1.Node) *corev1.Node {
 		},
 	}
 	if !equality.Semantic.DeepEqual(node.Status.Addresses, newAddresses) {
-		updated = newIfNil(updated, node)
+		updated = translator.NewIfNil(updated, node)
 		updated.Status.Addresses = newAddresses
 	}
 

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -3,9 +3,11 @@ package nodes
 import (
 	"context"
 	"encoding/json"
-	"github.com/loft-sh/vcluster/pkg/constants"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
+
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/loft-sh/vcluster/pkg/util/stringutil"
@@ -95,7 +97,7 @@ func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.
 	}
 
 	if !equality.Semantic.DeepEqual(vNode.Spec, *translatedSpec) {
-		updated = newIfNil(updated, vNode)
+		updated = translator.NewIfNil(updated, vNode)
 		updated.Spec = *translatedSpec
 	}
 
@@ -106,12 +108,12 @@ func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.
 	}
 
 	if !equality.Semantic.DeepEqual(vNode.Annotations, annotations) {
-		updated = newIfNil(updated, vNode)
+		updated = translator.NewIfNil(updated, vNode)
 		updated.Annotations = annotations
 	}
 
 	if !equality.Semantic.DeepEqual(vNode.Labels, labels) {
-		updated = newIfNil(updated, vNode)
+		updated = translator.NewIfNil(updated, vNode)
 		updated.Labels = labels
 	}
 
@@ -237,13 +239,6 @@ func (s *nodeSyncer) translateUpdateStatus(pNode *corev1.Node, vNode *corev1.Nod
 	}
 
 	return nil, nil
-}
-
-func newIfNil(updated *corev1.Node, pObj *corev1.Node) *corev1.Node {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
-	return updated
 }
 
 func mergeStrings(physical []string, virtual []string, oldPhysical []string) []string {

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -1,6 +1,7 @@
 package persistentvolumes
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -76,20 +77,20 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(vPv *corev1.Persistent
 	// check storage class. Do not copy the name, if it was created on virtual.
 	if !translate.Default.IsManagedCluster(pPv) {
 		if !equality.Semantic.DeepEqual(vPv.Spec.StorageClassName, translatedSpec.StorageClassName) && !isStorageClassCreatedOnVirtual {
-			updated = newIfNil(updated, vPv)
+			updated = translator.NewIfNil(updated, vPv)
 			updated.Spec.StorageClassName = translatedSpec.StorageClassName
 		}
 	}
 
 	// check claim ref. Do not copy, if it was created on virtual.
 	if !equality.Semantic.DeepEqual(vPv.Spec.ClaimRef, translatedSpec.ClaimRef) && !isClaimRefCreatedOnVirtual {
-		updated = newIfNil(updated, vPv)
+		updated = translator.NewIfNil(updated, vPv)
 		updated.Spec.ClaimRef = translatedSpec.ClaimRef
 	}
 
 	// check pv size
 	if vPv.Annotations != nil && vPv.Annotations[HostClusterPersistentVolumeAnnotation] != "" && !equality.Semantic.DeepEqual(pPv.Spec.Capacity, vPv.Spec.Capacity) {
-		updated = newIfNil(updated, vPv)
+		updated = translator.NewIfNil(updated, vPv)
 		updated.Spec.Capacity = translatedSpec.Capacity
 	}
 
@@ -101,60 +102,53 @@ func (s *persistentVolumeSyncer) translateUpdate(vPv *corev1.PersistentVolume, p
 
 	// TODO: translate the storage secrets
 	if !equality.Semantic.DeepEqual(pPv.Spec.PersistentVolumeSource, vPv.Spec.PersistentVolumeSource) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.PersistentVolumeSource = vPv.Spec.PersistentVolumeSource
 	}
 
 	if !equality.Semantic.DeepEqual(pPv.Spec.Capacity, vPv.Spec.Capacity) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.Capacity = vPv.Spec.Capacity
 	}
 
 	if !equality.Semantic.DeepEqual(pPv.Spec.AccessModes, vPv.Spec.AccessModes) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.AccessModes = vPv.Spec.AccessModes
 	}
 
 	if !equality.Semantic.DeepEqual(pPv.Spec.PersistentVolumeReclaimPolicy, vPv.Spec.PersistentVolumeReclaimPolicy) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.PersistentVolumeReclaimPolicy = vPv.Spec.PersistentVolumeReclaimPolicy
 	}
 
 	translatedStorageClassName := translateStorageClass(vPv.Spec.StorageClassName)
 	if !equality.Semantic.DeepEqual(pPv.Spec.StorageClassName, translatedStorageClassName) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.StorageClassName = translatedStorageClassName
 	}
 
 	if !equality.Semantic.DeepEqual(pPv.Spec.NodeAffinity, vPv.Spec.NodeAffinity) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.NodeAffinity = vPv.Spec.NodeAffinity
 	}
 
 	if !equality.Semantic.DeepEqual(pPv.Spec.VolumeMode, vPv.Spec.VolumeMode) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.VolumeMode = vPv.Spec.VolumeMode
 	}
 
 	if !equality.Semantic.DeepEqual(pPv.Spec.MountOptions, vPv.Spec.MountOptions) {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Spec.MountOptions = vPv.Spec.MountOptions
 	}
 
 	// check labels & annotations
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vPv, pPv)
 	if changed {
-		updated = newIfNil(updated, pPv)
+		updated = translator.NewIfNil(updated, pPv)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels
 	}
 
-	return updated
-}
-
-func newIfNil(updated *corev1.PersistentVolume, obj *corev1.PersistentVolume) *corev1.PersistentVolume {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/poddisruptionbudgets/translate.go
+++ b/pkg/controllers/resources/poddisruptionbudgets/translate.go
@@ -1,6 +1,7 @@
 package poddisruptionbudgets
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -20,7 +21,7 @@ func (pdb *pdbSyncer) translateUpdate(pObj, vObj *policyv1.PodDisruptionBudget) 
 	// check max available and min available in spec
 	if !equality.Semantic.DeepEqual(vObj.Spec.MaxUnavailable, pObj.Spec.MaxUnavailable) ||
 		!equality.Semantic.DeepEqual(vObj.Spec.MinAvailable, pObj.Spec.MinAvailable) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Spec.MaxUnavailable = vObj.Spec.MaxUnavailable
 		updated.Spec.MinAvailable = vObj.Spec.MinAvailable
 	}
@@ -28,7 +29,7 @@ func (pdb *pdbSyncer) translateUpdate(pObj, vObj *policyv1.PodDisruptionBudget) 
 	// check annotations
 	changed, updatedAnnotations, updatedLabels := pdb.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels
 	}
@@ -36,16 +37,9 @@ func (pdb *pdbSyncer) translateUpdate(pObj, vObj *policyv1.PodDisruptionBudget) 
 	// check LabelSelector
 	vObjLabelSelector := translate.Default.TranslateLabelSelector(vObj.Spec.Selector)
 	if !equality.Semantic.DeepEqual(vObjLabelSelector, pObj.Spec.Selector) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Spec.Selector = vObjLabelSelector
 	}
 
-	return updated
-}
-
-func newIfNil(updated *policyv1.PodDisruptionBudget, pObj *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/priorityclasses/translate.go
+++ b/pkg/controllers/resources/priorityclasses/translate.go
@@ -1,6 +1,7 @@
 package priorityclasses
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,21 +22,21 @@ func (s *priorityClassSyncer) translateUpdate(pObj, vObj *schedulingv1.PriorityC
 
 	// check subsets
 	if !equality.Semantic.DeepEqual(vObj.PreemptionPolicy, pObj.PreemptionPolicy) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.PreemptionPolicy = vObj.PreemptionPolicy
 	}
 
 	// check annotations
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels
 	}
 
 	// check description
 	if vObj.Description != pObj.Description {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Description = vObj.Description
 	}
 
@@ -45,16 +46,9 @@ func (s *priorityClassSyncer) translateUpdate(pObj, vObj *schedulingv1.PriorityC
 		translatedValue = 1000000000
 	}
 	if translatedValue != pObj.Value {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Value = translatedValue
 	}
 
-	return updated
-}
-
-func newIfNil(updated *schedulingv1.PriorityClass, obj *schedulingv1.PriorityClass) *schedulingv1.PriorityClass {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/secrets/translate.go
+++ b/pkg/controllers/resources/secrets/translate.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -19,30 +20,23 @@ func (s *secretSyncer) translateUpdate(pObj, vObj *corev1.Secret) *corev1.Secret
 
 	// check data
 	if !equality.Semantic.DeepEqual(vObj.Data, pObj.Data) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Data = vObj.Data
 	}
 
 	// check secret type
 	if vObj.Type != pObj.Type && vObj.Type != corev1.SecretTypeServiceAccountToken {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Type = vObj.Type
 	}
 
 	// check annotations
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels
 	}
 
-	return updated
-}
-
-func newIfNil(updated *corev1.Secret, pObj *corev1.Secret) *corev1.Secret {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/serviceaccounts/translate.go
+++ b/pkg/controllers/resources/serviceaccounts/translate.go
@@ -1,6 +1,7 @@
 package serviceaccounts
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,17 +26,10 @@ func (s *serviceAccountSyncer) translateUpdate(pObj, vObj *corev1.ServiceAccount
 	// check annotations & labels
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
-	return updated
-}
-
-func newIfNil(updated *corev1.ServiceAccount, pObj *corev1.ServiceAccount) *corev1.ServiceAccount {
-	if updated == nil {
-		return pObj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/storageclasses/host_sc_translate.go
+++ b/pkg/controllers/resources/storageclasses/host_sc_translate.go
@@ -1,6 +1,7 @@
 package storageclasses
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -14,43 +15,43 @@ func (s *hostStorageClassSyncer) translateUpdateBackwards(pObj, vObj *storagev1.
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Provisioner, pObj.Provisioner) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Provisioner = pObj.Provisioner
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Parameters, pObj.Parameters) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Parameters = pObj.Parameters
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.ReclaimPolicy, pObj.ReclaimPolicy) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.ReclaimPolicy = pObj.ReclaimPolicy
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.MountOptions, pObj.MountOptions) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.MountOptions = pObj.MountOptions
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.AllowVolumeExpansion, pObj.AllowVolumeExpansion) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.AllowVolumeExpansion = pObj.AllowVolumeExpansion
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.VolumeBindingMode, pObj.VolumeBindingMode) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.VolumeBindingMode = pObj.VolumeBindingMode
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.AllowedTopologies, pObj.AllowedTopologies) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.AllowedTopologies = pObj.AllowedTopologies
 	}
 

--- a/pkg/controllers/resources/storageclasses/translate.go
+++ b/pkg/controllers/resources/storageclasses/translate.go
@@ -1,6 +1,7 @@
 package storageclasses
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -14,52 +15,45 @@ func (s *storageClassSyncer) translateUpdate(pObj, vObj *storagev1.StorageClass)
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
 	if changed {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Provisioner, pObj.Provisioner) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Provisioner = vObj.Provisioner
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.Parameters, pObj.Parameters) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.Parameters = vObj.Parameters
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.ReclaimPolicy, pObj.ReclaimPolicy) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.ReclaimPolicy = vObj.ReclaimPolicy
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.MountOptions, pObj.MountOptions) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.MountOptions = vObj.MountOptions
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.AllowVolumeExpansion, pObj.AllowVolumeExpansion) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.AllowVolumeExpansion = vObj.AllowVolumeExpansion
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.VolumeBindingMode, pObj.VolumeBindingMode) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.VolumeBindingMode = vObj.VolumeBindingMode
 	}
 
 	if !equality.Semantic.DeepEqual(vObj.AllowedTopologies, pObj.AllowedTopologies) {
-		updated = newIfNil(updated, pObj)
+		updated = translator.NewIfNil(updated, pObj)
 		updated.AllowedTopologies = vObj.AllowedTopologies
 	}
 
-	return updated
-}
-
-func newIfNil(updated *storagev1.StorageClass, obj *storagev1.StorageClass) *storagev1.StorageClass {
-	if updated == nil {
-		return obj.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotclasses/translate.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotclasses/translate.go
@@ -2,6 +2,7 @@ package volumesnapshotclasses
 
 import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -14,32 +15,25 @@ func (s *volumeSnapshotClassSyncer) translateUpdateBackwards(pVSC *volumesnapsho
 
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vVSC, pVSC)
 	if changed {
-		updated = newIfNil(updated, vVSC)
+		updated = translator.NewIfNil(updated, vVSC)
 		updated.Labels = updatedLabels
 		updated.Annotations = updatedAnnotations
 	}
 
 	if !equality.Semantic.DeepEqual(vVSC.Driver, pVSC.Driver) {
-		updated = newIfNil(updated, vVSC)
+		updated = translator.NewIfNil(updated, vVSC)
 		updated.Driver = pVSC.Driver
 	}
 
 	if !equality.Semantic.DeepEqual(vVSC.Parameters, pVSC.Parameters) {
-		updated = newIfNil(updated, vVSC)
+		updated = translator.NewIfNil(updated, vVSC)
 		updated.Parameters = pVSC.Parameters
 	}
 
 	if !equality.Semantic.DeepEqual(vVSC.DeletionPolicy, pVSC.DeletionPolicy) {
-		updated = newIfNil(updated, vVSC)
+		updated = translator.NewIfNil(updated, vVSC)
 		updated.DeletionPolicy = pVSC.DeletionPolicy
 	}
 
-	return updated
-}
-
-func newIfNil(updated *volumesnapshotv1.VolumeSnapshotClass, objBase *volumesnapshotv1.VolumeSnapshotClass) *volumesnapshotv1.VolumeSnapshotClass {
-	if updated == nil {
-		return objBase.DeepCopy()
-	}
 	return updated
 }

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshots/translate.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshots/translate.go
@@ -6,6 +6,7 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,14 +41,14 @@ func (s *volumeSnapshotSyncer) translateUpdate(pVS, vVS *volumesnapshotv1.Volume
 
 	// snapshot class can be updated
 	if !equality.Semantic.DeepEqual(pVS.Spec.VolumeSnapshotClassName, vVS.Spec.VolumeSnapshotClassName) {
-		updated = newIfNil(updated, pVS)
+		updated = translator.NewIfNil(updated, pVS)
 		updated.Spec.VolumeSnapshotClassName = vVS.Spec.VolumeSnapshotClassName
 	}
 
 	// check if metadata changed
 	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vVS, pVS)
 	if changed {
-		updated = newIfNil(updated, pVS)
+		updated = translator.NewIfNil(updated, pVS)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels
 	}
@@ -60,15 +61,8 @@ func (s *volumeSnapshotSyncer) translateUpdateBackwards(pObj, vObj *volumesnapsh
 
 	// sync back the finalizers
 	if !equality.Semantic.DeepEqual(vObj.Finalizers, pObj.Finalizers) {
-		updated = newIfNil(updated, vObj)
+		updated = translator.NewIfNil(updated, vObj)
 		updated.Finalizers = pObj.Finalizers
-	}
-	return updated
-}
-
-func newIfNil(updated *volumesnapshotv1.VolumeSnapshot, objBase *volumesnapshotv1.VolumeSnapshot) *volumesnapshotv1.VolumeSnapshot {
-	if updated == nil {
-		return objBase.DeepCopy()
 	}
 	return updated
 }

--- a/pkg/controllers/syncer/translator/util.go
+++ b/pkg/controllers/syncer/translator/util.go
@@ -1,8 +1,10 @@
 package translator
 
 import (
-	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"os"
+	"reflect"
+
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -13,4 +15,14 @@ func PrintChanges(oldObject, newObject client.Object, log loghelper.Logger) {
 			log.Debugf("Updating object with: %v", string(rawPatch))
 		}
 	}
+}
+
+func NewIfNil[T interface {
+	DeepCopy() T
+}](updated, obj T) T {
+	if reflect.ValueOf(updated).IsNil() {
+		return obj.DeepCopy()
+	}
+
+	return updated
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**Please provide a short message that should be published in the vcluster release notes**
Refactored newIfNil function using go generics


**What else do we need to know?**
Trying to avoid use of reflection for checking if the updated object is nil. Benchmark says its not that bad, but still if we can find some way to avoid it.

```goos: linux
goarch: amd64
pkg: github.com/loft-sh/vcluster/pkg/controllers/syncer/translator
cpu: AMD Ryzen 5 5600U with Radeon Graphics         
BenchmarkNewIfNilGenerics-12    	 4560048	       336.8 ns/op	     624 B/op	       3 allocs/op
BenchmarkNewIfNilExisting-12    	 3870843	       287.5 ns/op	     624 B/op	       3 allocs/op
PASS
coverage: 4.0% of statements
ok  	github.com/loft-sh/vcluster/pkg/controllers/syncer/translator	3.258s
```

Closes ENG-826