### PR TITLE
fix: cert expiry should check for cert's expiry date

### DIFF
--- a/pkg/util/certhelper/cert.go
+++ b/pkg/util/certhelper/cert.go
@@ -102,6 +102,6 @@ func MakeEllipticPrivateKeyPEM() ([]byte, error) {
 
 // IsCertExpired checks if the certificate about to expire
 func IsCertExpired(cert *x509.Certificate) bool {
-	diffDays := time.Until(time.Now()).Hours() / 24.0
+	diffDays := time.Until(cert.NotAfter).Hours() / 24.0
 	return diffDays <= 90
 }

--- a/pkg/util/certhelper/cert_test.go
+++ b/pkg/util/certhelper/cert_test.go
@@ -1,0 +1,71 @@
+package certhelper
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestIsCertExpired(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		expiryDate time.Time
+		hasExpired bool
+	}{
+		{
+			name:       "valid cert expiring in 1 year",
+			expiryDate: time.Now().Add(365 * 24 * time.Hour),
+			hasExpired: false,
+		},
+		{
+			name:       "valid cert expiring in 91 days",
+			expiryDate: time.Now().Add(91 * 24 * time.Hour),
+			hasExpired: false,
+		},
+		{
+			name:       "valid cert expiring in 90 days",
+			expiryDate: time.Now().Add(90 * 24 * time.Hour),
+			hasExpired: true,
+		},
+		{
+			name:       "valid cert expiring in 30 days",
+			expiryDate: time.Now().Add(30 * 24 * time.Hour),
+			hasExpired: true,
+		},
+		{
+			name:       "valid cert expiring in 1 days",
+			expiryDate: time.Now().Add(1 * 24 * time.Hour),
+			hasExpired: true,
+		},
+		{
+			name:       "cert expiring now",
+			expiryDate: time.Now(),
+			hasExpired: true,
+		},
+		{
+			name:       "cert expired yesterday",
+			expiryDate: time.Now().Add(-1 * 24 * time.Hour),
+			hasExpired: true,
+		},
+		{
+			name:       "cert expired a month ago",
+			expiryDate: time.Now().Add(-30 * 24 * time.Hour),
+			hasExpired: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "example.com",
+				},
+				NotAfter: tt.expiryDate,
+			}
+
+			hasExpired := IsCertExpired(cert)
+			assert.Equal(t, hasExpired, tt.hasExpired)
+		})
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** 
The `IsCertExpired` check that is used to determine if certificates need to be regenerated is currently broken. The current check doesn't check for cert's expiration date. This change adds a fix to that part of the code while also adding a test to make sure any future refactors don't cause regression.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster has a bug for checking expiration of certs.


**What else do we need to know?** 
Hopefully the added test should catch if this issue should arise in future.