### PR TITLE
add pod cleanup for pause in multi ns mode

### DIFF
--- a/cmd/vclusterctl/cmd/pause.go
+++ b/cmd/vclusterctl/cmd/pause.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -71,6 +72,11 @@ func (cmd *PauseCmd) Run(args []string) error {
 	err = lifecycle.DeleteVClusterWorkloads(cmd.kubeClient, "vcluster.loft.sh/managed-by="+args[0], cmd.Namespace, cmd.Log)
 	if err != nil {
 		return errors.Wrap(err, "delete vcluster workloads")
+	}
+
+	err = lifecycle.DeleteMultiNamespaceVclusterWorkloads(context.TODO(), cmd.kubeClient, args[0], cmd.Namespace, cmd.Log)
+	if err != nil {
+		return errors.Wrap(err, "delete vcluster multinamespace workloads")
 	}
 
 	cmd.Log.Donef("Successfully paused vcluster %s/%s", cmd.Namespace, args[0])


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-920


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster when paused and running under multi namespace mode the host pods are not cleaned up


**What else do we need to know?** 
