### PR TITLE
Allow globalAnnotations of all objects created by the eks, k8s and k0s charts

### DIFF
--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -12,9 +12,10 @@ metadata:
 {{- if .Values.api.labels }}
 {{ toYaml .Values.api.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.api.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.api.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.api.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.api.replicas }}

--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -12,9 +12,10 @@ metadata:
 {{- if .Values.controller.labels }}
 {{ toYaml .Values.controller.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.controller.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.controller.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.controller.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.controller.replicas }}

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: custom-deployments
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations}}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4}}
+  {{- end}}  
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-

--- a/charts/eks/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/eks/templates/daemonset-hostpath-mapper.yaml
@@ -17,9 +17,10 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   {{- if .Values.hostpathMapper.dev }}

--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -12,9 +12,10 @@ metadata:
 {{- if .Values.etcd.labels }}
 {{ toYaml .Values.etcd.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.etcd.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.etcd.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.etcd.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-etcd-headless

--- a/charts/eks/templates/ingress.yaml
+++ b/charts/eks/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+{{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations  }}  
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations}}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}    
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/eks/templates/limitrange.yaml
+++ b/charts/eks/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/eks/templates/networkpolicy.yaml
+++ b/charts/eks/templates/networkpolicy.yaml
@@ -4,6 +4,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:
@@ -43,6 +47,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-control-plane
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/eks/templates/pre-install-hook-job-role.yaml
+++ b/charts/eks/templates/pre-install-hook-job-role.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}    
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded    
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps","services"]

--- a/charts/eks/templates/pre-install-hook-job-rolebinding.yaml
+++ b/charts/eks/templates/pre-install-hook-job-rolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations}}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/eks/templates/pre-install-hook-job-serviceaccount.yaml
+++ b/charts/eks/templates/pre-install-hook-job-serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations}}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/eks/templates/pre-install-hook-job.yaml
+++ b/charts/eks/templates/pre-install-hook-job.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations}}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/eks/templates/resourcequota.yaml
+++ b/charts/eks/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/eks/templates/serviceaccount.yaml
+++ b/charts/eks/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -11,9 +11,10 @@ metadata:
 {{- if .Values.syncer.labels }}
 {{ toYaml .Values.syncer.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.syncer.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.syncer.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.syncer.replicas }}

--- a/charts/eks/templates/workloadserviceaccount.yaml
+++ b/charts/eks/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-

--- a/charts/k0s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k0s/templates/daemonset-hostpath-mapper.yaml
@@ -17,9 +17,10 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   {{- if .Values.hostpathMapper.dev }}

--- a/charts/k0s/templates/ingress.yaml
+++ b/charts/k0s/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+  {{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k0s/templates/secret.yaml
+++ b/charts/k0s/templates/secret.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations}}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}    
+  {{- end }}
 type: Opaque
 stringData:
   {{- if .Values.serviceCIDR }}

--- a/charts/k0s/templates/serviceaccount.yaml
+++ b/charts/k0s/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -11,9 +11,10 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.annotations }}
+{{- $annotations := merge .Values.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-headless

--- a/charts/k0s/templates/workloadserviceaccount.yaml
+++ b/charts/k0s/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -12,9 +12,10 @@ metadata:
 {{- if .Values.controller.labels }}
 {{ toYaml .Values.controller.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.controller.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.controller.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.controller.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.controller.replicas }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -4,6 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-

--- a/charts/k8s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k8s/templates/daemonset-hostpath-mapper.yaml
@@ -17,9 +17,10 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   {{- if .Values.hostpathMapper.dev }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -12,9 +12,10 @@ metadata:
 {{- if .Values.etcd.labels }}
 {{ toYaml .Values.etcd.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.etcd.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.etcd.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.etcd.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   serviceName: {{ .Release.Name }}-etcd-headless

--- a/charts/k8s/templates/ingress.yaml
+++ b/charts/k8s/templates/ingress.yaml
@@ -2,9 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-  {{- if .Values.ingress.annotations }}
+  {{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if $annotations }}
   annotations:
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{ toYaml $annotations | nindent 4 }}
   {{- end }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 data:
   manifests: |-
     {{ .Values.init.manifests | nindent 4 | trim }}

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -4,6 +4,10 @@ kind: LimitRange
 metadata:
   name: {{ .Release.Name }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   limits:
   - default:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -4,6 +4,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:
@@ -43,6 +47,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-control-plane
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/k8s/templates/pre-install-hook-job-role.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }} 
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/k8s/templates/pre-install-hook-job-rolebinding.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-rolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }} 
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/k8s/templates/pre-install-hook-job-serviceaccount.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }} 
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/k8s/templates/pre-install-hook-job.yaml
+++ b/charts/k8s/templates/pre-install-hook-job.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Release.Name }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
+  {{- if .Values.globalAnnotations }}
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }} 
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -4,6 +4,10 @@ kind: ResourceQuota
 metadata:
   name:  {{ .Release.Name }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 spec:
   hard:
     {{- range $key, $val := .Values.isolation.resourceQuota.quota }}

--- a/charts/k8s/templates/scheduler-deployment.yaml
+++ b/charts/k8s/templates/scheduler-deployment.yaml
@@ -12,9 +12,10 @@ metadata:
 {{- if .Values.scheduler.labels }}
 {{ toYaml .Values.scheduler.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.scheduler.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.scheduler.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.scheduler.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.scheduler.replicas }}

--- a/charts/k8s/templates/serviceaccount.yaml
+++ b/charts/k8s/templates/serviceaccount.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -11,9 +11,10 @@ metadata:
 {{- if .Values.syncer.labels }}
 {{ toYaml .Values.syncer.labels | indent 4 }}
 {{- end }}
-  {{- if .Values.syncer.annotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.syncer.annotations }}
+  {{- if $annotations}}
   annotations:
-{{ toYaml .Values.syncer.annotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.syncer.replicas }}

--- a/charts/k8s/templates/workloadserviceaccount.yaml
+++ b/charts/k8s/templates/workloadserviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.globalAnnotations }}
+  annotations:
+{{ toYaml .Values.globalAnnotations | indent 4 }}
+  {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}


### PR DESCRIPTION
Added annotation of all objects created by the eks,8s and k0s charts.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #714 


**Please provide a short message that should be published in the vcluster release notes**
Added helm value "global.annotations" to eke, k8s and k0s charts that will add its annotations to all objects created in the chart. Annotations for specific objects have precedence over global ones.

**What else do we need to know?** 
