### PR TITLE
feat(charts): add workloadServiceAccount.annotations value

### DIFF
--- a/charts/eks/templates/workloadserviceaccount.yaml
+++ b/charts/eks/templates/workloadserviceaccount.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.workloadServiceAccount.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -291,6 +291,11 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Service account that should be used by the pods synced by vcluster
+workloadServiceAccount:
+  # This is not supported in multi-namespace mode
+  annotations: {}
+
 # Roles & ClusterRoles for the vcluster
 rbac:
   clusterRole:

--- a/charts/k0s/templates/workloadserviceaccount.yaml
+++ b/charts/k0s/templates/workloadserviceaccount.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.workloadServiceAccount.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -203,6 +203,11 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Service account that should be used by the pods synced by vcluster
+workloadServiceAccount:
+  # This is not supported in multi-namespace mode
+  annotations: {}
+
 # Roles & ClusterRoles for the vcluster
 rbac:
   clusterRole:

--- a/charts/k3s/templates/workloadserviceaccount.yaml
+++ b/charts/k3s/templates/workloadserviceaccount.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.workloadServiceAccount.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -211,6 +211,11 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Service account that should be used by the pods synced by vcluster
+workloadServiceAccount:
+  # This is not supported in multi-namespace mode
+  annotations: {}
+
 # Roles & ClusterRoles for the vcluster
 rbac:
   clusterRole:

--- a/charts/k8s/templates/workloadserviceaccount.yaml
+++ b/charts/k8s/templates/workloadserviceaccount.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.globalAnnotations }}
+  {{- $annotations := merge .Values.globalAnnotations .Values.workloadServiceAccount.annotations }}
+  {{- if $annotations }}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}
+{{ toYaml $annotations | indent 4 }}
   {{- end }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -293,6 +293,11 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Service account that should be used by the pods synced by vcluster
+workloadServiceAccount:
+  # This is not supported in multi-namespace mode
+  annotations: {}
+
 # Roles & ClusterRoles for the vcluster
 rbac:
   clusterRole:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Allows vcluster admin to annotate ServiceAccount used by all vcluster pods in the host cluster.


**Please provide a short message that should be published in the vcluster release notes**
Added the workloadServiceAccount.annotations helm value for setting annotations on the host ServiceAccount used by the pods synced by vcluster. However, these annotations will not be set if the multi-namespace mode is enabled.


**What else do we need to know?** 
