### PR TITLE
fix: always render the (cluster because multinamespace)role when multi ns enabled

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.persistentvolumes.enabled
     .Values.sync.storageclasses.enabled
     .Values.sync.priorityclasses.enabled
-    .Values.sync.volumesnapshots.enabled -}}
+    .Values.sync.volumesnapshots.enabled
+    .Values.multiNamespaceMode.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.persistentvolumes.enabled
     .Values.sync.storageclasses.enabled
     .Values.sync.priorityclasses.enabled
-    .Values.sync.volumesnapshots.enabled -}}
+    .Values.sync.volumesnapshots.enabled
+    .Values.multiNamespaceMode.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.persistentvolumes.enabled
     .Values.sync.storageclasses.enabled
     .Values.sync.priorityclasses.enabled
-    .Values.sync.volumesnapshots.enabled -}}
+    .Values.sync.volumesnapshots.enabled
+    .Values.multiNamespaceMode.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.persistentvolumes.enabled
     .Values.sync.storageclasses.enabled
     .Values.sync.priorityclasses.enabled
-    .Values.sync.volumesnapshots.enabled -}}
+    .Values.sync.volumesnapshots.enabled
+    .Values.multiNamespaceMode.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster doesn't render role needed for multinamespace mode


**What else do we need to know?** 
think I didn't realize before in testing since I copied values I use for home dev vclusters which included ingress sync, which caused that template logic to be true, which made things work.

would it make sense to have a (cluster)role especially for multinamespace mode instead of tacking on extra conditionals to existing roles making things a bit more confusing?
