### PR TITLE
Yaml typo: Ingress without ssl-passthrough

### DIFF
--- a/docs/pages/operator/external-access.mdx
+++ b/docs/pages/operator/external-access.mdx
@@ -258,7 +258,8 @@ spec:
         path: /
         pathType: ImplementationSpecific
   tls:
-  - hosts: my-vcluster.example.com
+  - hosts:
+    - my-vcluster.example.com
 ```
 
 With this configuration you will need to use [service account authentication](./accessing-vcluster.mdx#connect-via-service-accounts) in order to connect as the ingress controller won't be able to resolve the client-cert and client-key which is used by default as authentication method. To create a kube config that uses a service account, please run the following command:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes a small, error-causing typo in documentation example yaml.

**Please provide a short message that should be published in the vcluster release notes**

Without this PR, applying the yaml yields the error:
```
> kubectl apply -f ingress.yaml
Error from server (BadRequest): error when creating "ingress.yaml": Ingress in version "v1" cannot be handled as a Ingress: json: cannot unmarshal string into Go struct field IngressTLS.spec.tls.hosts of type []string
```

With this PR, applying the yaml will successfully create the ingress.
