### PR TITLE
fix: add error for blockingcacheclient when cache is not passed

### DIFF
--- a/pkg/util/blockingcacheclient/client.go
+++ b/pkg/util/blockingcacheclient/client.go
@@ -2,6 +2,7 @@ package blockingcacheclient
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,7 @@ func NewCacheClient(config *rest.Config, options client.Options) (client.Client,
 // defaultNewClient creates the default caching client
 func defaultNewClient(config *rest.Config, options client.Options) (client.Client, error) {
 	if options.Cache == nil {
-		options.Cache = &client.CacheOptions{}
+		return nil, fmt.Errorf("blockingcacheclient should always be created with a cache (options.Cache)")
 	}
 	options.Cache.Unstructured = true
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Raise error in case blockingcacheclient is created without a cache. This should prevent unexpected behavior or a less descriptive error at a later execution stage.

**Please provide a short message that should be published in the vcluster release notes**
N/A