### PR TITLE
fix(charts): rename coredns ConfigMap in eks chart for consistency

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: custom-deployments
+  name: {{ .Release.Name }}-coredns
   namespace: {{ .Release.Namespace }}
   {{- if .Values.globalAnnotations}}
   annotations:

--- a/charts/eks/templates/syncer-deployment.yaml
+++ b/charts/eks/templates/syncer-deployment.yaml
@@ -73,7 +73,7 @@ spec:
       {{- end }}
         - name: coredns
           configMap:
-            name: custom-deployments
+            name: {{ .Release.Name }}-coredns
         - name: certs
           secret:
             secretName: {{ .Release.Name }}-certs


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fix inconsistency in eks chart - rename the ConfigMap that contains coredns manifest to match other distros.


**Please provide a short message that should be published in the vcluster release notes**
The ConfigMap containing coredns manifests in EKS distro was renamed to `{{ .Release.Name }}-coredns` to match other distros.