### PR TITLE
Unable to sync `PersistentVolumeClaims` to host cluster when `StorageClass` sync is enabled

### DIFF
--- a/pkg/controllers/resources/persistentvolumeclaims/translate.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/translate.go
@@ -2,7 +2,6 @@ package persistentvolumeclaims
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -50,17 +49,10 @@ func (s *persistentVolumeClaimSyncer) translateSelector(ctx *synccontext.SyncCon
 	}
 
 	// translate storage class if we manage those in vcluster
-	if s.storageClassesEnabled {
-		if storageClassName == "" && vPvc.Spec.Selector == nil && vPvc.Spec.VolumeName == "" {
-			return nil, fmt.Errorf("no storage class defined for pvc %s/%s", vPvc.Namespace, vPvc.Name)
-		}
-
-		// translate storage class name if there is any
-		if storageClassName != "" {
-			translated := translate.Default.PhysicalNameClusterScoped(storageClassName)
-			delete(vPvc.Annotations, deprecatedStorageClassAnnotation)
-			vPvc.Spec.StorageClassName = &translated
-		}
+	if s.storageClassesEnabled && storageClassName != "" {
+		translated := translate.Default.PhysicalNameClusterScoped(storageClassName)
+		delete(vPvc.Annotations, deprecatedStorageClassAnnotation)
+		vPvc.Spec.StorageClassName = &translated
 	}
 
 	// translate selector & volume name


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves https://github.com/loft-sh/vcluster/issues/1126

**Please provide a short message that should be published in the vcluster release notes**
Ability to sync `PersistentVolumeClaims` with empty `storageClassName` to host cluster when `StorageClass` sync is enabled

**What else do we need to know?** 
All the details in the issue above.