### PR TITLE
Set runAsGroup field of securityContext for 'vcluster-rewrite-hosts' initContainer

### DIFF
--- a/pkg/controllers/resources/pods/translate/hosts.go
+++ b/pkg/controllers/resources/pods/translate/hosts.go
@@ -27,6 +27,7 @@ var (
 func rewritePodHostnameFQDN(pPod *corev1.Pod, defaultImageRegistry, hostsRewriteImage, fromHost, toHostname, toHostnameFQDN string) {
 	if pPod.Annotations == nil || pPod.Annotations[DisableSubdomainRewriteAnnotation] != "true" || pPod.Annotations[HostsRewrittenAnnotation] != "true" {
 		userID := coredns.GetUserID()
+		groupID := coredns.GetGroupID()
 		initContainer := corev1.Container{
 			Name:    HostsRewriteContainerName,
 			Image:   defaultImageRegistry + hostsRewriteImage,
@@ -34,6 +35,7 @@ func rewritePodHostnameFQDN(pPod *corev1.Pod, defaultImageRegistry, hostsRewrite
 			Args:    []string{"-c", "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)" + fromHost + "$/\\1 " + toHostnameFQDN + " " + toHostname + "/' /etc/hosts > /hosts/hosts"},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:                &userID,
+				RunAsGroup:               &groupID,
 				RunAsNonRoot:             &nonRoot,
 				Capabilities:             &capabilities,
 				AllowPrivilegeEscalation: &privilegeEscalation,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not correctly sync securityContext for StatefulSet workload
