### PR TITLE
fix: add package:write permission to push ghcr images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write   # This is the key for OIDC!
+      packages: read|write
     steps:
       - uses: actions/checkout@v2
       - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0
@@ -104,6 +105,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write   # This is the key for OIDC!
+      packages: read|write
     steps:
       - uses: actions/checkout@v2
       - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0


### PR DESCRIPTION
Hadn't noticed that permissions were set. The packages write permission is necessary to push images ghcr.io


Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
