### PR TITLE
feat: headless syncer deployment

### DIFF
--- a/charts/eks/templates/api-deployment.yaml
+++ b/charts/eks/templates/api-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.api.disabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -158,4 +159,5 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/api-service.yaml
+++ b/charts/eks/templates/api-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.api.disabled }}
 apiVersion: v1
 kind: Service
@@ -24,4 +25,5 @@ spec:
   selector:
     app: vcluster-api
     release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/controller-deployment.yaml
+++ b/charts/eks/templates/controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.controller.disabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -151,4 +152,5 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.controller.resources | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -257,4 +258,5 @@ data:
       - name: metrics
         port: 9153
         protocol: TCP
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/etcd-service.yaml
+++ b/charts/eks/templates/etcd-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.etcd.disabled }}
 apiVersion: v1
 kind: Service
@@ -28,4 +29,5 @@ spec:
   selector:
     app: vcluster-etcd
     release: {{ .Release.Name }}
+  {{- end }}
   {{- end }}

--- a/charts/eks/templates/etcd-statefulset-service.yaml
+++ b/charts/eks/templates/etcd-statefulset-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.etcd.disabled }}
 apiVersion: v1
 kind: Service
@@ -29,4 +30,5 @@ spec:
   selector:
     app: vcluster-etcd
     release: "{{ .Release.Name }}"
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.etcd.disabled }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -138,7 +139,6 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.etcd.resources | indent 10 }}
-{{- end }}
         livenessProbe:
           httpGet:
             path: /health
@@ -159,3 +159,5 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 24
+{{- end }}
+{{- end }}

--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.init.manifests }}
 apiVersion: v1
 kind: ConfigMap
@@ -49,4 +50,5 @@ data:
       {{- end }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/pre-install-hook-job-role.yaml
+++ b/charts/eks/templates/pre-install-hook-job-role.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,4 +16,5 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps","services"]
     verbs: ["create", "get", "list"]
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/pre-install-hook-job-rolebinding.yaml
+++ b/charts/eks/templates/pre-install-hook-job-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -19,4 +20,5 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}-job
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/pre-install-hook-job-serviceaccount.yaml
+++ b/charts/eks/templates/pre-install-hook-job-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -14,5 +15,6 @@ metadata:
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/eks/templates/pre-install-hook-job.yaml
+++ b/charts/eks/templates/pre-install-hook-job.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -68,4 +69,5 @@ spec:
       volumes:
         - name: cert-storage
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/charts/eks/templates/rbac/role.yaml
+++ b/charts/eks/templates/rbac/role.yaml
@@ -37,7 +37,7 @@ rules:
     verbs: ["patch", "update"]
   {{- end }}
   {{- end }}
-  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended }}
+  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended .Values.headless }}
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["create", "delete", "patch", "update"]

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -278,3 +279,4 @@ spec:
 {{ toYaml $container.resources | indent 10 }}
         {{- end }}
         {{- end }}
+{{- end }}

--- a/charts/eks/templates/syncer-service.yaml
+++ b/charts/eks/templates/syncer-service.yaml
@@ -35,9 +35,11 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
@@ -64,9 +66,11 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -4,6 +4,10 @@ defaultImageRegistry: ""
 
 globalAnnotations: {}
 
+# If true, will deploy vcluster in headless mode, which means no deployment
+# or statefulset is created.
+headless: false
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.coredns.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -270,5 +271,6 @@ data:
         - name: metrics
           port: 9153
           protocol: TCP
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.init.manifests }}
 apiVersion: v1
 kind: ConfigMap
@@ -49,4 +50,5 @@ data:
       {{- end }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/k0s/templates/rbac/role.yaml
+++ b/charts/k0s/templates/rbac/role.yaml
@@ -25,7 +25,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
-  {{- if or .Values.sync.pods.status .Values.rbac.role.extended }}
+  {{- if or .Values.sync.pods.status .Values.rbac.role.extended .Values.headless }}
   - apiGroups: [""]
     resources: ["pods/status"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/charts/k0s/templates/secret.yaml
+++ b/charts/k0s/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -52,4 +53,5 @@ stringData:
           node-monitor-grace-period: 1h
           node-monitor-period: 1h
           {{- end }}
+  {{- end }}
   {{- end }}

--- a/charts/k0s/templates/service.yaml
+++ b/charts/k0s/templates/service.yaml
@@ -35,9 +35,11 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
@@ -64,9 +66,11 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/k0s/templates/statefulset-service.yaml
+++ b/charts/k0s/templates/statefulset-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     app: vcluster
     release: "{{ .Release.Name }}"
+{{- end }}

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -339,3 +340,4 @@ spec:
 {{ toYaml $container.resources | indent 10 }}
         {{- end }}
         {{- end }}
+{{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -4,6 +4,10 @@ defaultImageRegistry: ""
 
 globalAnnotations: {}
 
+# If true, will deploy vcluster in headless mode, which means no deployment
+# or statefulset is created.
+headless: false
+
 # Plugins that should get loaded. Usually you want to apply those via 'vcluster create ... -f https://.../plugin.yaml'
 plugin: {}
 # Manually configure a plugin called test

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.coredns.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -270,5 +271,6 @@ data:
         - name: metrics
           port: 9153
           protocol: TCP
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.init.manifests }}
 apiVersion: v1
 kind: ConfigMap
@@ -49,4 +50,5 @@ data:
       {{- end }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -25,7 +25,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "pods", "pods/attach", "pods/portforward", "pods/exec", "persistentvolumeclaims"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
-  {{- if or .Values.sync.pods.status .Values.rbac.role.extended }}
+  {{- if or .Values.sync.pods.status .Values.rbac.role.extended .Values.headless }}
   - apiGroups: [""]
     resources: ["pods/status"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/charts/k3s/templates/service.yaml
+++ b/charts/k3s/templates/service.yaml
@@ -35,9 +35,11 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
@@ -64,9 +66,11 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/k3s/templates/statefulset-service.yaml
+++ b/charts/k3s/templates/statefulset-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if (eq (include "vcluster.k3s.workloadKind" .) "StatefulSet") }}
 apiVersion: v1
 kind: Service
@@ -24,4 +25,5 @@ spec:
   selector:
     app: vcluster
     release: "{{ .Release.Name }}"
+{{- end }}
 {{- end }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- $kind := include "vcluster.k3s.workloadKind" . -}}
 apiVersion: apps/v1
 kind: {{ $kind }}
@@ -408,3 +409,4 @@ spec:
 {{ toYaml $container.resources | indent 10 }}
         {{- end }}
         {{- end }}
+{{- end }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -5,6 +5,10 @@ globalAnnotations: {}
 # Make sure to scale up the replicas and use an external datastore
 enableHA: false
 
+# If true, will deploy vcluster in headless mode, which means no deployment
+# or statefulset is created.
+headless: false
+
 # DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
 # images within the vcluster will not be rewritten.
 defaultImageRegistry: ""

--- a/charts/k8s/templates/api-deployment.yaml
+++ b/charts/k8s/templates/api-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.api.disabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -183,4 +184,5 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.api.resources | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/api-service.yaml
+++ b/charts/k8s/templates/api-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.api.disabled }}
 apiVersion: v1
 kind: Service
