### PR TITLE
move service account token to secret

### DIFF
--- a/cmd/vcluster/context/flag_options.go
+++ b/cmd/vcluster/context/flag_options.go
@@ -85,7 +85,8 @@ type VirtualClusterOptions struct {
 	SyncAllSecrets     bool     `json:"syncAllSecrets,omitempty"`
 	SyncAllConfigMaps  bool     `json:"syncAllConfigMaps,omitempty"`
 
-	ProxyMetricsServer bool `json:"proxyMetricsServer,omitempty"`
+	ProxyMetricsServer         bool `json:"proxyMetricsServer,omitempty"`
+	ServiceAccountTokenSecrets bool `json:"serviceAccountTokenSecrets,omitempty"`
 
 	// DEPRECATED FLAGS
 	DeprecatedSyncNodeChanges          bool `json:"syncNodeChanges"`
@@ -165,6 +166,7 @@ func AddFlags(flags *pflag.FlagSet, options *VirtualClusterOptions) {
 	flags.BoolVar(&options.SyncAllSecrets, "sync-all-secrets", false, "Sync all secrets from virtual to host cluster")
 
 	flags.BoolVar(&options.ProxyMetricsServer, "proxy-metrics-server", false, "Proxy the host cluster metrics server")
+	flags.BoolVar(&options.ServiceAccountTokenSecrets, "service-account-token-secrets", false, "Create secrets for pod service account tokens instead of injecting it as annotations")
 
 	// Deprecated Flags
 	flags.BoolVar(&options.DeprecatedSyncNodeChanges, "sync-node-changes", false, "If enabled and --fake-nodes is false, the virtual cluster will proxy node updates from the virtual cluster to the host cluster. This is not recommended and should only be used if you know what you are doing.")

--- a/docs/pages/config-reference.mdx
+++ b/docs/pages/config-reference.mdx
@@ -42,6 +42,7 @@ Before using any particular flag mentioned below, we recommend making yourself f
       --server-ca-key string                      The path to the server ca key (default "/data/server/tls/server-ca.key")
       --service-account string                    If set, will set this host service account on the synced pods
       --service-name string                       The service name where the vcluster proxy will be available
+      --service-account-token-secrets bool        Create secrets for pod service account tokens instead of injecting it as annotations
       --set-owner                                 If true, will set the same owner the currently running syncer pod has on the synced resources (default true)
       --sync strings                              A list of sync controllers to enable. 'foo' enables the sync controller named 'foo', '-foo' disables the sync controller named 'foo'
       --sync-all-nodes                            If enabled and --fake-nodes is false, the virtual cluster will sync all nodes instead of only the needed ones

--- a/docs/pages/operator/security.mdx
+++ b/docs/pages/operator/security.mdx
@@ -182,6 +182,7 @@ which creates separate secrets for each pods Service Account Token and mounts it
 is not enabled by default but can be enabled on demand. To enable this one can use the `extraArgs` options of the vcluster chart as follows
 
 ```
-extraArgs:
-  - --service-account-token-secrets=true
+syncer:
+  extraArgs:
+    - --service-account-token-secrets=true
 ```

--- a/docs/pages/operator/security.mdx
+++ b/docs/pages/operator/security.mdx
@@ -173,3 +173,15 @@ vcluster is able to be ran as a non root user. Steps below show how to set the d
 ### Workload & Network Isolation within the vcluster
 
 The above mentioned methods also work for isolating workloads inside the vcluster itself, as you can just deploy resource quotas, limit ranges, admission controllers and network policies in there. To allow network policies to function correctly, you'll need to [enable this in vcluster](../architecture/networking.mdx) itself though.
+
+### Secret based Service Account tokens
+
+By default vcluster will create Service Account Tokens for each pod and inject them as an annotation in the respective pods
+metadata. This can be a security risk in certain senarios. To mitigate this there's a flag `--service-account-token-secrets` in vcluster
+which creates separate secrets for each pods Service Account Token and mounts it accordingly using projected volumes. This option
+is not enabled by default but can be enabled on demand. To enable this one can use the `extraArgs` options of the vcluster chart as follows
+
+```
+extraArgs:
+  - --service-account-token-secrets=true
+```

--- a/pkg/controllers/generic/import_syncer.go
+++ b/pkg/controllers/generic/import_syncer.go
@@ -152,6 +152,12 @@ func (s *importer) ExcludePhysical(pObj client.Object) bool {
 }
 
 func (s *importer) excludeObject(obj client.Object) bool {
+	// check if back sync is disabled eg. for service account token secrets
+	if obj.GetAnnotations() != nil &&
+		obj.GetAnnotations()[translate.SkipBacksyncInMultiNamespaceMode] == "true" {
+		return true
+	}
+
 	if obj.GetLabels() != nil &&
 		obj.GetLabels()[translate.ControllerLabel] != "" {
 		return true
@@ -183,11 +189,6 @@ func (s *importer) SyncUp(ctx *synccontext.SyncContext, pObj client.Object) (ctr
 			if err != nil && !kerrors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
-		}
-
-		// check if back sync is disabled eg. for service account token secrets
-		if pObj.GetAnnotations()[translate.SkipBacksyncInMultiNamespaceMode] == "true" {
 			return ctrl.Result{}, nil
 		}
 	}
@@ -270,9 +271,6 @@ func (s *importer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj c
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if !managed {
-		return ctrl.Result{}, nil
-	} else if pObj.GetAnnotations() != nil &&
-		pObj.GetAnnotations()[translate.SkipBacksyncInMultiNamespaceMode] == "true" {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -88,6 +89,7 @@ func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 
 		virtualClusterClient:  virtualClusterClient,
 		physicalClusterClient: physicalClusterClient,
+		physicalClusterConfig: ctx.PhysicalManager.GetConfig(),
 		podTranslator:         podTranslator,
 		nodeSelector:          nodeSelector,
 		tolerations:           tolerations,
@@ -105,6 +107,7 @@ type podSyncer struct {
 	podTranslator         translatepods.Translator
 	virtualClusterClient  kubernetes.Interface
 	physicalClusterClient kubernetes.Interface
+	physicalClusterConfig *rest.Config
 	nodeSelector          *metav1.LabelSelector
 	tolerations           []*corev1.Toleration
 

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -340,7 +340,7 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj 
 	}
 
 	// update the virtual pod if the spec has changed
-	updatedPod, err := s.translateUpdate(pPod, vPod)
+	updatedPod, err := s.translateUpdate(ctx.PhysicalClient, pPod, vPod)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if updatedPod != nil {

--- a/pkg/controllers/resources/pods/translate.go
+++ b/pkg/controllers/resources/pods/translate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	podtranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
@@ -52,6 +53,24 @@ func (s *podSyncer) getK8sIPDNSIPServiceList(ctx *synccontext.SyncContext, vPod 
 }
 
 func (s *podSyncer) translateUpdate(pObj, vObj *corev1.Pod) (*corev1.Pod, error) {
+	ctrlRuntimeClient, err := client.New(s.physicalClusterConfig, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	secret, exists, err := podtranslate.GetSecretIfExists(context.Background(), ctrlRuntimeClient, vObj.Name, vObj.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if exists {
+		// check if owner is vcluster service, if so, modify to pod as owner
+		err := podtranslate.SetPodAsOwner(context.Background(), pObj, ctrlRuntimeClient, secret)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return s.podTranslator.Diff(vObj, pObj)
 }
 

--- a/pkg/controllers/resources/pods/translate.go
+++ b/pkg/controllers/resources/pods/translate.go
@@ -52,20 +52,15 @@ func (s *podSyncer) getK8sIPDNSIPServiceList(ctx *synccontext.SyncContext, vPod 
 	return kubeIP, dnsIP, ptrServiceList, nil
 }
 
-func (s *podSyncer) translateUpdate(pObj, vObj *corev1.Pod) (*corev1.Pod, error) {
-	ctrlRuntimeClient, err := client.New(s.physicalClusterConfig, client.Options{})
-	if err != nil {
-		return nil, err
-	}
-
-	secret, exists, err := podtranslate.GetSecretIfExists(context.Background(), ctrlRuntimeClient, vObj.Name, vObj.Namespace)
+func (s *podSyncer) translateUpdate(pClient client.Client, pObj, vObj *corev1.Pod) (*corev1.Pod, error) {
+	secret, exists, err := podtranslate.GetSecretIfExists(context.Background(), pClient, vObj.Name, vObj.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	if exists {
 		// check if owner is vcluster service, if so, modify to pod as owner
-		err := podtranslate.SetPodAsOwner(context.Background(), pObj, ctrlRuntimeClient, secret)
+		err := podtranslate.SetPodAsOwner(context.Background(), pObj, pClient, secret)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/resources/pods/translate/sa_token_secret.go
+++ b/pkg/controllers/resources/pods/translate/sa_token_secret.go
@@ -1,0 +1,81 @@
+package translate
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SkipSATokenSecretBacksyncAnnotation = "vcluster.loft.sh/skip-sa-secret-backsync"
+)
+
+var PodServiceAccountTokenSecretName string
+
+func SecretNameFromPodName(podName string) string {
+	return fmt.Sprintf("%s-sa-token", podName)
+}
+
+func checkIfSecretExists(ctx context.Context, vClient client.Client, podName, namespace string) (bool, error) {
+	secret := &corev1.Secret{}
+
+	err := vClient.Get(ctx, types.NamespacedName{
+		Name:      SecretNameFromPodName(podName),
+		Namespace: namespace,
+	}, secret)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+func SATokenSecret(ctx context.Context, vClient client.Client, vPod *corev1.Pod, tokens map[string]string) error {
+	exists, err := checkIfSecretExists(ctx, vClient, vPod.Name, vPod.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		// create to secret with the given token
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SecretNameFromPodName(vPod.Name),
+				Namespace: vPod.Namespace,
+
+				Annotations: map[string]string{
+					SkipSATokenSecretBacksyncAnnotation: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: corev1.SchemeGroupVersion.Version,
+						Kind:       vPod.Kind,
+						Name:       vPod.Name,
+						UID:        vPod.UID,
+					},
+				},
+			},
+			Type:       corev1.SecretTypeOpaque,
+			StringData: tokens,
+		}
+
+		err := vClient.Create(ctx, secret)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}

--- a/pkg/controllers/resources/pods/translate/sa_token_secret.go
+++ b/pkg/controllers/resources/pods/translate/sa_token_secret.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +55,7 @@ func SATokenSecret(ctx context.Context, vClient client.Client, vPod *corev1.Pod,
 				Namespace: vPod.Namespace,
 
 				Annotations: map[string]string{
-					SkipSATokenSecretBacksyncAnnotation: "true",
+					translate.SkipBacksyncInMultiNamespaceMode: "true",
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/priorityclasses"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
-	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -476,19 +475,6 @@ func (t *translator) translateProjectedVolume(projectedVolume *corev1.ProjectedV
 				return errors.Wrap(err, "create token")
 			} else if token.Status.Token == "" {
 				return errors.New("received empty token")
-			}
-
-			// set the token as annotation
-			if pPod.Annotations == nil {
-				pPod.Annotations = map[string]string{}
-			}
-			var annotation string
-			for {
-				annotation = ServiceAccountTokenAnnotation + random.RandomString(8)
-				if pPod.Annotations[annotation] == "" {
-					pPod.Annotations[annotation] = token.Status.Token
-					break
-				}
 			}
 
 			// rewrite projected volume

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -199,7 +199,7 @@ func TestVolumeTranslation(t *testing.T) {
 		tr := &translator{
 			eventRecorder: fakeRecorder,
 			log:           loghelper.New("pods-syncer-translator-test"),
-			vClient:       fake.NewClientBuilder().Build(),
+			pClient:       fake.NewClientBuilder().Build(),
 		}
 
 		pPod := testCase.vPod.DeepCopy()

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestPodAffinityTermsTranslation(t *testing.T) {
@@ -198,6 +199,7 @@ func TestVolumeTranslation(t *testing.T) {
 		tr := &translator{
 			eventRecorder: fakeRecorder,
 			log:           loghelper.New("pods-syncer-translator-test"),
+			vClient:       fake.NewClientBuilder().Build(),
 		}
 
 		pPod := testCase.vPod.DeepCopy()

--- a/pkg/controllers/resources/pods/util.go
+++ b/pkg/controllers/resources/pods/util.go
@@ -2,6 +2,9 @@ package pods
 
 import (
 	"github.com/loft-sh/vcluster/pkg/util/translate"
+
+	podtranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -33,6 +36,12 @@ func SecretNamesFromVolumes(pod *corev1.Pod) []string {
 			for j := range pod.Spec.Volumes[i].Projected.Sources {
 				if pod.Spec.Volumes[i].Projected.Sources[j].Secret != nil {
 					secrets = append(secrets, pod.Namespace+"/"+pod.Spec.Volumes[i].Projected.Sources[j].Secret.Name)
+				}
+
+				// check if projected volume source is a serviceaccount and in such a case
+				// we re-write it as a secret too, handle accordingly
+				if pod.Spec.Volumes[i].Projected.Sources[j].ServiceAccountToken != nil {
+					secrets = append(secrets, pod.Namespace+"/"+podtranslate.SecretNameFromPodName(pod.Name))
 				}
 			}
 		}

--- a/pkg/controllers/resources/pods/util.go
+++ b/pkg/controllers/resources/pods/util.go
@@ -41,7 +41,7 @@ func SecretNamesFromVolumes(pod *corev1.Pod) []string {
 				// check if projected volume source is a serviceaccount and in such a case
 				// we re-write it as a secret too, handle accordingly
 				if pod.Spec.Volumes[i].Projected.Sources[j].ServiceAccountToken != nil {
-					secrets = append(secrets, pod.Namespace+"/"+podtranslate.SecretNameFromPodName(pod.Name))
+					secrets = append(secrets, pod.Namespace+"/"+podtranslate.SecretNameFromPodName(pod.Name, pod.Namespace))
 				}
 			}
 		}

--- a/pkg/controllers/syncer/syncer.go
+++ b/pkg/controllers/syncer/syncer.go
@@ -133,6 +133,13 @@ func (r *syncerController) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		return captureSyncTelemetry(r.syncer.Sync(syncContext, pObj, vObj))(vObj.GetObjectKind().GroupVersionKind(), reconcileStart)
 	} else if vObj == nil && pObj != nil {
+		if pObj.GetAnnotations() != nil {
+			if shouldSkip, ok := pObj.GetAnnotations()[translate.SkipBacksyncInMultiNamespaceMode]; ok && shouldSkip == "true" {
+				// do not delete
+				return ctrl.Result{}, nil
+			}
+		}
+
 		// check if up syncer
 		upSyncer, ok := r.syncer.(UpSyncer)
 		if ok {

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -36,6 +36,10 @@ var (
 	ManagedLabelsAnnotation      = "vcluster.loft.sh/managed-labels"
 )
 
+const (
+	SkipBacksyncInMultiNamespaceMode = "vcluster.loft.sh/skip-backsync"
+)
+
 var Owner client.Object
 
 func GetOwnerReference(object client.Object) []metav1.OwnerReference {

--- a/test/commonValues.yaml
+++ b/test/commonValues.yaml
@@ -1,4 +1,6 @@
 syncer:
+  extraArgs:
+    - --service-account-token-secrets=true
   image: REPLACE_IMAGE_NAME
   env:
   - name: DEBUG


### PR DESCRIPTION
add to index for secret syncer

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves  ENG-1172 #968


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster service account token was mounted using downward API and annotation. We are now instead doing it with a dedicated secret containing all projected service account tokens


**What else do we need to know?** 
