### PR TITLE
Docs: Add "--update-current=false" to "Exposing vcluster"

### DIFF
--- a/docs/pages/operator/external-access.mdx
+++ b/docs/pages/operator/external-access.mdx
@@ -278,7 +278,7 @@ kubectl get ns
 
 In order to access the virtual cluster from within the host cluster, you can directly connect to the vcluster service. Make sure you can access that service and then create a kube config in the following form:
 ```
-vcluster connect my-vcluster -n my-vcluster --server=my-vcluster.my-vcluster --insecure --update-current=false
+vcluster connect my-vcluster -n my-vcluster --update-current=false --server=my-vcluster.my-vcluster --insecure --update-current=false
 ```
 
 Now access the virtual cluster with:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

The flag `--update-current=false` was probably intended to be here because immediately after it, a code snippet suggests the use of `kubectl --kubeconfig ...`. This code snippet would not work without `--update-current=false`.