### PR TITLE
change vcluster plugin order

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -189,9 +189,6 @@ Corefile: |-
       health
       ready
       rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
-      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
-      {{- end }}
       kubernetes cluster.local in-addr.arpa ip6.arpa {
           {{- if .Values.pro }}
           {{- if .Values.coredns.integrated }}
@@ -205,6 +202,9 @@ Corefile: |-
           fallthrough in-addr.arpa ip6.arpa
           {{- end }}
       }
+      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
+      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
+      {{- end }}
       hosts /etc/NodeHosts {
           ttl 60
           reload 15s

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -189,9 +189,6 @@ Corefile: |-
       health
       ready
       rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
-      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
-      {{- end }}
       kubernetes cluster.local in-addr.arpa ip6.arpa {
           {{- if .Values.pro }}
           {{- if .Values.coredns.integrated }}
@@ -205,6 +202,9 @@ Corefile: |-
           fallthrough in-addr.arpa ip6.arpa
           {{- end }}
       }
+      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
+      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
+      {{- end }}
       hosts /etc/NodeHosts {
           ttl 60
           reload 15s

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -189,9 +189,6 @@ Corefile: |-
       health
       ready
       rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
-      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
-      {{- end }}
       kubernetes cluster.local in-addr.arpa ip6.arpa {
           {{- if .Values.pro }}
           {{- if .Values.coredns.integrated }}
@@ -199,12 +196,15 @@ Corefile: |-
           {{- end }}
           {{- end }}
           pods insecure
-          {{- if .Values.fallbackHostDns }}
-          fallthrough cluster.local in-addr.arpa ip6.arpa
+          {{- if or (.Values.fallbackHostDns) (and .Values.coredns.integrated .Values.coredns.plugin.enabled) }}
+          fallthrough cluster.local in-addr.arpa ip6.arpa 
           {{- else }}
           fallthrough in-addr.arpa ip6.arpa
           {{- end }}
       }
+      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
+      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
+      {{- end }}
       hosts /etc/NodeHosts {
           ttl 60
           reload 15s

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -189,9 +189,6 @@ Corefile: |-
       health
       ready
       rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
-      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
-      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
-      {{- end }}
       kubernetes cluster.local in-addr.arpa ip6.arpa {
           {{- if .Values.pro }}
           {{- if .Values.coredns.integrated }}
@@ -205,6 +202,9 @@ Corefile: |-
           fallthrough in-addr.arpa ip6.arpa
           {{- end }}
       }
+      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
+      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
+      {{- end }}
       hosts /etc/NodeHosts {
           ttl 60
           reload 15s


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves issue related to coredns plugin giving preference to kubernetes first followed by coredns plugin


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
