### PR TITLE
fix extra conainer statuses syncing in case of host sidecar injection

### DIFF
--- a/test/e2e_isolation_mode/isolated.go
+++ b/test/e2e_isolation_mode/isolated.go
@@ -97,8 +97,10 @@ var _ = ginkgo.Describe("Isolated mode", func() {
 				return true, nil
 			} else {
 				e, _ := f.VclusterClient.CoreV1().Events("default").List(ctx, metav1.ListOptions{TypeMeta: p.TypeMeta})
-				if strings.Contains(e.Items[0].Message, `Invalid value: "2": must be less than or equal to cpu limit`) {
-					return true, fmt.Errorf(`invalid value: "2": must be less than or equal to cpu limit`)
+				if len(e.Items) > 0 {
+					if strings.Contains(e.Items[0].Message, `Invalid value: "2": must be less than or equal to cpu limit`) {
+						return true, fmt.Errorf(`invalid value: "2": must be less than or equal to cpu limit`)
+					}
 				}
 			}
 			return false, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1004 ENG-1290


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would sync up extra container statuses in case of host injected sidecars


**What else do we need to know?** 
