### PR TITLE
fix: ensure multinamespace role name not broken by truncation

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Whether to create a cluster role or not
 {{- end -}}
 
 {{- define "vcluster.clusterRoleNameMultinamespace" -}}
-{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-mn-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Whether to create a cluster role or not
 {{- end -}}
 
 {{- define "vcluster.clusterRoleNameMultinamespace" -}}
-{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-mn-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Whether to create a cluster role or not
 {{- end -}}
 
 {{- define "vcluster.clusterRoleNameMultinamespace" -}}
-{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-mn-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Whether to create a cluster role or not
 {{- end -}}
 
 {{- define "vcluster.clusterRoleNameMultinamespace" -}}
-{{- printf "vc-%s-v-%s-mn" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-mn-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vclusters in multinamespace mode with long release names would not get the second cluster role created


**What else do we need to know?** 
basically just a better version of the previous "fix", this time hopefully for real :D