### PR TITLE
fix: the usage of the Bundled helm chart

### DIFF
--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -21,7 +21,7 @@ data:
   charts: |-
   {{- range .Values.init.helm }}
   {{- /* only render this chart entry if either of chart or bundle is defined */}}
-  {{- if or .chart .bundle }}
+  {{- if .chart }}
     - name: {{ .chart.name }}
       repo: {{ .chart.repo }}
       version: {{ .chart.version }}
@@ -31,12 +31,14 @@ data:
       {{- if .chart.password }}
       password: {{ .chart.password }}
       {{- end }}
-      {{- else if .bundle }}
-      bundle: {{ .bundle }}
-      {{- end }}
       {{- if .insecure }}
       insecure: true
       {{- end}}
+  {{- end }}
+  {{- if .bundle }}
+    - bundle: {{ .bundle }}
+  {{- end }}
+  {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}
       values: |-
         {{ (.values | default "") | nindent 8 | trim }}
@@ -47,6 +49,7 @@ data:
       releaseName: {{ .release.name }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -21,7 +21,7 @@ data:
   charts: |-
   {{- range .Values.init.helm }}
   {{- /* only render this chart entry if either of chart or bundle is defined */}}
-  {{- if or .chart .bundle }}
+  {{- if .chart }}
     - name: {{ .chart.name }}
       repo: {{ .chart.repo }}
       version: {{ .chart.version }}
@@ -31,12 +31,14 @@ data:
       {{- if .chart.password }}
       password: {{ .chart.password }}
       {{- end }}
-      {{- else if .bundle }}
-      bundle: {{ .bundle }}
-      {{- end }}
       {{- if .insecure }}
       insecure: true
       {{- end}}
+  {{- end }}
+  {{- if .bundle }}
+    - bundle: {{ .bundle }}
+  {{- end }}
+  {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}
       values: |-
         {{ (.values | default "") | nindent 8 | trim }}
@@ -47,6 +49,7 @@ data:
       releaseName: {{ .release.name }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -21,7 +21,7 @@ data:
   charts: |-
   {{- range .Values.init.helm }}
   {{- /* only render this chart entry if either of chart or bundle is defined */}}
-  {{- if or .chart .bundle }}
+  {{- if .chart }}
     - name: {{ .chart.name }}
       repo: {{ .chart.repo }}
       version: {{ .chart.version }}
@@ -31,12 +31,14 @@ data:
       {{- if .chart.password }}
       password: {{ .chart.password }}
       {{- end }}
-      {{- else if .bundle }}
-      bundle: {{ .bundle }}
-      {{- end }}
       {{- if .insecure }}
       insecure: true
       {{- end}}
+  {{- end }}
+  {{- if .bundle }}
+    - bundle: {{ .bundle }}
+  {{- end }}
+  {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}
       values: |-
         {{ (.values | default "") | nindent 8 | trim }}
@@ -47,6 +49,7 @@ data:
       releaseName: {{ .release.name }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -21,7 +21,7 @@ data:
   charts: |-
   {{- range .Values.init.helm }}
   {{- /* only render this chart entry if either of chart or bundle is defined */}}
-  {{- if or .chart .bundle }}
+  {{- if .chart }}
     - name: {{ .chart.name }}
       repo: {{ .chart.repo }}
       version: {{ .chart.version }}
@@ -31,12 +31,14 @@ data:
       {{- if .chart.password }}
       password: {{ .chart.password }}
       {{- end }}
-      {{- else if .bundle }}
-      bundle: {{ .bundle }}
-      {{- end }}
       {{- if .insecure }}
       insecure: true
       {{- end}}
+  {{- end }}
+  {{- if .bundle }}
+    - bundle: {{ .bundle }}
+  {{- end }}
+  {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}
       values: |-
         {{ (.values | default "") | nindent 8 | trim }}
@@ -47,6 +49,7 @@ data:
       releaseName: {{ .release.name }}
       releaseNamespace: {{ .release.namespace }}
       {{- end }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** 
resolves #1057


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue when using a bundled helm chart in the init object, currently the helm template logic is using the `.chart` field when that field is not really available when `.bundle` is provided.


**What else do we need to know?** 
