### PR TITLE
Fix: Update fake node arch the same as host node

### DIFF
--- a/pkg/controllers/resources/nodes/fake_syncer.go
+++ b/pkg/controllers/resources/nodes/fake_syncer.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
@@ -156,9 +157,9 @@ func CreateFakeNode(ctx context.Context,
 			Name: name,
 			Labels: map[string]string{
 				"vcluster.loft.sh/fake-node": "true",
-				"beta.kubernetes.io/arch":    "amd64",
+				"beta.kubernetes.io/arch":    runtime.GOARCH,
 				"beta.kubernetes.io/os":      "linux",
-				"kubernetes.io/arch":         "amd64",
+				"kubernetes.io/arch":         runtime.GOARCH,
 				"kubernetes.io/hostname":     translate.SafeConcatName("fake", name),
 				"kubernetes.io/os":           "linux",
 			},

--- a/pkg/controllers/resources/nodes/fake_syncer_test.go
+++ b/pkg/controllers/resources/nodes/fake_syncer_test.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"context"
+	goruntime "runtime"
 	"testing"
 
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -63,9 +64,9 @@ func TestFakeSync(t *testing.T) {
 			Name: baseName.Name,
 			Labels: map[string]string{
 				"vcluster.loft.sh/fake-node": "true",
-				"beta.kubernetes.io/arch":    "amd64",
+				"beta.kubernetes.io/arch":    goruntime.GOARCH,
 				"beta.kubernetes.io/os":      "linux",
-				"kubernetes.io/arch":         "amd64",
+				"kubernetes.io/arch":         goruntime.GOARCH,
 				"kubernetes.io/hostname":     "fake-" + baseName.Name,
 				"kubernetes.io/os":           "linux",
 			},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
I'm running vCluster in a cluster consisting of ARM64 nodes. I encountered an arch label mismatch when migrating applications from the host cluster to vCluster. However, the issue was resolved by updating the fake node architecture to match that of the host node.


**Please provide a short message that should be published in the vcluster release notes**
Resolved an issue where running applications in vCluster on ARM64 nodes were encountering architecture label mismatches.

**What else do we need to know?** 
* just build-snapshot -> ok
* go test ./pkg/controllers/resources/nodes/ -> ok