### PR TITLE
Update supported distros to v1.26

### DIFF
--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -100,7 +100,6 @@ spec:
           {{- end }}
           - '--node-monitor-grace-period=180s'
           - '--node-monitor-period=30s'
-          - '--port=0'
           - '--pvclaimbinder-sync-period=60s'
           - '--requestheader-client-ca-file=/run/config/pki/front-proxy-ca.crt'
           - '--root-ca-file=/run/config/pki/ca.crt'

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -159,7 +159,7 @@ syncer:
 
 # Etcd settings
 etcd:
-  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-24-3
+  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-24-7
   # The amount of replicas to run 
   replicas: 1
   # NodeSelector used
@@ -193,7 +193,7 @@ etcd:
 
 # Kubernetes Controller Manager settings
 controller:
-  image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4
+  image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.9-eks-1-24-7
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used 
@@ -216,7 +216,7 @@ controller:
 
 # Kubernetes API Server settings
 api:
-  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3
+  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.9-eks-1-24-7
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1
@@ -241,7 +241,7 @@ api:
 
 # Core DNS settings
 coredns:
-  image: public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-3
+  image: public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-7
   replicas: 1
   resources:
     limits:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -139,7 +139,7 @@ syncer:
 # Virtual Cluster (k0s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: k0sproject/k0s:v1.25.3-k0s.0
+  image: k0sproject/k0s:v1.26.0-k0s.0
   command:
     - k0s
   baseArgs:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -150,7 +150,7 @@ syncer:
 # Virtual Cluster (k3s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: rancher/k3s:v1.25.3-k3s1
+  image: rancher/k3s:v1.26.0-k3s1
   command:
     - /bin/k3s
   baseArgs:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -197,7 +197,7 @@ etcd:
   securityContext: {}
 # Kubernetes Controller Manager settings
 controller:
-  image: registry.k8s.io/kube-controller-manager:v1.26.0
+  image: registry.k8s.io/kube-controller-manager:v1.26.1
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used 
@@ -219,7 +219,7 @@ controller:
   securityContext: {}
 # Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
 scheduler:
-  image: registry.k8s.io/kube-scheduler:v1.26.0
+  image: registry.k8s.io/kube-scheduler:v1.26.1
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -241,7 +241,7 @@ scheduler:
 
 # Kubernetes API Server settings
 api:
