### PR TITLE
chore: lock cosign version and update commands to v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,9 @@ jobs:
         run: brew install helm
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0
+        with:
+          cosign-release: ' v2.0.0'
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
@@ -48,7 +50,9 @@ jobs:
       id-token: write   # This is the key for OIDC!
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0
+        with:
+          cosign-release: ' v2.0.0'
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
@@ -84,7 +88,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Sign Container Image
         run: |
-          COSIGN_EXPERIMENTAL=1 cosign sign --force loftsh/vcluster@${{ steps.docker_build.outputs.digest }}
+          cosign sign --yes loftsh/vcluster@${{ steps.docker_build.outputs.digest }}
   publish-vcluster-cli-image:
     if: startsWith(github.ref, 'refs/tags/v') == true
     runs-on: ubuntu-22.04
@@ -92,7 +96,9 @@ jobs:
       id-token: write   # This is the key for OIDC!
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0
+        with:
+          cosign-release: ' v2.0.0'
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
@@ -128,7 +134,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Sign Container Image
         run: |
-          COSIGN_EXPERIMENTAL=1 cosign sign --force loftsh/vcluster-cli@${{ steps.docker_build.outputs.digest }}
+          cosign sign --yes loftsh/vcluster-cli@${{ steps.docker_build.outputs.digest }}
   publish-chart:
     if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [publish-vcluster-image, publish-vcluster-cli-image]

--- a/hack/build-cli.sh
+++ b/hack/build-cli.sh
@@ -72,6 +72,6 @@ for OS in ${VCLUSTER_BUILD_PLATFORMS[@]}; do
     GOARCH=${ARCH} GOOS=${OS} ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
       -o "${VCLUSTER_ROOT}/release/${NAME}" cmd/vclusterctl/main.go
     shasum -a 256 "${VCLUSTER_ROOT}/release/${NAME}" | cut -d ' ' -f 1 > "${VCLUSTER_ROOT}/release/${NAME}".sha256
-    COSIGN_EXPERIMENTAL=1 cosign sign-blob --output-signature "${VCLUSTER_ROOT}/release/${NAME}".sha256.sig --output-certificate "${VCLUSTER_ROOT}/release/${NAME}".sha256.pem "${VCLUSTER_ROOT}/release/${NAME}".sha256
+    cosign sign-blob --yes --output-signature "${VCLUSTER_ROOT}/release/${NAME}".sha256.sig --output-certificate "${VCLUSTER_ROOT}/release/${NAME}".sha256.pem "${VCLUSTER_ROOT}/release/${NAME}".sha256
   done
 done


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind chore

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves failing release pipeline and locks the versions to improve release pipeline stability.
Commands have been updated based on [the changelog for v2](https://github.com/sigstore/cosign/blob/main/CHANGELOG.md#v200).

**Please provide a short message that should be published in the vcluster release notes**
N/A