### PR TITLE
fix helm chart resource name

### DIFF
--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-api
+  name: {{ template "vcluster.name" . }}-api
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.api.labels }}
 {{ toYaml .Values.api.labels | indent 4 }}
@@ -30,7 +30,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-api
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.api.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-api
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.api.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -63,7 +63,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.api.volumes }}
 {{ toYaml .Values.api.volumes | indent 8 }}
       {{- end }}
@@ -88,7 +88,7 @@ spec:
           - '--etcd-cafile=/run/config/pki/etcd-ca.crt'
           - '--etcd-certfile=/run/config/pki/apiserver-etcd-client.crt'
           - '--etcd-keyfile=/run/config/pki/apiserver-etcd-client.key'
-          - '--etcd-servers=https://{{ .Release.Name }}-etcd:2379'
+          - '--etcd-servers=https://{{ template "vcluster.name" . }}-etcd:2379'
           - '--kubelet-client-certificate=/run/config/pki/apiserver-kubelet-client.crt'
           - '--kubelet-client-key=/run/config/pki/apiserver-kubelet-client.key'
           - '--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname'
@@ -145,7 +145,7 @@ spec:
           - name: SERVICE_CIDR
             valueFrom:
               configMapKeyRef:
-                name: "vc-cidr-{{ .Release.Name }}"
+                name: "vc-cidr-{{ template "vcluster.name" . }}"
                 key: cidr
           {{- end }}
         volumeMounts:

--- a/charts/eks/templates/api-service.yaml
+++ b/charts/eks/templates/api-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-api
+  name: {{ template "vcluster.name" . }}-api
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.api.serviceAnnotations }}
   {{- if $annotations }}
@@ -23,5 +23,5 @@ spec:
       protocol: TCP
   selector:
     app: vcluster-api
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
 {{- end }}

--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-controller
+  name: {{ template "vcluster.name" . }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-controller
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.controller.labels }}
 {{ toYaml .Values.controller.labels | indent 4 }}
@@ -30,7 +30,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-controller
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.controller.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-controller
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.controller.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -63,7 +63,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.controller.volumes }}
 {{ toYaml .Values.controller.volumes | indent 8 }}
       {{- end }}
@@ -138,7 +138,7 @@ spec:
           - name: SERVICE_CIDR
             valueFrom:
               configMapKeyRef:
-                name: "vc-cidr-{{ .Release.Name }}"
+                name: "vc-cidr-{{ template "vcluster.name" . }}"
                 key: cidr
           {{- end }}
         volumeMounts:

--- a/charts/eks/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/eks/templates/daemonset-hostpath-mapper.yaml
@@ -6,13 +6,13 @@ kind: DaemonSet
 kind: Deployment
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-hostpath-mapper
+  name: {{ template "vcluster.name" . }}-hostpath-mapper
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-hostpath-mapper
     component: hostpath-mapper
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
@@ -28,19 +28,19 @@ spec:
   selector:
     matchLabels:
       app: vcluster-hostpath-mapper
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
       component: hostpath-mapper
   template:
     metadata:
       labels:
         app: vcluster-hostpath-mapper
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
         component: hostpath-mapper
     spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       containers:
       - name: hostpath-mapper
@@ -61,21 +61,21 @@ spec:
                 fieldPath: spec.nodeName
         args:
           - maphostpaths
-          - --name={{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
           - --target-namespace={{ .Release.Namespace }}
         volumeMounts:
           - name: logs
             mountPath: /var/log
           - name: virtual-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
           - name: pod-logs
             mountPath: /var/log/pods
           - name: virtual-pod-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
           - name: kubelet-pods
             mountPath: /var/vcluster/physical/kubelet/pods
           - name: virtual-kubelet-pods
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
           - name: kubeconfig
             mountPath: /data/server/tls
         resources:
@@ -86,7 +86,7 @@ spec:
             path: /var/log
         - name: virtual-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
         - name: pod-logs
           hostPath:
             path: /var/log/pods
@@ -95,12 +95,12 @@ spec:
             path: /var/lib/kubelet/pods
         - name: virtual-pod-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
         - name: virtual-kubelet-pods
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
         - name: kubeconfig
           secret:
-            secretName: vc-{{ .Release.Name }}
+            secretName: vc-{{ template "vcluster.name" . }}
 {{ end }}
 

--- a/charts/eks/templates/etcd-service.yaml
+++ b/charts/eks/templates/etcd-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-etcd
+  name: {{ template "vcluster.name" . }}-etcd
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
@@ -27,5 +27,5 @@ spec:
       protocol: TCP
   selector:
     app: vcluster-etcd
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
   {{- end }}

--- a/charts/eks/templates/etcd-statefulset-service.yaml
+++ b/charts/eks/templates/etcd-statefulset-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-etcd-headless
+  name: {{ template "vcluster.name" . }}-etcd-headless
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
@@ -28,5 +28,5 @@ spec:
   clusterIP: None
   selector:
     app: vcluster-etcd
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
 {{- end }}

--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-etcd
+  name: {{ template "vcluster.name" . }}-etcd
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.etcd.labels }}
 {{ toYaml .Values.etcd.labels | indent 4 }}
@@ -17,13 +17,13 @@ metadata:
 {{ toYaml .Values.etcd.annotations | indent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ .Release.Name }}-etcd-headless
