### PR TITLE
fix: watch and enqueue node events when scheduler enabled

### DIFF
--- a/pkg/constants/indices.go
+++ b/pkg/constants/indices.go
@@ -14,6 +14,11 @@ const (
 	IndexByHostName = "IndexByHostName"
 
 	IndexByClusterIP = "IndexByClusterIP"
+
+	// IndexRunningNonVClusterPodsByNode is only used when the vcluster scheduler is enabled.
+	// It maps non-vcluster pods on the node to the node name, so that the node syncer may
+	// calculate the allocatable resources on the node.
+	IndexRunningNonVClusterPodsByNode = "IndexRunningNonVClusterPodsByNode"
 )
 
 const DefaultCacheSyncTimeout = time.Minute * 15

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -181,7 +181,7 @@ func (s *nodeSyncer) translateUpdateStatus(ctx *synccontext.SyncContext, pNode *
 
 			var nonVClusterPods int64
 			podList := &corev1.PodList{}
-			err := s.podCache.List(ctx.Context, podList, client.MatchingFields{indexPodByRunningNonVClusterNode: pNode.Name})
+			err := s.unmanagedPodCache.List(ctx.Context, podList, client.MatchingFields{constants.IndexRunningNonVClusterPodsByNode: pNode.Name})
 			if err != nil {
 				klog.Errorf("Error listing pods: %v", err)
 			} else {


### PR DESCRIPTION
when using the vcluster scheduler we take into account consumed resources in the pod, but don't immediately trigger the node syncer to do this. This sometimes leads to scheduling resources onto nodes where they don't fit.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-2340


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster scheduler was late to see resource consumption


**What else do we need to know?** 
