### PR TITLE
Add serviceAnnotations helm value for all charts

### DIFF
--- a/charts/eks/templates/api-service.yaml
+++ b/charts/eks/templates/api-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.api.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/eks/templates/api-service.yaml
+++ b/charts/eks/templates/api-service.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.api.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -225,6 +225,9 @@ data:
       annotations:
         prometheus.io/port: "9153"
         prometheus.io/scrape: "true"
+        {{- if .Values.coredns.service.annotations }}
+{{ toYaml .Values.coredns.service.annotations | indent 8 }}
+        {{- end }}
       labels:
         k8s-app: kube-dns
         kubernetes.io/cluster-service: "true"

--- a/charts/eks/templates/etcd-service.yaml
+++ b/charts/eks/templates/etcd-service.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/eks/templates/etcd-service.yaml
+++ b/charts/eks/templates/etcd-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/eks/templates/etcd-statefulset-service.yaml
+++ b/charts/eks/templates/etcd-statefulset-service.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   publishNotReadyAddresses: true
   ports:

--- a/charts/eks/templates/etcd-statefulset-service.yaml
+++ b/charts/eks/templates/etcd-statefulset-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   publishNotReadyAddresses: true

--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{ toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -2,6 +2,8 @@
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""
 
+globalAnnotations: {}
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false
@@ -156,6 +158,7 @@ syncer:
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
   securityContext: {}
+  serviceAnnotations: {}
 
 # Etcd settings
 etcd:
@@ -190,6 +193,7 @@ etcd:
     #className:
   priorityClassName: ""
   securityContext: {}
+  serviceAnnotations: {}
 
 # Kubernetes Controller Manager settings
 controller:
@@ -238,11 +242,16 @@ api:
       memory: 300Mi
   priorityClassName: ""
   securityContext: {}
+  serviceAnnotations: {}
 
 # Core DNS settings
 coredns:
   image: public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-7
   replicas: 1
+  # CoreDNS service configurations
+  service:
+    # Extra Annotations
+    annotations: {}
   resources:
     limits:
       cpu: 1000m

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{ toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/k0s/templates/statefulset-service.yaml
+++ b/charts/k0s/templates/statefulset-service.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   ports:

--- a/charts/k0s/templates/statefulset-service.yaml
+++ b/charts/k0s/templates/statefulset-service.yaml
@@ -8,6 +8,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: https

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -2,6 +2,8 @@
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""
 
+globalAnnotations: {}
+
 # Plugins that should get loaded. Usually you want to apply those via 'vcluster create ... -f https://.../plugin.yaml'
 plugin: {}
 # Manually configure a plugin called test
@@ -135,6 +137,7 @@ syncer:
       cpu: 10m
       memory: 64Mi
   kubeConfigContextName: "my-vcluster"
+  serviceAnnotations: {}
 
 # Virtual Cluster (k0s) configuration
 vcluster:

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{ toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/k3s/templates/statefulset-service.yaml
+++ b/charts/k3s/templates/statefulset-service.yaml
@@ -9,9 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{ toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   ports:

--- a/charts/k3s/templates/statefulset-service.yaml
+++ b/charts/k3s/templates/statefulset-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   ports:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -146,6 +146,7 @@ syncer:
       cpu: 20m
       memory: 64Mi
   kubeConfigContextName: "my-vcluster"
+  serviceAnnotations: {}
 
 # Virtual Cluster (k3s) configuration
 vcluster:

--- a/charts/k8s/templates/api-service.yaml
+++ b/charts/k8s/templates/api-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.api.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/k8s/templates/api-service.yaml
+++ b/charts/k8s/templates/api-service.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.api.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/k8s/templates/etcd-service.yaml
+++ b/charts/k8s/templates/etcd-service.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/k8s/templates/etcd-service.yaml
+++ b/charts/k8s/templates/etcd-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/k8s/templates/etcd-statefulset-service.yaml
+++ b/charts/k8s/templates/etcd-statefulset-service.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
+  {{- if $annotations }}
+  annotations:
+  {{ toYaml $annotations | nindent 4 }}
+  {{- end }}
 spec:
   publishNotReadyAddresses: true
   ports:

--- a/charts/k8s/templates/etcd-statefulset-service.yaml
+++ b/charts/k8s/templates/etcd-statefulset-service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   publishNotReadyAddresses: true

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
   annotations:
-  {{ toYaml $annotations | nindent 4 }}
+  {{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{ toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   type: {{ if eq .Values.service.type "LoadBalancer" -}}ClusterIP{{- else }} {{- .Values.service.type }}  {{- end }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -2,6 +2,8 @@
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""
 
+globalAnnotations: {}
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false
@@ -161,6 +163,7 @@ syncer:
   kubeConfigContextName: "my-vcluster"
   # Security context configuration
   securityContext: {}
+  serviceAnnotations: {}
 
 # Etcd settings
 etcd:
@@ -195,6 +198,8 @@ etcd:
     #className:
   priorityClassName: ""
   securityContext: {}
+  serviceAnnotations: {}
+  
 # Kubernetes Controller Manager settings
 controller:
   image: registry.k8s.io/kube-controller-manager:v1.26.1
@@ -263,6 +268,8 @@ api:
       memory: 300Mi
   priorityClassName: ""
   securityContext: {}
+  serviceAnnotations: {}
+  
 # Service account that should be used by the vcluster
 serviceAccount:
   create: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #897 


**Please provide a short message that should be published in the vcluster release notes**
Added a serviceAnnotations Helm value to all charts which can be used to set annotations for core vcluster services

Closes ENG-876
**What else do we need to know?** 
coredns component already has a helm value coredns.service.annotations which can be used for the same purpose