### PR TITLE
docs: fix labelSelector syntax for virtual to host sync

### DIFF
--- a/docs/pages/architecture/synced-resources.mdx
+++ b/docs/pages/architecture/synced-resources.mdx
@@ -179,8 +179,8 @@ sync:
         - apiVersion: cert-manager.io/v1
           kind: Certificate
           selector: 
-            - labelSelector: 
-              - "label-key": "label-value"
+            labelSelector: 
+              "label-key": "label-value"
 ```
 
 


### PR DESCRIPTION
/kind documentation

**What does this pull request do? Which issues does it resolve?**

Fix labelSelector documentation for virtual to host sync (see types)


**Please provide a short message that should be published in the vcluster release notes**

Fix labelSelector documentation for virtual to host sync


