### PR TITLE
fix(chart): ClusterRole name conflict in multi-namespace mode

### DIFF
--- a/charts/eks/templates/rbac/role.yaml
+++ b/charts/eks/templates/rbac/role.yaml
@@ -6,7 +6,11 @@ kind: Role
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleName" . }}
+{{- else }}
   name: {{ .Release.Name }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/eks/templates/rbac/rolebinding.yaml
+++ b/charts/eks/templates/rbac/rolebinding.yaml
@@ -28,8 +28,10 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
+  name: {{ template "vcluster.clusterRoleName" . }}
 {{- else }}
   kind: Role
+  name: {{ .Release.Name }}
 {{- end }}
   name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -6,7 +6,11 @@ kind: Role
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleName" . }}
+{{- else }}
   name: {{ .Release.Name }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/k0s/templates/rbac/rolebinding.yaml
+++ b/charts/k0s/templates/rbac/rolebinding.yaml
@@ -28,8 +28,10 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
+  name: {{ template "vcluster.clusterRoleName" . }}
 {{- else }}
   kind: Role
+  name: {{ .Release.Name }}
 {{- end }}
   name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -6,7 +6,11 @@ kind: Role
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleName" . }}
+{{- else }}
   name: {{ .Release.Name }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/k3s/templates/rbac/rolebinding.yaml
+++ b/charts/k3s/templates/rbac/rolebinding.yaml
@@ -28,9 +28,10 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
+  name: {{ template "vcluster.clusterRoleName" . }}
 {{- else }}
   kind: Role
-{{- end }}
   name: {{ .Release.Name }}
+{{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -6,7 +6,11 @@ kind: Role
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleName" . }}
+{{- else }}
   name: {{ .Release.Name }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/charts/k8s/templates/rbac/rolebinding.yaml
+++ b/charts/k8s/templates/rbac/rolebinding.yaml
@@ -28,8 +28,10 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
+  name: {{ template "vcluster.clusterRoleName" . }}
 {{- else }}
   kind: Role
+  name: {{ .Release.Name }}
 {{- end }}
   name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes conflict that can occur when more than one multi-namespace vcluster is installed into the same host cluster. E.g.:
> error executing 'helm upgrade vcluster --values /tmp/710276097 --install --namespace vc ./charts/k3s --kube-context minikube': Error: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "vcluster" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "vc": current value is "mn"



**Please provide a short message that should be published in the vcluster release notes**
N/A IMHO, because the multi-namespace mode is a completely new feature