### PR TITLE
add support for coredns 1.11.0

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -156,8 +156,8 @@ data:
               runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
               allowPrivilegeEscalation: false
               capabilities:
-                drop:
-                - all
+                add:
+                  - NET_BIND_SERVICE
               readOnlyRootFilesystem: true
             livenessProbe:
               httpGet:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -151,8 +151,8 @@ data:
                 runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
-                  drop:
-                    - ALL
+                  add:
+                    - NET_BIND_SERVICE
                 readOnlyRootFilesystem: true
               livenessProbe:
                 httpGet:

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -151,8 +151,8 @@ data:
                 runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
-                  drop:
-                    - ALL
+                  add:
+                    - NET_BIND_SERVICE
                 readOnlyRootFilesystem: true
               livenessProbe:
                 httpGet:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -151,8 +151,8 @@ data:
                 runAsGroup: {{`{{.RUN_AS_GROUP}}`}}
                 allowPrivilegeEscalation: false
                 capabilities:
-                  drop:
-                    - ALL
+                  add:
+                    - NET_BIND_SERVICE
                 readOnlyRootFilesystem: true
               livenessProbe:
                 httpGet:

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultImage          = "coredns/coredns:1.10.1"
+	DefaultImage          = "coredns/coredns:1.11.0"
 	ManifestRelativePath  = "coredns/coredns.yaml"
 	ManifestsOutputFolder = "/tmp/manifests-to-apply"
 	VarImage              = "IMAGE"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-1857 #1141 #1151 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster coreDNS would fail to come up for the latest coreDNS release `1.11.0` due to lacking capabilities.


**What else do we need to know?** 
