### PR TITLE
Add v1.28 support for all distros

### DIFF
--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -177,7 +177,7 @@ syncer:
 
 # Etcd settings
 etcd:
-  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-27-11
+  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.9-eks-1-28-6
   # The amount of replicas to run
   replicas: 1
   # NodeSelector used
@@ -212,7 +212,7 @@ etcd:
 
 # Kubernetes Controller Manager settings
 controller:
-  image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.4-eks-1-27-11
+  image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.28.2-eks-1-28-6
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -235,7 +235,7 @@ controller:
 
 # Kubernetes API Server settings
 api:
-  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.4-eks-1-27-11
+  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.28.2-eks-1-28-6
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1
@@ -263,7 +263,7 @@ api:
 coredns:
   integrated: false
   enabled: true
-  image: public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-11
+  image: public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-28-6
   replicas: 1
   # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
   # nodeSelector:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -155,7 +155,7 @@ syncer:
 # Virtual Cluster (k0s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: k0sproject/k0s:v1.26.0-k0s.0
+  image: k0sproject/k0s:v1.28.2-k0s.0
   command:
     - k0s
   baseArgs:

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -162,7 +162,7 @@ syncer:
 # Virtual Cluster (k3s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: rancher/k3s:v1.27.3-k3s1
+  image: rancher/k3s:v1.28.2-k3s1
   command:
     - /bin/k3s
   baseArgs:

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -216,7 +216,7 @@ etcd:
 
 # Kubernetes Controller Manager settings
 controller:
-  image: registry.k8s.io/kube-controller-manager:v1.28.0
+  image: registry.k8s.io/kube-controller-manager:v1.28.2
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -238,7 +238,7 @@ controller:
   securityContext: {}
 # Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
 scheduler:
-  image: registry.k8s.io/kube-scheduler:v1.28.0
+  image: registry.k8s.io/kube-scheduler:v1.28.2
   # The amount of replicas to run the deployment with
   replicas: 1
   # NodeSelector used
@@ -260,7 +260,7 @@ scheduler:
 
 # Kubernetes API Server settings
 api:
-  image: registry.k8s.io/kube-apiserver:v1.28.0
+  image: registry.k8s.io/kube-apiserver:v1.28.2
   extraArgs: []
   # The amount of replicas to run the deployment with
   replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/loft-sh/agentapi/v3 v3.3.0-ci.1.0.20230925121720-6c3f4d5f792e
 	github.com/loft-sh/api/v3 v3.0.0-20231002075709-103158ad55b5
 	github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1
-	github.com/loft-sh/utils v0.0.28
+	github.com/loft-sh/utils v0.0.29
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/term v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1 h1:6Mzn38wXBgxU
 github.com/loft-sh/loftctl/v3 v3.0.0-20231005113406-74b569e42fd1/go.mod h1:3BaJ2HAsvk9D/F/K4tk1IFe+R/e504YtbKINmw8OGoA=
 github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a h1:/gqqjKpcHEdFXIX41lx1Y/FBqT/72gbPpf7sa20tyM8=
 github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a/go.mod h1:YImeRjXH34Yf5E79T7UHBQpDZl9fIaaFRgyZ/bkY+UQ=