+  serviceName: {{ template "vcluster.name" . }}-etcd-headless
   replicas: {{ .Values.etcd.replicas }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: vcluster-etcd
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   {{- if (hasKey .Values.etcd "volumeClaimTemplates") }}
   volumeClaimTemplates:
 {{ toYaml .Values.etcd.volumeClaimTemplates | indent 4 }}
@@ -48,7 +48,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-etcd
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.etcd.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -72,7 +72,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.volumes }}
 {{ toYaml .Values.etcd.volumes | indent 8 }}
       {{- end }}
@@ -95,12 +95,12 @@ spec:
           - '--cert-file=/run/config/pki/etcd-server.crt'
           - '--client-cert-auth=true'
           - '--data-dir=/var/lib/etcd'
-          - '--advertise-client-urls=https://$(NAME).{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}:2379'
-          - '--initial-advertise-peer-urls=https://$(NAME).{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}:2380'
+          - '--advertise-client-urls=https://$(NAME).{{ template "vcluster.name" . }}-etcd-headless.{{ .Release.Namespace }}:2379'
+          - '--initial-advertise-peer-urls=https://$(NAME).{{ template "vcluster.name" . }}-etcd-headless.{{ .Release.Namespace }}:2380'
           {{- $releaseName := .Release.Name -}}
           {{- $releaseNamespace := .Release.Namespace }}
           - '--initial-cluster={{ range $index := untilStep 0 (int .Values.etcd.replicas) 1 }}{{ if (ne (int $index) 0) }},{{ end }}{{ $releaseName }}-etcd-{{ $index }}=https://{{ $releaseName }}-etcd-{{ $index }}.{{ $releaseName }}-etcd-headless.{{ $releaseNamespace }}:2380{{ end }}'
-          - '--initial-cluster-token={{ .Release.Name }}'
+          - '--initial-cluster-token={{ template "vcluster.name" . }}'
           - '--initial-cluster-state=new'
           - '--listen-client-urls=https://0.0.0.0:2379'
           - '--listen-metrics-urls=http://0.0.0.0:2381'

--- a/charts/eks/templates/ingress.yaml
+++ b/charts/eks/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
   {{- toYaml .Values.ingress.annotations | nindent 4 }}
   {{- end }}
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
@@ -18,7 +18,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ template "vcluster.name" . }}
                 port:
                   name: https
             path: /

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-init-manifests
+  name: {{ template "vcluster.name" . }}-init-manifests
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 data:
   manifests: |-
@@ -40,7 +40,7 @@ data:
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}
-      releaseName: {{ .release.name }}
+      releaseName: {{ template "vcluster.name" . }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
   {{- end }}

--- a/charts/eks/templates/limitrange.yaml
+++ b/charts/eks/templates/limitrange.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: {{ .Release.Name }}-limit-range
+  name: {{ template "vcluster.name" . }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   limits:

--- a/charts/eks/templates/networkpolicy.yaml
+++ b/charts/eks/templates/networkpolicy.yaml
@@ -2,12 +2,12 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-workloads
+  name: {{ template "vcluster.name" . }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to the vcluster control plane
     - ports:
@@ -16,7 +16,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ template "vcluster.name" . }}
     # Allows outgoing connections to DNS server
     - ports:
       - port: 53
@@ -28,7 +28,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
         - ipBlock:
             cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
@@ -41,12 +41,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-control-plane
+  name: {{ template "vcluster.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to all pods with
     # port 443, 8443 or 6443. This is needed for host Kubernetes

--- a/charts/eks/templates/pre-install-hook-job-role.yaml
+++ b/charts/eks/templates/pre-install-hook-job-role.yaml
@@ -2,7 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install

--- a/charts/eks/templates/pre-install-hook-job-rolebinding.yaml
+++ b/charts/eks/templates/pre-install-hook-job-rolebinding.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
@@ -10,10 +10,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-job
+    name: {{ template "vcluster.name" . }}-job
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/eks/templates/pre-install-hook-job-serviceaccount.yaml
+++ b/charts/eks/templates/pre-install-hook-job-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install

--- a/charts/eks/templates/pre-install-hook-job.yaml
+++ b/charts/eks/templates/pre-install-hook-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
@@ -12,7 +12,7 @@ spec:
   backoffLimit: 3
   template:
     metadata:
-      name: {{ .Release.Name }}-job
+      name: {{ template "vcluster.name" . }}-job
       {{- if .Values.job.podAnnotations }}
       annotations:
 {{ toYaml .Values.job.podAnnotations | indent 8 }}
@@ -22,7 +22,7 @@ spec:
 {{ toYaml .Values.job.podLabels | indent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Release.Name }}-job
+      serviceAccountName: {{ template "vcluster.name" . }}-job
       restartPolicy: OnFailure
       nodeSelector:
 {{ toYaml .Values.job.nodeSelector | indent 8 }}
@@ -50,7 +50,7 @@ spec:
             - /vcluster
             - certs
           args:
-            - --prefix={{ .Release.Name }}
+            - --prefix={{ template "vcluster.name" . }}
             - --etcd-replicas={{ .Values.etcd.replicas }}
             {{- if .Values.serviceCIDR }}
             - --service-cidr={{ .Values.serviceCIDR }}

--- a/charts/eks/templates/resourcequota.yaml
+++ b/charts/eks/templates/resourcequota.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name:  {{ .Release.Name }}-quota
+  name:  {{ template "vcluster.name" . }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   hard:

--- a/charts/eks/templates/serviceaccount.yaml
+++ b/charts/eks/templates/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.syncer.labels }}
 {{ toYaml .Values.syncer.labels | indent 4 }}
@@ -29,7 +29,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.syncer.podAnnotations }}
@@ -38,7 +38,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.syncer.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
       {{- if or .Values.syncer.securityContext.runAsUser .Values.syncer.securityContext.runAsNonRoot }}
