### PR TITLE
chore: update supported and default k8s versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
-	github.com/loft-sh/utils v0.0.20
+	github.com/loft-sh/utils v0.0.21
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 h1:nHHjmvjitIiyP
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
-github.com/loft-sh/utils v0.0.20 h1:7J63Vp8rO0Yvyo3Nzu2wBWnqBW8qmscNP++zfSeLKBI=
-github.com/loft-sh/utils v0.0.20/go.mod h1:0lw0bzifz03np3AJvwVLCTAfWK8AE2dNwfEAq/YxoyY=
+github.com/loft-sh/utils v0.0.21 h1:GSmg/PL90rfR3RzVlNIu1kK5xWWECiSsxxPHwzG5rgo=
+github.com/loft-sh/utils v0.0.21/go.mod h1:0lw0bzifz03np3AJvwVLCTAfWK8AE2dNwfEAq/YxoyY=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
@@ -8,39 +8,39 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.1-eks-1-27-3",
-	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.4-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.9-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.13-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.17-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.17-eks-1-22-27",
+	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.1-eks-1-27-4",
+	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.4-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.9-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.13-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.17-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.17-eks-1-22-28",
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.1-eks-1-27-3",
-	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.4-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.9-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.13-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.17-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.17-eks-1-22-27",
+	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.1-eks-1-27-4",
+	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.4-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.9-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.13-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.17-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.17-eks-1-22-28",
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-27-3",
-	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-22-27",
+	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-27-4",
+	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-22-28",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-3",
-	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-27",
+	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-4",
+	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-28",
 }
 
 func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleLogger) (string, error) {
@@ -55,12 +55,12 @@ func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleL
 	etcdImage := EKSEtcdVersionMap[serverVersionString]
 	corednsImage, ok := EKSCoreDNSVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 26 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
-			apiImage = EKSAPIVersionMap["1.26"]
-			controllerImage = EKSControllerVersionMap["1.26"]
-			etcdImage = EKSEtcdVersionMap["1.26"]
-			corednsImage = EKSCoreDNSVersionMap["1.26"]
+		if serverMinorInt > 27 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.27", serverVersionString)
+			apiImage = EKSAPIVersionMap["1.27"]
+			controllerImage = EKSControllerVersionMap["1.27"]
+			etcdImage = EKSEtcdVersionMap["1.27"]
+			corednsImage = EKSCoreDNSVersionMap["1.27"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			apiImage = EKSAPIVersionMap["1.22"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
@@ -8,10 +8,10 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.27": "k0sproject/k0s:v1.27.1-k0s.0",
-	"1.26": "k0sproject/k0s:v1.26.4-k0s.0",
-	"1.25": "k0sproject/k0s:v1.25.8-k0s.1",
-	"1.24": "k0sproject/k0s:v1.24.12-k0s.1",
+	"1.27": "k0sproject/k0s:v1.27.2-k0s.0",
+	"1.26": "k0sproject/k0s:v1.26.5-k0s.0",
+	"1.25": "k0sproject/k0s:v1.25.10-k0s.0",
+	"1.24": "k0sproject/k0s:v1.24.14-k0s.0",
 	"1.23": "k0sproject/k0s:v1.23.15-k0s.0",
 }
 
@@ -24,9 +24,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleL
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 26 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
-			image = K0SVersionMap["1.26"]
+		if serverMinorInt > 27 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.27", serverVersionString)
+			image = K0SVersionMap["1.27"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
 			image = K0SVersionMap["1.23"]

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
@@ -11,10 +11,10 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.27": "rancher/k3s:v1.27.1-k3s1",
-	"1.26": "rancher/k3s:v1.26.4-k3s1",
-	"1.25": "rancher/k3s:v1.25.9-k3s1",
-	"1.24": "rancher/k3s:v1.24.13-k3s1",
+	"1.27": "rancher/k3s:v1.27.2-k3s1",
+	"1.26": "rancher/k3s:v1.26.5-k3s1",
+	"1.25": "rancher/k3s:v1.25.10-k3s1",
+	"1.24": "rancher/k3s:v1.24.14-k3s1",
 	"1.23": "rancher/k3s:v1.23.17-k3s1",
 }
 
@@ -38,9 +38,9 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleL
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 26 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
-				image = K3SVersionMap["1.26"]
+			if serverMinorInt > 27 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.27", serverVersionString)
+				image = K3SVersionMap["1.27"]
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
 				image = K3SVersionMap["1.23"]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,7 +251,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/utils v0.0.20
+# github.com/loft-sh/utils v0.0.21
 ## explicit; go 1.20
 github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Introduced support for Kubernetes 1.27. Updated supported Kubernetes patch versions of the previous releases.