### PR TITLE
fix: bundle should not start a new list entry

### DIFF
--- a/charts/eks/templates/init-configmap.yaml
+++ b/charts/eks/templates/init-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   {{- if .Values.globalAnnotations}}
   annotations:
-{{ toYaml .Values.globalAnnotations | indent 4 }}    
+{{ toYaml .Values.globalAnnotations | indent 4 }}
   {{- end }}
 data:
   manifests: |-
@@ -36,7 +36,7 @@ data:
       {{- end}}
   {{- end }}
   {{- if .bundle }}
-    - bundle: {{ .bundle }}
+      bundle: {{ .bundle }}
   {{- end }}
   {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -389,6 +389,22 @@ init:
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
   manifestsTemplate: ''
   helm: []
+    # - bundle: <string> - base64-encoded .tar.gz file content (optional - overrides chart.repo)
+    #   chart:
+    #     name: <string>  REQUIRED
+    #     version: <string>  REQUIRED
+    #     repo: <string>  (optional when bundle is used)
+    #     username: <string>   (if required for repo)
+    #     password: <string>   (if required for repo)
+    #     insecure: boolean    (if required for repo)
+    #   release:
+    #     releaseName: <string> REQUIRED
+    #     releaseNamespace: <string> REQUIRED
+    #     timeout: number
+    #   values: |-  string YAML object
+    #     foo: bar
+    #   valuesTemplate: |-  string YAML object
+    #     foo: {{ .Release.Name }}
 
 # If enabled will deploy vcluster in an isolated mode with pod security
 # standards, limit ranges and resource quotas

--- a/charts/k0s/templates/init-configmap.yaml
+++ b/charts/k0s/templates/init-configmap.yaml
@@ -36,7 +36,7 @@ data:
       {{- end}}
   {{- end }}
   {{- if .bundle }}
-    - bundle: {{ .bundle }}
+      bundle: {{ .bundle }}
   {{- end }}
   {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -412,6 +412,22 @@ init:
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
   manifestsTemplate: ''
   helm: []
+    # - bundle: <string> - base64-encoded .tar.gz file content (optional - overrides chart.repo)
+    #   chart:
+    #     name: <string>  REQUIRED
+    #     version: <string>  REQUIRED
+    #     repo: <string>  (optional when bundle is used)
+    #     username: <string>   (if required for repo)
+    #     password: <string>   (if required for repo)
+    #     insecure: boolean    (if required for repo)
+    #   release:
+    #     releaseName: <string> REQUIRED
+    #     releaseNamespace: <string> REQUIRED
+    #     timeout: number
+    #   values: |-  string YAML object
+    #     foo: bar
+    #   valuesTemplate: |-  string YAML object
+    #     foo: {{ .Release.Name }}
 
 multiNamespaceMode:
   enabled: false

--- a/charts/k3s/templates/init-configmap.yaml
+++ b/charts/k3s/templates/init-configmap.yaml
@@ -36,7 +36,7 @@ data:
       {{- end}}
   {{- end }}
   {{- if .bundle }}
-    - bundle: {{ .bundle }}
+      bundle: {{ .bundle }}
   {{- end }}
   {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -432,6 +432,22 @@ init:
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
   manifestsTemplate: ''
   helm: []
+    # - bundle: <string> - base64-encoded .tar.gz file content (optional - overrides chart.repo)
+    #   chart:
+    #     name: <string>  REQUIRED
+    #     version: <string>  REQUIRED
+    #     repo: <string>  (optional when bundle is used)
+    #     username: <string>   (if required for repo)
+    #     password: <string>   (if required for repo)
+    #     insecure: boolean    (if required for repo)
+    #   release:
+    #     releaseName: <string> REQUIRED
+    #     releaseNamespace: <string> REQUIRED
+    #     timeout: number
+    #   values: |-  string YAML object
+    #     foo: bar
+    #   valuesTemplate: |-  string YAML object
+    #     foo: {{ .Release.Name }}
 
 multiNamespaceMode:
   enabled: false

--- a/charts/k8s/templates/init-configmap.yaml
+++ b/charts/k8s/templates/init-configmap.yaml
@@ -36,7 +36,7 @@ data:
       {{- end}}
   {{- end }}
   {{- if .bundle }}
-    - bundle: {{ .bundle }}
+      bundle: {{ .bundle }}
   {{- end }}
   {{- if or .chart .bundle }}
       {{- if or .values .valuesTemplate }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -477,6 +477,22 @@ init:
   # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
   manifestsTemplate: ''
   helm: []
+    # - bundle: <string> - base64-encoded .tar.gz file content (optional - overrides chart.repo)
+    #   chart:
+    #     name: <string>  REQUIRED
+    #     version: <string>  REQUIRED
+    #     repo: <string>  (optional when bundle is used)
+    #     username: <string>   (if required for repo)
+    #     password: <string>   (if required for repo)
+    #     insecure: boolean    (if required for repo)
+    #   release:
+    #     releaseName: <string> REQUIRED
+    #     releaseNamespace: <string> REQUIRED
+    #     timeout: number
+    #   values: |-  string YAML object
+    #     foo: bar
+    #   valuesTemplate: |-  string YAML object
+    #     foo: {{ .Release.Name }}
 
 multiNamespaceMode:
   enabled: false

--- a/docs/pages/operator/init-manifests.mdx
+++ b/docs/pages/operator/init-manifests.mdx
@@ -78,6 +78,9 @@ Next we can paste the bundle in our values file:
 init:
   helm:
     - bundle: <base64_encoded_tar_bundle>
+      chart:
+        name: my-chart
+        version: <chart version>
       values: |-
         foo: bar
       release:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1211 

This fixes an issue where the `bundle` attribute was starting a new list entry and cutting off any provided `chart` information which is needed for extracting the tar file into a specific filename.

Also updated the documentation example and values.yaml files to provide more information on the `init` helm chart entries.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster could not apply more than one bundled helm chart.


**What else do we need to know?** 
The `init` code assumes that the `chart.name`, `chart.repo` and `chart.version` are populated for both `bundle` and `repo` charts.  The `repo` is not technically needed for bundled charts and the filename can be generated without it.  Requiring the name and version for a bundled chart may seem a little odd, but it's the way the tar file name is determined, so unless that code gets refactored the `chart.name` and `chart.version` should be specified even for bundled charts.