### PR TITLE
reimplement fake kubelet services for node InternalIP addresses

### DIFF
--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -150,6 +150,9 @@ spec:
           {{- if .Values.sync.secrets.all }}
           - --sync-all-secrets=true
           {{- end }}
+          {{- if not .Values.sync.nodes.fakeKubeletIPs }}
+          - --fake-kubelet-ips=false
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -54,6 +54,7 @@ sync:
   fake-persistentvolumes:
     enabled: true # will be ignored if persistentvolumes.enabled = true
   nodes:
+    fakeKubeletIPs: true
     enabled: false
     # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster 
     # will sync all nodes instead of only the ones where some pods are running.

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -203,6 +203,9 @@ spec:
           {{- if .Values.sync.secrets.all }}
           - --sync-all-secrets=true
           {{- end }}
+          {{- if not .Values.sync.nodes.fakeKubeletIPs }}
+          - --fake-kubelet-ips=false
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -50,6 +50,7 @@ sync:
   fake-persistentvolumes:
     enabled: true # will be ignored if persistentvolumes.enabled = true
   nodes:
+    fakeKubeletIPs: true
     enabled: false
     # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster 
     # will sync all nodes instead of only the ones where some pods are running.

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -267,6 +267,9 @@ spec:
           {{- if .Values.sync.secrets.all }}
           - --sync-all-secrets=true
           {{- end }}
+          {{- if not .Values.sync.nodes.fakeKubeletIPs }}
+          - --fake-kubelet-ips=false
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -55,6 +55,7 @@ sync:
   fake-persistentvolumes:
     enabled: true # will be ignored if persistentvolumes.enabled = true
   nodes:
+    fakeKubeletIPs: true
     enabled: false
     # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster 
     # will sync all nodes instead of only the ones where some pods are running.

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -185,6 +185,9 @@ spec:
           {{- if .Values.sync.secrets.all }}
           - --sync-all-secrets=true
           {{- end }}
