### PR TITLE
Remove tolerations on EKS chart

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -103,15 +103,6 @@ data:
         spec:
           priorityClassName: "system-cluster-critical"
           serviceAccountName: coredns
-          tolerations:
-            - key: "CriticalAddonsOnly"
-              operator: "Exists"
-            - key: "node-role.kubernetes.io/control-plane"
-              operator: "Exists"
-              effect: "NoSchedule"
-            - key: "node-role.kubernetes.io/master"
-              operator: "Exists"
-              effect: "NoSchedule"
           nodeSelector:
             kubernetes.io/os: linux
           topologySpreadConstraints:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
original issue was at #251
original PR was at #353 

**Please provide a short message that should be published in the vcluster release notes**
Remove tolerations for CoreDNS pods on EKS chart

**What else do we need to know?** 

The original PR addressed the issue by removing this from the regular chart, which can be seen here: https://github.com/loft-sh/vcluster/blob/de1552f073c4b9600f6c13b89fcbee29fc9a8bf8/charts/k8s/templates/coredns.yaml

This PR brings the EKS chart to parity with that chart.
