### PR TITLE
Update synced-resources.mdx

### DIFF
--- a/docs/pages/architecture/synced-resources.mdx
+++ b/docs/pages/architecture/synced-resources.mdx
@@ -199,8 +199,8 @@ sync:
       import:
         - kind: Secret
           apiVersion: v1
-	- kind: IngressClass
-	  apiVersion: networking.k8s.io/v1
+        - kind: IngressClass
+          apiVersion: networking.k8s.io/v1
 ```
 
 :::info

--- a/docs/pages/architecture/synced-resources.mdx
+++ b/docs/pages/architecture/synced-resources.mdx
@@ -199,14 +199,12 @@ sync:
       import:
         - kind: Secret
           apiVersion: v1
+	- kind: IngressClass
+	  apiVersion: networking.k8s.io/v1
 ```
 
 :::info
 The sync from Host to Virtual cluster is supported only in ["Multi-namespace mode"](#multi-namespace-mode)
-:::
-
-:::info
-Only the namespaced resources are supported at this time.
 :::
 
 #### Patch syntax


### PR DESCRIPTION
remove info about importing only namespaced resources added `IngressClass` – cluster scoped resource – in the example

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves documentation for ENG-887 and #952 


**Please provide a short message that should be published in the vcluster release notes**
Fix docs for importing cluster scoped resources


**What else do we need to know?** 
