### PR TITLE
keep internalIP for fakeKubelet node, since some e2e test will get it…

### DIFF
--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -138,7 +138,7 @@ func (s *nodeSyncer) translateUpdateStatus(pNode *corev1.Node, vNode *corev1.Nod
 			},
 		}
 		for _, oldAddress := range translatedStatus.Addresses {
-			if oldAddress.Type == corev1.NodeInternalIP || oldAddress.Type == corev1.NodeInternalDNS || oldAddress.Type == corev1.NodeHostName {
+			if oldAddress.Type == corev1.NodeInternalDNS || oldAddress.Type == corev1.NodeHostName {
 				continue
 			}
 


### PR DESCRIPTION
keep internalIP for fakeKubelet node, since some e2e test will get it as the access IP of some NodePort service and users may use it like e2e test case.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #
when i use vcluster(v0.14.0 + k8s v1.20.15) and host cluster (k8s v1.19.9) to run k8s e2e conformance of  v1.20.15,
I found that some case will failed because the case try to get the node internalIP as the access IP of NodePort service.
I think user application run on the vcluster may do it the same as test case does. so I try to fix this by keeping internalIP for fakeKubelet node.

k8s v1.20.15 e2e conformance test case run in vcluster(v0.14.0 + k8s v1.20.15) failed list as follows:
- [sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP [Conformance]
- [sig-network] Services should have session affinity timeout work for NodePort service [LinuxOnly] [Conformance]
- [sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
- [sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
- [sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol [Conformance]



**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster failed running k8s e2e conformance test


**What else do we need to know?** 
