### PR TITLE
Updated spelling of the figure label and alt text to vCluster

### DIFF
--- a/docs/pages/networking/networking.mdx
+++ b/docs/pages/networking/networking.mdx
@@ -4,8 +4,8 @@ sidebar_label: Overview
 ---
 
 <figure>
-  <img src="/docs/media/diagrams/vcluster-networking.svg" alt="vcluster Networking" />
-  <figcaption>vcluster - Networking</figcaption>
+  <img src="/docs/media/diagrams/vcluster-networking.svg" alt="vCluster Networking" />
+  <figcaption>vCluster - Networking</figcaption>
 </figure>
 
 By default, resources such as `Service` and `Ingress` are synced from the virtual cluster to the host cluster in order to enable correct network functionality for the vCluster.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Updated the figure caption and alt text from vcluster to vCluster in networking.mdx


**Please provide a short message that should be published in the vcluster release notes**
docs: update figure caption and alt text vCluster capitalization for networking.mdx
