### PR TITLE
create clusterrole and pod permissions when coredns plugin enabled

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.priorityclasses.enabled
     .Values.sync.volumesnapshots.enabled
     .Values.proxy.metricsServer.nodes.enabled
-    .Values.multiNamespaceMode.enabled -}}
+    .Values.multiNamespaceMode.enabled
+    .Values.coredns.plugin.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -26,6 +26,11 @@ rules:
     resources: [ "pods", "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
+  {{- if .Values.coredns.plugin.enabled }}
+  - apiGroups: [""]
+    resources: [ "pods"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
   {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
   - apiGroups: [""]
     resources: ["nodes/proxy"]

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.priorityclasses.enabled
     .Values.sync.volumesnapshots.enabled
     .Values.proxy.metricsServer.nodes.enabled
-    .Values.multiNamespaceMode.enabled -}}
+    .Values.multiNamespaceMode.enabled
+    .Values.coredns.plugin.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/k0s/templates/rbac/clusterrole.yaml
+++ b/charts/k0s/templates/rbac/clusterrole.yaml
@@ -26,6 +26,11 @@ rules:
     resources: [ "pods", "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
+  {{- if .Values.coredns.plugin.enabled }}
+  - apiGroups: [""]
+    resources: [ "pods"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
   {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
   - apiGroups: [""]
     resources: ["nodes/proxy"]

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.priorityclasses.enabled
     .Values.sync.volumesnapshots.enabled
     .Values.proxy.metricsServer.nodes.enabled
-    .Values.multiNamespaceMode.enabled -}}
+    .Values.multiNamespaceMode.enabled
+    .Values.coredns.plugin.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -26,6 +26,11 @@ rules:
     resources: [ "pods", "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
+  {{- if .Values.coredns.plugin.enabled }}
+  - apiGroups: [""]
+    resources: [ "pods"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
   {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
   - apiGroups: [""]
     resources: ["nodes/proxy"]

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -58,7 +58,8 @@ Whether to create a cluster role or not
     .Values.sync.priorityclasses.enabled
     .Values.sync.volumesnapshots.enabled
     .Values.proxy.metricsServer.nodes.enabled
-    .Values.multiNamespaceMode.enabled -}}
+    .Values.multiNamespaceMode.enabled
+    .Values.coredns.plugin.enabled -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/charts/k8s/templates/rbac/clusterrole.yaml
+++ b/charts/k8s/templates/rbac/clusterrole.yaml
@@ -26,6 +26,11 @@ rules:
     resources: [ "pods", "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
+  {{- if .Values.coredns.plugin.enabled }}
+  - apiGroups: [""]
+    resources: [ "pods"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
   {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
   - apiGroups: [""]
     resources: ["nodes/proxy"]


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-2307


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster.Pro was missing clusterrole permission to get pods for other vclusters as targets


**What else do we need to know?** 
