### PR TITLE
Update github actions to use the latest job output syntax

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -100,7 +100,7 @@ jobs:
           set -x
           sudo apt-get install -y jq
           paths=$(ls -d ./test/e2e*)
-          echo "::set-output name=matrix::$(printf '%s\n' "${paths}" | jq -R . | jq -cs .)"
+          echo "matrix=$(printf '%s\n' "${paths}" | jq -R . | jq -cs .)" >> "$GITHUB_OUTPUT"
     outputs:
       matrix: ${{ steps.set-paths-matrix.outputs.matrix }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
-          echo "::set-output name=release_version::$RELEASE_VERSION"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind refactoring

**What does this pull request do? Which issues does it resolve?** 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Please provide a short message that should be published in the vcluster release notes**
Updated GitHub actions to use latest job output syntax.


**What else do we need to know?** 

Signed-off-by: Thomas Kosiewski <thomas.kosiewski@loft.sh>
