### PR TITLE
set vcluster-rewrite-hosts resource requests equal to limits

### DIFF
--- a/pkg/controllers/resources/pods/translate/hosts.go
+++ b/pkg/controllers/resources/pods/translate/hosts.go
@@ -47,8 +47,8 @@ func rewritePodHostnameFQDN(pPod *corev1.Pod, defaultImageRegistry, hostsRewrite
 					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				},
 				Requests: map[corev1.ResourceName]resource.Quantity{
-					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
+					corev1.ResourceCPU:    resource.MustParse("30m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				},
 			},
 			VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1085


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was setting resource requests not equal to limits for the `vcluster-rewrite-hosts` init container, preventing proper usage of the static CPU policy in Kubernetes.


**What else do we need to know?** 
Full writeup of the issue can be found in https://github.com/loft-sh/vcluster/issues/1085