### PR TITLE
add vcluster.extraVolumeMounts to provide option for HA use cases

### DIFF
--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -218,6 +218,9 @@ spec:
           - name: config
             mountPath: /etc/rancher
 {{ toYaml .Values.vcluster.volumeMounts | indent 10 }}
+        {{- if .Values.vcluster.extraVolumeMounts }}
+{{ toYaml .Values.vcluster.extraVolumeMounts | indent 10 }}
+        {{- end }}
         resources:
 {{ toYaml .Values.vcluster.resources | indent 10 }}
       {{- end }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -176,6 +176,7 @@ vcluster:
     - --flannel-backend=none
     - --kube-apiserver-arg=bind-address=127.0.0.1
   extraArgs: []
+  extraVolumeMounts: []
   volumeMounts:
     - mountPath: /data
       name: data


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1273


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster needs some extra mount volumes and doing that overrides the default /data mount points and thus vcluster to come up


**What else do we need to know?** 
