### PR TITLE
Improve dual stack support

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -444,7 +444,11 @@ func (cmd *CreateCmd) prepare(vClusterName string) error {
 
 	// get service cidr
 	if cmd.CIDR == "" {
-		cmd.CIDR = servicecidr.GetServiceCIDR(cmd.kubeClient, cmd.Namespace)
+		cidr, warning := servicecidr.GetServiceCIDR(cmd.kubeClient, cmd.Namespace)
+		if warning != "" {
+			cmd.log.Warn(warning)
+		}
+		cmd.CIDR = cidr
 	}
 
 	return nil

--- a/cmd/vclusterctl/cmd/get/service_cidr.go
+++ b/cmd/vclusterctl/cmd/get/service_cidr.go
@@ -69,7 +69,10 @@ func (cmd *serviceCIDRCmd) Run(cobraCmd *cobra.Command) error {
 		}
 	}
 
-	cidr := servicecidr.GetServiceCIDR(client, cmd.Namespace)
+	cidr, warning := servicecidr.GetServiceCIDR(client, cmd.Namespace)
+	if warning != "" {
+		cmd.log.Debugf(warning)
+	}
 
 	_, err = cmd.log.Write([]byte(cidr))
 	if err != nil {

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -4,11 +4,11 @@ set +e  # Continue on errors
 COLOR_CYAN="\033[0;36m"
 COLOR_RESET="\033[0m"
 
-RUN_CMD="export CONFIG=\$(cat hack/test-config.yaml) && go run -mod vendor cmd/vcluster/main.go start"
-RUN_CMD_K8S="echo \"Run syncer with k8s flags\" && export CONFIG=\$(cat hack/test-config.yaml) && go run -mod vendor cmd/vcluster/main.go start --request-header-ca-cert=/pki/ca.crt --client-ca-cert=/pki/ca.crt --server-ca-cert=/pki/ca.crt --server-ca-key=/pki/ca.key --kube-config=/pki/admin.conf"
-RUN_CMD_K0S="echo \"Run syncer with k0s flags\" && export CONFIG=\$(cat hack/test-config.yaml) && go run -mod vendor cmd/vcluster/main.go start --request-header-ca-cert=/data/k0s/pki/ca.crt --client-ca-cert=/data/k0s/pki/ca.crt --server-ca-cert=/data/k0s/pki/ca.crt --server-ca-key=/data/k0s/pki/ca.key --kube-config=/data/k0s/pki/admin.conf"
-RUN_CMD_EKS="echo \"Run syncer with eks flags\" && export CONFIG=\$(cat hack/test-config.yaml) && go run -mod vendor cmd/vcluster/main.go start  --request-header-ca-cert=/pki/ca.crt --client-ca-cert=/pki/ca.crt --server-ca-cert=/pki/ca.crt --server-ca-key=/pki/ca.key --kube-config=/pki/admin.conf"
-DEBUG_CMD="export CONFIG=\$(cat hack/test-config.yaml) && dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- start"
+RUN_CMD="CONFIG=\$(cat hack/test-config.yaml) go run -mod vendor cmd/vcluster/main.go start"
+RUN_CMD_K8S="echo \"Run syncer with k8s flags\" && CONFIG=\$(cat hack/test-config.yaml) go run -mod vendor cmd/vcluster/main.go start --request-header-ca-cert=/pki/ca.crt --client-ca-cert=/pki/ca.crt --server-ca-cert=/pki/ca.crt --server-ca-key=/pki/ca.key --kube-config=/pki/admin.conf"
+RUN_CMD_K0S="echo \"Run syncer with k0s flags\" && CONFIG=\$(cat hack/test-config.yaml) go run -mod vendor cmd/vcluster/main.go start --request-header-ca-cert=/data/k0s/pki/ca.crt --client-ca-cert=/data/k0s/pki/ca.crt --server-ca-cert=/data/k0s/pki/ca.crt --server-ca-key=/data/k0s/pki/ca.key --kube-config=/data/k0s/pki/admin.conf"
+RUN_CMD_EKS="echo \"Run syncer with eks flags\" && CONFIG=\$(cat hack/test-config.yaml) go run -mod vendor cmd/vcluster/main.go start  --request-header-ca-cert=/pki/ca.crt --client-ca-cert=/pki/ca.crt --server-ca-cert=/pki/ca.crt --server-ca-key=/pki/ca.key --kube-config=/pki/admin.conf"
+DEBUG_CMD="CONFIG=\$(cat hack/test-config.yaml) dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- start"
 
 echo -e "${COLOR_CYAN}
    ____              ____

--- a/hack/test-config.yaml
+++ b/hack/test-config.yaml
@@ -1,18 +1,18 @@
 version: v1beta1
-export:
-  - kind: Task
-    apiVersion: tekton.dev/v1
-  - kind: TaskRun
-    apiVersion: tekton.dev/v1
-  - kind: Pipeline
-    apiVersion: tekton.dev/v1
-  - kind: PipelineRun
-    apiVersion: tekton.dev/v1
-import:
-  - kind: PipelineRun
-    apiVersion: tekton.dev/v1
-  - kind: TaskRun
-    apiVersion: tekton.dev/v1
-  - kind: Pod
-    apiVersion: v1
-    replaceOnConflict: true
+# export:
+#   - kind: Task
+#     apiVersion: tekton.dev/v1
+#   - kind: TaskRun
+#     apiVersion: tekton.dev/v1
+#   - kind: Pipeline
+#     apiVersion: tekton.dev/v1
+#   - kind: PipelineRun
+#     apiVersion: tekton.dev/v1
+# import:
+#   - kind: PipelineRun
+#     apiVersion: tekton.dev/v1
+#   - kind: TaskRun
+#     apiVersion: tekton.dev/v1
+#   - kind: Pod
+#     apiVersion: v1
+#     replaceOnConflict: true

--- a/pkg/controllers/generic/export_syncer.go
+++ b/pkg/controllers/generic/export_syncer.go
@@ -2,10 +2,11 @@ package generic
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"regexp"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/log"
@@ -29,6 +30,10 @@ import (
 )
 
 func CreateExporters(ctx *context.ControllerContext, exporterConfig *config.Config) error {
+	if len(exporterConfig.Exports) == 0 {
+		return nil
+	}
+
 	scheme := ctx.LocalManager.GetScheme()
 	registerCtx := util.ToRegisterContext(ctx)
 

--- a/pkg/controllers/generic/import_syncer.go
+++ b/pkg/controllers/generic/import_syncer.go
@@ -3,10 +3,11 @@ package generic
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"regexp"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	context2 "github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/config"
@@ -31,6 +32,10 @@ import (
 )
 
 func CreateImporters(ctx *context2.ControllerContext, config *config.Config) error {
+	if len(config.Imports) == 0 {
+		return nil
+	}
+
 	scheme := ctx.LocalManager.GetScheme()
 	registerCtx := util.ToRegisterContext(ctx)
 

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -197,9 +197,10 @@ func SyncKubernetesService(ctx context.Context, virtualClient client.Client, loc
 	if vObj.Spec.ClusterIP != pObj.Spec.ClusterIP || !equality.Semantic.DeepEqual(vObj.Spec.Ports, translatedPorts) {
 		newService := vObj.DeepCopy()
 		newService.Spec.ClusterIP = pObj.Spec.ClusterIP
+		newService.Spec.ClusterIPs = pObj.Spec.ClusterIPs
+		newService.Spec.IPFamilies = pObj.Spec.IPFamilies
 		newService.Spec.Ports = translatedPorts
-		if vObj.Spec.ClusterIP != pObj.Spec.ClusterIP {
-			newService.Spec.ClusterIPs = nil
+		if vObj.Spec.ClusterIP != pObj.Spec.ClusterIP || !equality.Semantic.DeepEqual(vObj.Spec.ClusterIPs, pObj.Spec.ClusterIPs) {
 
 			// delete & create with correct ClusterIP
 			err = virtualClient.Delete(ctx, vObj)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #911 
resolves ENG-937
With this change the vcluster should use exactly the same "service-cluster-ip-range" as the host cluster, including the correct order of the IPv4/IPv6 CIDR rages in case of dual stack. The syncer will sync both IPs of the Kubernetes service.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fail to start in a cluster that uses dual-stack networking, with IPv6 as the default option for the Service network.


**What else do we need to know?** 
I also fixed a few things related to generic sync which were breaking local development in some cases.