### PR TITLE
Add coredns `nodeSelector` Values

### DIFF
--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -105,6 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
+{{ toYaml .Values.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -105,7 +105,9 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
+            {{- if .Values.coredns.nodeSelector }}
+{{ toYaml .Values.coredns.nodeSelector | indent 12 }}
+            {{- end }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/eks/templates/coredns.yaml
+++ b/charts/eks/templates/coredns.yaml
@@ -105,7 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.nodeSelector | indent 6 }}
+{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -265,6 +265,9 @@ coredns:
   enabled: true
   image: public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-11
   replicas: 1
+  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # nodeSelector:
+  #   kubernetes.io/arch: arm64
   # CoreDNS service configurations
   service:
     # Extra Annotations

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -265,7 +265,7 @@ coredns:
   enabled: true
   image: public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-11
   replicas: 1
-  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
   # nodeSelector:
   #   kubernetes.io/arch: arm64
   # CoreDNS service configurations

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -105,6 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
+{{ toYaml .Values.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -105,7 +105,9 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
+            {{- if .Values.coredns.nodeSelector }}
+{{ toYaml .Values.coredns.nodeSelector | indent 12 }}
+            {{- end }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k0s/templates/coredns.yaml
+++ b/charts/k0s/templates/coredns.yaml
@@ -105,7 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.nodeSelector | indent 6 }}
+{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -329,7 +329,7 @@ coredns:
   # If CoreDns is enabled
   enabled: true
   replicas: 1
-  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
   # nodeSelector:
   #   kubernetes.io/arch: arm64
   # image: my-core-dns-image:latest

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -329,6 +329,9 @@ coredns:
   # If CoreDns is enabled
   enabled: true
   replicas: 1
+  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # nodeSelector:
+  #   kubernetes.io/arch: arm64
   # image: my-core-dns-image:latest
   # config: |-
   #   .:1053 {

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -105,7 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -105,6 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
+{{ toYaml .Values.nodeSelector | indent 8 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -105,7 +105,9 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
+            {{- if .Values.coredns.nodeSelector }}
+{{ toYaml .Values.coredns.nodeSelector | indent 12 }}
+            {{- end }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k3s/templates/coredns.yaml
+++ b/charts/k3s/templates/coredns.yaml
@@ -105,7 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.nodeSelector | indent 6 }}
+{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -348,7 +348,7 @@ coredns:
   integrated: false
   enabled: true
   replicas: 1
-  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
   # nodeSelector:
   #   kubernetes.io/arch: arm64
   # image: my-core-dns-image:latest

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -348,6 +348,9 @@ coredns:
   integrated: false
   enabled: true
   replicas: 1
+  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # nodeSelector:
+  #   kubernetes.io/arch: arm64
   # image: my-core-dns-image:latest
   # config: |-
   #   .:1053 {

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -105,6 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
+{{ toYaml .Values.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -105,7 +105,9 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
+            {{- if .Values.coredns.nodeSelector }}
+{{ toYaml .Values.coredns.nodeSelector | indent 12 }}
+            {{- end }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k8s/templates/coredns.yaml
+++ b/charts/k8s/templates/coredns.yaml
@@ -105,7 +105,7 @@ data:
           serviceAccountName: coredns
           nodeSelector:
             kubernetes.io/os: linux
-{{ toYaml .Values.nodeSelector | indent 6 }}
+{{ toYaml .Values.coredns.nodeSelector | indent 6 }}
           topologySpreadConstraints:
             - maxSkew: 1
               topologyKey: kubernetes.io/hostname

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -393,6 +393,9 @@ coredns:
   integrated: false
   enabled: true
   replicas: 1
+  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # nodeSelector:
+  #   kubernetes.io/arch: arm64
   # image: my-core-dns-image:latest
   # config: |-
   #   .:1053 {

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -393,7 +393,7 @@ coredns:
   integrated: false
   enabled: true
   replicas: 1
-  # The nodeSelector example below specifices that coredns shoudl only be scheduled to nodes with the arm64 label
+  # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
   # nodeSelector:
   #   kubernetes.io/arch: arm64
   # image: my-core-dns-image:latest


### PR DESCRIPTION
Add Values.coredns.nodeSelector for coredns Deployment

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

Adds Values.coredns.nodeSelector with coredns deployment. This allows deploying a vcluster with coredns enabled to a GKE arm64 based node pool (as well as ensuring it gets deployed to an arm64 node in other multi-arch clusters).

**Please provide a short message that should be published in the vcluster release notes**
Added `Values.coredns.nodeSelector` support for coredns


**What else do we need to know?** 