-  image: registry.k8s.io/kube-apiserver:v1.26.0
+  image: registry.k8s.io/kube-apiserver:v1.26.1
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
-	github.com/loft-sh/utils v0.0.14
+	github.com/loft-sh/utils v0.0.15
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyP
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
-github.com/loft-sh/utils v0.0.14 h1:oSMqghhW3Pqc/3OxQbbpelqx7wyIVPQM24CnZEKwW0s=
-github.com/loft-sh/utils v0.0.14/go.mod h1:n2L3X4i7d8kb2NF+q5duKa41N+N6fBde6XY2AolgSBI=
+github.com/loft-sh/utils v0.0.15 h1:OfW9D6Xf7wFxplK1b7pjVVyYeh8tvZcygbGBcHEYc9A=
+github.com/loft-sh/utils v0.0.15/go.mod h1:n2L3X4i7d8kb2NF+q5duKa41N+N6fBde6XY2AolgSBI=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
@@ -8,34 +8,34 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.13-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.15-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.14-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.9-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.15-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.17-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.14-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.20.15-eks-1-20-22",
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.13-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.15-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.14-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.9-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.15-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.17-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.14-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.20.15-eks-1-20-22",
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-24-3",
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-20-22",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-3",
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-20-22",
 }
 

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
@@ -8,10 +8,11 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.25": "k0sproject/k0s:v1.25.3-k0s.0",
-	"1.24": "k0sproject/k0s:v1.24.7-k0s.0",
-	"1.23": "k0sproject/k0s:v1.23.13-k0s.0",
-	"1.22": "k0sproject/k0s:v1.22.15-k0s.0",
+	"1.26": "k0sproject/k0s:v1.26.0-k0s.0",
+	"1.25": "k0sproject/k0s:v1.25.5-k0s.0",
+	"1.24": "k0sproject/k0s:v1.24.9-k0s.0",
+	"1.23": "k0sproject/k0s:v1.23.15-k0s.0",
+	"1.22": "k0sproject/k0s:v1.22.17-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {
@@ -23,9 +24,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 25 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
-			image = K0SVersionMap["1.25"]
+		if serverMinorInt > 26 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
+			image = K0SVersionMap["1.26"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			image = K0SVersionMap["1.22"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
@@ -12,10 +12,11 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.25": "rancher/k3s:v1.25.3-k3s1",
-	"1.24": "rancher/k3s:v1.24.7-k3s1",
-	"1.23": "rancher/k3s:v1.23.13-k3s1",
-	"1.22": "rancher/k3s:v1.22.15-k3s1",
+	"1.26": "rancher/k3s:v1.26.0-k3s1",
+	"1.25": "rancher/k3s:v1.25.5-k3s1",
+	"1.24": "rancher/k3s:v1.24.9-k3s1",
+	"1.23": "rancher/k3s:v1.23.15-k3s1",
+	"1.22": "rancher/k3s:v1.22.17-k3s1",
 	"1.21": "rancher/k3s:v1.21.14-k3s1",
 	"1.20": "rancher/k3s:v1.20.15-k3s1",
 	"1.19": "rancher/k3s:v1.19.16-k3s1",
@@ -59,10 +60,10 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 25 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
-				image = K3SVersionMap["1.25"]
-				serverVersionString = "1.25"
+			if serverMinorInt > 26 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
+				image = K3SVersionMap["1.26"]
+				serverVersionString = "1.26"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
@@ -8,30 +8,30 @@ import (
 )
 
 var K8SAPIVersionMap = map[string]string{
-	"1.26": "registry.k8s.io/kube-apiserver:v1.26.0",
-	"1.25": "registry.k8s.io/kube-apiserver:v1.25.5",
-	"1.24": "registry.k8s.io/kube-apiserver:v1.24.9",
-	"1.23": "registry.k8s.io/kube-apiserver:v1.23.15",
+	"1.26": "registry.k8s.io/kube-apiserver:v1.26.1",
+	"1.25": "registry.k8s.io/kube-apiserver:v1.25.6",
+	"1.24": "registry.k8s.io/kube-apiserver:v1.24.10",
+	"1.23": "registry.k8s.io/kube-apiserver:v1.23.16",
 	"1.22": "registry.k8s.io/kube-apiserver:v1.22.17",
 	"1.21": "registry.k8s.io/kube-apiserver:v1.21.14",
 	"1.20": "registry.k8s.io/kube-apiserver:v1.20.15",
 }
 
 var K8SControllerVersionMap = map[string]string{
-	"1.26": "registry.k8s.io/kube-controller-manager:v1.26.0",
-	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.5",
-	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.9",
-	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.15",
+	"1.26": "registry.k8s.io/kube-controller-manager:v1.26.1",
+	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.6",
+	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.10",
+	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.16",
 	"1.22": "registry.k8s.io/kube-controller-manager:v1.22.17",
 	"1.21": "registry.k8s.io/kube-controller-manager:v1.21.14",
 	"1.20": "registry.k8s.io/kube-controller-manager:v1.20.15",
 }
 
 var K8SSchedulerVersionMap = map[string]string{
-	"1.26": "registry.k8s.io/kube-scheduler:v1.26.0",
-	"1.25": "registry.k8s.io/kube-scheduler:v1.25.5",
-	"1.24": "registry.k8s.io/kube-scheduler:v1.24.9",
-	"1.23": "registry.k8s.io/kube-scheduler:v1.23.15",
+	"1.26": "registry.k8s.io/kube-scheduler:v1.26.1",
+	"1.25": "registry.k8s.io/kube-scheduler:v1.25.6",
+	"1.24": "registry.k8s.io/kube-scheduler:v1.24.10",
+	"1.23": "registry.k8s.io/kube-scheduler:v1.23.16",
 	"1.22": "registry.k8s.io/kube-scheduler:v1.22.17",
 	"1.21": "registry.k8s.io/kube-scheduler:v1.21.14",
 	"1.20": "registry.k8s.io/kube-scheduler:v1.20.15",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -239,7 +239,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/utils v0.0.14
+# github.com/loft-sh/utils v0.0.15
 ## explicit; go 1.19
 github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Updated supported distros to v1.26


**What else do we need to know?**    
- updated k0s,k3s,k8s chart image to latest stable release for v1.26
- updated eks chart image to latest stable release for v1.24

Closes ENG-894