@@ -75,7 +75,7 @@ spec:
             name: custom-deployments
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.syncer.volumes }}
 {{ toYaml .Values.syncer.volumes | indent 8 }}
       {{- end }}
@@ -100,13 +100,13 @@ spec:
         {{- end }}
         {{- if not .Values.syncer.noArgs }}
         args:
-          - --name={{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
           - --request-header-ca-cert=/pki/ca.crt
           - --client-ca-cert=/pki/ca.crt
           - --server-ca-cert=/pki/ca.crt
           - --server-ca-key=/pki/ca.key
           - --kube-config=/pki/admin.conf
-          - --service-account=vc-workload-{{ .Release.Name }}
+          - --service-account=vc-workload-{{ template "vcluster.name" . }}
           {{- range $key, $container := .Values.plugin }}
           {{- if not $container.optional }}
           - --plugins={{ $key }}

--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
@@ -37,18 +37,18 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lb
+  name: {{ template "vcluster.name" . }}-lb
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -66,7 +66,7 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/eks/templates/workloadserviceaccount.yaml
+++ b/charts/eks/templates/workloadserviceaccount.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-workload-{{ .Release.Name }}
+  name: vc-workload-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -4,6 +4,11 @@ defaultImageRegistry: ""
 
 globalAnnotations: {}
 
+# By default, fullname uses '-. This
+# overrides that and uses the given string instead.
+nameOverride: ""
+fullnameOverride: ""
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-coredns
+  name: {{ template "vcluster.name" . }}-coredns
   namespace: {{ .Release.Namespace }}
 data:
 {{- if .Values.coredns.manifests }}

--- a/charts/k0s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k0s/templates/daemonset-hostpath-mapper.yaml
@@ -6,13 +6,13 @@ kind: DaemonSet
 kind: Deployment
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-hostpath-mapper
+  name: {{ template "vcluster.name" . }}-hostpath-mapper
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-hostpath-mapper
     component: hostpath-mapper
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
@@ -28,19 +28,19 @@ spec:
   selector:
     matchLabels:
       app: vcluster-hostpath-mapper
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
       component: hostpath-mapper
   template:
     metadata:
       labels:
         app: vcluster-hostpath-mapper
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
         component: hostpath-mapper
     spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       containers:
       - name: hostpath-mapper
@@ -61,21 +61,21 @@ spec:
                 fieldPath: spec.nodeName
         args:
           - maphostpaths
-          - --name={{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
           - --target-namespace={{ .Release.Namespace }}
         volumeMounts:
           - name: logs
             mountPath: /var/log
           - name: virtual-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
           - name: pod-logs
             mountPath: /var/log/pods
           - name: virtual-pod-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
           - name: kubelet-pods
             mountPath: /var/vcluster/physical/kubelet/pods
           - name: virtual-kubelet-pods
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
           - name: kubeconfig
             mountPath: /data/server/tls
         resources:
@@ -86,7 +86,7 @@ spec:
             path: /var/log
         - name: virtual-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
         - name: pod-logs
           hostPath:
             path: /var/log/pods
@@ -95,12 +95,12 @@ spec:
             path: /var/lib/kubelet/pods
         - name: virtual-pod-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
         - name: virtual-kubelet-pods
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
         - name: kubeconfig
           secret:
-            secretName: vc-{{ .Release.Name }}
+            secretName: vc-{{ template "vcluster.name" . }}
 {{ end }}
 

--- a/charts/k0s/templates/ingress.yaml
+++ b/charts/k0s/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
   {{- toYaml .Values.ingress.annotations | nindent 4 }}
   {{- end }}
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
@@ -18,7 +18,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ template "vcluster.name" . }}
                 port:
                   name: https
             path: /

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-init-manifests
+  name: {{ template "vcluster.name" . }}-init-manifests
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 data:
   manifests: |-
@@ -40,7 +40,7 @@ data:
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}
-      releaseName: {{ .release.name }}
+      releaseName: {{ template "vcluster.name" . }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
   {{- end }}

--- a/charts/k0s/templates/limitrange.yaml
+++ b/charts/k0s/templates/limitrange.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: {{ .Release.Name }}-limit-range
+  name: {{ template "vcluster.name" . }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   limits:

--- a/charts/k0s/templates/networkpolicy.yaml
+++ b/charts/k0s/templates/networkpolicy.yaml
@@ -2,12 +2,12 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-workloads
+  name: {{ template "vcluster.name" . }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to the vcluster control plane
     - ports:
@@ -16,7 +16,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ template "vcluster.name" . }}
     # Allows outgoing connections to DNS server
     - ports:
       - port: 53
@@ -28,7 +28,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
         - ipBlock:
             cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
@@ -41,12 +41,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-control-plane
+  name: {{ template "vcluster.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to all pods with
     # port 443, 8443 or 6443. This is needed for host Kubernetes

--- a/charts/k0s/templates/resourcequota.yaml
+++ b/charts/k0s/templates/resourcequota.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name:  {{ .Release.Name }}-quota
+  name:  {{ template "vcluster.name" . }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   hard:

--- a/charts/k0s/templates/secret.yaml
+++ b/charts/k0s/templates/secret.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vc-{{ .Release.Name }}-config
+  name: vc-{{ template "vcluster.name" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque
 stringData:

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
@@ -37,18 +37,18 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lb
+  name: {{ template "vcluster.name" . }}-lb
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -66,7 +66,7 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/k0s/templates/serviceaccount.yaml
+++ b/charts/k0s/templates/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k0s/templates/statefulset-service.yaml
+++ b/charts/k0s/templates/statefulset-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-headless
+  name: {{ template "vcluster.name" . }}-headless
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "vcluster.fullname" . }}
+    app: {{ template "vcluster.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
@@ -22,4 +22,4 @@ spec:
   clusterIP: None
   selector:
     app: vcluster
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
@@ -16,12 +16,12 @@ metadata:
 {{ toYaml .Values.annotations | indent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ .Release.Name }}-headless
+  serviceName: {{ template "vcluster.name" . }}-headless
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   {{- if (hasKey .Values "volumeClaimTemplates") }}
   volumeClaimTemplates:
 {{ toYaml .Values.volumeClaimTemplates | indent 4 }}
@@ -46,7 +46,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
       {{- if or .Values.securityContext.runAsUser .Values.securityContext.runAsNonRoot }}
@@ -74,11 +74,11 @@ spec:
       {{- end }}
         - name: k0s-config
           secret:
-            secretName: vc-{{ .Release.Name }}-config
+            secretName: vc-{{ template "vcluster.name" . }}-config
       {{- if .Values.coredns.enabled }}
         - name: coredns
           configMap:
-            name: {{ .Release.Name }}-coredns
+            name: {{ template "vcluster.name" . }}-coredns
       {{- end }}
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
@@ -126,7 +126,7 @@ spec:
           - name: CONFIG_READY
             valueFrom:
               secretKeyRef:
-                name: "vc-{{ .Release.Name }}-config"
+                name: "vc-{{ template "vcluster.name" . }}-config"
                 key: CONFIG_READY
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
@@ -157,8 +157,8 @@ spec:
         {{- end }}
         {{- if not .Values.syncer.noArgs }}
         args:
-          - --name={{ .Release.Name }}
-          - --service-account=vc-workload-{{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
+          - --service-account=vc-workload-{{ template "vcluster.name" . }}
           - --request-header-ca-cert=/data/k0s/pki/ca.crt
           - --client-ca-cert=/data/k0s/pki/ca.crt
           - --server-ca-cert=/data/k0s/pki/ca.crt

--- a/charts/k0s/templates/workloadserviceaccount.yaml
+++ b/charts/k0s/templates/workloadserviceaccount.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-workload-{{ .Release.Name }}
+  name: vc-workload-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -4,6 +4,11 @@ defaultImageRegistry: ""
 
 globalAnnotations: {}
 
+# By default, fullname uses '-. This
+# overrides that and uses the given string instead.
+nameOverride: ""
+fullnameOverride: ""
+
 # Plugins that should get loaded. Usually you want to apply those via 'vcluster create ... -f https://.../plugin.yaml'
 plugin: {}
 # Manually configure a plugin called test

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-coredns
+  name: {{ template "vcluster.name" . }}-coredns
   namespace: {{ .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:

--- a/charts/k3s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k3s/templates/daemonset-hostpath-mapper.yaml
@@ -6,13 +6,13 @@ kind: DaemonSet
 kind: Deployment
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-hostpath-mapper
+  name: {{ template "vcluster.name" . }}-hostpath-mapper
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-hostpath-mapper
     component: hostpath-mapper
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
@@ -28,19 +28,19 @@ spec:
   selector:
     matchLabels:
       app: vcluster-hostpath-mapper
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
       component: hostpath-mapper
   template:
     metadata:
       labels:
         app: vcluster-hostpath-mapper
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
         component: hostpath-mapper
     spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       containers:
       - name: hostpath-mapper
@@ -61,21 +61,21 @@ spec:
                 fieldPath: spec.nodeName
         args:
           - maphostpaths
-          - --name={{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
           - --target-namespace={{ .Release.Namespace }}
         volumeMounts:
           - name: logs
             mountPath: /var/log
           - name: virtual-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
           - name: pod-logs
             mountPath: /var/log/pods
           - name: virtual-pod-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
           - name: kubelet-pods
             mountPath: /var/vcluster/physical/kubelet/pods
           - name: virtual-kubelet-pods
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
           - name: kubeconfig
             mountPath: /data/server/tls
         resources:
@@ -86,7 +86,7 @@ spec:
             path: /var/log
         - name: virtual-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
         - name: pod-logs
           hostPath:
             path: /var/log/pods
@@ -95,12 +95,12 @@ spec:
             path: /var/lib/kubelet/pods
         - name: virtual-pod-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
         - name: virtual-kubelet-pods
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
         - name: kubeconfig
           secret:
-            secretName: vc-{{ .Release.Name }}
+            secretName: vc-{{ template "vcluster.name" . }}
 {{ end }}
 

--- a/charts/k3s/templates/ingress.yaml
+++ b/charts/k3s/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
   {{- toYaml $annotations | nindent 4 }}
   {{- end }}
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
@@ -19,7 +19,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ template "vcluster.name" . }}
                 port:
                   name: https
             path: /

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-init-manifests
+  name: {{ template "vcluster.name" . }}-init-manifests
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -44,7 +44,7 @@ data:
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}
-      releaseName: {{ .release.name }}
+      releaseName: {{ template "vcluster.name" . }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
   {{- end }}

--- a/charts/k3s/templates/limitrange.yaml
+++ b/charts/k3s/templates/limitrange.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: {{ .Release.Name }}-limit-range
+  name: {{ template "vcluster.name" . }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:

--- a/charts/k3s/templates/networkpolicy.yaml
+++ b/charts/k3s/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-workloads
+  name: {{ template "vcluster.name" . }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -11,7 +11,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to the vcluster control plane
     - ports:
@@ -20,7 +20,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ template "vcluster.name" . }}
     # Allows outgoing connections to DNS server
     - ports:
       - port: 53
@@ -32,7 +32,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
         - ipBlock:
             cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
@@ -45,12 +45,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-control-plane
+  name: {{ template "vcluster.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to all pods with
     # port 443, 8443 or 6443. This is needed for host Kubernetes

--- a/charts/k3s/templates/pdb.yaml
+++ b/charts/k3s/templates/pdb.yaml
@@ -2,12 +2,12 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -23,5 +23,5 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
 {{- end }}

--- a/charts/k3s/templates/resourcequota.yaml
+++ b/charts/k3s/templates/resourcequota.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name:  {{ .Release.Name }}-quota
+  name:  {{ template "vcluster.name" . }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
   {{- if .Values.globalAnnotations }}
   annotations:

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
@@ -37,18 +37,18 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lb
+  name: {{ template "vcluster.name" . }}-lb
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -66,7 +66,7 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/k3s/templates/serviceaccount.yaml
+++ b/charts/k3s/templates/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:

--- a/charts/k3s/templates/statefulset-service.yaml
+++ b/charts/k3s/templates/statefulset-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-headless
+  name: {{ template "vcluster.name" . }}-headless
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "vcluster.fullname" . }}
+    app: {{ template "vcluster.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
@@ -23,5 +23,5 @@ spec:
   clusterIP: None
   selector:
     app: vcluster
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
 {{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: {{ $kind }}
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
@@ -19,7 +19,7 @@ metadata:
   {{- end }}
 spec:
 {{- if (eq $kind "StatefulSet") }}
-  serviceName: {{ .Release.Name }}-headless
+  serviceName: {{ template "vcluster.name" . }}-headless
 {{- end }}
   replicas: {{ .Values.replicas }}
 {{- if (and (eq $kind "Deployment") (.Values.enableHA)) }}
@@ -36,7 +36,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   {{- if (eq $kind "StatefulSet") }}
   {{- if (hasKey .Values "volumeClaimTemplates") }}
   volumeClaimTemplates:
@@ -63,7 +63,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -90,7 +90,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -104,7 +104,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       tolerations:
@@ -112,7 +112,7 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
       {{- if or .Values.securityContext.runAsUser .Values.securityContext.runAsNonRoot }}
@@ -129,7 +129,7 @@ spec:
       {{- if .Values.coredns.enabled }}
         - name: coredns
           configMap:
-            name: {{ .Release.Name }}-coredns
+            name: {{ template "vcluster.name" . }}-coredns
       {{- end }}
       {{- if not .Values.storage.persistence }}
         - name: data
@@ -193,7 +193,7 @@ spec:
           - name: SERVICE_CIDR
             valueFrom:
               configMapKeyRef:
-                name: "vc-cidr-{{ .Release.Name }}"
+                name: "vc-cidr-{{ template "vcluster.name" . }}"
                 key: cidr
           {{- end }}
         securityContext:
@@ -223,8 +223,8 @@ spec:
         {{- end }}
         {{- if not .Values.syncer.noArgs }}
         args:
-          - --name={{ .Release.Name }}
-          - --service-account=vc-workload-{{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
+          - --service-account=vc-workload-{{ template "vcluster.name" . }}
           {{- range $key, $container := .Values.plugin }}
           {{- if not $container.optional }}
           - --plugins={{ $key }}

--- a/charts/k3s/templates/workloadserviceaccount.yaml
+++ b/charts/k3s/templates/workloadserviceaccount.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-workload-{{ .Release.Name }}
+  name: vc-workload-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -1,6 +1,11 @@
 # These annotations will be applied to all objects created in this chart
 globalAnnotations: {}
 
+# By default, fullname uses '-. This
+# overrides that and uses the given string instead.
+nameOverride: ""
+fullnameOverride: ""
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the replicas and use an external datastore
 enableHA: false

--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-api
+  name: {{ template "vcluster.name" . }}-api
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.api.labels }}
 {{ toYaml .Values.api.labels | indent 4 }}
@@ -30,7 +30,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-api
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.api.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-api
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.api.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -64,7 +64,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -78,7 +78,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if .Values.api.topologySpreadConstraints }}
@@ -93,12 +93,12 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.api.volumes }}
 {{ toYaml .Values.api.volumes | indent 8 }}
       {{- end }}
@@ -118,7 +118,7 @@ spec:
           - '--etcd-cafile=/run/config/pki/etcd-ca.crt'
           - '--etcd-certfile=/run/config/pki/apiserver-etcd-client.crt'
           - '--etcd-keyfile=/run/config/pki/apiserver-etcd-client.key'
-          - '--etcd-servers=https://{{ .Release.Name }}-etcd:2379'
+          - '--etcd-servers=https://{{ template "vcluster.name" . }}-etcd:2379'
           - '--proxy-client-cert-file=/run/config/pki/front-proxy-client.crt'
           - '--proxy-client-key-file=/run/config/pki/front-proxy-client.key'
           - '--requestheader-allowed-names=front-proxy-client'
@@ -171,7 +171,7 @@ spec:
           - name: SERVICE_CIDR
             valueFrom:
               configMapKeyRef:
-                name: "vc-cidr-{{ .Release.Name }}"
+                name: "vc-cidr-{{ template "vcluster.name" . }}"
                 key: cidr
           {{- end }}
         volumeMounts:

--- a/charts/k8s/templates/api-service.yaml
+++ b/charts/k8s/templates/api-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-api
+  name: {{ template "vcluster.name" . }}-api
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.api.serviceAnnotations }}
   {{- if $annotations }}
@@ -23,5 +23,5 @@ spec:
       protocol: TCP
   selector:
     app: vcluster-api
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
 {{- end }}

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-controller
+  name: {{ template "vcluster.name" . }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-controller
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.controller.labels }}
 {{ toYaml .Values.controller.labels | indent 4 }}
@@ -30,7 +30,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-controller
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.controller.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-controller
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.controller.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -64,7 +64,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -78,7 +78,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if .Values.controller.topologySpreadConstraints }}
@@ -93,12 +93,12 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.controller.volumes }}
 {{ toYaml .Values.controller.volumes | indent 8 }}
       {{- end }}
@@ -176,7 +176,7 @@ spec:
           - name: SERVICE_CIDR
             valueFrom:
               configMapKeyRef:
-                name: "vc-cidr-{{ .Release.Name }}"
+                name: "vc-cidr-{{ template "vcluster.name" . }}"
                 key: cidr
           {{- end }}
         volumeMounts:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-coredns
+  name: {{ template "vcluster.name" . }}-coredns
   namespace: {{ .Release.Namespace }}
 data:
 {{- if .Values.coredns.manifests }}

--- a/charts/k8s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k8s/templates/daemonset-hostpath-mapper.yaml
@@ -6,13 +6,13 @@ kind: DaemonSet
 kind: Deployment
 {{- end }}
 metadata:
-  name: {{ .Release.Name }}-hostpath-mapper
+  name: {{ template "vcluster.name" . }}-hostpath-mapper
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-hostpath-mapper
     component: hostpath-mapper
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
@@ -28,19 +28,19 @@ spec:
   selector:
     matchLabels:
       app: vcluster-hostpath-mapper
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
       component: hostpath-mapper
   template:
     metadata:
       labels:
         app: vcluster-hostpath-mapper
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
         component: hostpath-mapper
     spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       containers:
       - name: hostpath-mapper
@@ -61,21 +61,21 @@ spec:
                 fieldPath: spec.nodeName
         args:
           - maphostpaths
-          - --name={{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
           - --target-namespace={{ .Release.Namespace }}
         volumeMounts:
           - name: logs
             mountPath: /var/log
           - name: virtual-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
           - name: pod-logs
             mountPath: /var/log/pods
           - name: virtual-pod-logs
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
           - name: kubelet-pods
             mountPath: /var/vcluster/physical/kubelet/pods
           - name: virtual-kubelet-pods
-            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            mountPath: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
           - name: kubeconfig
             mountPath: /data/server/tls
         resources:
@@ -86,7 +86,7 @@ spec:
             path: /var/log
         - name: virtual-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log
         - name: pod-logs
           hostPath:
             path: /var/log/pods
@@ -95,12 +95,12 @@ spec:
             path: /var/lib/kubelet/pods
         - name: virtual-pod-logs
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/log/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/log/pods
         - name: virtual-kubelet-pods
           hostPath:
-            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ .Release.Name }}/kubelet/pods
+            path: /tmp/vcluster/{{ .Release.Namespace }}/{{ template "vcluster.name" . }}/kubelet/pods
         - name: kubeconfig
           secret:
-            secretName: vc-{{ .Release.Name }}
+            secretName: vc-{{ template "vcluster.name" . }}
 {{ end }}
 

--- a/charts/k8s/templates/etcd-service.yaml
+++ b/charts/k8s/templates/etcd-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-etcd
+  name: {{ template "vcluster.name" . }}-etcd
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
@@ -27,5 +27,5 @@ spec:
       protocol: TCP
   selector:
     app: vcluster-etcd
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
   {{- end }}

--- a/charts/k8s/templates/etcd-statefulset-service.yaml
+++ b/charts/k8s/templates/etcd-statefulset-service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-etcd-headless
+  name: {{ template "vcluster.name" . }}-etcd-headless
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.etcd.serviceAnnotations }}
   {{- if $annotations }}
@@ -28,5 +28,5 @@ spec:
   clusterIP: None
   selector:
     app: vcluster-etcd
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
 {{- end }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-etcd
+  name: {{ template "vcluster.name" . }}-etcd
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.etcd.labels }}
 {{ toYaml .Values.etcd.labels | indent 4 }}
@@ -17,13 +17,13 @@ metadata:
 {{ toYaml .Values.etcd.annotations | indent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ .Release.Name }}-etcd-headless
+  serviceName: {{ template "vcluster.name" . }}-etcd-headless
   replicas: {{ .Values.etcd.replicas }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: vcluster-etcd
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   {{- if (hasKey .Values.etcd "volumeClaimTemplates") }}
   volumeClaimTemplates:
 {{ toYaml .Values.etcd.volumeClaimTemplates | indent 4 }}
@@ -48,7 +48,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-etcd
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.etcd.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -73,7 +73,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -87,7 +87,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if .Values.etcd.topologySpreadConstraints }}
@@ -102,12 +102,12 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.volumes }}
 {{ toYaml .Values.etcd.volumes | indent 8 }}
       {{- end }}
