### PR TITLE
fix: coredns deploy psp cap

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- if .Values.globalAnnotations}}
   annotations:
 {{ toYaml .Values.globalAnnotations | indent 4}}
-  {{- end}}  
+  {{- end}}
 data:
 {{- if .Values.coredns.manifests }}
   coredns.yaml: |-
@@ -158,6 +158,8 @@ data:
               capabilities:
                 add:
                   - NET_BIND_SERVICE
+                drop:
+                  - ALL
               readOnlyRootFilesystem: true
             livenessProbe:
               httpGet:

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -153,6 +153,8 @@ data:
                 capabilities:
                   add:
                     - NET_BIND_SERVICE
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
               livenessProbe:
                 httpGet:

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -153,6 +153,8 @@ data:
                 capabilities:
                   add:
                     - NET_BIND_SERVICE
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
               livenessProbe:
                 httpGet:

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -153,6 +153,8 @@ data:
                 capabilities:
                   add:
                     - NET_BIND_SERVICE
+                  drop:
+                    - ALL
                 readOnlyRootFilesystem: true
               livenessProbe:
                 httpGet:


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where coredns deployment breaks the Security policy for dropping ALL caps and only add NET_BIND_SERVICE 


**What else do we need to know?** 
This is a regression. We added NET_BIND_SERVICE when updating coredns image but removed the drop: ALL in securityContext.capabilities.
