### PR TITLE
fix: invalid workflow permission value

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write   # This is the key for OIDC!
-      packages: read|write
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write   # This is the key for OIDC!
-      packages: read|write
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: sigstore/cosign-installer@bd2d1189b064bcddc3903176a807dcdba72d7fd0


### PR DESCRIPTION
turns out read|write is invalid. I suppose write implies read?
The syntax doc for actions is confusing


Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
