### PR TITLE
Add TLS support to Ingress

### DIFF
--- a/charts/eks/templates/ingress.yaml
+++ b/charts/eks/templates/ingress.yaml
@@ -24,4 +24,8 @@ spec:
                   name: https
             path: /
             pathType: {{ .Values.ingress.pathType }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
 {{- end }}

--- a/charts/eks/templates/ingress.yaml
+++ b/charts/eks/templates/ingress.yaml
@@ -2,7 +2,10 @@
 apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
-{{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations  }}  
+{{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations  }}
+  {{- if .Values.ingress.tls }}
+    {{- $annotations = omit $annotations "nginx.ingress.kubernetes.io/ssl-passthrough" }}
+  {{- end }}
   {{- if $annotations }}
   annotations:
   {{- toYaml $annotations | nindent 4 }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -367,6 +367,11 @@ ingress:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  # Ingress TLS configuration
+  tls: []
+    # - secretName: tls-vcluster.local
+    #   hosts:
+    #     - vcluster.local
 
 # Set "enable" to true when running vcluster in an OpenShift host
 # This will add an extra rule to the deployed role binding in order

--- a/charts/k0s/templates/ingress.yaml
+++ b/charts/k0s/templates/ingress.yaml
@@ -3,6 +3,9 @@ apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   {{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if .Values.ingress.tls }}
+    {{- $annotations = omit $annotations "nginx.ingress.kubernetes.io/ssl-passthrough" }}
+  {{- end }}
   {{- if $annotations }}
   annotations:
   {{- toYaml $annotations | nindent 4 }}

--- a/charts/k0s/templates/ingress.yaml
+++ b/charts/k0s/templates/ingress.yaml
@@ -24,4 +24,8 @@ spec:
                   name: https
             path: /
             pathType: {{ .Values.ingress.pathType }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
 {{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -277,6 +277,11 @@ ingress:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  # Ingress TLS configuration
+  tls: []
+    # - secretName: tls-vcluster.local
+    #   hosts:
+    #     - vcluster.local
 
 # Configure SecurityContext of the containers in the VCluster pod
 securityContext:

--- a/charts/k3s/templates/ingress.yaml
+++ b/charts/k3s/templates/ingress.yaml
@@ -24,4 +24,8 @@ spec:
                   name: https
             path: /
             pathType: {{ .Values.ingress.pathType }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
 {{- end }}

--- a/charts/k3s/templates/ingress.yaml
+++ b/charts/k3s/templates/ingress.yaml
@@ -3,6 +3,9 @@ apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
 {{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if .Values.ingress.tls }}
+    {{- $annotations = omit $annotations "nginx.ingress.kubernetes.io/ssl-passthrough" }}
+  {{- end }}
   {{- if $annotations }}
   annotations:
   {{- toYaml $annotations | nindent 4 }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -304,6 +304,11 @@ ingress:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  # Ingress TLS configuration
+  tls: []
+    # - secretName: tls-vcluster.local
+    #   hosts:
+    #     - vcluster.local
 
 # Configure SecurityContext of the containers in the VCluster pod
 securityContext:

--- a/charts/k8s/templates/ingress.yaml
+++ b/charts/k8s/templates/ingress.yaml
@@ -24,4 +24,8 @@ spec:
                   name: https
             path: /
             pathType: {{ .Values.ingress.pathType }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
 {{- end }}

--- a/charts/k8s/templates/ingress.yaml
+++ b/charts/k8s/templates/ingress.yaml
@@ -3,6 +3,9 @@ apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   {{- $annotations := merge .Values.ingress.annotations .Values.globalAnnotations }}
+  {{- if .Values.ingress.tls }}
+    {{- $annotations = omit $annotations "nginx.ingress.kubernetes.io/ssl-passthrough" }}
+  {{- end }}
   {{- if $annotations }}
   annotations:
   {{ toYaml $annotations | nindent 4 }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -368,6 +368,11 @@ ingress:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  # Ingress TLS configuration
+  tls: []
+    # - secretName: tls-vcluster.local
+    #   hosts:
+    #     - vcluster.local
 
 # Set "enable" to true when running vcluster in an OpenShift host
 # This will add an extra rule to the deployed role binding in order


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?**
Adds optional TLS configuration for Ingress in `values.yaml` and the respective change in `templates/ingress.yaml` of all 4 distro charts. 

**Please provide a short message that should be published in the vcluster release notes**
Added TLS support when exposing VCluster's with Ingress reources.

**What else do we need to know?** 
- Although including standard comments in the `values.yaml` file, this may need to be documented in the products documentation (`docs/`).
- I only tested with the default k3s distro chart. Here is a quick command to checkout the template:
```bash
helm template my-vcluster ./charts/k3s \
  --set ingress.enabled=true \
  --set ingress.host=vcluster.maze.omg.lol \
  --set ingress.tls[0].hosts[0]=vcluster.maze.omg.lol \
  --set ingress.tls[0].secretName=tls-vcluster.maze.omg.lol \
  | grep -A 25 'kind: Ingress'
```
