### PR TITLE
Add ownerreferences to synced services

### DIFF
--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -353,10 +353,11 @@ func registerServiceSyncControllers(ctx *context.ControllerContext) error {
 		}
 
 		controller := &servicesync.ServiceSyncer{
-			SyncServices: mapping,
-			From:         ctx.VirtualManager,
-			To:           ctx.LocalManager,
-			Log:          loghelper.New("map-virtual-service-syncer"),
+			SyncServices:          mapping,
+			IsVirtualToHostSyncer: true,
+			From:                  ctx.VirtualManager,
+			To:                    ctx.LocalManager,
+			Log:                   loghelper.New("map-virtual-service-syncer"),
 		}
 		err = controller.Register()
 		if err != nil {

--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -123,6 +123,8 @@ func (e *ServiceSyncer) syncServiceWithSelector(ctx context.Context, fromService
 				Ports: fromService.Spec.Ports,
 			},
 		}
+
+		toService.OwnerReferences = translate.GetOwnerReference(nil)
 		toService.Spec.Selector = translate.Default.TranslateLabels(fromService.Spec.Selector, fromService.Namespace, nil)
 		e.Log.Infof("Create target service %s/%s because it is missing", to.Namespace, to.Name)
 		return ctrl.Result{}, e.To.GetClient().Create(ctx, toService)
@@ -189,6 +191,8 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 				ClusterIP: corev1.ClusterIPNone,
 			},
 		}
+
+		toService.OwnerReferences = translate.GetOwnerReference(nil)
 		e.Log.Infof("Create target service %s/%s because it is missing", to.Namespace, to.Name)
 		return ctrl.Result{}, e.To.GetClient().Create(ctx, toService)
 	} else if toService.Labels == nil || toService.Labels[translate.ControllerLabel] != "vcluster" {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #896 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster doesn't clean up services that have been created via the `--map-virtual-service` option when the vcluster is delete.


**What else do we need to know?** 