@@ -24,4 +25,5 @@ spec:
   selector:
     app: vcluster-api
     release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/controller-deployment.yaml
+++ b/charts/k8s/templates/controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.controller.disabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -189,4 +190,5 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.controller.resources | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.coredns.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -270,5 +271,6 @@ data:
         - name: metrics
           port: 9153
           protocol: TCP
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s/templates/etcd-service.yaml
+++ b/charts/k8s/templates/etcd-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.etcd.disabled }}
 apiVersion: v1
 kind: Service
@@ -28,4 +29,5 @@ spec:
   selector:
     app: vcluster-etcd
     release: {{ .Release.Name }}
+  {{- end }}
   {{- end }}

--- a/charts/k8s/templates/etcd-statefulset-service.yaml
+++ b/charts/k8s/templates/etcd-statefulset-service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.etcd.disabled }}
 apiVersion: v1
 kind: Service
@@ -29,4 +30,5 @@ spec:
   selector:
     app: vcluster-etcd
     release: "{{ .Release.Name }}"
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if not .Values.etcd.disabled }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -173,7 +174,6 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.etcd.resources | indent 10 }}
-{{- end }}
         livenessProbe:
           httpGet:
             path: /health
@@ -194,3 +194,5 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           failureThreshold: 24
+{{- end }}
+{{- end }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.init.manifests }}
 apiVersion: v1
 kind: ConfigMap
@@ -49,4 +50,5 @@ data:
       {{- end }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/pre-install-hook-job-role.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-role.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,4 +16,5 @@ rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps","services"]
     verbs: ["create", "get", "list"]
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/pre-install-hook-job-rolebinding.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -19,4 +20,5 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}-job
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/pre-install-hook-job-serviceaccount.yaml
+++ b/charts/k8s/templates/pre-install-hook-job-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -14,5 +15,6 @@ metadata:
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s/templates/pre-install-hook-job.yaml
+++ b/charts/k8s/templates/pre-install-hook-job.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if .Values.job.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -68,4 +69,5 @@ spec:
       volumes:
         - name: cert-storage
           emptyDir: {}
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/rbac/role.yaml
+++ b/charts/k8s/templates/rbac/role.yaml
@@ -37,7 +37,7 @@ rules:
     verbs: ["patch", "update"]
   {{- end }}
   {{- end }}
-  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended }}
+  {{- if or .Values.sync.endpoints.enabled .Values.rbac.role.extended .Values.headless }}
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["create", "delete", "patch", "update"]

--- a/charts/k8s/templates/scheduler-deployment.yaml
+++ b/charts/k8s/templates/scheduler-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 {{- if and .Values.sync.nodes.enableScheduler (not .Values.scheduler.disabled) }}
 apiVersion: apps/v1
 kind: Deployment
@@ -156,4 +157,5 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.scheduler.resources | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/k8s/templates/syncer-deployment.yaml
+++ b/charts/k8s/templates/syncer-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.headless }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -318,3 +319,4 @@ spec:
 {{ toYaml $container.resources | indent 10 }}
         {{- end }}
         {{- end }}
+{{- end }}

--- a/charts/k8s/templates/syncer-service.yaml
+++ b/charts/k8s/templates/syncer-service.yaml
@@ -35,9 +35,11 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
 ---
 {{ if eq .Values.service.type "LoadBalancer" }}
 apiVersion: v1
@@ -64,9 +66,11 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if not .Values.headless }}
   selector:
     app: vcluster
     release: {{ .Release.Name }}
+  {{- end }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -4,6 +4,10 @@ defaultImageRegistry: ""
 
 globalAnnotations: {}
 
+# If true, will deploy vcluster in headless mode, which means no deployment
+# or statefulset is created.
+headless: false
+
 # If the control plane is deployed in high availability mode
 # Make sure to scale up the syncer.replicas, etcd.replicas, api.replicas & controller.replicas
 enableHA: false


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Allows to deploy vcluster in headless mode which doesn't deploy any vcluster control plane and only the needed permissions and service for it.
