### PR TITLE
fix: panic in CRD handling

### DIFF
--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -258,7 +258,7 @@ func EnsureCRDFromPhysicalCluster(ctx context.Context, pConfig *rest.Config, vCo
 			version.Storage = true
 			newVersions = append(newVersions, version)
 
-			if version.Subresources.Status != nil {
+			if version.Subresources != nil && version.Subresources.Status != nil {
 				hasStatusSubresource = true
 			}
 			break


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
Conversation in #vcluster chat: https://loft-sh.slack.com/archives/C01N273CF4P/p1684448482227579


**Please provide a short message that should be published in the vcluster release notes**
Fixed a panic in generic crd handling

**What else do we need to know?** 

To repro:

- install backendconfig crd: https://github.com/mstergianis/kubernetes-models-ts/blob/411c2f1e8af0b2a54bba4b6336b1e2f186cf4cf7/packages/gke/crd/backendconfigs.yaml#L4

- create vcluster with these values
```yaml
sync:
  generic:
    generic:
    clusterRole:
      extraRules:
        - apiGroups: ["apiextensions.k8s.io"]
          resources: ["customresourcedefinitions"]
          verbs: ["get", "list", "watch"]
    config: |-
      version: v1beta1
      import:
        - kind: BackendConfig
          apiVersion: cloud.google.com/v1
  ingresses:
    enabled: true
multiNamespaceMode:
  enabled: true
vcluster:
  image: rancher/k3s:v1.23.5-k3s1
```
