### PR TITLE
fix: increase timeout for retrieving working vcluster pods

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -314,7 +314,7 @@ func (cmd *ConnectCmd) getVClusterKubeConfig(vclusterName string, command []stri
 	var err error
 	podName := cmd.PodName
 	if podName == "" {
-		waitErr := wait.PollImmediate(time.Second, time.Second*6, func() (bool, error) {
+		waitErr := wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
 			// get vcluster pod name
 			var pods *corev1.PodList
 			pods, err = cmd.kubeClient.CoreV1().Pods(cmd.Namespace).List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
This change increases the timeout for retrieving a list of vcluster pods in a running state. It was observed that when running a command such as `vcluster create --upgrade`, when changes deployed incurred redeploy of vcluster pods, it was seen that we hit a failure such as follows because it takes ~15s or so for the pods to come back:

```
fatal    finding vcluster pod: timed out waiting for the condition - can't find a running vcluster pod in namespace vcluster-testvc
```

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would timeout on retrieving a list of running `vcluster` pods for a given cluster when they were recently redeployed.

**What else do we need to know?** 
The timeouts don't occur when `--connect=false` is set because it follows a different codepath. 