### PR TITLE
feat(syncer): add --namespace-labels flag

### DIFF
--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -79,9 +79,10 @@ type VirtualClusterOptions struct {
 	HostMetricsBindAddress    string `json:"hostMetricsBindAddress,omitempty"`
 	VirtualMetricsBindAddress string `json:"virtualMetricsBindAddress,omitempty"`
 
-	MultiNamespaceMode bool `json:"multiNamespaceMode,omitempty"`
-	SyncAllSecrets     bool `json:"syncAllSecrets,omitempty"`
-	SyncAllConfigMaps  bool `json:"syncAllConfigMaps,omitempty"`
+	MultiNamespaceMode bool     `json:"multiNamespaceMode,omitempty"`
+	NamespaceLabels    []string `json:"namespaceLabels,omitempty"`
+	SyncAllSecrets     bool     `json:"syncAllSecrets,omitempty"`
+	SyncAllConfigMaps  bool     `json:"syncAllConfigMaps,omitempty"`
 
 	// DEPRECATED FLAGS
 	DeprecatedSyncNodeChanges          bool `json:"syncNodeChanges"`
@@ -155,6 +156,7 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 
 	flags.BoolVar(&options.RewriteHostPaths, "rewrite-host-paths", false, "If enabled, syncer will rewite hostpaths in synced pod volumes")
 	flags.BoolVar(&options.MultiNamespaceMode, "multi-namespace-mode", false, "If enabled, syncer will create a namespace for each virtual namespace and use the original names for the synced namespaced resources")
+	flags.StringSliceVar(&options.NamespaceLabels, "namespace-labels", []string{}, "Defines one or more labels that will be added to the namespaces synced in the multi-namespace mode. Format: \"labelKey=labelValue\". Multiple values can be passed in a comma-separated string.")
 	flags.BoolVar(&options.SyncAllConfigMaps, "sync-all-configmaps", false, "Sync all configmaps from virtual to host cluster")
 	flags.BoolVar(&options.SyncAllSecrets, "sync-all-secrets", false, "Sync all secrets from virtual to host cluster")
 

--- a/pkg/controllers/resources/namespaces/translate.go
+++ b/pkg/controllers/resources/namespaces/translate.go
@@ -3,18 +3,29 @@ package namespaces
 import (
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (s *namespaceSyncer) translate(vObj client.Object) *corev1.Namespace {
 	newNamespace := s.TranslateMetadata(vObj).(*corev1.Namespace)
+	// add user defined namespace labels
+	for k, v := range s.namespaceLabels {
+		newNamespace.Labels[k] = v
+	}
 	return newNamespace
 }
 
 func (s *namespaceSyncer) translateUpdate(pObj, vObj *corev1.Namespace) *corev1.Namespace {
 	var updated *corev1.Namespace
-	changed, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
-	if changed {
+
+	_, updatedAnnotations, updatedLabels := s.TranslateMetadataUpdate(vObj, pObj)
+	// add user defined namespace labels
+	for k, v := range s.namespaceLabels {
+		updatedLabels[k] = v
+	}
+	// check if any labels or annotations changed
+	if !equality.Semantic.DeepEqual(updatedAnnotations, pObj.GetAnnotations()) || !equality.Semantic.DeepEqual(updatedLabels, pObj.GetLabels()) {
 		updated = translator.NewIfNil(updated, pObj)
 		updated.Annotations = updatedAnnotations
 		updated.Labels = updatedLabels


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Adds an option to set additional labels on the namespaces synced in the multi-namespace mode.


**Please provide a short message that should be published in the vcluster release notes**
Add --namespace-labels flag to allow setting additional labels on the namespaces synced in the multi-namespace mode.

**What else do we need to know?** 
Closes ENG-843