### PR TITLE
fix(vcluster): ensure node addresses match certificate wildcard

### DIFF
--- a/pkg/constants/indices.go
+++ b/pkg/constants/indices.go
@@ -8,4 +8,6 @@ const (
 	IndexByIngressSecret = "IndexByIngressSecret"
 	IndexByPodSecret     = "IndexByPodSecret"
 	IndexByConfigMap     = "IndexByConfigMap"
+	// IndexByHostName is used to map rewritten hostnames(advertised as node addresses) to nodenames
+	IndexByHostName = "IndexByHostName"
 )

--- a/pkg/controllers/resources/nodes/fake_syncer_test.go
+++ b/pkg/controllers/resources/nodes/fake_syncer_test.go
@@ -1,10 +1,11 @@
 package nodes
 
 import (
+	"testing"
+
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"gotest.tools/assert"
-	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -108,7 +109,7 @@ func TestFakeSync(t *testing.T) {
 			},
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},

--- a/pkg/controllers/resources/nodes/syncer_test.go
+++ b/pkg/controllers/resources/nodes/syncer_test.go
@@ -1,9 +1,10 @@
 package nodes
 
 import (
+	"testing"
+
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"testing"
 
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -65,7 +66,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -91,7 +92,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -196,7 +197,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -221,7 +222,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -320,7 +321,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -341,7 +342,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -458,7 +459,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -479,7 +480,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},
@@ -523,7 +524,7 @@ func TestSync(t *testing.T) {
 		Status: corev1.NodeStatus{
 			Addresses: []corev1.NodeAddress{
 				{
-					Address: getNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
+					Address: GetNodeHost(baseName.Name, generictesting.DefaultTestCurrentNamespace),
 					Type:    corev1.NodeHostName,
 				},
 			},

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -133,7 +133,7 @@ func (s *nodeSyncer) translateUpdateStatus(pNode *corev1.Node, vNode *corev1.Nod
 		// translate addresses
 		newAddresses := []corev1.NodeAddress{
 			{
-				Address: getNodeHost(vNode.Name, s.currentNamespace),
+				Address: GetNodeHost(vNode.Name, s.currentNamespace),
 				Type:    corev1.NodeHostName,
 			},
 		}


### PR DESCRIPTION
x509 certificate wildcards don't match subdomains, so we replace the
node address hostname dots with dashes, index that, and translate it
back to the nodename as necessary.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-1013


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster metrics were unreachable under certain conditions.


**What else do we need to know?** 
