### PR TITLE
Support for nodeSelector, affinity and tolerations in hostpathMapper

### DIFF
--- a/charts/eks/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/eks/templates/daemonset-hostpath-mapper.yaml
@@ -43,6 +43,18 @@ spec:
       {{- else }}
       serviceAccountName: vc-{{ .Release.Name }}
       {{- end }}
+      {{- if .Values.hostpathMapper.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hostpathMapper.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.affinity }}
+      affinity:
+{{ toYaml .Values.hostpathMapper.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.tolerations }}
+      tolerations:
+{{ toYaml .Values.hostpathMapper.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: hostpath-mapper
         {{- if .Values.hostpathMapper.image }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -327,6 +327,10 @@ rbac:
     # Support for this value will be removed in a future version of the vcluster
     extended: false
 
+# Extra Annotations for the stateful set
+annotations: {}
+podAnnotations: {}
+
 # Syncer service configurations
 service:
   type: ClusterIP

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -134,6 +134,12 @@ hostpathMapper:
     # requests:
     #   cpu: 20m
     #   memory: 50Mi
+  # Node selectors to use for the hostpathMapper
+  nodeSelector: {}
+  # Affinity to use for the hostpathMapper
+  affinity: {}
+  # Tolerations to use for the hostpathMapper
+  tolerations: [] 
 
 # Syncer configuration
 syncer:

--- a/charts/k0s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k0s/templates/daemonset-hostpath-mapper.yaml
@@ -43,6 +43,18 @@ spec:
       {{- else }}
       serviceAccountName: vc-{{ .Release.Name }}
       {{- end }}
+      {{- if .Values.hostpathMapper.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hostpathMapper.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.affinity }}
+      affinity:
+{{ toYaml .Values.hostpathMapper.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.tolerations }}
+      tolerations:
+{{ toYaml .Values.hostpathMapper.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: hostpath-mapper
         {{- if .Values.hostpathMapper.image }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -135,6 +135,12 @@ hostpathMapper:
     # requests:
     #   cpu: 20m
     #   memory: 50Mi
+  # Node selectors to use for the hostpathMapper
+  nodeSelector: {}
+  # Affinity to use for the hostpathMapper
+  affinity: {}
+  # Tolerations to use for the hostpathMapper
+  tolerations: [] 
 
 # Syncer configuration
 syncer:

--- a/charts/k3s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k3s/templates/daemonset-hostpath-mapper.yaml
@@ -42,6 +42,18 @@ spec:
       {{- else }}
       serviceAccountName: vc-{{ .Release.Name }}
       {{- end }}
+      {{- if .Values.hostpathMapper.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hostpathMapper.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.affinity }}
+      affinity:
+{{ toYaml .Values.hostpathMapper.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.tolerations }}
+      tolerations:
+{{ toYaml .Values.hostpathMapper.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: hostpath-mapper
         {{- if .Values.hostpathMapper.image }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -140,6 +140,12 @@ hostpathMapper:
     # requests:
     #   cpu: 20m
     #   memory: 50Mi
+  # Node selectors to use for the hostpathMapper
+  nodeSelector: {}
+  # Affinity to use for the hostpathMapper
+  affinity: {}
+  # Tolerations to use for the hostpathMapper
+  tolerations: [] 
 
 # Syncer configuration
 syncer:

--- a/charts/k8s/templates/daemonset-hostpath-mapper.yaml
+++ b/charts/k8s/templates/daemonset-hostpath-mapper.yaml
@@ -43,6 +43,18 @@ spec:
       {{- else }}
       serviceAccountName: vc-{{ .Release.Name }}
       {{- end }}
+      {{- if .Values.hostpathMapper.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hostpathMapper.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.affinity }}
+      affinity:
+{{ toYaml .Values.hostpathMapper.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.hostpathMapper.tolerations }}
+      tolerations:
+{{ toYaml .Values.hostpathMapper.tolerations | indent 8 }}
+      {{- end }}
       containers:
       - name: hostpath-mapper
         {{- if .Values.hostpathMapper.image }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -139,6 +139,12 @@ hostpathMapper:
     # requests:
     #   cpu: 20m
     #   memory: 50Mi
+  # Node selectors to use for the hostpathMapper
+  nodeSelector: {}
+  # Affinity to use for the hostpathMapper
+  affinity: {}
+  # Tolerations to use for the hostpathMapper
+  tolerations: [] 
 
 # Syncer configuration
 syncer:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -328,6 +328,10 @@ rbac:
     # Support for this value will be removed in a future version of the vcluster
     extended: false
 
+# Extra Annotations for the stateful set
+annotations: {}
+podAnnotations: {}
+
 # Syncer service configurations
 service:
   type: ClusterIP


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves https://github.com/loft-sh/vcluster/issues/861. Furthermore, fixes daemonset annotations rendering with default values in `eks` and `k8s`:
```bash
Error: UPGRADE FAILED: template: vcluster-eks/templates/daemonset-hostpath-mapper.yaml:20:61: executing "vcluster-eks/templates/daemonset-hostpath-mapper.yaml" at <.Values.annotations>: wrong type for value; expected map[string]interface {}; got interface {}
```

**Please provide a short message that should be published in the vcluster release notes**
Support for nodeSelector, affinity and tolerations in hostpathMapper

**What else do we need to know?** 
n/a