### PR TITLE
added the possibility to run handlers before the filters

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -228,6 +228,10 @@ func NewServer(ctx *options.ControllerContext, requestHeaderCaFile, clientCaFile
 		})
 	}
 
+	for _, handler := range ctx.ExtraHandlers {
+		h = handler(h)
+	}
+
 	serverhelper.HandleRoute(s.handler, "/", h)
 
 	return s, nil

--- a/pkg/setup/options/controller_context.go
+++ b/pkg/setup/options/controller_context.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"context"
+	"net/http"
 
 	servertypes "github.com/loft-sh/vcluster/pkg/server/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -26,4 +27,7 @@ type ControllerContext struct {
 	AdditionalServerFilters []servertypes.Filter
 	Options                 *VirtualClusterOptions
 	StopChan                <-chan struct{}
+
+	//set of extra services that should handle the traffic or pass it along
+	ExtraHandlers []func(http.Handler) http.Handler
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of eng-2316
adds the possibility to run extra handlers before the filters are applied, so that we can run generic services on top of the syncer

**Please provide a short message that should be published in the vcluster release notes**
added the possibility to run handlers before the filters

**What else do we need to know?** 
