### PR TITLE
Fixed how certain ingress annotations that points to a secret are synced when a namespace is also defined

### DIFF
--- a/pkg/controllers/resources/ingresses/syncer.go
+++ b/pkg/controllers/resources/ingresses/syncer.go
@@ -95,12 +95,15 @@ func translateIngressAnnotations(annotations map[string]string, ingressNamespace
 		}
 
 		splitted := strings.Split(annotations[k], "/")
-		if len(splitted) == 1 {
-			foundSecrets = append(foundSecrets, ingressNamespace+"/"+splitted[0])
-			newAnnotations[k] = translate.Default.PhysicalName(splitted[0], ingressNamespace)
-		} else if len(splitted) == 2 {
-			foundSecrets = append(foundSecrets, splitted[0]+"/"+splitted[1])
-			newAnnotations[k] = translate.Default.PhysicalName(splitted[1], splitted[0])
+		if len(splitted) == 1 { // If value is only "secret"
+			secret := splitted[0]
+			foundSecrets = append(foundSecrets, ingressNamespace+"/"+secret)
+			newAnnotations[k] = translate.Default.PhysicalName(secret, ingressNamespace)
+		} else if len(splitted) == 2 { // If value is "namespace/secret"
+			namespace := splitted[0]
+			secret := splitted[1]
+			foundSecrets = append(foundSecrets, namespace+"/"+secret)
+			newAnnotations[k] = translate.Default.PhysicalNamespace(namespace)+"/"+translate.Default.PhysicalName(secret, namespace)
 		} else {
 			newAnnotations[k] = v
 		}

--- a/pkg/controllers/resources/ingresses/syncer_test.go
+++ b/pkg/controllers/resources/ingresses/syncer_test.go
@@ -295,6 +295,7 @@ func TestSync(t *testing.T) {
 						Labels:    baseIngress.Labels,
 						Annotations: map[string]string{
 							"nginx.ingress.kubernetes.io/auth-secret": "my-secret",
+							"nginx.ingress.kubernetes.io/auth-tls-secret": baseIngress.Namespace+"/my-secret",
 						},
 					},
 				},
@@ -317,6 +318,7 @@ func TestSync(t *testing.T) {
 							Labels:    baseIngress.Labels,
 							Annotations: map[string]string{
 								"nginx.ingress.kubernetes.io/auth-secret": "my-secret",
+								"nginx.ingress.kubernetes.io/auth-tls-secret": baseIngress.Namespace+"/my-secret",
 							},
 						},
 					},
@@ -331,7 +333,8 @@ func TestSync(t *testing.T) {
 							Labels:    createdIngress.Labels,
 							Annotations: map[string]string{
 								"nginx.ingress.kubernetes.io/auth-secret": translate.Default.PhysicalName("my-secret", baseIngress.Namespace),
-								"vcluster.loft.sh/managed-annotations":    "nginx.ingress.kubernetes.io/auth-secret",
+								"nginx.ingress.kubernetes.io/auth-tls-secret": createdIngress.Namespace+"/"+translate.Default.PhysicalName("my-secret", baseIngress.Namespace),
+								"vcluster.loft.sh/managed-annotations":    "nginx.ingress.kubernetes.io/auth-secret\nnginx.ingress.kubernetes.io/auth-tls-secret",
 								"vcluster.loft.sh/object-name":            baseIngress.Name,
 								"vcluster.loft.sh/object-namespace":       baseIngress.Namespace,
 								translate.UIDAnnotation:                   "",


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
Fixes how `translateIngressAnnotations` handles namespaces.
- Motivation: The [nginx.ingress.kubernetes.io/auth-tls-secret](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#client-certificate-authentication) annotation requires the format `namespace/secret` to work
- Previous behaviour: Annotations with value `namespace/secret` were translated to `physicalSecret`
- Current behaviour: Annotations with value `namespace/secret` are translated to `physicalNamespace/physicalSecret`

**Please provide a short message that should be published in the vcluster release notes**
Fixed how certain ingress annotations that points to a secret are synced when a namespace is also defined