@@ -130,12 +130,12 @@ spec:
           - '--cert-file=/run/config/pki/etcd-server.crt'
           - '--client-cert-auth=true'
           - '--data-dir=/var/lib/etcd'
-          - '--advertise-client-urls=https://$(NAME).{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}:2379'
-          - '--initial-advertise-peer-urls=https://$(NAME).{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}:2380'
+          - '--advertise-client-urls=https://$(NAME).{{ template "vcluster.name" . }}-etcd-headless.{{ .Release.Namespace }}:2379'
+          - '--initial-advertise-peer-urls=https://$(NAME).{{ template "vcluster.name" . }}-etcd-headless.{{ .Release.Namespace }}:2380'
           {{- $releaseName := .Release.Name -}}
           {{- $releaseNamespace := .Release.Namespace }}
           - '--initial-cluster={{ range $index := untilStep 0 (int .Values.etcd.replicas) 1 }}{{ if (ne (int $index) 0) }},{{ end }}{{ $releaseName }}-etcd-{{ $index }}=https://{{ $releaseName }}-etcd-{{ $index }}.{{ $releaseName }}-etcd-headless.{{ $releaseNamespace }}:2380{{ end }}'
-          - '--initial-cluster-token={{ .Release.Name }}'
+          - '--initial-cluster-token={{ template "vcluster.name" . }}'
           - '--initial-cluster-state=new'
           - '--listen-client-urls=https://0.0.0.0:2379'
           - '--listen-metrics-urls=http://0.0.0.0:2381'

