### PR TITLE
fix: added server name for service monitor

### DIFF
--- a/charts/k0s/templates/service-monitor.yaml
+++ b/charts/k0s/templates/service-monitor.yaml
@@ -28,4 +28,5 @@ spec:
       keySecret:
         name: vc-{{ .Release.Name }}
         key: client-key
+      serverName: 127.0.0.1
 {{- end }}

--- a/charts/k8s/templates/service-monitor.yaml
+++ b/charts/k8s/templates/service-monitor.yaml
@@ -28,4 +28,5 @@ spec:
       keySecret:
         name: vc-{{ .Release.Name }}
         key: client-key
+      serverName: 127.0.0.1
 {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster's service monitor could not work because the server name was not set properly in k8s and k0s

**What else do we need to know?** 
