### PR TITLE
feat(nodes): Add filtering to Node Labels on Node Sync

### DIFF
--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -40,10 +40,10 @@ type VirtualClusterOptions struct {
 	DisableFakeKubelets bool     `json:"disableFakeKubelets,omitempty"`
 	ClearNodeImages     bool     `json:"clearNodeImages,omitempty"`
 	TranslateImages     []string `json:"translateImages,omitempty"`
-
-	NodeSelector        string `json:"nodeSelector,omitempty"`
-	EnforceNodeSelector bool   `json:"enforceNodeSelector,omitempty"`
-	ServiceAccount      string `json:"serviceAccount,omitempty"`
+	NodeLabelsExclude   []string `json:"nodeLabelsExclude,omitempty"`
+	NodeSelector        string   `json:"nodeSelector,omitempty"`
+	EnforceNodeSelector bool     `json:"enforceNodeSelector,omitempty"`
+	ServiceAccount      string   `json:"serviceAccount,omitempty"`
 
 	OverrideHosts               bool   `json:"overrideHosts,omitempty"`
 	OverrideHostsContainerImage string `json:"overrideHostsContainerImage,omitempty"`
@@ -124,7 +124,7 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 	flags.StringSliceVar(&options.Tolerations, "enforce-toleration", []string{}, "If set will apply the provided tolerations to all pods in the vcluster")
 	flags.StringVar(&options.NodeSelector, "node-selector", "", "If nodes sync is enabled, nodes with the given node selector will be synced to the virtual cluster. If fake nodes are used, and --enforce-node-selector flag is set, then vcluster will ensure that no pods are scheduled outside of the node selector.")
 	flags.StringVar(&options.ServiceAccount, "service-account", "", "If set, will set this host service account on the synced pods")
-
+	flags.StringSliceVar(&options.NodeLabelsExclude, "node-labels-exclude", []string{}, "Excludes this list of labels from nodes being synced from the host cluster to virtual cluster, only used when nodes sync is enabled.")
 	flags.BoolVar(&options.OverrideHosts, "override-hosts", true, "If enabled, vcluster will override a containers /etc/hosts file if there is a subdomain specified for the pod (spec.subdomain).")
 	flags.StringVar(&options.OverrideHostsContainerImage, "override-hosts-container-image", DefaultHostsRewriteImage, "The image for the init container that is used for creating the override hosts file.")
 

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -59,6 +59,7 @@ func NewSyncer(ctx *synccontext.RegisterContext, nodeService nodeservice.NodeSer
 		nodeServiceProvider: nodeService,
 		nodeSelector:        nodeSelector,
 		clearImages:         ctx.Options.ClearNodeImages,
+		nodeLabelsExclude:   ctx.Options.NodeLabelsExclude,
 		useFakeKubelets:     !ctx.Options.DisableFakeKubelets,
 
 		physicalClient:      ctx.PhysicalManager.GetClient(),
@@ -75,9 +76,9 @@ type nodeSyncer struct {
 	enforceNodeSelector bool
 	nodeSelector        labels.Selector
 	useFakeKubelets     bool
-
-	physicalClient client.Client
-	virtualClient  client.Client
+	nodeLabelsExclude   []string
+	physicalClient      client.Client
+	virtualClient       client.Client
 
 	podCache            client.Reader
 	nodeServiceProvider nodeservice.NodeServiceProvider

--- a/pkg/controllers/resources/nodes/syncer_test.go
+++ b/pkg/controllers/resources/nodes/syncer_test.go
@@ -560,4 +560,95 @@ func TestSync(t *testing.T) {
 			},
 		},
 	})
+
+	baseName = types.NamespacedName{
+		Name: "mynode",
+	}
+
+	baseNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: baseName.Name,
+			Labels: map[string]string{
+				"test":                   "true",
+				"excluded.kubernetes.io": "true",
+			},
+		},
+		Status: corev1.NodeStatus{
+			DaemonEndpoints: corev1.NodeDaemonEndpoints{
+				KubeletEndpoint: corev1.DaemonEndpoint{
+					Port: 0,
+				},
+			},
+			NodeInfo: corev1.NodeSystemInfo{
+				Architecture: "amd64",
+			},
+			Images: []corev1.ContainerImage{
+				{
+					Names: []string{"ghcr.io/jetpack/calico"},
+				},
+			},
+		},
+	}
+	baseVNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: baseName.Name,
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Address: "127.0.0.1",
+					Type:    corev1.NodeInternalIP,
+				},
+			},
+			DaemonEndpoints: corev1.NodeDaemonEndpoints{
+				KubeletEndpoint: corev1.DaemonEndpoint{
+					Port: nodeservice.KubeletPort,
+				},
+			},
+		},
+	}
+	editedNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: baseName.Name,
+			Labels: map[string]string{
+				"test": "true",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Address: "127.0.0.1",
+					Type:    corev1.NodeInternalIP,
+				},
+			},
+			DaemonEndpoints: corev1.NodeDaemonEndpoints{
+				KubeletEndpoint: corev1.DaemonEndpoint{
+					Port: nodeservice.KubeletPort,
+				},
+			},
+			NodeInfo: corev1.NodeSystemInfo{
+				Architecture: "amd64",
+			},
+			Images: []corev1.ContainerImage{},
+		},
+	}
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name:                 "Clear Node Label -- Should not have excluded.kubernetes.io label",
+			InitialPhysicalState: []runtime.Object{baseNode},
+			InitialVirtualState:  []runtime.Object{baseVNode},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Node"): {editedNode},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				ctx.Options.SyncAllNodes = true
+				ctx.Options.ClearNodeImages = true
+				ctx.Options.NodeLabelsExclude = []string{"excluded.kubernetes.io"}
+				syncCtx, syncerSvc := newFakeSyncer(t, ctx)
+				_, err := syncerSvc.Sync(syncCtx, baseNode, baseNode)
+				assert.NilError(t, err)
+			},
+		},
+	})
 }

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -240,6 +240,10 @@ func (s *nodeSyncer) translateUpdateStatus(ctx *synccontext.SyncContext, pNode *
 		translatedStatus.Images = make([]corev1.ContainerImage, 0)
 	}
 
+	for _, nodeLabel := range s.nodeLabelsExclude {
+		delete(vNode.Labels, nodeLabel)
+	}
+
 	// check if the status has changed
 	if !equality.Semantic.DeepEqual(vNode.Status, *translatedStatus) {
 		newNode := vNode.DeepCopy()


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** 
Adds functionality to filter the labels on nodes as they get synced down. Prevents information about the host cluster nodes being leaked.


**Please provide a short message that should be published in the vcluster release notes**
Add capability to filter out specific labels from Nodes synced into vcluster. 


**What else do we need to know?** 
Could possibly tie this to nodes synced enabled.