### PR TITLE
feat(pro): use email as platform id when available

### DIFF
--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -115,8 +115,11 @@ func GetPlatformUserID(self *managementv1.Self) string {
 	if cliconfig.GetConfig(log.Discard).TelemetryDisabled || self == nil {
 		return ""
 	}
-
-	return self.Status.Subject
+	platformID := self.Status.Subject
+	if self.Status.User != nil && self.Status.User.Email != "" {
+		platformID = self.Status.User.Email
+	}
+	return platformID
 }
 
 // GetPlatformInstanceID returns the loft instance id


### PR DESCRIPTION
When using vcluster pro, the vcluster telemetry will send the user email with events like create/error instead of a username like `admin`


**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-2665



