### PR TITLE
Fixed use command expecting only one arg

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -85,8 +85,10 @@ func NewConnectCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Log:         log.GetInstance(),
 	}
 
+	useLine, nameValidator := loftctlUtil.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+
 	cobraCmd := &cobra.Command{
-		Use:   "connect" + loftctlUtil.VClusterNameOnlyUseLine,
+		Use:   "connect" + useLine,
 		Short: "Connect to a virtual cluster",
 		Long: `
 #######################################################
@@ -101,7 +103,7 @@ vcluster connect test -n test -- bash
 vcluster connect test -n test -- kubectl get ns
 #######################################################
 	`,
-		Args:              loftctlUtil.VClusterNameOnlyValidator,
+		Args:              nameValidator,
 		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Check for newer version

--- a/cmd/vclusterctl/cmd/disconnect.go
+++ b/cmd/vclusterctl/cmd/disconnect.go
@@ -44,7 +44,7 @@ vcluster disconnect
 	`,
 		Args: cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.Run(cobraCmd, args)
+			return cmd.Run()
 		},
 	}
 
@@ -52,7 +52,7 @@ vcluster disconnect
 }
 
 // Run executes the functionality
-func (cmd *DisconnectCmd) Run(*cobra.Command, []string) error {
+func (cmd *DisconnectCmd) Run() error {
 	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
 		CurrentContext: cmd.Context,
 	}).RawConfig()

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/loft-sh/agentapi/v3 v3.3.0-ci.1.0.20230925121720-6c3f4d5f792e
 	github.com/loft-sh/api/v3 v3.0.0-20231002075709-103158ad55b5
-	github.com/loft-sh/loftctl/v3 v3.0.0-20231002131651-85b7f5df694d
+	github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1
 	github.com/loft-sh/utils v0.0.28
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/loft-sh/external-types v0.0.2-0.20230301201552-ec939da949b4 h1:eSuBR+
 github.com/loft-sh/external-types v0.0.2-0.20230301201552-ec939da949b4/go.mod h1:qnerIOkD67CmTkV8HsXQit6BfB7Qiw45bSUy1oefIXU=
 github.com/loft-sh/jspolicy v0.1.0 h1:FNAWR6tRX5NRWxAf9RI/86NRH83NXYbobLHSZyMND74=
 github.com/loft-sh/jspolicy v0.1.0/go.mod h1:4Zi38iEB0JvhnkrNHPpoueSUWQ1OlHMNB9JHTGEsPO0=
-github.com/loft-sh/loftctl/v3 v3.0.0-20231002131651-85b7f5df694d h1:9W6GSLteEuzGI4t/XBXA1j3C8lJYeWSqv8D6KcX75qQ=
-github.com/loft-sh/loftctl/v3 v3.0.0-20231002131651-85b7f5df694d/go.mod h1:C9Ez2aioZvT2s7Jiv5xny7htt8IO/i6akwvGHVxWKsU=
+github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1 h1:6Mzn38wXBgxUPOQaYSd4ezYPQephfg3odhMh+dhZ6Cs=
+github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1/go.mod h1:3BaJ2HAsvk9D/F/K4tk1IFe+R/e504YtbKINmw8OGoA=
 github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a h1:/gqqjKpcHEdFXIX41lx1Y/FBqT/72gbPpf7sa20tyM8=
 github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a/go.mod h1:YImeRjXH34Yf5E79T7UHBQpDZl9fIaaFRgyZ/bkY+UQ=
 github.com/loft-sh/utils v0.0.28 h1:Dzco2sfXX0L2DHA6Vm6OwdJmF07zujmAynNVlpOm/0o=

--- a/test/e2e_cli/connect/connect.go
+++ b/test/e2e_cli/connect/connect.go
@@ -1,0 +1,45 @@
+package connect
+
+import (
+	"os"
+	"strings"
+
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+)
+
+var _ = ginkgo.Describe("Connect to vCluster", func() {
+	f := framework.DefaultFramework
+
+	ginkgo.BeforeEach(func() {
+		disconnectCmd := cmd.NewDisconnectCmd(&flags.GlobalFlags{})
+		disconnectCmd.SetArgs([]string{})
+
+		err := disconnectCmd.Execute()
+		if err != nil && !strings.Contains(err.Error(), "not a vcluster context") {
+			framework.ExpectNoError(err)
+		}
+	})
+
+	ginkgo.It("should connect to an OSS vcluster", func() {
+		kcfgFile, err := os.CreateTemp("", "kubeconfig")
+		framework.ExpectNoError(err)
+
+		connectCmd := cmd.NewConnectCmd(&flags.GlobalFlags{})
+		connectCmd.Flags().Set("kube-config", kcfgFile.Name())
+		connectCmd.SetArgs([]string{f.VclusterName})
+
+		err = connectCmd.Execute()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("should connect to an OSS vcluster and execute a command", func() {
+		connectCmd := cmd.NewConnectCmd(&flags.GlobalFlags{})
+		connectCmd.SetArgs([]string{f.VclusterName, "--", "kubectl", "get", "ns"})
+
+		err := connectCmd.Execute()
+		framework.ExpectNoError(err)
+	})
+})

--- a/test/e2e_cli/e2e_cli_suite_test.go
+++ b/test/e2e_cli/e2e_cli_suite_test.go
@@ -1,0 +1,44 @@
+package e2ecli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	// Enable cloud provider auth
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	// Register tests
+	_ "github.com/loft-sh/vcluster/test/e2e_cli/connect"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+}
+
+func TestRunE2ETests(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	err := framework.CreateFramework(context.Background(), scheme)
+	if err != nil {
+		log.GetInstance().Fatalf("Error setting up framework: %v", err)
+	}
+
+	var _ = ginkgo.AfterSuite(func() {
+		err = framework.DefaultFramework.Cleanup()
+		if err != nil {
+			log.GetInstance().Warnf("Error executing testsuite cleanup: %v", err)
+		}
+	})
+
+	ginkgo.RunSpecs(t, "Vcluster CLI e2e suite")
+}

--- a/test/e2e_cli/values.yaml
+++ b/test/e2e_cli/values.yaml
@@ -1,0 +1,3 @@
+# empty values file to avoid no file or dir error
+# this test suite will be run for all configurations
+# so add values for this test suite in commonValues.yaml

--- a/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/get/secret.go
+++ b/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/get/secret.go
@@ -66,7 +66,7 @@ devspace get secret test-secret.key --project myproject
 ########################################################
 	`
 	}
