### PR TITLE
Add support for spec.schedulingGates in calcDiffSpec

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -911,6 +911,12 @@ func (t *translator) calcSpecDiff(pObj, vObj *corev1.Pod) *corev1.PodSpec {
 		updatedPodSpec.InitContainers = updatedContainer
 	}
 
+	schedulingGatesVal, equal := isPodSpecSchedulingGatesDiff(pObj.Spec.SchedulingGates, vObj.Spec.SchedulingGates)
+	if !equal {
+		updatedPodSpec = pObj.Spec.DeepCopy()
+		updatedPodSpec.SchedulingGates = schedulingGatesVal
+	}
+
 	return updatedPodSpec
 }
 
@@ -958,4 +964,16 @@ func isInt64Different(i1, i2 *int64) (*int64, bool) {
 	}
 
 	return updated, false
+}
+
+func isPodSpecSchedulingGatesDiff(pGates, vGates []corev1.PodSchedulingGate) ([]corev1.PodSchedulingGate, bool) {
+	if len(vGates) != len(pGates) {
+		return vGates, false
+	}
+	for i, v := range vGates {
+		if v.Name != pGates[i].Name {
+			return vGates, false
+		}
+	}
+	return vGates, true
 }

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -911,10 +911,12 @@ func (t *translator) calcSpecDiff(pObj, vObj *corev1.Pod) *corev1.PodSpec {
 		updatedPodSpec.InitContainers = updatedContainer
 	}
 
-	schedulingGatesVal, equal := isPodSpecSchedulingGatesDiff(pObj.Spec.SchedulingGates, vObj.Spec.SchedulingGates)
-	if !equal {
-		updatedPodSpec = pObj.Spec.DeepCopy()
-		updatedPodSpec.SchedulingGates = schedulingGatesVal
+	isEqual := isPodSpecSchedulingGatesDiff(pObj.Spec.SchedulingGates, vObj.Spec.SchedulingGates)
+	if !isEqual {
+		if updatedPodSpec == nil {
+			updatedPodSpec = pObj.Spec.DeepCopy()
+		}
+		updatedPodSpec.SchedulingGates = vObj.Spec.SchedulingGates
 	}
 
 	return updatedPodSpec
@@ -966,14 +968,14 @@ func isInt64Different(i1, i2 *int64) (*int64, bool) {
 	return updated, false
 }
 
-func isPodSpecSchedulingGatesDiff(pGates, vGates []corev1.PodSchedulingGate) ([]corev1.PodSchedulingGate, bool) {
+func isPodSpecSchedulingGatesDiff(pGates, vGates []corev1.PodSchedulingGate) bool {
 	if len(vGates) != len(pGates) {
-		return vGates, false
+		return false
 	}
 	for i, v := range vGates {
 		if v.Name != pGates[i].Name {
-			return vGates, false
+			return false
 		}
 	}
-	return vGates, true
+	return true
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #845


**Please provide a short message that should be published in the vcluster release notes**
Added ability to sync down the `spec.schedulingGates` property in the `calcSpecDiff` function for the pod translator package.


**What else do we need to know?** 
Used `rancher/k3s:v1.26.3-k3s1` image with `--kube-apiserver-arg=feature-gates=PodSchedulingReadiness=true` for the server args in the k3s chart for testing.