### PR TITLE
fix: disable CGO when building CLI via build-cli.sh

### DIFF
--- a/hack/build-cli.sh
+++ b/hack/build-cli.sh
@@ -69,7 +69,7 @@ for OS in ${VCLUSTER_BUILD_PLATFORMS[@]}; do
     fi
 
     echo "Building for ${OS}/${ARCH}"
-    GOARCH=${ARCH} GOOS=${OS} ${GO_BUILD_CMD} -tags embed_charts -ldflags "${GO_BUILD_LDFLAGS}"\
+    CGO_ENABLED=0 GOARCH=${ARCH} GOOS=${OS} ${GO_BUILD_CMD} -tags embed_charts -ldflags "${GO_BUILD_LDFLAGS}"\
       -o "${VCLUSTER_ROOT}/release/${NAME}" cmd/vclusterctl/main.go
     shasum -a 256 "${VCLUSTER_ROOT}/release/${NAME}" | cut -d ' ' -f 1 > "${VCLUSTER_ROOT}/release/${NAME}".sha256
     cosign sign-blob --yes --output-signature "${VCLUSTER_ROOT}/release/${NAME}".sha256.sig --output-certificate "${VCLUSTER_ROOT}/release/${NAME}".sha256.pem "${VCLUSTER_ROOT}/release/${NAME}".sha256


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves https://loft-sh.slack.com/archives/C01N273CF4P/p1686308243191459


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster v0.15.1 CLI would fail in environments with older glibc version.


**What else do we need to know?** 
v0.15.1 uses dynamically linked libc:
```
$  ldd $(which vcluster)
	linux-vdso.so.1 (0x00007ffed80a9000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f7443e25000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f7444017000)
```
Building with this change produces static binary, just as it was in v0.15.0:
```
$ ldd ./release/vcluster-linux-amd64
	not a dynamic executable
```