--- a/charts/k8s/templates/ingress.yaml
+++ b/charts/k8s/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
   {{- toYaml .Values.ingress.annotations | nindent 4 }}
   {{- end }}
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
@@ -18,7 +18,7 @@ spec:
         paths:
           - backend:
               service:
-                name: {{ .Release.Name }}
+                name: {{ template "vcluster.name" . }}
                 port:
                   name: https
             path: /

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-init-manifests
+  name: {{ template "vcluster.name" . }}-init-manifests
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 data:
   manifests: |-
@@ -40,7 +40,7 @@ data:
       {{- end}}
       {{- if .release }}
       timeout: {{ .timeout | default "120s" | quote }}
-      releaseName: {{ .release.name }}
+      releaseName: {{ template "vcluster.name" . }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
   {{- end }}

--- a/charts/k8s/templates/limitrange.yaml
+++ b/charts/k8s/templates/limitrange.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: {{ .Release.Name }}-limit-range
+  name: {{ template "vcluster.name" . }}-limit-range
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   limits:

--- a/charts/k8s/templates/networkpolicy.yaml
+++ b/charts/k8s/templates/networkpolicy.yaml
@@ -2,12 +2,12 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-workloads
+  name: {{ template "vcluster.name" . }}-workloads
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to the vcluster control plane
     - ports:
@@ -16,7 +16,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ template "vcluster.name" . }}
     # Allows outgoing connections to DNS server
     - ports:
       - port: 53
