### PR TITLE
fix: don't expose kubelet when using LoadBalancer svc

### DIFF
--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -8,8 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}
   ports:
     - name: https
       port: 443
@@ -25,12 +29,43 @@ spec:
     - {{ $f }}
     {{- end }}
   {{- end }}
-  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
+  {{- if eq .Values.service.type "NodePort" }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+---
+{{ if eq .Values.service.type "LoadBalancer" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
@@ -43,7 +78,4 @@ spec:
     - "{{ $f }}"
     {{- end }}
   {{- end }}
-  {{- end }}
-  selector:
-    app: vcluster
-    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -8,8 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}
   ports:
     - name: https
       port: 443
@@ -25,12 +29,43 @@ spec:
     - {{ $f }}
     {{- end }}
   {{- end }}
-  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
+  {{- if eq .Values.service.type "NodePort" }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+---
+{{ if eq .Values.service.type "LoadBalancer" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
@@ -43,7 +78,4 @@ spec:
     - "{{ $f }}"
     {{- end }}
   {{- end }}
-  {{- end }}
-  selector:
-    app: vcluster
-    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}
   ports:
     - name: https
       port: 443
@@ -29,12 +29,43 @@ spec:
     - {{ $f }}
     {{- end }}
   {{- end }}
-  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
+  {{- if eq .Values.service.type "NodePort" }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+---
+{{ if eq .Values.service.type "LoadBalancer" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
@@ -47,7 +78,4 @@ spec:
     - "{{ $f }}"
     {{- end }}
   {{- end }}
-  {{- end }}
-  selector:
-    app: vcluster
-    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -8,8 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}
   ports:
     - name: https
       port: 443
@@ -25,12 +29,43 @@ spec:
     - {{ $f }}
     {{- end }}
   {{- end }}
-  {{- if (or (eq (.Values.service.type) "LoadBalancer") (eq (.Values.service.type) "NodePort")) }}
+  {{- if eq .Values.service.type "NodePort" }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
-  {{- if (eq (.Values.service.type) "LoadBalancer") }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
+---
+{{ if eq .Values.service.type "LoadBalancer" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-lb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    app: vcluster
+    release: {{ .Release.Name }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
@@ -43,7 +78,4 @@ spec:
     - "{{ $f }}"
     {{- end }}
   {{- end }}
-  {{- end }}
-  selector:
-    app: vcluster
-    release: {{ .Release.Name }}
+{{- end }}

--- a/pkg/util/translate/lb_service_name.go
+++ b/pkg/util/translate/lb_service_name.go
@@ -1,0 +1,9 @@
+package translate
+
+import "fmt"
+
+// GetLoadBalancerSVCName retrieves the service name if service name is set to type LoadBalancer.
+// A separate service is created in this case so as to expose only the apiserver and not the kubelet port
+func GetLoadBalancerSVCName(serviceName string) string {
+	return fmt.Sprintf("%s-lb", serviceName)
+}

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -29,7 +29,8 @@ var (
 	MarkerLabel     = "vcluster.loft.sh/managed-by"
 	LabelPrefix     = "vcluster.loft.sh/label"
 	ControllerLabel = "vcluster.loft.sh/controlled-by"
-	Suffix          = "suffix"
+	// Suffix is the vcluster name, usually set at start time
+	Suffix = "suffix"
 
 	ManagedAnnotationsAnnotation = "vcluster.loft.sh/managed-annotations"
 	ManagedLabelsAnnotation      = "vcluster.loft.sh/managed-labels"


### PR DESCRIPTION
Creates two services when vcluster is configured with `.Values.service.type` `LoadBalancer`(one of ClusterIP and one of LoadBalancer).

The new loadBalancer service is called `<vclustername>-lb`

TODO: 
- [x] fix the connect command to use the exposed server with the new service.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #930

resolves ENG-1006



**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster LoadBalancer service failed to create


**What else do we need to know?** 

Pre-change, the diff for the templates of all distro services was nil except globalAnnotations was only in k3s.  So I just copied the whole file after editing the on in k3s/templates.
```
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
```
