### PR TITLE
feat(chart): expose .securityContext.runAsGroup

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -176,6 +176,7 @@ data:
             securityContext:
               runAsNonRoot:  true
               runAsUser:  {{`{{.RUN_AS_USER}}`}}
+              runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
               allowPrivilegeEscalation: false
               capabilities:
                 drop:

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -174,8 +174,8 @@ data:
               name: metrics
               protocol: TCP
             securityContext:
-              runAsUser: {{ .RUN_AS_USER }}
-              runAsNonRoot: {{ .RUN_AS_NON_ROOT }}
+              runAsNonRoot:  true
+              runAsUser:  {{`{{.RUN_AS_USER}}`}}
               allowPrivilegeEscalation: false
               capabilities:
                 drop:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -177,6 +177,7 @@ data:
               securityContext:
                 runAsNonRoot: true
                 runAsUser: {{`{{.RUN_AS_USER}}`}}
+                runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -175,8 +175,8 @@ data:
                   name: metrics
                   protocol: TCP
               securityContext:
+                runAsNonRoot: true
                 runAsUser: {{`{{.RUN_AS_USER}}`}}
-                runAsNonRoot: {{`{{.RUN_AS_NON_ROOT}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -181,6 +181,7 @@ data:
               securityContext:
                 runAsNonRoot: true
                 runAsUser: {{`{{.RUN_AS_USER}}`}}
+                runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -179,8 +179,8 @@ data:
                   name: metrics
                   protocol: TCP
               securityContext:
+                runAsNonRoot: true
                 runAsUser: {{`{{.RUN_AS_USER}}`}}
-                runAsNonRoot: {{`{{.RUN_AS_NON_ROOT}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -177,6 +177,7 @@ data:
               securityContext:
                 runAsNonRoot: true
                 runAsUser: {{`{{.RUN_AS_USER}}`}}
+                runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -175,8 +175,8 @@ data:
                   name: metrics
                   protocol: TCP
               securityContext:
+                runAsNonRoot: true
                 runAsUser: {{`{{.RUN_AS_USER}}`}}
-                runAsNonRoot: {{`{{.RUN_AS_NON_ROOT}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/docs/pages/fragments/non-root-vcluster.mdx
+++ b/docs/pages/fragments/non-root-vcluster.mdx
@@ -14,9 +14,12 @@ import TabItem from '@theme/TabItem'
 Create a `values.yaml` file with the following lines:
 
 ```
+#fsGroup: 12345
 securityContext:
   runAsUser: 12345
+  runAsGroup: 12345
   runAsNonRoot: true
+
 ```
 
 Then create the vcluster with the following command:
@@ -32,8 +35,10 @@ Update the `vcluster.yaml` file described in the [deployment guide](../getting-s
 You will need to add the `securityContext` block as shown below:
 
 ```yaml
+#fsGroup: 12345
 securityContext:
   runAsUser: 12345
+  runAsGroup: 12345
   runAsNonRoot: true
 ```
 
@@ -46,7 +51,7 @@ You will need to add the `securityContext` blocks to the containers as shown bel
 
 ```
 kubectl create namespace host-namespace-1
-helm template my-vcluster vcluster --repo https://charts.loft.sh --set securityContext.runAsUser=12345 --set securityContext.runAsNonRoot=true -n host-namespace-1 | kubectl apply -f -
+helm template my-vcluster vcluster --repo https://charts.loft.sh --set securityContext.runAsGroup=12345 --set fsGroup=12345 --set securityContext.runAsUser=12345 --set securityContext.runAsNonRoot=true -n host-namespace-1 | kubectl apply -f -
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
- fix(chart): ignoring .securityContext values for coredns
- feat(chart): expose .securityContext.runAsGroup for coredns

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #742 
resolves ENG-414

**Please provide a short message that should be published in the vcluster release notes**


fix: pass securityContext.runAsGroup setting to coredns


**What else do we need to know?** 

Updated documentation as well