### PR TITLE
fix: log only the messages of the correct level

### DIFF
--- a/pkg/util/log/log_sink.go
+++ b/pkg/util/log/log_sink.go
@@ -64,7 +64,7 @@ func (l *logSink) Info(level int, msg string, keysAndValues ...interface{}) {
 // commandline flags might be used to set the logging verbosity and disable
 // some info logs.
 func (l *logSink) Enabled(level int) bool {
-	return true
+	return level >= l.level
 }
 
 // Error logs an error, with the given message and key/value pairs as context.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-1137


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would log debug-level messages by default.
