### PR TITLE
now handles both deprecated `replicas` and `syncer.replicas`

### DIFF
--- a/charts/k0s/templates/_migrate.tpl
+++ b/charts/k0s/templates/_migrate.tpl
@@ -2,5 +2,5 @@
   handles both replicas and syncer.replicas
 */}}
 {{- define "vcluster.replicas" -}}
-{{ if .Values.syncer.replicas }}{{ .Values.syncer.replicas }}{{ else }}{{ .Values.replicas }}{{ end }}
+{{ if .Values.replicas }}{{ .Values.replicas }}{{ else }}{{ .Values.syncer.replicas }}{{ end }}
 {{- end }}

--- a/charts/k0s/templates/_migrate.tpl
+++ b/charts/k0s/templates/_migrate.tpl
@@ -1,0 +1,6 @@
+{{/*
+  handles both replicas and syncer.replicas
+*/}}
+{{- define "vcluster.replicas" -}}
+{{ if .Values.syncer.replicas }}{{ .Values.syncer.replicas }}{{ else }}{{ .Values.replicas }}{{ end }}
+{{- end }}

--- a/charts/k0s/templates/syncer.yaml
+++ b/charts/k0s/templates/syncer.yaml
@@ -25,7 +25,7 @@ spec:
     whenDeleted: Delete
   {{- end }}
   {{- end }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{include "vcluster.replicas" .}}
   selector:
     matchLabels:
       app: vcluster

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -134,6 +134,7 @@ proxy:
 
 # Syncer configuration
 syncer:
+  replicas: 1
   # Image to use for the syncer
   # image: ghcr.io/loft-sh/vcluster
   imagePullPolicy: ""
@@ -226,9 +227,6 @@ rbac:
     # all entries in excludedApiResources will be excluded from the Role created for vcluster
     excludedApiResources:
       # - pods/exec
-
-# The amount of replicas to run the statefulset with
-replicas: 1
 
 # If vCluster persistent volume claims should get deleted automatically.
 autoDeletePersistentVolumeClaims: true

--- a/charts/k3s/templates/_migrate.tpl
+++ b/charts/k3s/templates/_migrate.tpl
@@ -2,5 +2,5 @@
   handles both replicas and syncer.replicas
 */}}
 {{- define "vcluster.replicas" -}}
-{{ if .Values.syncer.replicas }}{{ .Values.syncer.replicas }}{{ else }}{{ .Values.replicas }}{{ end }}
+{{ if .Values.replicas }}{{ .Values.replicas }}{{ else }}{{ .Values.syncer.replicas }}{{ end }}
 {{- end }}

--- a/charts/k3s/templates/_migrate.tpl
+++ b/charts/k3s/templates/_migrate.tpl
@@ -1,0 +1,6 @@
+{{/*
+  handles both replicas and syncer.replicas
+*/}}
+{{- define "vcluster.replicas" -}}
+{{ if .Values.syncer.replicas }}{{ .Values.syncer.replicas }}{{ else }}{{ .Values.replicas }}{{ end }}
+{{- end }}

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -50,7 +50,7 @@ rules:
     resources: ["endpoints"]
     verbs: ["create", "delete", "patch", "update"]
   {{- end }}
-  {{- if or (gt (int .Values.replicas) 1) .Values.rbac.role.extended }}
+  {{- if or (gt (int .Values.replicas) 1) (gt (int .Values.syncer.replicas) 1) .Values.rbac.role.extended }}
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -50,7 +50,7 @@ rules:
     resources: ["endpoints"]
     verbs: ["create", "delete", "patch", "update"]
   {{- end }}
-  {{- if or (gt ( include "vcluster.replicas" . ) 1 ) .Values.rbac.role.extended }}
+  {{- if or (gt (int ( include "vcluster.replicas" . )) 1 ) .Values.rbac.role.extended }}
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/charts/k3s/templates/rbac/role.yaml
+++ b/charts/k3s/templates/rbac/role.yaml
@@ -50,7 +50,7 @@ rules:
     resources: ["endpoints"]
     verbs: ["create", "delete", "patch", "update"]
   {{- end }}
-  {{- if or (gt (int .Values.replicas) 1) (gt (int .Values.syncer.replicas) 1) .Values.rbac.role.extended }}
+  {{- if or (gt ( include "vcluster.replicas" . ) 1 ) .Values.rbac.role.extended }}
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/charts/k3s/templates/syncer.yaml
+++ b/charts/k3s/templates/syncer.yaml
@@ -25,7 +25,7 @@ spec:
     whenDeleted: Delete
   {{- end }}
   {{- end }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{include "vcluster.replicas" .}}
   selector:
     matchLabels:
       app: vcluster

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -253,10 +253,6 @@ rbac:
     excludedApiResources:
       # - pods/exec
 
-# The amount of replicas to run the statefulset with
-# THIS IS DEPRECATED. Please use syncer.replicas instead
-# replicas: 1
-
 # If vCluster persistent volume claims should get deleted automatically.
 autoDeletePersistentVolumeClaims: true
 

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -135,6 +135,7 @@ proxy:
 
 # Syncer configuration
 syncer:
+  replicas: 1
   # Image to use for the syncer
   # image: ghcr.io/loft-sh/vcluster
   extraArgs: []
@@ -253,7 +254,8 @@ rbac:
       # - pods/exec
 
 # The amount of replicas to run the statefulset with
-replicas: 1
+# THIS IS DEPRECATED. Please use syncer.replicas instead
+# replicas: 1
 
 # If vCluster persistent volume claims should get deleted automatically.
 autoDeletePersistentVolumeClaims: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of eng-2715 


**Please provide a short message that should be published in the vcluster release notes**
deprecates `replicas` in favour of `syncer.replicas` to converge different distros configs

**What else do we need to know?** 
