### PR TITLE
Fix failing  Conformance test - evicts pods with minTolerationSeconds

### DIFF
--- a/charts/k8s/templates/syncer.yaml
+++ b/charts/k8s/templates/syncer.yaml
@@ -402,11 +402,11 @@ spec:
                 - '--cluster-signing-cert-file=/pki/ca.crt'
                 - '--cluster-signing-key-file=/pki/ca.key'
                 {{- if or (not .Values.scheduler.disabled) .Values.sync.nodes.enableScheduler }}
-                - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
-                {{- else }}
                 - '--controllers=*,-nodeipam,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
                 - '--node-monitor-grace-period=1h'
                 - '--node-monitor-period=1h'
+                {{- else }}
+                - '--controllers=*,-nodeipam,-nodelifecycle,-persistentvolume-binder,-attachdetach,-persistentvolume-expander,-cloud-node-lifecycle,-ttl'
                 {{- end }}
                 - '--horizontal-pod-autoscaler-sync-period=60s'
                 - '--kubeconfig=/pki/controller-manager.conf'


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not evict pods correctly when scheduler was enabled