+          {{- if not .Values.sync.nodes.fakeKubeletIPs }}
+          - --fake-kubelet-ips=false
+          {{- end }}
           {{- range $f := .Values.syncer.extraArgs }}
           - {{ $f | quote }}
           {{- end }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -54,6 +54,7 @@ sync:
   fake-persistentvolumes:
     enabled: true # will be ignored if persistentvolumes.enabled = true
   nodes:
+    fakeKubeletIPs: true
     enabled: false
     # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster 
     # will sync all nodes instead of only the ones where some pods are running.

--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -39,6 +39,7 @@ type VirtualClusterOptions struct {
 	SyncAllNodes        bool     `json:"syncAllNodes,omitempty"`
 	EnableScheduler     bool     `json:"enableScheduler,omitempty"`
 	DisableFakeKubelets bool     `json:"disableFakeKubelets,omitempty"`
+	FakeKubeletIPs      bool     `json:"fakeKubeletIPs,omitempty"`
 	ClearNodeImages     bool     `json:"clearNodeImages,omitempty"`
 	TranslateImages     []string `json:"translateImages,omitempty"`
 
@@ -121,6 +122,7 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 	flags.BoolVar(&options.SyncAllNodes, "sync-all-nodes", false, "If enabled and --fake-nodes is false, the virtual cluster will sync all nodes instead of only the needed ones")
 	flags.BoolVar(&options.EnableScheduler, "enable-scheduler", false, "If enabled, will expect a scheduler running in the virtual cluster")
 	flags.BoolVar(&options.DisableFakeKubelets, "disable-fake-kubelets", false, "If disabled, the virtual cluster will not create fake kubelet endpoints to support metrics-servers")
+	flags.BoolVar(&options.FakeKubeletIPs, "fake-kubelet-ips", true, "If enabled, virtual cluster will assign fake ips of type NodeInternalIP to fake the kubelets")
 	flags.BoolVar(&options.ClearNodeImages, "node-clear-image-status", false, "If enabled, when syncing real nodes, the status.images data will be removed from the vcluster nodes")
 
 	flags.StringSliceVar(&options.TranslateImages, "translate-image", []string{}, "Translates image names from the virtual pod to the physical pod (e.g. coredns/coredns=mirror.io/coredns/coredns)")

--- a/pkg/constants/indices.go
+++ b/pkg/constants/indices.go
@@ -10,4 +10,6 @@ const (
 	IndexByConfigMap     = "IndexByConfigMap"
 	// IndexByHostName is used to map rewritten hostnames(advertised as node addresses) to nodenames
 	IndexByHostName = "IndexByHostName"
+
+	IndexByClusterIP = "IndexByClusterIP"
 )

--- a/pkg/controllers/resources/nodes/fake_syncer_test.go
+++ b/pkg/controllers/resources/nodes/fake_syncer_test.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
@@ -29,9 +30,18 @@ func newFakeFakeSyncer(t *testing.T, ctx *synccontext.RegisterContext) (*synccon
 	assert.NilError(t, err)
 
 	syncContext, object := generictesting.FakeStartSyncer(t, ctx, func(ctx *synccontext.RegisterContext) (syncer.Object, error) {
-		return NewFakeSyncer(ctx)
+		return NewFakeSyncer(ctx, &fakeNodeServiceProvider{})
 	})
 	return syncContext, object.(*fakeNodeSyncer)
+}
+
+type fakeNodeServiceProvider struct{}
+
+func (f *fakeNodeServiceProvider) Start(ctx context.Context) {}
+func (f *fakeNodeServiceProvider) Lock()                     {}
+func (f *fakeNodeServiceProvider) Unlock()                   {}
+func (f *fakeNodeServiceProvider) GetNodeIP(ctx context.Context, name types.NamespacedName) (string, error) {
+	return "127.0.0.1", nil
 }
 
 func TestFakeSync(t *testing.T) {

--- a/pkg/controllers/resources/nodes/nodeservice/node_service.go
+++ b/pkg/controllers/resources/nodes/nodeservice/node_service.go
@@ -1,0 +1,177 @@
+package nodeservice
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// ServiceClusterLabel identifies to which vcluster the node service belongs if there are multiple in one namespace
+	ServiceClusterLabel = "vcluster.loft.sh/belongs-to"
+	// ServiceNodeLabel specifies which node this service represents
+	ServiceNodeLabel = "vcluster.loft.sh/node"
+	// KubeletPort is the port we pretend the kubelet is running under
+	KubeletPort = int32(10250)
+	// KubeletTargetPort is the port vcluster will run under
+	KubeletTargetPort = 8443
+)
+
+type NodeServiceProvider interface {
+	sync.Locker
+	// Start starts the node service garbage collector
+	Start(ctx context.Context)
+	// GetNodeIP returns a new fake node ip
+	GetNodeIP(ctx context.Context, name types.NamespacedName) (string, error)
+}
+
+func NewNodeServiceProvider(serviceName, currentNamespace string, currentNamespaceClient client.Client, virtualClient client.Client, uncachedVirtualClient client.Client) NodeServiceProvider {
+	return &nodeServiceProvider{
+		serviceName:            serviceName,
+		currentNamespace:       currentNamespace,
+		currentNamespaceClient: currentNamespaceClient,
+		virtualClient:          virtualClient,
+		uncachedVirtualClient:  uncachedVirtualClient,
+	}
+}
+
+type nodeServiceProvider struct {
+	serviceName            string
+	currentNamespace       string
+	currentNamespaceClient client.Client
+
+	virtualClient         client.Client
+	uncachedVirtualClient client.Client
+
+	serviceMutex sync.Mutex
+}
+
+func (n *nodeServiceProvider) Start(ctx context.Context) {
+	wait.Until(func() {
+		err := n.cleanupNodeServices(ctx)
+		if err != nil {
+			klog.Errorf("error cleaning up node services: %v", err)
+		}
+	}, time.Second*4, ctx.Done())
+}
+
+func (n *nodeServiceProvider) cleanupNodeServices(ctx context.Context) error {
+	n.serviceMutex.Lock()
+	defer n.serviceMutex.Unlock()
+
+	serviceList := &corev1.ServiceList{}
+	err := n.currentNamespaceClient.List(ctx, serviceList, client.InNamespace(n.currentNamespace), client.MatchingLabels{
+		ServiceClusterLabel: translate.Suffix,
+	})
+	if err != nil {
+		return errors.Wrap(err, "list services")
+	}
+
+	errors := []error{}
+	for _, s := range serviceList.Items {
+		exist := false
+		if s.Labels[ServiceNodeLabel] != "" {
+			// check if node still exists
+			err = n.virtualClient.Get(ctx, client.ObjectKey{Name: s.Labels[ServiceNodeLabel]}, &corev1.Node{})
+			if err != nil {
+				if !kerrors.IsNotFound(err) {
+					klog.Infof("error retrieving node %s: %v", s.Labels[ServiceNodeLabel], err)
+					continue
+				}
+
+				// make sure node really does not exist
+				err = n.uncachedVirtualClient.Get(ctx, client.ObjectKey{Name: s.Labels[ServiceNodeLabel]}, &corev1.Node{})
+				if err == nil {
+					exist = true
+				}
+			} else {
+				exist = true
+			}
+		}
+
+		if !exist {
+			klog.Infof("Cleaning up kubelet service for node %s", s.Labels[ServiceNodeLabel])
+			err = n.currentNamespaceClient.Delete(ctx, &s)
+			if err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}
+
+func (n *nodeServiceProvider) Lock() {
+	n.serviceMutex.Lock()
+}
+
+func (n *nodeServiceProvider) Unlock() {
+	n.serviceMutex.Unlock()
+}
+
+func (n *nodeServiceProvider) GetNodeIP(ctx context.Context, name types.NamespacedName) (string, error) {
+	serviceName := translate.SafeConcatName(translate.Suffix, "node", strings.ReplaceAll(name.Name, ".", "-"))
+
+	service := &corev1.Service{}
+	err := n.currentNamespaceClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: n.currentNamespace}, service)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return "", errors.Wrap(err, "list services")
+	} else if err == nil {
+		return service.Spec.ClusterIP, nil
+	}
+
+	// find out the labels to select ourself
+	vclusterService := &corev1.Service{}
+	err = n.currentNamespaceClient.Get(ctx, types.NamespacedName{Name: n.serviceName, Namespace: n.currentNamespace}, vclusterService)
+	if err != nil {
+		return "", errors.Wrap(err, "get vcluster service")
+	}
+
+	// create the new service
+	nodeService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: n.currentNamespace,
+			Name:      serviceName,
+			Labels: map[string]string{
+				ServiceClusterLabel: translate.Suffix,
+				ServiceNodeLabel:    name.Name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:       int32(KubeletPort),
+					TargetPort: intstr.FromInt(KubeletTargetPort),
+				},
+			},
+			Selector: vclusterService.Spec.Selector,
+		},
+	}
+
+	// set owner if defined
+	if translate.Owner != nil {
+		nodeService.SetOwnerReferences(translate.GetOwnerReference(nil))
+	}
+
+	// create the service
+	klog.Infof("Generating kubelet service for node %s", name.Name)
+	err = n.currentNamespaceClient.Create(ctx, nodeService)
+	if err != nil {
+		return "", errors.Wrap(err, "create node service")
+	}
+
+	return nodeService.Spec.ClusterIP, nil
+}

