### PR TITLE
fix(chart): fix non k3s charts rolebinding name

### DIFF
--- a/charts/eks/templates/rbac/rolebinding.yaml
+++ b/charts/eks/templates/rbac/rolebinding.yaml
@@ -33,6 +33,5 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}
 {{- end }}
-  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/k0s/templates/rbac/rolebinding.yaml
+++ b/charts/k0s/templates/rbac/rolebinding.yaml
@@ -33,6 +33,5 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}
 {{- end }}
-  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/k8s/templates/rbac/rolebinding.yaml
+++ b/charts/k8s/templates/rbac/rolebinding.yaml
@@ -33,6 +33,5 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}
 {{- end }}
-  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster non k3s templates had a small issue w/ role binding name


**What else do we need to know?** 
Guessing this just got missed in the other charts, so I made the non k3s charts look like the k3s one!