@@ -28,7 +28,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ template "vcluster.name" . }}
         - ipBlock:
             cidr: {{ .Values.isolation.networkPolicy.outgoingConnections.ipBlock.cidr }}
             except:
@@ -41,12 +41,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Release.Name }}-control-plane
+  name: {{ template "vcluster.name" . }}-control-plane
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   egress:
     # Allows outgoing connections to all pods with
     # port 443, 8443 or 6443. This is needed for host Kubernetes

--- a/charts/k8s/templates/pre-install-hook-job-role.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-role.yaml
@@ -2,7 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install

--- a/charts/k8s/templates/pre-install-hook-job-rolebinding.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-rolebinding.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
@@ -10,10 +10,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-job
+    name: {{ template "vcluster.name" . }}-job
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/k8s/templates/pre-install-hook-job-serviceaccount.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install

--- a/charts/k8s/templates/pre-install-hook-job.yaml
+++ b/charts/k8s/templates/pre-install-hook-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-job
+  name: {{ template "vcluster.name" . }}-job
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
@@ -12,7 +12,7 @@ spec:
   backoffLimit: 3
   template:
     metadata:
-      name: {{ .Release.Name }}-job
+      name: {{ template "vcluster.name" . }}-job
       {{- if .Values.job.podAnnotations }}
       annotations:
 {{ toYaml .Values.job.podAnnotations | indent 8 }}
