### PR TITLE
feat: add .Values.fallbackHostDns

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -70,9 +70,13 @@ data:
             health
             ready
             rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-            kubernetes cluster.local in-addr.arpa ip6.arpa {
+            kubernetes cluster.local in-addr.arpa ip6.arpa { 
               pods insecure
+              {{- if .Values.fallbackHostDns }}
+              fallthrough cluster.local in-addr.arpa ip6.arpa
+              {{- else }}
               fallthrough in-addr.arpa ip6.arpa
+              {{- end }}
             }
             hosts /etc/coredns/NodeHosts {
               ttl 60
@@ -80,13 +84,15 @@ data:
               fallthrough
             }
             prometheus :9153
-  {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            {{- if .Values.fallbackHostDns }}
+            forward . {{`{{.HOST_CLUSTER_DNS}}`}}
+            {{- else if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
             forward . /etc/resolv.conf 8.8.8.8 {
               policy sequential
             }
-  {{- else }}
+            {{- else }}
             forward . /etc/resolv.conf
-  {{- end }}
+            {{- end }}
             cache 30
             loop
             reload

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -87,6 +87,12 @@ sync:
     config: |-
       ---
 
+# If enabled, will fallback to host dns for resolving domains. This
+# is useful if using istio or dapr in the host cluster and sidecar
+# containers cannot connect to the central instance. Its also useful
+# if you want to access host cluster services from within the vcluster.
+fallbackHostDns: false
+
 # Map Services between host and virtual cluster
 mapServices:
   # Services that should get mapped from the

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -76,7 +76,11 @@ data:
             rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
             kubernetes {{- if .Values.vcluster.clusterDomain }} {{ .Values.vcluster.clusterDomain }} {{- end }} cluster.local in-addr.arpa ip6.arpa {
               pods insecure
+              {{- if .Values.fallbackHostDns }}
+              fallthrough cluster.local in-addr.arpa ip6.arpa
+              {{- else }}
               fallthrough in-addr.arpa ip6.arpa
+              {{- end }}
             }
             hosts /etc/coredns/NodeHosts {
               ttl 60
@@ -84,7 +88,9 @@ data:
               fallthrough
             }
             prometheus :9153
-            {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            {{- if .Values.fallbackHostDns }}
+            forward . {{`{{.HOST_CLUSTER_DNS}}`}}
+            {{- else if and .Values.isolation.enabled .Values.isolation.networkPolicy.enabled }}
             forward . /etc/resolv.conf 8.8.8.8 {
               policy sequential
             }

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -88,6 +88,12 @@ sync:
     config: |-
       ---
 
+# If enabled, will fallback to host dns for resolving domains. This
+# is useful if using istio or dapr in the host cluster and sidecar
+# containers cannot connect to the central instance. Its also useful
+# if you want to access host cluster services from within the vcluster.
+fallbackHostDns: false
+
 # Map Services between host and virtual cluster
 mapServices:
   # Services that should get mapped from the

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -78,9 +78,13 @@ data:
             health
             ready
             rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-            kubernetes cluster.local in-addr.arpa ip6.arpa {
+            kubernetes cluster.local in-addr.arpa ip6.arpa { 
               pods insecure
+              {{- if .Values.fallbackHostDns }}
+              fallthrough cluster.local in-addr.arpa ip6.arpa
+              {{- else }}
               fallthrough in-addr.arpa ip6.arpa
+              {{- end }}
             }
             hosts /etc/coredns/NodeHosts {
               ttl 60
@@ -88,7 +92,9 @@ data:
               fallthrough
             }
             prometheus :9153
-            {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            {{- if .Values.fallbackHostDns }}
+            forward . {{`{{.HOST_CLUSTER_DNS}}`}}
+            {{- else if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
             forward . /etc/resolv.conf 8.8.8.8 {
               policy sequential
             }

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -93,6 +93,11 @@ sync:
     config: |-
       ---
 
+# If enabled, will fallback to host dns for resolving domains. This
+# is useful if using istio or dapr in the host cluster and sidecar
+# containers cannot connect to the central instance. Its also useful
+# if you want to access host cluster services from within the vcluster.
+fallbackHostDns: false
 
 # Map Services between host and virtual cluster
 mapServices:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -76,7 +76,11 @@ data:
             rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
             kubernetes cluster.local in-addr.arpa ip6.arpa {
               pods insecure
+              {{- if .Values.fallbackHostDns }}
+              fallthrough cluster.local in-addr.arpa ip6.arpa
+              {{- else }}
               fallthrough in-addr.arpa ip6.arpa
+              {{- end }}
             }
             hosts /etc/coredns/NodeHosts {
               ttl 60
@@ -84,7 +88,9 @@ data:
               fallthrough
             }
             prometheus :9153
-            {{- if and .Values.isolation.enabled  .Values.isolation.networkPolicy.enabled }}
+            {{- if .Values.fallbackHostDns }}
+            forward . {{`{{.HOST_CLUSTER_DNS}}`}}
+            {{- else if and .Values.isolation.enabled .Values.isolation.networkPolicy.enabled }}
             forward . /etc/resolv.conf 8.8.8.8 {
               policy sequential
             }

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -92,6 +92,12 @@ sync:
     config: |-
       ---
 
+# If enabled, will fallback to host dns for resolving domains. This
+# is useful if using istio or dapr in the host cluster and sidecar
+# containers cannot connect to the central instance. Its also useful
+# if you want to access host cluster services from within the vcluster.
+fallbackHostDns: false
+
 # Map Services between host and virtual cluster
 mapServices:
   # Services that should get mapped from the

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -28,6 +28,7 @@ deployments:
       values: &values
         job:
           enabled: false
+        fallbackHostDns: true
         service:
           type: NodePort
         serviceCIDR: $([ $1 == "dev" ] && vcluster get service-cidr || echo "null")

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -18,6 +18,7 @@ const (
 	ManifestRelativePath  = "coredns/coredns.yaml"
 	ManifestsOutputFolder = "/tmp/manifests-to-apply"
 	VarImage              = "IMAGE"
+	VarHostDNS            = "HOST_CLUSTER_DNS"
 	VarRunAsUser          = "RUN_AS_USER"
 	VarRunAsNonRoot       = "RUN_AS_NON_ROOT"
 	VarRunAsGroup         = "RUN_AS_GROUP"
@@ -72,7 +73,22 @@ func getManifestVariables(defaultImageRegistry string, serverVersion *version.In
 	} else {
 		vars[VarLogInDebug] = ""
 	}
+	vars[VarHostDNS] = getNameserver()
 	return vars
+}
+
+func getNameserver() string {
+	raw, err := os.ReadFile("/etc/resolv.conf")
+	if err != nil {
+		return "/etc/resolv.conf"
+	}
+
+	nameservers := GetNameservers(raw)
+	if len(nameservers) == 0 {
+		return "/etc/resolv.conf"
+	}
+
+	return nameservers[0]
 }
 
 // GetGroupID retrieves the current group id and if the current process is running

--- a/pkg/coredns/resolv.go
+++ b/pkg/coredns/resolv.go
@@ -1,0 +1,45 @@
+package coredns
+
+import (
+	"bytes"
+	"regexp"
+)
+
+var (
+	ipv4NumBlock = `(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)`
+	ipv4Address  = `(` + ipv4NumBlock + `\.){3}` + ipv4NumBlock
+	// This is not an IPv6 address verifier as it will accept a super-set of IPv6, and also
+	// will *not match* IPv4-Embedded IPv6 Addresses (RFC6052), but that and other variants
+	// -- e.g. other link-local types -- either won't work in containers or are unnecessary.
+	// For readability and sufficiency for Docker purposes this seemed more reasonable than a
+	// 1000+ character regexp with exact and complete IPv6 validation
+	ipv6Address = `([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{0,4})(%\w+)?`
+	nsRegexp    = regexp.MustCompile(`^\s*nameserver\s*((` + ipv4Address + `)|(` + ipv6Address + `))\s*$`)
+)
+
+// GetNameservers returns nameservers (if any) listed in /etc/resolv.conf
+func GetNameservers(resolvConf []byte) []string {
+	nameservers := []string{}
+	for _, line := range getLines(resolvConf, []byte("#")) {
+		ns := nsRegexp.FindSubmatch(line)
+		if len(ns) > 0 {
+			nameservers = append(nameservers, string(ns[1]))
+		}
+	}
+	return nameservers
+}
+
+// getLines parses input into lines and strips away comments.
+func getLines(input []byte, commentMarker []byte) [][]byte {
+	lines := bytes.Split(input, []byte("\n"))
+	var output [][]byte
+	for _, currentLine := range lines {
+		var commentIndex = bytes.Index(currentLine, commentMarker)
+		if commentIndex == -1 {
+			output = append(output, currentLine)
+		} else {
+			output = append(output, currentLine[:commentIndex])
+		}
+	}
+	return output
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #955
Resolves ENG-1117

**Please provide a short message that should be published in the vcluster release notes**
Added a new helm value `.Values.fallbackHostDns` that configured the coredns to fallback to the host dns if a service or domain couldn't be found within the vcluster.
