### PR TITLE
Added defaultImageRegistry to coredns templates

### DIFF
--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -160,7 +160,7 @@ data:
           containers:
             - name: coredns
               {{- if .Values.coredns.image }}
-              image: {{ .Values.coredns.image }}
+              image: {{ .Values.defaultImageRegistry }}{{ .Values.coredns.image }}
               {{- else }}
               image: {{`{{.IMAGE}}`}}
               {{- end }}

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -120,7 +120,7 @@ data:
           containers:
             - name: coredns
               {{- if .Values.coredns.image }}
-              image: {{ .Values.coredns.image }}
+              image: {{ .Values.defaultImageRegistry }}{{ .Values.coredns.image }}
               {{- else }}
               image: {{`{{.IMAGE}}`}}
               {{- end }}

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -160,7 +160,7 @@ data:
           containers:
             - name: coredns
               {{- if .Values.coredns.image }}
-              image: {{ .Values.coredns.image }}
+              image: {{ .Values.defaultImageRegistry }}{{ .Values.coredns.image }}
               {{- else }}
               image: {{`{{.IMAGE}}`}}
               {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster coredns helm templates failed to use the defaultImageRegistry


**What else do we need to know?** 