-github.com/loft-sh/utils v0.0.28 h1:Dzco2sfXX0L2DHA6Vm6OwdJmF07zujmAynNVlpOm/0o=
-github.com/loft-sh/utils v0.0.28/go.mod h1:9hlX9cGpWHg3mNi/oBlv3X4ePGDMK66k8MbOZGFMDTI=
+github.com/loft-sh/utils v0.0.29 h1:P/MObccXToAZy2QoJSQDJ+OJx1qHitpFHEVj3QBSNJs=
+github.com/loft-sh/utils v0.0.29/go.mod h1:9hlX9cGpWHg3mNi/oBlv3X4ePGDMK66k8MbOZGFMDTI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/eks.go
@@ -8,35 +8,31 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.4-eks-1-27-11",
-	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.7-eks-1-26-17",
-	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.12-eks-1-25-21",
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.16-eks-1-24-25",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.17-eks-1-23-30",
+	"1.28": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.28.2-eks-1-28-6",
+	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.6-eks-1-27-13",
+	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.9-eks-1-26-19",
+	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.14-eks-1-25-23",
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.4-eks-1-27-11",
-	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.7-eks-1-26-17",
-	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.12-eks-1-25-21",
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.16-eks-1-24-25",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.17-eks-1-23-30",
+	"1.28": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.28.2-eks-1-28-6",
+	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.6-eks-1-27-13",
+	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.9-eks-1-26-19",
+	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.14-eks-1-25-23",
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-27-11",
-	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-26-17",
-	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-25-21",
-	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-24-25",
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-23-30",
+	"1.28": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.9-eks-1-28-6",
+	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-27-13",
+	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-26-19",
+	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.8-eks-1-25-23",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-11",
-	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-17",
-	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-21",
-	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-24-25",
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-30",
+	"1.28": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-28-6",
+	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-13",
+	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-19",
+	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-23",
 }
 
 func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger) (string, error) {
@@ -57,18 +53,18 @@ func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger
 		etcdImage = EKSEtcdVersionMap[serverVersionString]
 		corednsImage, ok = EKSCoreDNSVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 27 {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.27", "serverVersion", serverVersionString)
-				apiImage = EKSAPIVersionMap["1.27"]
-				controllerImage = EKSControllerVersionMap["1.27"]
-				etcdImage = EKSEtcdVersionMap["1.27"]
-				corednsImage = EKSCoreDNSVersionMap["1.27"]
+			if serverMinorInt > 28 {
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.28", "serverVersion", serverVersionString)
+				apiImage = EKSAPIVersionMap["1.28"]
+				controllerImage = EKSControllerVersionMap["1.28"]
+				etcdImage = EKSEtcdVersionMap["1.28"]
+				corednsImage = EKSCoreDNSVersionMap["1.28"]
 			} else {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.23", "serverVersion", serverVersionString)
-				apiImage = EKSAPIVersionMap["1.23"]
-				controllerImage = EKSControllerVersionMap["1.23"]
-				etcdImage = EKSEtcdVersionMap["1.23"]
-				corednsImage = EKSCoreDNSVersionMap["1.23"]
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.25", "serverVersion", serverVersionString)
+				apiImage = EKSAPIVersionMap["1.25"]
+				controllerImage = EKSControllerVersionMap["1.25"]
+				etcdImage = EKSEtcdVersionMap["1.25"]
+				corednsImage = EKSCoreDNSVersionMap["1.25"]
 			}
 		}
 	}

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k0s.go
@@ -8,10 +8,10 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.27": "k0sproject/k0s:v1.27.5-k0s.0",
+	"1.28": "k0sproject/k0s:v1.28.2-k0s.0",
+	"1.27": "k0sproject/k0s:v1.27.6-k0s.0",
 	"1.26": "k0sproject/k0s:v1.26.9-k0s.0",
 	"1.25": "k0sproject/k0s:v1.25.14-k0s.0",
-	"1.24": "k0sproject/k0s:v1.24.17-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger) (string, error) {
@@ -26,12 +26,12 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger
 		var ok bool
 		image, ok = K0SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 27 {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.27", "serverVersion", serverVersionString)
-				image = K0SVersionMap["1.27"]
+			if serverMinorInt > 28 {
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.28", "serverVersion", serverVersionString)
+				image = K0SVersionMap["1.28"]
 			} else {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.24", "serverVersion", serverVersionString)
-				image = K0SVersionMap["1.24"]
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.25", "serverVersion", serverVersionString)
+				image = K0SVersionMap["1.25"]
 			}
 		}
 	}

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k3s.go
@@ -15,8 +15,6 @@ var K3SVersionMap = map[string]string{
 	"1.27": "rancher/k3s:v1.27.6-k3s1",
 	"1.26": "rancher/k3s:v1.26.9-k3s1",
 	"1.25": "rancher/k3s:v1.25.14-k3s1",
-	"1.24": "rancher/k3s:v1.24.17-k3s1",
-	"1.23": "rancher/k3s:v1.23.17-k3s1",
 }
 
 var replaceRegEx = regexp.MustCompile("[^0-9]+")
