### PR TITLE
Fix secret syncer when both ingresses and all secret syncing are enabled

### DIFF
--- a/pkg/controllers/resources/secrets/syncer.go
+++ b/pkg/controllers/resources/secrets/syncer.go
@@ -165,7 +165,10 @@ func (s *secretSyncer) isSecretUsed(ctx *synccontext.SyncContext, vObj runtime.O
 			return false, err
 		}
 
-		return meta.LenList(ingressesList) > 0, nil
+		isUsed = meta.LenList(ingressesList) > 0
+		if isUsed {
+			return true, nil
+		}
 	}
 
 	if s.syncAllSecrets {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster did not correctly sync all secrets when both all secrets and ingress sync were enabled.


**What else do we need to know?** 
The all-secret synchronization flag was ignored when the ingresses sync was enabled.