### PR TITLE
fix(chart): fix overwriting second clusterrole/binding when using multinamespace mode

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -67,6 +67,10 @@ Whether to create a cluster role or not
 {{- printf "vc-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "vcluster.clusterRoleNameMultinamespace" -}}
+{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -75,5 +75,8 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
 {{- end }}

--- a/charts/eks/templates/rbac/role.yaml
+++ b/charts/eks/templates/rbac/role.yaml
@@ -7,7 +7,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.multiNamespaceMode.enabled }}
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   name: {{ .Release.Name }}
 {{- end }}

--- a/charts/eks/templates/rbac/rolebinding.yaml
+++ b/charts/eks/templates/rbac/rolebinding.yaml
@@ -6,8 +6,12 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
+{{- else }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -28,7 +32,7 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   kind: Role
   name: {{ .Release.Name }}

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -67,6 +67,10 @@ Whether to create a cluster role or not
 {{- printf "vc-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "vcluster.clusterRoleNameMultinamespace" -}}
+{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/k0s/templates/rbac/clusterrole.yaml
+++ b/charts/k0s/templates/rbac/clusterrole.yaml
@@ -75,5 +75,8 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
 {{- end }}

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -7,7 +7,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.multiNamespaceMode.enabled }}
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   name: {{ .Release.Name }}
 {{- end }}

--- a/charts/k0s/templates/rbac/rolebinding.yaml
+++ b/charts/k0s/templates/rbac/rolebinding.yaml
@@ -6,8 +6,12 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
+{{- else }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -28,7 +32,7 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   kind: Role
   name: {{ .Release.Name }}

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -67,6 +67,10 @@ Whether to create a cluster role or not
 {{- printf "vc-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "vcluster.clusterRoleNameMultinamespace" -}}
+{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -75,5 +75,8 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
 {{- end }}

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -7,7 +7,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.multiNamespaceMode.enabled }}
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   name: {{ .Release.Name }}
 {{- end }}

--- a/charts/k3s/templates/rbac/rolebinding.yaml
+++ b/charts/k3s/templates/rbac/rolebinding.yaml
@@ -6,8 +6,12 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
+{{- else }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -28,7 +32,7 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   kind: Role
   name: {{ .Release.Name }}

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -67,6 +67,10 @@ Whether to create a cluster role or not
 {{- printf "vc-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "vcluster.clusterRoleNameMultinamespace" -}}
+{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/k8s/templates/rbac/clusterrole.yaml
+++ b/charts/k8s/templates/rbac/clusterrole.yaml
@@ -75,5 +75,8 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["create", "delete", "patch", "update", "get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
   {{- end }}
 {{- end }}

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -7,7 +7,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.multiNamespaceMode.enabled }}
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   name: {{ .Release.Name }}
 {{- end }}

--- a/charts/k8s/templates/rbac/rolebinding.yaml
+++ b/charts/k8s/templates/rbac/rolebinding.yaml
@@ -6,8 +6,12 @@ kind: RoleBinding
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.multiNamespaceMode.enabled }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
+{{- else }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -28,7 +32,7 @@ subjects:
 roleRef:
 {{- if .Values.multiNamespaceMode.enabled }}
   kind: ClusterRole
-  name: {{ template "vcluster.clusterRoleName" . }}
+  name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   kind: Role
   name: {{ .Release.Name }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster charts for Multinamespace mode would overwrite role/bindings causing syncer to have insufficient privileges


**What else do we need to know?** 
N/A