### PR TITLE
fix: Virtual-to-Host service mapping should work with omitted Host namespace

### DIFF
--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -305,8 +305,13 @@ func registerInitManifestsController(ctx *context.ControllerContext) error {
 }
 
 func registerServiceSyncControllers(ctx *context.ControllerContext) error {
+	hostNamespace := ctx.Options.TargetNamespace
+	if ctx.Options.MultiNamespaceMode {
+		hostNamespace = ctx.CurrentNamespace
+	}
+
 	if len(ctx.Options.MapHostServices) > 0 {
-		mapping, err := parseMapping(ctx.Options.MapHostServices, ctx.Options.TargetNamespace, "")
+		mapping, err := parseMapping(ctx.Options.MapHostServices, hostNamespace, "")
 		if err != nil {
 			return errors.Wrap(err, "parse physical service mapping")
 		}
@@ -353,7 +358,7 @@ func registerServiceSyncControllers(ctx *context.ControllerContext) error {
 	}
 
 	if len(ctx.Options.MapVirtualServices) > 0 {
-		mapping, err := parseMapping(ctx.Options.MapVirtualServices, "", ctx.Options.TargetNamespace)
+		mapping, err := parseMapping(ctx.Options.MapVirtualServices, "", hostNamespace)
 		if err != nil {
 			return errors.Wrap(err, "parse physical service mapping")
 		}

--- a/test/multins_values.yaml
+++ b/test/multins_values.yaml
@@ -1,7 +1,2 @@
 multiNamespaceMode:
   enabled: true
-
-mapServices:
-  fromVirtual:
-  - from: test/test
-    to: vcluster/test


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes incorrect behavior in multi-namespace mode and makes it match the behavior in the default mode - host namespace can be omitted in the mapping definition, the namespace where vcluster is installed is used in such case.
The change made to the `test/multins_values.yaml` would have resulted in test failure previously.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where virtual-to-host service mapping validation would fail in multi-namespace mode if the host service namespace was omitted.