### PR TITLE
enable optional generic resource syncing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,8 @@ type Import struct {
 type SyncBase struct {
 	TypeInformation `yaml:",inline" json:",inline"`
 
+	Optional bool `yaml:"optional,omitempty" json:"optional,omitempty"`
+
 	// ReplaceOnConflict determines if the controller should try to recreate the object
 	// if there is a problem applying
 	ReplaceOnConflict bool `yaml:"replaceOnConflict,omitempty" json:"replaceOnConflict,omitempty"`

--- a/pkg/controllers/generic/export_syncer.go
+++ b/pkg/controllers/generic/export_syncer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
 
 	"github.com/loft-sh/vcluster/cmd/vcluster/context"
 	"github.com/loft-sh/vcluster/pkg/log"
@@ -46,12 +47,15 @@ func CreateExporters(ctx *context.ControllerContext, exporterConfig *config.Conf
 				registerCtx.VirtualManager.GetConfig(),
 				gvk)
 			if err != nil {
+				if exportConfig.Optional {
+					klog.Infof("error ensuring CRD %s(%s) from host cluster: %v. Skipping exportSyncer as resource is optional", exportConfig.Kind, exportConfig.APIVersion, err)
+					continue
+				}
+
 				return fmt.Errorf("error creating %s(%s) syncer: %v", exportConfig.Kind, exportConfig.APIVersion, err)
 			}
 		}
-	}
 
-	for _, exportConfig := range exporterConfig.Exports {
 		reversePatches := []*config.Patch{
 			{
 				Operation: config.PatchTypeCopyFromObject,
@@ -63,11 +67,13 @@ func CreateExporters(ctx *context.ControllerContext, exporterConfig *config.Conf
 		exportConfig.ReversePatches = reversePatches
 
 		s, err := createExporter(registerCtx, exportConfig)
+		klog.Infof("creating exporter for %s/%s", exportConfig.APIVersion, exportConfig.Kind)
 		if err != nil {
 			return fmt.Errorf("error creating %s(%s) syncer: %v", exportConfig.Kind, exportConfig.APIVersion, err)
 		}
 
 		err = syncer.RegisterSyncer(registerCtx, s)
+		klog.Infof("registering export syncer for %s/%s", exportConfig.APIVersion, exportConfig.Kind)
 		if err != nil {
 			return fmt.Errorf("error registering syncer %v", err)
 		}

--- a/test/e2e_generic/values.yaml
+++ b/test/e2e_generic/values.yaml
@@ -17,3 +17,7 @@ sync:
       import:
         - kind: IngressClass
           apiVersion: networking.k8s.io/v1
+        # test to ensure optional resources work without crashing
+        - kind: ClusterIssuer
+          apiVersion: cert-manager.io/v1
+          optional: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-997 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fail in case the specified resource in the import/export generic config does not exist on host cluster. We now have the concept of `optional` resources


**What else do we need to know?** 