-	useLine, validator := util.NamedPositionalArgsValidator(true, "SECRET_NAME")
+	useLine, validator := util.NamedPositionalArgsValidator(true, true, "SECRET_NAME")
 	c := &cobra.Command{
 		Use:   "secret" + useLine,
 		Short: "Returns the key value of a project / shared secret",

--- a/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/set/secret.go
+++ b/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/set/secret.go
@@ -71,7 +71,7 @@ devspace set secret test-secret.key value --project myproject
 #######################################################
 	`
 	}
-	useLine, validator := util.NamedPositionalArgsValidator(true, "SECRET_NAME", "SECRET_VALUE")
+	useLine, validator := util.NamedPositionalArgsValidator(true, true, "SECRET_NAME", "SECRET_VALUE")
 	c := &cobra.Command{
 		Use:   "secret" + useLine,
 		Short: "Sets the key value of a project / shared secret",

--- a/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/use/space.go
+++ b/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/use/space.go
@@ -67,7 +67,7 @@ devspace use space myspace --project myproject
 ########################################################
 	`
 	}
-	useLine, validator := util.NamedPositionalArgsValidator(false, "SPACE_NAME")
+	useLine, validator := util.NamedPositionalArgsValidator(false, false, "SPACE_NAME")
 	c := &cobra.Command{
 		Use:   "space" + useLine,
 		Short: "Creates a kube context for the given space",

--- a/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/use/vcluster.go
+++ b/vendor/github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/use/vcluster.go
@@ -76,7 +76,7 @@ devspace use vcluster myvcluster --cluster mycluster --space myspace
 ########################################################
 	`
 	}
-	useLine, validator := util.NamedPositionalArgsValidator(false, "VCLUSTER_NAME")
+	useLine, validator := util.NamedPositionalArgsValidator(false, false, "VCLUSTER_NAME")
 	c := &cobra.Command{
 		Use:   "vcluster" + useLine,
 		Short: "Creates a kube context for the given virtual cluster",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -343,7 +343,7 @@ github.com/loft-sh/external-types/loft-sh/admin-services/pkg/server
 # github.com/loft-sh/jspolicy v0.1.0
 ## explicit; go 1.16
 github.com/loft-sh/jspolicy/pkg/apis/policy/v1beta1
-# github.com/loft-sh/loftctl/v3 v3.0.0-20231002131651-85b7f5df694d
+# github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1
 ## explicit; go 1.21.1
 github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd
 github.com/loft-sh/loftctl/v3/cmd/loftctl/cmd/connect


### PR DESCRIPTION
Signed-off-by: Thomas Kosiewski <thomas.kosiewski@loft.sh>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #1272


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster cli would not allow to pass additional arguments to connect subcommand