@@ -22,7 +22,7 @@ spec:
 {{ toYaml .Values.job.podLabels | indent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Release.Name }}-job
+      serviceAccountName: {{ template "vcluster.name" . }}-job
       restartPolicy: OnFailure
       nodeSelector:
 {{ toYaml .Values.job.nodeSelector | indent 8 }}
@@ -50,7 +50,7 @@ spec:
             - /vcluster
             - certs
           args:
-            - --prefix={{ .Release.Name }}
+            - --prefix={{ template "vcluster.name" . }}
             - --etcd-replicas={{ .Values.etcd.replicas }}
             {{- if .Values.serviceCIDR }}
             - --service-cidr={{ .Values.serviceCIDR }}

--- a/charts/k8s/templates/resourcequota.yaml
+++ b/charts/k8s/templates/resourcequota.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name:  {{ .Release.Name }}-quota
+  name:  {{ template "vcluster.name" . }}-quota
   namespace: {{ .Values.isolation.namespace | default .Release.Namespace }}
 spec:
   hard:

--- a/charts/k8s/templates/scheduler-deployment.yaml
+++ b/charts/k8s/templates/scheduler-deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-scheduler
+  name: {{ template "vcluster.name" . }}-scheduler
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster-scheduler
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.scheduler.labels }}
 {{ toYaml .Values.scheduler.labels | indent 4 }}
