### PR TITLE
fix(ci): E2E workflow should fail faster if the vcluster wasn't ready

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -159,7 +159,7 @@ jobs:
       continue-on-error: true
     
     - name: Collect deployment information in case vcluster fails to start
-      if: steps.wait-until-vcluster-is-ready.outcome == 'failure'
+      if: steps.wait-until-vcluster-is-ready.outcome != 'success'
       run: |
         set -x 
         kubectl get pods -o yaml -n ${{ env.VCLUSTER_NAMESPACE }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
For example in [this workflow run](https://github.com/loft-sh/vcluster/actions/runs/3800221712/jobs/6463528938) the "Wait until vcluster is ready" step was skipped because vcluster failed to install, and the "Collect deployment information in case vcluster fails to start" should have been started, but it was skipped instead. Current behavior wastes time (waiting for results and also CI minutes) before inevitably failing.

**Please provide a short message that should be published in the vcluster release notes**
N/A for CI changes