### PR TITLE
http content-type json 

### DIFF
--- a/pkg/server/filters/metrics.go
+++ b/pkg/server/filters/metrics.go
@@ -202,6 +202,8 @@ func rewriteStats(ctx context.Context, data []byte, vClient client.Client) ([]by
 
 func executeRequest(req *http.Request, h http.Handler) (int, http.Header, []byte, error) {
 	clonedRequest := req.Clone(req.Context())
+	clonedRequest.Header.Set("Content-Type", "application/json")
+	clonedRequest.Header.Set("Accept", "application/json")
 	fakeWriter := httptest.NewRecorder()
 	h.ServeHTTP(fakeWriter, clonedRequest)
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

![image](https://github.com/loft-sh/vcluster/assets/38821215/18904ba2-ace6-4aab-b535-6fdd22d13c9f)

 ~/Desktop/vcluster-debug   v0.15.0 ±✚  kubectl --kubeconfig ./pki/local.config top pods -A
Error from server (InternalError): invalid character 'k' looking for beginning of value



```
When using the vcluster proxy indicator, use the kubectl request, default is protobuf format,
But the data will be parsed later using json.Unmarshal,
This is where things go wrong
 
```



after change:

![image](https://github.com/loft-sh/vcluster/assets/38821215/71779925-6868-4a76-8e7e-57383f276934)
