### PR TITLE
fix: k0s Pro chart is not using Pro image

### DIFF
--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -151,7 +151,7 @@ spec:
         {{- if .Values.syncer.image }}
         image: "{{ .Values.defaultImageRegistry }}{{ .Values.syncer.image }}"
         {{- else }}
-        {{- if .pro }}
+        {{- if .Values.pro }}
         image: "{{ .Values.defaultImageRegistry }}ghcr.io/loft-sh/vcluster-pro:{{ .Chart.Version }}"
         {{- else }}
         image: "{{ .Values.defaultImageRegistry }}ghcr.io/loft-sh/vcluster:{{ .Chart.Version }}"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Because of a small mistake in the Helm chart for k0s, the Pro image was not used when deploying vCluster.Pro distro.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue vCluster.Pro distro would use the wrong syncer image with the k0s. 