### PR TITLE
Fix: vclusterctl - Wrong connect logic for the list command

### DIFF
--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -21,7 +21,9 @@ type VCluster struct {
 	Namespace  string
 	Created    time.Time
 	AgeSeconds int
+	Context    string
 	Status     string
+	Connected  bool
 }
 
 // ListCmd holds the login cmd flags
@@ -68,13 +70,14 @@ vcluster list --namespace test
 
 // Run executes the functionality
 func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
-	if cmd.Context == "" {
-		rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
-		if err != nil {
-			return err
-		}
+	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
+	if err != nil {
+		return err
+	}
+	currentContext := rawConfig.CurrentContext
 
-		cmd.Context = rawConfig.CurrentContext
+	if cmd.Context == "" {
+		cmd.Context = currentContext
 	}
 
 	namespace := metav1.NamespaceAll
@@ -88,7 +91,24 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.output == "json" {
-		bytes, err := json.MarshalIndent(&vClusters, "", "    ")
+		var output []VCluster
+		for _, vcluster := range vClusters {
+			vclusterOutput := VCluster{
+				Name:       vcluster.Name,
+				Namespace:  vcluster.Namespace,
+				Created:    vcluster.Created.Time,
+				AgeSeconds: int(time.Since(vcluster.Created.Time).Round(time.Second).Seconds()),
+				Context:    vcluster.Context,
+				Status:     string(vcluster.Status),
+			}
+			vclusterOutput.Connected = currentContext == find.VClusterContextName(
+				vcluster.Name,
+				vcluster.Namespace,
+				vcluster.Context,
+			)
+			output = append(output, vclusterOutput)
+		}
+		bytes, err := json.MarshalIndent(output, "", "    ")
 		if err != nil {
 			return errors.Wrap(err, "json marshal vclusters")
 		}
@@ -98,7 +118,7 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		values := [][]string{}
 		for _, vcluster := range vClusters {
 			connected := ""
-			if cmd.Context == find.VClusterContextName(vcluster.Name, vcluster.Namespace, vcluster.Context) {
+			if currentContext == find.VClusterContextName(vcluster.Name, vcluster.Namespace, vcluster.Context) {
 				connected = "True"
 			}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

The `list` command doesn't correctly return if the virtual cluster is connected when applying the global context filtering (option `--context`) in the `table` output format.

The `json` output format was also missing the `connected` and `age` fields available in the `table` format.

The solution for the connected logic is to run the routine to detect the current context and use that as a reference when looping over the existing virtual clusters. This is required because `cmd.Context` could contain the filtering context instead of the connected one.

For the `json` output, the type `VCluster`, created on the same file, was used to build the correct output format. Missing fields were added to it.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster list` was returning the wrong logic for `connected` flag.

**What else do we need to know?** 
None.