### PR TITLE
Include vcluster service name in K3s cert SANs by default

### DIFF
--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -172,6 +172,7 @@ spec:
           {{- else }}
             --service-cidr=$(SERVICE_CIDR)
           {{- end }}
+            --tls-san={{ .Release.Name }}
           {{- range $f := .Values.vcluster.extraArgs }}
             {{ $f }}
           {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Ensures that a K3s-based vcluster's Service can be reached by other applications within the host K8s cluster via its DNS name without encountering certificate issues.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the vcluster Service name was missing from the K3s certificate SANs

**What else do we need to know?** 
The vcluster Service name is automatically included as a cert SAN when using CNCF K8s. Therefore, for the sake of consistency, it should work the same way with K3s. Otherwise we need to rely on the ClusterIP or manually adding a `--tls-san=<my_vcluster_name>` to the K3s extraArgs every time.