### PR TITLE
add `loft.sh/paused-date` annotation to paused clusters

### DIFF
--- a/pkg/constants/annotation.go
+++ b/pkg/constants/annotation.go
@@ -6,6 +6,7 @@ const (
 
 	PausedAnnotation         = "loft.sh/paused"
 	PausedReplicasAnnotation = "loft.sh/paused-replicas"
+	PausedDateAnnotation     = "loft.sh/paused-date"
 
 	// NodeSuffix is the dns suffix for our nodes
 	NodeSuffix = "nodes.vcluster.com"

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -132,6 +132,7 @@ func scaleDownDeployment(kubeClient kubernetes.Interface, labelSelector, namespa
 
 		item.Annotations[constants.PausedAnnotation] = "true"
 		item.Annotations[constants.PausedReplicasAnnotation] = strconv.Itoa(replicas)
+		item.Annotations[constants.PausedDateAnnotation] = time.Now().Format("2006-01-02T15:04:05.000Z")
 		item.Spec.Replicas = &zero
 
 		patch := client.MergeFrom(originalObject)
@@ -193,6 +194,7 @@ func scaleDownStatefulSet(kubeClient kubernetes.Interface, labelSelector, namesp
 
 		item.Annotations[constants.PausedAnnotation] = "true"
 		item.Annotations[constants.PausedReplicasAnnotation] = strconv.Itoa(replicas)
+		item.Annotations[constants.PausedDateAnnotation] = time.Now().Format("2006-01-02T15:04:05.000Z")
 		item.Spec.Replicas = &zero
 
 		patch := client.MergeFrom(originalObject)
@@ -289,6 +291,7 @@ func scaleUpDeployment(kubeClient kubernetes.Interface, labelSelector string, na
 		replicas32 := int32(replicas)
 		delete(item.Annotations, constants.PausedAnnotation)
 		delete(item.Annotations, constants.PausedReplicasAnnotation)
+		delete(item.Annotations, constants.PausedDateAnnotation)
 		item.Spec.Replicas = &replicas32
 
 		patch := client.MergeFrom(originalObject)
@@ -334,6 +337,7 @@ func scaleUpStatefulSet(kubeClient kubernetes.Interface, labelSelector string, n
 		replicas32 := int32(replicas)
 		delete(item.Annotations, constants.PausedAnnotation)
 		delete(item.Annotations, constants.PausedReplicasAnnotation)
+		delete(item.Annotations, constants.PausedDateAnnotation)
 		item.Spec.Replicas = &replicas32
 
 		patch := client.MergeFrom(originalObject)


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind feature


**What does this pull request do? Which issues does it resolve?** 
resolves #981


**Please provide a short message that should be published in the vcluster release notes**
Adds a `loft.sh/paused-date` annotation to vcluster's statefulset/deployment when a vcluster is paused. Annotation is removed once cluster resumed 

