### PR TITLE
Bug Fix: Add check if coredns files exists before trying to apply

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -339,6 +339,10 @@ func startControllers(ctx *context2.ControllerContext, rawConfig *api.Config, se
 		_ = wait.ExponentialBackoff(wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func() (bool, error) {
 			err := coredns.ApplyManifest(ctx.Options.DefaultImageRegistry, ctx.VirtualManager.GetConfig(), serverVersion)
 			if err != nil {
+				if errors.Is(err, coredns.ErrNoCoreDNSManifests) {
+					klog.Infof("No CoreDNS manifests found, skipping CoreDNS configuration")
+					return true, nil
+				}
 				klog.Infof("Failed to apply CoreDNS configuration from the manifest file: %v", err)
 				return false, nil
 			}

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -27,6 +27,8 @@ const (
 	defaultGID            = int64(1001)
 )
 
+var ErrNoCoreDNSManifests = fmt.Errorf("no coredns manifests found")
+
 func ApplyManifest(defaultImageRegistry string, inClusterConfig *rest.Config, serverVersion *version.Info) error {
 	vars := getManifestVariables(defaultImageRegistry, serverVersion)
 	output, err := processManifestTemplate(vars)
@@ -115,6 +117,10 @@ func GetUserID() int64 {
 
 func processManifestTemplate(vars map[string]interface{}) ([]byte, error) {
 	manifestInputPath := path.Join(constants.ContainerManifestsFolder, ManifestRelativePath)
+	// check if the manifestInputPath exists
+	if _, err := os.Stat(manifestInputPath); os.IsNotExist(err) {
+		return nil, ErrNoCoreDNSManifests
+	}
 	manifestTemplate, err := template.ParseFiles(manifestInputPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse %s: %v", manifestInputPath, err)


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind bugfix

**What does this pull request do? 
resolves https://github.com/loft-sh/vcluster/issues/992


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where disabling coredns results in an error loop during syncer start up. The following PR adds a check for if the file exists and if not we exit the coredns loop and skip the apply of it. 