--- a/pkg/controllers/resources/nodes/register.go
+++ b/pkg/controllers/resources/nodes/register.go
@@ -1,14 +1,25 @@
 package nodes
 
 import (
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
-	if !ctx.Controllers.Has("nodes") {
-		return NewFakeSyncer(ctx)
+	uncachedVirtualClient, err := client.New(ctx.VirtualManager.GetConfig(), client.Options{
+		Scheme: ctx.VirtualManager.GetScheme(),
+		Mapper: ctx.VirtualManager.GetRESTMapper(),
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	return NewSyncer(ctx)
+	nodeService := nodeservice.NewNodeServiceProvider(ctx.Options.ServiceName, ctx.CurrentNamespace, ctx.CurrentNamespaceClient, ctx.VirtualManager.GetClient(), uncachedVirtualClient)
+	if !ctx.Controllers.Has("nodes") {
+		return NewFakeSyncer(ctx, nodeService)
+	}
+
+	return NewSyncer(ctx, nodeService)
 }

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -2,10 +2,12 @@ package nodes
 
 import (
 	"context"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
@@ -28,7 +30,7 @@ var (
 	indexPodByRunningNonVClusterNode = "indexpodbyrunningnonvclusternode"
 )
 
-func NewSyncer(ctx *synccontext.RegisterContext) (syncer.Object, error) {
+func NewSyncer(ctx *synccontext.RegisterContext, nodeServiceProvider nodeservice.NodeServiceProvider) (syncer.Object, error) {
 	var err error
 	var nodeSelector labels.Selector
 	if ctx.Options.SyncAllNodes {
@@ -58,9 +60,11 @@ func NewSyncer(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 		nodeSelector:        nodeSelector,
 		clearImages:         ctx.Options.ClearNodeImages,
 		useFakeKubelets:     !ctx.Options.DisableFakeKubelets,
+		fakeKubeletIPs:      ctx.Options.FakeKubeletIPs,
 
 		physicalClient:      ctx.PhysicalManager.GetClient(),
 		virtualClient:       ctx.VirtualManager.GetClient(),
+		nodeServiceProvider: nodeServiceProvider,
 		enforcedTolerations: tolerations,
 
 		currentNamespace: ctx.CurrentNamespace,
@@ -75,11 +79,13 @@ type nodeSyncer struct {
 	enforceNodeSelector bool
 	nodeSelector        labels.Selector
 	useFakeKubelets     bool
+	fakeKubeletIPs      bool
 
 	physicalClient client.Client
 	virtualClient  client.Client
 
 	podCache            client.Reader
+	nodeServiceProvider nodeservice.NodeServiceProvider
 	enforcedTolerations []*corev1.Toleration
 	currentNamespace    string
 }
@@ -131,10 +137,14 @@ func (s *nodeSyncer) ModifyController(ctx *synccontext.RegisterContext, builder 
 		podCache.WaitForCacheSync(ctx.Context)
 		s.podCache = podCache
 	}
-	return modifyController(ctx, builder)
+	return modifyController(ctx, s.nodeServiceProvider, builder)
 }
 
-func modifyController(ctx *synccontext.RegisterContext, builder *builder.Builder) (*builder.Builder, error) {
+func modifyController(ctx *synccontext.RegisterContext, nodeServiceProvider nodeservice.NodeServiceProvider, builder *builder.Builder) (*builder.Builder, error) {
+	go func() {
+		nodeServiceProvider.Start(ctx.Context)
+	}()
+
 	return builder.Watches(source.NewKindWithCache(&corev1.Pod{}, ctx.PhysicalManager.GetCache()), handler.EnqueueRequestsFromMapFunc(func(object client.Object) []reconcile.Request {
 		pod, ok := object.(*corev1.Pod)
 		if !ok || pod == nil || !translate.Default.IsManaged(pod) || pod.Spec.NodeName == "" {
@@ -227,7 +237,7 @@ func (s *nodeSyncer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj
 		return ctrl.Result{}, ctx.VirtualClient.Delete(ctx.Context, vObj)
 	}
 
-	updatedVNode, err := s.translateUpdateStatus(pNode, vNode)
+	updatedVNode, err := s.translateUpdateStatus(ctx, pNode, vNode)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "update node status")
 	} else if updatedVNode != nil {

--- a/pkg/controllers/resources/nodes/syncer_test.go
+++ b/pkg/controllers/resources/nodes/syncer_test.go
@@ -30,7 +30,7 @@ func newFakeSyncer(t *testing.T, ctx *synccontext.RegisterContext) (*synccontext
 	assert.NilError(t, err)
 
 	syncContext, object := generictesting.FakeStartSyncer(t, ctx, func(ctx *synccontext.RegisterContext) (syncer.Object, error) {
-		return NewSyncer(ctx)
+		return NewSyncer(ctx, &fakeNodeServiceProvider{})
 	})
 	return syncContext, object.(*nodeSyncer)
 }

--- a/pkg/controllers/syncer/fake_syncer.go
+++ b/pkg/controllers/syncer/fake_syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"

--- a/pkg/server/filters/nodename.go
+++ b/pkg/server/filters/nodename.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes/nodeservice"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
@@ -19,9 +20,9 @@ type nodeName int
 // does not conflict with the keys defined in pkg/api.
 const nodeNameKey nodeName = iota
 
-func WithNodeName(h http.Handler, cli client.Client) http.Handler {
+func WithNodeName(h http.Handler, currentNamespace string, fakeKubeletIPs bool, virtualClient, physicalClient client.Client) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		nodeName := nodeNameFromHost(req, cli)
+		nodeName := nodeNameFromHost(req, currentNamespace, fakeKubeletIPs, virtualClient, physicalClient)
 		if nodeName != "" {
 			req = req.WithContext(context.WithValue(req.Context(), nodeNameKey, nodeName))
 		}
@@ -35,21 +36,37 @@ func NodeNameFrom(ctx context.Context) (string, bool) {
 	return info, ok
 }
 
-func nodeNameFromHost(req *http.Request, cli client.Client) string {
+func nodeNameFromHost(req *http.Request, currentNamespace string, fakeKubeletIPs bool, virtualClient client.Client, physicalClient client.Client) string {
 	splitted := strings.Split(req.Host, ":")
 	if len(splitted) == 2 {
 		hostname := splitted[0]
 		nodeList := &corev1.NodeList{}
-		err := cli.List(req.Context(), nodeList, client.MatchingFields{constants.IndexByHostName: hostname})
+		err := virtualClient.List(req.Context(), nodeList, client.MatchingFields{constants.IndexByHostName: hostname})
 		if err != nil && !errors.IsNotFound(err) {
 			klog.Error(err, "couldn't fetch nodename for hostname")
-			return ""
 		}
 		if len(nodeList.Items) == 1 {
 			nodeName := nodeList.Items[0].Name
 			return nodeName
 		}
+
+		if fakeKubeletIPs {
+			// try to fetch hostname by node service clusterIP
+			serviceList := &corev1.ServiceList{}
+			err = physicalClient.List(req.Context(), serviceList, client.InNamespace(currentNamespace), client.MatchingFields{constants.IndexByClusterIP: hostname})
+			if err != nil {
+				klog.Error(err, "couldn't fetch nodename from nodeservice")
+				return ""
+			}
+
+			// we found a service?
+			if len(serviceList.Items) > 0 {
+				serviceLabels := serviceList.Items[0].Labels
+				if len(serviceLabels) > 0 && serviceLabels[nodeservice.ServiceNodeLabel] != "" {
+					return serviceLabels[nodeservice.ServiceNodeLabel]
+				}
+			}
+		}
 	}
 	return ""
-
 }

--- a/test/e2e_node/node.go
+++ b/test/e2e_node/node.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/loft-sh/vcluster/test/framework"
 	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,5 +30,21 @@ var _ = ginkgo.Describe("Node sync", func() {
 		}
 
 		framework.ExpectEqual(true, reflect.DeepEqual(hostNodeLabels, virtualNodeLabels))
+	})
+
+	ginkgo.It("fake nodes have fake kubelet service IPs", func() {
+		virtualNodes, err := f.VclusterClient.CoreV1().Nodes().List(f.Context, metav1.ListOptions{})
+		framework.ExpectNoError(err)
+
+		for _, nodes := range virtualNodes.Items {
+			var foundInternalIPAddress bool
+			for _, address := range nodes.Status.Addresses {
+				if address.Type == corev1.NodeInternalIP {
+					foundInternalIPAddress = true
+				}
+			}
+
+			framework.ExpectEqual(foundInternalIPAddress, true)
+		}
 	})
 })


### PR DESCRIPTION
this is needed for proper resolution of kubelet metrics targets for prometheus

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-1197


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where prometheus was not able to get kubelet metrics because the fake nodes did not have `Addresses` of type `InternalIP`


**What else do we need to know?** 
