### PR TITLE
fix(syncer): don't trigger nil pointer bug in library

### DIFF
--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -144,7 +144,7 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 
 	flags.StringVar(&options.DefaultImageRegistry, "default-image-registry", "", "This address will be prepended to all deployed system images by vcluster")
 
-	flags.StringVar(&options.EnforcePodSecurityStandard, "enforce-pod-security-standard", "", "This can be set to privileged, baseline, restricted and vcluster would make sure during translation that these policies are enforced.")
+	flags.StringVar(&options.EnforcePodSecurityStandard, "enforce-pod-security-standard", "", "This can be set to 'privileged', 'baseline', or 'restricted' to make vcluster enforce these policies during translation.")
 	flags.StringSliceVar(&options.SyncLabels, "sync-labels", []string{}, "The specified labels will be synced to physical resources, in addition to their vcluster translated versions.")
 	flags.StringSliceVar(&options.Plugins, "plugins", []string{}, "The plugins to wait for during startup")
 

--- a/pkg/controllers/resources/pods/validate_pod_security.go
+++ b/pkg/controllers/resources/pods/validate_pod_security.go
@@ -47,8 +47,9 @@ func (s *podSyncer) validatePodSecurityStandards(ctx context.Context, pod *corev
 	}
 
 	adm := &admission.Admission{
-		Evaluator: evaluator,
-		Metrics:   &FakeMetricsRecorder{},
+		Evaluator:     evaluator,
+		Metrics:       &FakeMetricsRecorder{},
+		Configuration: &admissionapi.PodSecurityConfiguration{},
 	}
 
 	nsPolicy, nsError := admissionapi.ToPolicy(podSecurityDefaults)


### PR DESCRIPTION
The k8s admission library assumes the admission configuration pointer
is not nil and panics if it is not.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

resolves ENG-1103

**Please provide a short message that should be published in the vcluster release notes**
Fixed an edge-case where vcluster triggers a k8s bug.


**What else do we need to know?** 

Made a small edit to the flag doc.
