### PR TITLE
fix(syncer): disable csi object syncers if api absent

### DIFF
--- a/cmd/vcluster/context/context.go
+++ b/cmd/vcluster/context/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +37,16 @@ func NewControllerContext(currentNamespace string, localManager ctrl.Manager, vi
 
 	// parse enabled controllers
 	controllers, err := parseControllers(options)
+	if err != nil {
+		return nil, err
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(localManager.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	controllers, err = disableMissingAPIs(discoveryClient, controllers)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/vcluster/context/enable_controllers_test.go
+++ b/cmd/vcluster/context/enable_controllers_test.go
@@ -6,7 +6,10 @@ import (
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	fakeDiscovery "k8s.io/client-go/discovery/fake"
+	clientTesting "k8s.io/client-go/testing"
 )
 
 func TestEnableControllers(t *testing.T) {
@@ -115,6 +118,7 @@ func TestEnableControllers(t *testing.T) {
 		if tc.optsModifier != nil {
 			tc.optsModifier(&opts)
 		}
+
 		foundControllers, err := parseControllers(&opts)
 		if tc.expectError {
 			assert.ErrorContains(t, err, tc.errSubString, "should have failed validation")
@@ -122,12 +126,94 @@ func TestEnableControllers(t *testing.T) {
 			assert.NilError(t, err, "should have passed validation")
 		}
 
-		expectedNotFound := sets.New[string](tc.expectEnabled...).Difference(foundControllers)
+		expectedNotFound := sets.New(tc.expectEnabled...).Difference(foundControllers)
 		assert.Assert(t, is.Len(sets.List(expectedNotFound), 0), "should be enabled, but not enabled")
 
-		disabledFound := sets.New[string](tc.expectDisabled...).Intersection(foundControllers)
+		disabledFound := sets.New(tc.expectDisabled...).Intersection(foundControllers)
 		assert.Assert(t, is.Len(sets.List(disabledFound), 0), "should be disabled, but found enabled")
 
 	}
 
+}
+
+var csiStorageCapacityV1 = metav1.APIResource{
+	Name:         "csistoragecapacities",
+	SingularName: "csistoragecapacity",
+	Namespaced:   false,
+	Group:        "storage.k8s.io",
+	Version:      "v1",
+	Kind:         "CSIStorageCapacity",
+}
+
+var csiDriverV1 = metav1.APIResource{
+	Name:         "csidrivers",
+	SingularName: "csidriver",
+	Namespaced:   false,
+	Group:        "storage.k8s.io",
+	Version:      "v1",
+	Kind:         "CSIDriver",
+}
+
+var csiNodeV1 = metav1.APIResource{
+	Name:         "csinodes",
+	SingularName: "csinode",
+	Namespaced:   false,
+	Group:        "storage.k8s.io",
+	Version:      "v1",
+	Kind:         "CSINode",
+}
+
+func TestDisableMissingAPIs(t *testing.T) {
+	tests := []struct {
+		name             string
+		apis             map[string][]metav1.APIResource
+		expectedNotFound sets.Set[string]
+		expectedFound    sets.Set[string]
+	}{
+		{
+			name:             "K8s 1.21 or lower",
+			apis:             map[string][]metav1.APIResource{},
+			expectedNotFound: schedulerRequiredControllers,
+			expectedFound:    sets.New[string](),
+		},
+		{
+			name: "K8s 1.23 or lower",
+			apis: map[string][]metav1.APIResource{
+				storageV1GroupVersion: {csiNodeV1, csiDriverV1},
+			},
+			expectedNotFound: sets.New("csistoragecapacities"),
+			expectedFound:    sets.New("csinodes", "csidrivers"),
+		},
+		{
+			name: "K8s 1.24 or higher",
+			apis: map[string][]metav1.APIResource{
+				storageV1GroupVersion: {csiNodeV1, csiDriverV1, csiStorageCapacityV1},
+			},
+			expectedNotFound: sets.New[string](),
+			expectedFound:    sets.New("csistoragecapacities", "csinodes", "csidrivers"),
+		},
+	}
+
+	for i, testCase := range tests {
+		t.Logf("running test #%d: %q", i, testCase.name)
+		// initialize mocked discovery
+		resourceLists := []*metav1.APIResourceList{}
+		for groupVersion, resourceList := range testCase.apis {
+			resourceLists = append(resourceLists, &metav1.APIResourceList{GroupVersion: groupVersion, APIResources: resourceList})
+		}
+		fakeDisoveryClient := &fakeDiscovery.FakeDiscovery{Fake: &clientTesting.Fake{Resources: resourceLists}}
+
+		// run function
+		actualControllers, err := disableMissingAPIs(fakeDisoveryClient, ExistingControllers.Clone())
+		assert.NilError(t, err)
+
+		// unexpectedly not disabled
+		notDisabled := actualControllers.Intersection(testCase.expectedNotFound).UnsortedList()
+		assert.Assert(t, is.Len(notDisabled, 0), "expected %q to be disabled", testCase.expectedNotFound.UnsortedList())
+
+		// should be enabled
+		missing := testCase.expectedFound.Difference(actualControllers).UnsortedList()
+		assert.Assert(t, is.Len(missing, 0), "expected %q to be found, but found only: %q", testCase.expectedFound.UnsortedList(), actualControllers.Intersection(testCase.expectedFound).UnsortedList())
+
+	}
 }

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -115,12 +115,13 @@ func ExecuteInitializers(controllerCtx *context.ControllerContext, syncers []syn
 	errorGroup, ctx := errgroup.WithContext(controllerCtx.Context)
 	registerContext.Context = ctx
 	for _, s := range syncers {
+		name := s.Name()
 		initializer, ok := s.(syncer.Initializer)
 		if ok {
 			errorGroup.Go(func() error {
 				err := initializer.Init(registerContext)
 				if err != nil {
-					return errors.Wrapf(err, "ensure prerequisites for %s syncer", s.Name())
+					return errors.Wrapf(err, "ensure prerequisites for %s syncer", name)
 				}
 				return nil
 			})


### PR DESCRIPTION
- fix(syncer): disable csi object syncers if api absent
- refactor: remove loop variable capture in logging

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

resolves ENG-803

fixes #863 

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where vcluster crashes on older versions of k8s if both scheduler and PVC syncer are enabled.


**What else do we need to know?** 
Example log on 1.23:
```
W0201 08:19:48.068487       1 enable_controllers.go:180] host kubernetes apiserver not advertising resource "csistora
gecapacities" in GroupVersion "storage.k8s.io/v1", disabling the syncer
```
