### PR TITLE
renamed kubelet-config to worker-config as it is removed in k0s 1.29

### DIFF
--- a/charts/k0s/templates/syncer.yaml
+++ b/charts/k0s/templates/syncer.yaml
@@ -274,9 +274,9 @@ spec:
                 {{- end }}
                 - --status-socket=/run/k0s/status.sock
                 {{- if not .Values.sync.nodes.enableScheduler }}
-                - --disable-components=konnectivity-server,kube-scheduler,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config
+                - --disable-components=konnectivity-server,kube-scheduler,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server
                 {{- else }}
-                - --disable-components=konnectivity-server,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,kubelet-config
+                - --disable-components=konnectivity-server,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server
                 {{- end }}
                 {{- range $f := .Values.vcluster.extraArgs }}
                 - {{ $f | quote }}

--- a/charts/k0s/templates/syncer.yaml
+++ b/charts/k0s/templates/syncer.yaml
@@ -274,9 +274,9 @@ spec:
                 {{- end }}
                 - --status-socket=/run/k0s/status.sock
                 {{- if not .Values.sync.nodes.enableScheduler }}
-                - --disable-components=konnectivity-server,kube-scheduler,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server
+                - --disable-components=konnectivity-server,kube-scheduler,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,worker-config
                 {{- else }}
-                - --disable-components=konnectivity-server,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server
+                - --disable-components=konnectivity-server,csr-approver,kube-proxy,coredns,network-provider,helm,metrics-server,worker-config
                 {{- end }}
                 {{- range $f := .Values.vcluster.extraArgs }}
                 - {{ $f | quote }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -169,7 +169,7 @@ syncer:
 # Virtual Cluster (k0s) configuration
 vcluster:
   # Image to use for the virtual cluster
-  image: k0sproject/k0s:v1.28.2-k0s.0
+  image: k0sproject/k0s:v1.29.1-k0s.0
   imagePullPolicy: ""
   command:
     - /binaries/k0s

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/loft-sh/api/v3 v3.0.0-20240123094839-7e1855cd6ad7
 	github.com/loft-sh/loftctl/v3 v3.0.0-20240123132211-f09474d1f54c
 	github.com/loft-sh/utils v0.0.29
-	github.com/loft-sh/vcluster-values v0.0.0-20240202080304-a3a5b74a4bfb
+	github.com/loft-sh/vcluster-values v0.0.0-20240202091012-8385efc731ba
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/locker v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a h1:/gqqjKpcHEdFXIX41lx
 github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a/go.mod h1:YImeRjXH34Yf5E79T7UHBQpDZl9fIaaFRgyZ/bkY+UQ=
 github.com/loft-sh/utils v0.0.29 h1:P/MObccXToAZy2QoJSQDJ+OJx1qHitpFHEVj3QBSNJs=
 github.com/loft-sh/utils v0.0.29/go.mod h1:9hlX9cGpWHg3mNi/oBlv3X4ePGDMK66k8MbOZGFMDTI=
-github.com/loft-sh/vcluster-values v0.0.0-20240202080304-a3a5b74a4bfb h1:7pJNZMCxdt1DOyv6ezc5RkgyaqngjJ9CTj2HCjJeLq0=
-github.com/loft-sh/vcluster-values v0.0.0-20240202080304-a3a5b74a4bfb/go.mod h1:J34xtWyMbjM+NRgVWxO0IVDB5XYUaX52jPQNqEAhu4M=
+github.com/loft-sh/vcluster-values v0.0.0-20240202091012-8385efc731ba h1:0euB0vEWBPofSOtYnqbn6O2wNGYEklaz3vEzh0qgpag=
+github.com/loft-sh/vcluster-values v0.0.0-20240202091012-8385efc731ba/go.mod h1:J34xtWyMbjM+NRgVWxO0IVDB5XYUaX52jPQNqEAhu4M=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/vendor/github.com/loft-sh/vcluster-values/values/k0s.go
+++ b/vendor/github.com/loft-sh/vcluster-values/values/k0s.go
@@ -7,10 +7,10 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
+	"1.29": "k0sproject/k0s:v1.29.1-k0s.0",
 	"1.28": "k0sproject/k0s:v1.28.2-k0s.0",
 	"1.27": "k0sproject/k0s:v1.27.6-k0s.0",
 	"1.26": "k0sproject/k0s:v1.26.9-k0s.0",
-	"1.25": "k0sproject/k0s:v1.25.14-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *ChartOptions, log logr.Logger) (string, error) {
@@ -25,12 +25,12 @@ func getDefaultK0SReleaseValues(chartOptions *ChartOptions, log logr.Logger) (st
 		var ok bool
 		image, ok = K0SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 28 {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.28", "serverVersion", serverVersionString)
-				image = K0SVersionMap["1.28"]
+			if serverMinorInt > 29 {
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.29", "serverVersion", serverVersionString)
+				image = K0SVersionMap["1.29"]
 			} else {
-				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.25", "serverVersion", serverVersionString)
-				image = K0SVersionMap["1.25"]
+				log.Info("officially unsupported host server version, will fallback to virtual cluster version v1.26", "serverVersion", serverVersionString)
+				image = K0SVersionMap["1.26"]
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -431,7 +431,7 @@ github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader
 github.com/loft-sh/utils/pkg/downloader/commands
 github.com/loft-sh/utils/pkg/extract
-# github.com/loft-sh/vcluster-values v0.0.0-20240202080304-a3a5b74a4bfb
+# github.com/loft-sh/vcluster-values v0.0.0-20240202091012-8385efc731ba
 ## explicit; go 1.21.5
 github.com/loft-sh/vcluster-values/helmvalues
 github.com/loft-sh/vcluster-values/values


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where k0s wouldn't start because we were disabling an option that was removed in the k0s 1.29 


**What else do we need to know?** 
