### PR TITLE
Allow virtual cluster to host cluster service mapping to work with multi-namespace mode

### DIFF
--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -364,6 +364,11 @@ func registerServiceSyncControllers(ctx *context.ControllerContext) error {
 			To:                    ctx.LocalManager,
 			Log:                   loghelper.New("map-virtual-service-syncer"),
 		}
+
+		if ctx.Options.MultiNamespaceMode {
+			controller.CreateEndpoints = true
+		}
+
 		err = controller.Register()
 		if err != nil {
 			return errors.Wrap(err, "register virtual service sync controller")


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**Please provide a short message that should be published in the vcluster release notes**
Allow virtual cluster to host cluster service mapping to work with multi-namespace mode


**What else do we need to know?** 
Currently, in case of Virtual->Host service mapping, the service that gets created on the host cluster relies on label-selector based method to map the workloads. This works for single-namespace mode, as the end service and workloads are in the same namespace. But, for multi-namespace, it doesn't work as the workload is in a different namespace.

With this PR, we are creating a headless service on the host and setting the endpoint for this service equal to the clusterIP of the virtual cluster service.

Closes ENG-891