### PR TITLE
Skip Event Reconciliation on cache miss due to object of non-default namespace

### DIFF
--- a/pkg/controllers/resources/events/syncer.go
+++ b/pkg/controllers/resources/events/syncer.go
@@ -73,7 +73,7 @@ func (s *eventSyncer) reconcile(ctx *synccontext.SyncContext, req ctrl.Request) 
 	pObj := s.Resource()
 	err := ctx.PhysicalClient.Get(ctx.Context, req.NamespacedName, pObj)
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
+		if !kerrors.IsNotFound(err) && !strings.Contains(err.Error(), "because of unknown namespace for the cache") {
 			return err
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fail event reconciliation on cache miss of objects belonging to non default namespace of the cache.

Closes ENG-2024