### PR TITLE
fix(vclusterctl): allow user to select different context if we can't

### DIFF
--- a/cmd/vclusterctl/cmd/find/find.go
+++ b/cmd/vclusterctl/cmd/find/find.go
@@ -113,11 +113,13 @@ func VClusterFromContext(originalContext string) (name string, namespace string,
 	}
 
 	splitted := strings.Split(originalContext, "_")
-	if len(splitted) < 4 {
-		return "", "", ""
+	// vcluster_<name>_<namespace>_<context>
+	if len(splitted) >= 4 {
+		return splitted[1], splitted[2], strings.Join(splitted[3:], "_")
 	}
 
-	return splitted[1], splitted[2], strings.Join(splitted[3:], "_")
+	// we don't know for sure, but most likely specified custom vcluster context name
+	return originalContext, "", ""
 }
 
 func findInContext(ctx context.Context, context, name, namespace string, timeout time.Duration, isParentContext bool) ([]VCluster, error) {

--- a/cmd/vclusterctl/cmd/find/find_test.go
+++ b/cmd/vclusterctl/cmd/find/find_test.go
@@ -1,0 +1,32 @@
+package find_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/find"
+)
+
+func TestVClusterFromContext(t *testing.T) {
+	type test struct {
+		originalContext string
+		want            []string
+	}
+
+	tests := []test{
+		{originalContext: "foo", want: []string{"", "", ""}},
+		{originalContext: "vcluster_context", want: []string{"vcluster_context", "", ""}},
+		{originalContext: "vcluster_context_foobar", want: []string{"vcluster_context_foobar", "", ""}},
+		{originalContext: "vcluster_test_vcluster-test_minikube", want: []string{"test", "vcluster-test", "minikube"}},
+		{originalContext: "vcluster_test_vcluster-test_minikube_test", want: []string{"test", "vcluster-test", "minikube_test"}},
+	}
+
+	for _, test := range tests {
+		a, b, c := find.VClusterFromContext(test.originalContext)
+		got := []string{a, b, c}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Fatalf("got %v, want %v", got, test.want)
+		}
+	}
+
+}


### PR DESCRIPTION
figure out which one to use based on the context name. Can occur if vcluster connects to user-provided context

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1073 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster disconnect` wasn't able to determine the original context and failed if a custom context was provided 


**What else do we need to know?** 