@@ -43,8 +41,8 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger
 				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.28", "serverVersion", serverVersionString)
 				image = K3SVersionMap["1.28"]
 			} else {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.23", "serverVersion", serverVersionString)
-				image = K3SVersionMap["1.23"]
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.25", "serverVersion", serverVersionString)
+				image = K3SVersionMap["1.25"]
 			}
 		}
 	}

--- a/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
+++ b/vendor/github.com/loft-sh/utils/pkg/helm/values/k8s.go
@@ -12,7 +12,6 @@ var K8SAPIVersionMap = map[string]string{
 	"1.27": "registry.k8s.io/kube-apiserver:v1.27.6",
 	"1.26": "registry.k8s.io/kube-apiserver:v1.26.9",
 	"1.25": "registry.k8s.io/kube-apiserver:v1.25.14",
-	"1.24": "registry.k8s.io/kube-apiserver:v1.24.17",
 }
 
 var K8SControllerVersionMap = map[string]string{
@@ -20,7 +19,6 @@ var K8SControllerVersionMap = map[string]string{
 	"1.27": "registry.k8s.io/kube-controller-manager:v1.27.6",
 	"1.26": "registry.k8s.io/kube-controller-manager:v1.26.9",
 	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.14",
-	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.17",
 }
 
 var K8SSchedulerVersionMap = map[string]string{
@@ -28,7 +26,6 @@ var K8SSchedulerVersionMap = map[string]string{
 	"1.27": "registry.k8s.io/kube-scheduler:v1.27.6",
 	"1.26": "registry.k8s.io/kube-scheduler:v1.26.9",
 	"1.25": "registry.k8s.io/kube-scheduler:v1.25.14",
-	"1.24": "registry.k8s.io/kube-scheduler:v1.24.17",
 }
 
 var K8SEtcdVersionMap = map[string]string{
@@ -36,7 +33,6 @@ var K8SEtcdVersionMap = map[string]string{
 	"1.27": "registry.k8s.io/etcd:3.5.7-0",
 	"1.26": "registry.k8s.io/etcd:3.5.6-0",
 	"1.25": "registry.k8s.io/etcd:3.5.6-0",
-	"1.24": "registry.k8s.io/etcd:3.5.6-0",
 }
 
 func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger) (string, error) {
@@ -64,11 +60,11 @@ func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log logr.Logger
 				schedulerImage = K8SSchedulerVersionMap["1.28"]
 				etcdImage = K8SEtcdVersionMap["1.28"]
 			} else {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.24", "serverVersion", serverVersionString)
-				apiImage = K8SAPIVersionMap["1.24"]
-				controllerImage = K8SControllerVersionMap["1.24"]
-				schedulerImage = K8SSchedulerVersionMap["1.24"]
-				etcdImage = K8SEtcdVersionMap["1.24"]
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.25", "serverVersion", serverVersionString)
+				apiImage = K8SAPIVersionMap["1.25"]
+				controllerImage = K8SControllerVersionMap["1.25"]
+				schedulerImage = K8SSchedulerVersionMap["1.25"]
+				etcdImage = K8SEtcdVersionMap["1.25"]
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -394,7 +394,7 @@ github.com/loft-sh/log/scanner
 github.com/loft-sh/log/survey
 github.com/loft-sh/log/table
 github.com/loft-sh/log/terminal
-# github.com/loft-sh/utils v0.0.28
+# github.com/loft-sh/utils v0.0.29
 ## explicit; go 1.20
 github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Adds support for Kubernetes 1.28 for all distros of vcluster.

Closes ENG-1932
