### PR TITLE
fix: remove vcluster name and namespace from Node hostnames

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -69,7 +69,7 @@ data:
             errors
             health
             ready
-            rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
+            rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
             kubernetes cluster.local in-addr.arpa ip6.arpa { 
               pods insecure
               {{- if .Values.fallbackHostDns }}

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -73,7 +73,7 @@ data:
             errors
             health
             ready
-            rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
+            rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
             kubernetes {{- if .Values.vcluster.clusterDomain }} {{ .Values.vcluster.clusterDomain }} {{- end }} cluster.local in-addr.arpa ip6.arpa {
               pods insecure
               {{- if .Values.fallbackHostDns }}

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -77,7 +77,7 @@ data:
             errors
             health
             ready
-            rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
+            rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
             kubernetes cluster.local in-addr.arpa ip6.arpa { 
               pods insecure
               {{- if .Values.fallbackHostDns }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -73,7 +73,7 @@ data:
             errors
             health
             ready
-            rewrite name regex .*\.{{ .Release.Name }}\.{{ .Release.Namespace }}\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
+            rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
             kubernetes cluster.local in-addr.arpa ip6.arpa {
               pods insecure
               {{- if .Values.fallbackHostDns }}

--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -321,8 +321,17 @@ func filterOutPhysicalDaemonSets(pl *corev1.PodList) []corev1.Pod {
 }
 
 func GetNodeHost(nodeName, currentNamespace string) string {
-	hostname := strings.ReplaceAll(nodeName, ".", "-") + "." + translate.Suffix + "." + currentNamespace + "." + constants.NodeSuffix
+	hostname := strings.ReplaceAll(nodeName, ".", "-") + "." + constants.NodeSuffix
 	log := loghelper.New("GetNodeHost()")
+	log.Debugf("translating nodename %q into hostname: %q", nodeName, hostname)
+	return hostname
+}
+
+// GetNodeHostLegacy returns Node hostname in a format used in 0.14.x release.
+// This function is added for backwards compatibility and may be removed in a future release.
+func GetNodeHostLegacy(nodeName, currentNamespace string) string {
+	hostname := strings.ReplaceAll(nodeName, ".", "-") + "." + translate.Suffix + "." + currentNamespace + "." + constants.NodeSuffix
+	log := loghelper.New("GetNodeHostLegacy()")
 	log.Debugf("translating nodename %q into hostname: %q", nodeName, hostname)
 	return hostname
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -120,7 +120,7 @@ func NewServer(ctx *context2.ControllerContext, requestHeaderCaFile, clientCaFil
 		}
 
 		err = cache.IndexField(ctx.Context, &corev1.Node{}, constants.IndexByHostName, func(rawObj client.Object) []string {
-			return []string{nodes.GetNodeHost(rawObj.GetName(), ctx.CurrentNamespace)}
+			return []string{nodes.GetNodeHost(rawObj.GetName(), ctx.CurrentNamespace), nodes.GetNodeHostLegacy(rawObj.GetName(), ctx.CurrentNamespace)}
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #956 


**Please provide a short message that should be published in the vcluster release notes**
Changed the hostname format for Node addresses of the "hostname" type. The name and namespace of the vcluster were removed from the path. This change is backward compatible in this release, but future releases may drop backward compatibility.