### PR TITLE
fix: race condition, cache and metrics proxy

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -405,9 +405,6 @@ func StartControllers(controllerContext *context2.ControllerContext) error {
 		telemetry.Collector.RecordEvent(telemetry.Collector.NewEvent(telemetrytypes.EventLeadershipStarted))
 	}
 
-	// register APIService
-	go RegisterOrDeregisterAPIService(controllerContext)
-
 	// setup CoreDNS according to the manifest file
 	go func() {
 		_ = wait.ExponentialBackoffWithContext(controllerContext.Context, wait.Backoff{Duration: time.Second, Factor: 1.5, Cap: time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
@@ -462,6 +459,9 @@ func StartControllers(controllerContext *context2.ControllerContext) error {
 	// Wait for caches to be synced
 	controllerContext.LocalManager.GetCache().WaitForCacheSync(controllerContext.Context)
 	controllerContext.VirtualManager.GetCache().WaitForCacheSync(controllerContext.Context)
+
+	// register APIService
+	go RegisterOrDeregisterAPIService(controllerContext)
 
 	// make sure owner is set if it is there
 	err = FindOwner(controllerContext)

--- a/pkg/metricsapiservice/register.go
+++ b/pkg/metricsapiservice/register.go
@@ -63,7 +63,8 @@ func deleteOperation(ctx context.Context, client client.Client) wait.ConditionWi
 				return true, nil
 			}
 
-			return false, err
+			klog.Errorf("error creating api service %v", err)
+			return false, nil
 		}
 
 		return true, nil
@@ -95,7 +96,7 @@ func createOperation(ctx context.Context, client client.Client) wait.ConditionWi
 			}
 
 			klog.Errorf("error creating api service %v", err)
-			return false, err
+			return false, nil
 		}
 
 		return true, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Should resolve the following error:
> start.go:381] Error registering metrics apiservice: the cache is not started, can not read objects


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not initialize metrics proxy due to a race condition.


**What else do we need to know?** 