@@ -30,7 +30,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-scheduler
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.scheduler.podAnnotations }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster-scheduler
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.scheduler.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -64,7 +64,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -78,7 +78,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if .Values.scheduler.topologySpreadConstraints }}
@@ -93,12 +93,12 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.scheduler.volumes }}
 {{ toYaml .Values.scheduler.volumes | indent 8 }}
       {{- end }}

--- a/charts/k8s/templates/serviceaccount.yaml
+++ b/charts/k8s/templates/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.syncer.labels }}
 {{ toYaml .Values.syncer.labels | indent 4 }}
@@ -29,7 +29,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ template "vcluster.name" . }}
   template:
     metadata:
   {{- if .Values.syncer.podAnnotations }}
@@ -38,7 +38,7 @@ spec:
   {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ template "vcluster.name" . }}
       {{- range $k, $v := .Values.syncer.podLabels }}
         {{ $k }}: {{ $v | quote }}
       {{- end }}
@@ -63,7 +63,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -77,7 +77,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ template "vcluster.name" . }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if .Values.syncer.topologySpreadConstraints }}
@@ -91,16 +91,16 @@ spec:
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ template "vcluster.name" . }}
       {{- end }}
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ template "vcluster.name" . }}-certs
       {{- if .Values.coredns.enabled }}
         - name: coredns
           configMap:
-            name: {{ .Release.Name }}-coredns
+            name: {{ template "vcluster.name" . }}-coredns
       {{- end }}
       {{- if or .Values.syncer.securityContext.runAsUser .Values.syncer.securityContext.runAsNonRoot }}
         - name: helm-cache
@@ -132,13 +132,13 @@ spec:
         {{- end }}
         {{- if not .Values.syncer.noArgs }}
         args:
-          - --name={{ .Release.Name }}
+          - --name={{ template "vcluster.name" . }}
           - --request-header-ca-cert=/pki/ca.crt
           - --client-ca-cert=/pki/ca.crt
           - --server-ca-cert=/pki/ca.crt
           - --server-ca-key=/pki/ca.key
           - --kube-config=/pki/admin.conf
-          - --service-account=vc-workload-{{ .Release.Name }}
+          - --service-account=vc-workload-{{ template "vcluster.name" . }}
           {{- range $key, $container := .Values.plugin }}
           {{- if not $container.optional }}
           - --plugins={{ $key }}

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge .Values.globalAnnotations .Values.syncer.serviceAnnotations }}
   {{- if $annotations }}
@@ -37,18 +37,18 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lb
+  name: {{ template "vcluster.name" . }}-lb
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations }}
   annotations:
@@ -66,7 +66,7 @@ spec:
   {{- end }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ template "vcluster.name" . }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/k8s/templates/workloadserviceaccount.yaml
+++ b/charts/k8s/templates/workloadserviceaccount.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vc-workload-{{ .Release.Name }}
+  name: vc-workload-{{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ template "vcluster.name" . }}"
     heritage: "{{ .Release.Service }}"
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -4,6 +4,11 @@ defaultImageRegistry: ""
 
 globalAnnotations: {}
 
+# By default, fullname uses '-. This
+# overrides that and uses the given string instead.
+nameOverride: ""
+fullnameOverride: ""
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Apply de nameOverride and fullnameOverride correctly.


**Please provide a short message that should be published in the vcluster release notes**
The nameOverride and fullnameOverride were not applying to resource name.


**What else do we need to know?** 
Just changed from {{ .Release.name . }} to {{ template "vcluster.name" . }}