### PR TITLE
chore: update workflow runners to a newer ubuntu version

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   unit-test:
     name: Execute all tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.19
         uses: actions/setup-go@v1


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind chore

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Should fix failing workflow runs:
https://github.com/loft-sh/vcluster/actions/runs/4231767129


**Please provide a short message that should be published in the vcluster release notes**
N/A


**What else do we need to know?** 
> The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002