### PR TITLE
fix(generic-sync): Added check for status subresource on resource import

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,17 +21,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: ./go.mod
           cache: false
       - name: Generate Embedded Helm Charts
         run: |
           go generate ./...
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
-        with:
-          args: -v --config=.golangci.yml --whole-files
-          only-new-issues: true

--- a/.ignore
+++ b/.ignore
@@ -1,1 +1,2 @@
 !/.github/
+/vendor/

--- a/cmd/vcluster/cmd/cp.go
+++ b/cmd/vcluster/cmd/cp.go
@@ -10,7 +10,7 @@ func NewCpCommand() *cobra.Command {
 		Use:   "cp",
 		Short: "copy a file",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		RunE: func(_ *cobra.Command, args []string) (err error) {
 			return cp.Cp(args[0], args[1])
 		},
 	}

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -26,7 +26,7 @@ func NewStartCommand() *cobra.Command {
 		Use:   "start",
 		Short: "Execute the vcluster",
 		Args:  cobra.NoArgs,
-		RunE: func(cobraCmd *cobra.Command, args []string) (err error) {
+		RunE: func(cobraCmd *cobra.Command, _ []string) (err error) {
 			// start telemetry
 			telemetry.Start(false)
 			defer telemetry.Collector.Flush()

--- a/cmd/vclusterctl/cmd/completion.go
+++ b/cmd/vclusterctl/cmd/completion.go
@@ -50,7 +50,7 @@ func wrapCompletionFuncWithTimeout(defaultDirective cobra.ShellCompDirective, co
 // newValidVClusterNameFunc returns a function that handles shell completion when the argument is vcluster_name
 // It takes into account the namespace if specified by the --namespace flag.
 func newValidVClusterNameFunc(globalFlags *flags.GlobalFlags) completionFunc {
-	fn := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	fn := func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		vclusters, _, err := find.ListVClusters(cmd.Context(), nil, globalFlags.Context, "", globalFlags.Namespace, "", log.Default.ErrorStreamOnly())
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
@@ -66,7 +66,7 @@ func newValidVClusterNameFunc(globalFlags *flags.GlobalFlags) completionFunc {
 
 // newNamespaceCompletionFunc handles shell completions for the namespace flag
 func newNamespaceCompletionFunc(ctx context.Context) completionFunc {
-	fn := func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	fn := func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		restConfig, err := config.GetConfig()
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp

--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -48,35 +48,28 @@ import (
 // ConnectCmd holds the cmd flags
 type ConnectCmd struct {
 	*flags.GlobalFlags
-
-	KubeConfigContextName string
-	KubeConfig            string
-	PodName               string
-	UpdateCurrent         bool
-	Print                 bool
-	BackgroundProxy       bool
-	LocalPort             int
-	Address               string
-
-	ServiceAccount            string
+	rawConfig                 clientcmdapi.Config
+	kubeClientConfig          clientcmd.ClientConfig
+	Log                       log.Logger
+	errorChan                 chan error
+	interruptChan             chan struct{}
+	restConfig                *rest.Config
+	kubeClient                *kubernetes.Clientset
 	ServiceAccountClusterRole string
+	PodName                   string
+	Address                   string
+	KubeConfigContextName     string
+	Server                    string
+	KubeConfig                string
+	Project                   string
+	ServiceAccount            string
+	LocalPort                 int
 	ServiceAccountExpiration  int
-
-	Server   string
-	Insecure bool
-
-	Project string
-
-	Log log.Logger
-
-	kubeClientConfig clientcmd.ClientConfig
-	kubeClient       *kubernetes.Clientset
-	restConfig       *rest.Config
-	rawConfig        clientcmdapi.Config
-
-	portForwarding bool
-	interruptChan  chan struct{}
-	errorChan      chan error
+	Print                     bool
+	UpdateCurrent             bool
+	BackgroundProxy           bool
+	portForwarding            bool
+	Insecure                  bool
 }
 
 // NewConnectCmd creates a new command

--- a/cmd/vclusterctl/cmd/connect_test.go
+++ b/cmd/vclusterctl/cmd/connect_test.go
@@ -33,10 +33,10 @@ func TestExchangeContextName(t *testing.T) {
 		CurrentContext: defaultContextName,
 	}
 	testTable := []struct {
-		desc           string
-		newContextName string
 		config         *clientcmdapi.Config
 		expectedConfig *clientcmdapi.Config
+		desc           string
+		newContextName string
 	}{
 		{
 			desc:           "KubeConfigContextName specified",

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -45,21 +45,17 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-var (
-	CreatedByVClusterAnnotation = "vcluster.loft.sh/created"
-)
+var CreatedByVClusterAnnotation = "vcluster.loft.sh/created"
 
 // CreateCmd holds the login cmd flags
 type CreateCmd struct {
 	*flags.GlobalFlags
-	create.Options
-
-	log log.Logger
-
-	localCluster     bool
+	rawConfig        clientcmdapi.Config
+	log              log.Logger
 	kubeClientConfig clientcmd.ClientConfig
 	kubeClient       *kubernetes.Clientset
-	rawConfig        clientcmdapi.Config
+	create.Options
+	localCluster bool
 }
 
 // NewCreateCmd creates a new command
@@ -628,7 +624,7 @@ func (cmd *CreateCmd) getKubernetesVersion() (*version.Info, error) {
 	}
 
 	if kubernetesVersion == nil {
-		kubernetesVersion, err = cmd.kubeClient.DiscoveryClient.ServerVersion()
+		kubernetesVersion, err = cmd.kubeClient.ServerVersion()
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -32,7 +32,10 @@ import (
 // DeleteCmd holds the delete cmd flags
 type DeleteCmd struct {
 	*flags.GlobalFlags
-
+	log                 log.Logger
+	rawConfig           *clientcmdapi.Config
+	restConfig          *rest.Config
+	kubeClient          *kubernetes.Clientset
 	Project             string
 	Wait                bool
 	KeepPVC             bool
@@ -40,11 +43,6 @@ type DeleteCmd struct {
 	DeleteConfigMap     bool
 	AutoDeleteNamespace bool
 	IgnoreNotFound      bool
-
-	rawConfig  *clientcmdapi.Config
-	restConfig *rest.Config
-	kubeClient *kubernetes.Clientset
-	log        log.Logger
 }
 
 // NewDeleteCmd creates a new command

--- a/cmd/vclusterctl/cmd/disconnect.go
+++ b/cmd/vclusterctl/cmd/disconnect.go
@@ -43,7 +43,7 @@ vcluster disconnect
 #######################################################
 	`,
 		Args: cobra.NoArgs,
-		RunE: func(cobraCmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return cmd.Run()
 		},
 	}

--- a/cmd/vclusterctl/cmd/import.go
+++ b/cmd/vclusterctl/cmd/import.go
@@ -26,13 +26,11 @@ import (
 
 type ImportCmd struct {
 	*flags.GlobalFlags
-
+	Log            log.Logger
 	ClusterName    string
 	Project        string
 	ImportName     string
 	DisableUpgrade bool
-
-	Log log.Logger
 }
 
 func NewImportCmd(globalFlags *flags.GlobalFlags) (*cobra.Command, error) {
@@ -92,7 +90,7 @@ vcluster import my-vcluster --cluster connected-cluster \
 // Run executes the functionality
 func (cmd *ImportCmd) Run(ctx context.Context, args []string, proClient client.Client) error {
 	// Get vClusterName from command argument
-	var vClusterName = args[0]
+	vClusterName := args[0]
 
 	managementClient, err := proClient.Management()
 	if err != nil {

--- a/cmd/vclusterctl/cmd/info.go
+++ b/cmd/vclusterctl/cmd/info.go
@@ -36,7 +36,7 @@ vcluster info
 	`,
 		Args:   cobra.NoArgs,
 		Hidden: true,
-		RunE: func(cobraCmd *cobra.Command, args []string) error {
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			infos := cliInfo{
 				Version:   cobraCmd.Root().Version,
 				OS:        runtime.GOOS,

--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -20,14 +20,14 @@ import (
 
 // VCluster holds information about a cluster
 type VCluster struct {
+	Created    time.Time
 	Name       string
 	Namespace  string
-	Created    time.Time
-	AgeSeconds int
 	Context    string
 	Cluster    string
 	Version    string
 	Status     string
+	AgeSeconds int
 	Connected  bool
 	Pro        bool
 }

--- a/cmd/vclusterctl/cmd/pause.go
+++ b/cmd/vclusterctl/cmd/pause.go
@@ -28,12 +28,10 @@ import (
 // PauseCmd holds the cmd flags
 type PauseCmd struct {
 	*flags.GlobalFlags
-
+	Log           log.Logger
+	kubeClient    *kubernetes.Clientset
 	Project       string
 	ForceDuration int64
-
-	kubeClient *kubernetes.Clientset
-	Log        log.Logger
 }
 
 // NewPauseCmd creates a new command

--- a/cmd/vclusterctl/cmd/pro/reset.go
+++ b/cmd/vclusterctl/cmd/pro/reset.go
@@ -46,7 +46,7 @@ vcluster pro reset password --user admin
 		Short: "Resets the password of a user",
 		Long:  description,
 		Args:  cobra.NoArgs,
-		RunE: func(cobraCmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return cmd.Run()
 		},
 	}

--- a/cmd/vclusterctl/cmd/pro/start.go
+++ b/cmd/vclusterctl/cmd/pro/start.go
@@ -47,7 +47,7 @@ before running this command:
 ########################################################
 	`,
 		Args: cobra.NoArgs,
-		RunE: func(cobraCmd *cobra.Command, args []string) error {
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},
 	}

--- a/cmd/vclusterctl/cmd/resume.go
+++ b/cmd/vclusterctl/cmd/resume.go
@@ -20,11 +20,9 @@ import (
 // ResumeCmd holds the cmd flags
 type ResumeCmd struct {
 	*flags.GlobalFlags
-
-	Project string
-
-	kubeClient *kubernetes.Clientset
 	Log        log.Logger
+	kubeClient *kubernetes.Clientset
+	Project    string
 }
 
 // NewResumeCmd creates a new command

--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -24,7 +24,7 @@ func NewRootCmd(log log.Logger) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "Welcome to vcluster!",
-		PersistentPreRun: func(cobraCmd *cobra.Command, args []string) {
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			if globalFlags.Silent {
 				log.SetLevel(logrus.FatalLevel)
 			} else if globalFlags.Debug {

--- a/cmd/vclusterctl/cmd/upgrade.go
+++ b/cmd/vclusterctl/cmd/upgrade.go
@@ -9,9 +9,8 @@ import (
 
 // UpgradeCmd is a struct that defines a command call for "upgrade"
 type UpgradeCmd struct {
+	log     log.Logger
 	Version string
-
-	log log.Logger
 }
 
 // NewUpgradeCmd creates a new upgrade command

--- a/cmd/vclusterctl/cmd/version.go
+++ b/cmd/vclusterctl/cmd/version.go
@@ -8,7 +8,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of vcluster",
 	Long:  `All software has versions. This is Vcluster's.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		root := cmd.Root()
 		root.SetArgs([]string{"--version"})
 		_ = root.Execute()

--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.18.0 // indirect
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/pkg/controllers/generic/export_syncer.go
+++ b/pkg/controllers/generic/export_syncer.go
@@ -235,7 +235,8 @@ func (f *exporter) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj c
 		return f.TranslateMetadata(ctx.Context, vObj), nil
 	}, &virtualToHostNameResolver{
 		namespace:       vObj.GetNamespace(),
-		targetNamespace: translate.Default.PhysicalNamespace(vObj.GetNamespace())})
+		targetNamespace: translate.Default.PhysicalNamespace(vObj.GetNamespace()),
+	})
 	if err != nil {
 		// when invalid, auto delete and recreate to recover
 		if kerrors.IsInvalid(err) && f.config.ReplaceWhenInvalid {
@@ -316,7 +317,8 @@ func (r *virtualToHostNameResolver) TranslateNameWithNamespace(name string, name
 
 			return types.NamespacedName{
 				Namespace: translate.Default.PhysicalNamespace(namespace),
-				Name:      translate.Default.PhysicalName(name, ns)}
+				Name:      translate.Default.PhysicalName(name, ns),
+			}
 		}), nil
 	}
 
@@ -358,25 +360,30 @@ func validateExportConfig(config *config.Export) error {
 }
 
 type hostToVirtualNameResolver struct {
-	gvk  schema.GroupVersionKind
 	pObj client.Object
+	gvk  schema.GroupVersionKind
 }
 
 func (r *hostToVirtualNameResolver) TranslateName(string, *regexp.Regexp, string) (string, error) {
 	return "", fmt.Errorf("translation not supported from host to virtual object")
 }
+
 func (r *hostToVirtualNameResolver) TranslateNameWithNamespace(string, string, *regexp.Regexp, string) (string, error) {
 	return "", fmt.Errorf("translation not supported from host to virtual object")
 }
+
 func (r *hostToVirtualNameResolver) TranslateLabelKey(string) (string, error) {
 	return "", fmt.Errorf("translation not supported from host to virtual object")
 }
+
 func (r *hostToVirtualNameResolver) TranslateLabelExpressionsSelector(*metav1.LabelSelector) (*metav1.LabelSelector, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")
 }
+
 func (r *hostToVirtualNameResolver) TranslateLabelSelector(map[string]string) (map[string]string, error) {
 	return nil, fmt.Errorf("translation not supported from host to virtual object")
 }
+
 func (r *hostToVirtualNameResolver) TranslateNamespaceRef(string) (string, error) {
 	return "", fmt.Errorf("translation not supported from host to virtual object")
 }

--- a/pkg/controllers/generic/import_syncer.go
+++ b/pkg/controllers/generic/import_syncer.go
@@ -114,13 +114,12 @@ func createImporter(ctx *synccontext.RegisterContext, config *config.Import, gvk
 
 type importer struct {
 	translator.Translator
-	patcher       *patcher
-	gvk           schema.GroupVersionKind
-	config        *config.Import
 	virtualClient client.Client
-	name          string
-
+	patcher       *patcher
+	config        *config.Import
 	syncerOptions *syncertypes.Options
+	gvk           schema.GroupVersionKind
+	name          string
 }
 
 func (s *importer) Resource() client.Object {
@@ -204,7 +203,7 @@ func (s *importer) SyncToVirtual(ctx *synccontext.SyncContext, pObj client.Objec
 		return s.TranslateMetadata(ctx.Context, vObj), nil
 	}, &hostToVirtualImportNameResolver{virtualClient: s.virtualClient, ctx: ctx.Context})
 	if err != nil {
-		//TODO: add eventRecorder?
+		// TODO: add eventRecorder?
 		// s.EventRecorder().Eventf(vObj, "Warning", "SyncError", "Error syncing to virtual cluster: %v", err)
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}
@@ -443,18 +442,23 @@ type hostToVirtualImportNameResolver struct {
 func (r *hostToVirtualImportNameResolver) TranslateName(name string, _ *regexp.Regexp, _ string) (string, error) {
 	return name, nil
 }
+
 func (r *hostToVirtualImportNameResolver) TranslateNameWithNamespace(name string, _ string, _ *regexp.Regexp, _ string) (string, error) {
 	return name, nil
 }
+
 func (r *hostToVirtualImportNameResolver) TranslateLabelKey(key string) (string, error) {
 	return key, nil
 }
+
 func (r *hostToVirtualImportNameResolver) TranslateLabelExpressionsSelector(selector *metav1.LabelSelector) (*metav1.LabelSelector, error) {
 	return selector, nil
 }
+
 func (r *hostToVirtualImportNameResolver) TranslateLabelSelector(selector map[string]string) (map[string]string, error) {
 	return selector, nil
 }
+
 func (r *hostToVirtualImportNameResolver) TranslateNamespaceRef(namespace string) (string, error) {
 	vNamespace := (&corev1.Namespace{}).DeepCopyObject().(client.Object)
 	err := clienthelper.GetByIndex(r.ctx, r.virtualClient, vNamespace, constants.IndexByPhysicalName, namespace)

--- a/pkg/controllers/generic/patcher.go
+++ b/pkg/controllers/generic/patcher.go
@@ -16,16 +16,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var (
-	fieldManager = "vcluster-syncer"
-)
+var fieldManager = "vcluster-syncer"
 
 type patcher struct {
-	fromClient client.Client
-	toClient   client.Client
-
-	statusIsSubresource bool
+	fromClient          client.Client
+	toClient            client.Client
 	log                 log.Logger
+	statusIsSubresource bool
 }
 
 func (s *patcher) ApplyPatches(ctx context.Context, fromObj, toObj client.Object, patchesConfig, reversePatchesConfig []*config.Patch, translateMetadata func(vObj client.Object) (client.Object, error), nameResolver patches.NameResolver) (client.Object, error) {

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -312,7 +312,7 @@ func RegisterServiceSyncControllers(ctx *options.ControllerContext) error {
 		// manager that listens on global services
 		globalLocalManager, err := ctrl.NewManager(ctx.LocalManager.GetConfig(), ctrl.Options{
 			Scheme: ctx.LocalManager.GetScheme(),
-			MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+			MapperProvider: func(_ *rest.Config, _ *http.Client) (meta.RESTMapper, error) {
 				return ctx.LocalManager.GetRESTMapper(), nil
 			},
 			Metrics:        metricsserver.Options{BindAddress: "0"},

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -70,21 +70,17 @@ func NewSyncer(ctx *synccontext.RegisterContext, nodeServiceProvider nodeservice
 }
 
 type nodeSyncer struct {
-	enableScheduler bool
-
-	clearImages bool
-
-	enforceNodeSelector bool
 	nodeSelector        labels.Selector
-	useFakeKubelets     bool
-	fakeKubeletIPs      bool
-
-	physicalClient client.Client
-	virtualClient  client.Client
-
+	physicalClient      client.Client
+	virtualClient       client.Client
 	unmanagedPodCache   client.Reader
 	nodeServiceProvider nodeservice.Provider
 	enforcedTolerations []*corev1.Toleration
+	enableScheduler     bool
+	clearImages         bool
+	enforceNodeSelector bool
+	useFakeKubelets     bool
+	fakeKubeletIPs      bool
 }
 
 func (s *nodeSyncer) Resource() client.Object {
@@ -144,16 +140,16 @@ func (s *nodeSyncer) ModifyController(ctx *synccontext.RegisterContext, bld *bui
 		bld.WatchesRawSource(
 			source.Kind(podCache, &corev1.Pod{}),
 			handler.Funcs{
-				GenericFunc: func(ctx context.Context, ev event.GenericEvent, q workqueue.RateLimitingInterface) {
+				GenericFunc: func(_ context.Context, ev event.GenericEvent, q workqueue.RateLimitingInterface) {
 					enqueueNonVclusterPod(nil, ev.Object, q)
 				},
-				CreateFunc: func(ctx context.Context, ev event.CreateEvent, q workqueue.RateLimitingInterface) {
+				CreateFunc: func(_ context.Context, ev event.CreateEvent, q workqueue.RateLimitingInterface) {
 					enqueueNonVclusterPod(nil, ev.Object, q)
 				},
-				UpdateFunc: func(ctx context.Context, ue event.UpdateEvent, q workqueue.RateLimitingInterface) {
+				UpdateFunc: func(_ context.Context, ue event.UpdateEvent, q workqueue.RateLimitingInterface) {
 					enqueueNonVclusterPod(ue.ObjectOld, ue.ObjectNew, q)
 				},
-				DeleteFunc: func(ctx context.Context, ev event.DeleteEvent, q workqueue.RateLimitingInterface) {
+				DeleteFunc: func(_ context.Context, ev event.DeleteEvent, q workqueue.RateLimitingInterface) {
 					enqueueNonVclusterPod(nil, ev.Object, q)
 				},
 			},

--- a/pkg/controllers/resources/storageclasses/syncer.go
+++ b/pkg/controllers/resources/storageclasses/syncer.go
@@ -11,9 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	DefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
-)
+var DefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
 func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 	return &storageClassSyncer{
@@ -63,7 +61,7 @@ func (s *storageClassSyncer) SyncToHost(ctx *synccontext.SyncContext, vObj clien
 }
 
 func NewStorageClassTranslator() translate.PhysicalNameTranslator {
-	return func(vName string, vObj client.Object) string {
+	return func(vName string, _ client.Object) string {
 		return translateStorageClassName(vName)
 	}
 }

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -69,7 +69,7 @@ func StartLeaderElection(ctx *options.ControllerContext, scheme *runtime.Scheme,
 		RenewDeadline: time.Duration(ctx.Options.RenewDeadline) * time.Second,
 		RetryPeriod:   time.Duration(ctx.Options.RetryPeriod) * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(ctx context.Context) {
+			OnStartedLeading: func(_ context.Context) {
 				klog.Info("Acquired leadership and run vcluster in leader mode")
 
 				// start vcluster in leader mode

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -24,11 +24,13 @@ func New(name string) Logger {
 		l,
 	}
 }
+
 func NewFromExisting(log logr.Logger, name string) Logger {
 	return &logger{
 		log.WithName(name),
 	}
 }
+
 func NewWithoutName() Logger {
 	return &logger{
 		log.Log,
@@ -38,6 +40,7 @@ func NewWithoutName() Logger {
 func (l *logger) Base() logr.Logger {
 	return l.Logger
 }
+
 func (l *logger) WithName(name string) Logger {
 	return &logger{
 		Logger: l.Logger.WithName(name),
@@ -45,13 +48,13 @@ func (l *logger) WithName(name string) Logger {
 }
 
 func (l *logger) Infof(format string, a ...interface{}) {
-	l.Logger.Info(fmt.Sprintf(format, a...))
+	l.WithCallDepth(1).Info(fmt.Sprintf(format, a...))
 }
 
 func (l *logger) Debugf(format string, a ...interface{}) {
-	l.Logger.V(1).Info(fmt.Sprintf(format, a...))
+	l.Logger.WithCallDepth(1).V(1).Info(fmt.Sprintf(format, a...))
 }
 
 func (l *logger) Errorf(format string, a ...interface{}) {
-	l.Logger.Error(fmt.Errorf(format, a...), "")
+	l.WithCallDepth(1).Error(fmt.Errorf(format, a...), "")
 }

--- a/pkg/pro/version.go
+++ b/pkg/pro/version.go
@@ -48,7 +48,7 @@ func LatestCompatibleVersion(ctx context.Context) (string, error) {
 		return MinimumVersionTag, nil
 	}
 
-	eligibleReleases := lo.FilterMap(releases, func(release *github.RepositoryRelease, index int) (semver.Version, bool) {
+	eligibleReleases := lo.FilterMap(releases, func(release *github.RepositoryRelease, _ int) (semver.Version, bool) {
 		tagName := release.GetTagName()
 		if tagName == "" {
 			return semver.Version{}, false

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,20 +60,16 @@ import (
 
 // Server is a http.Handler which proxies Kubernetes APIs to remote API server.
 type Server struct {
-	uncachedVirtualClient client.Client
-	cachedVirtualClient   client.Client
-
-	currentNamespace       string
+	uncachedVirtualClient  client.Client
+	cachedVirtualClient    client.Client
 	currentNamespaceClient client.Client
-
-	fakeKubeletIPs bool
-
-	certSyncer cert.Syncer
-	handler    *http.ServeMux
-
-	redirectResources   []delegatingauthorizer.GroupVersionResourceVerb
-	requestHeaderCaFile string
-	clientCaFile        string
+	certSyncer             cert.Syncer
+	handler                *http.ServeMux
+	currentNamespace       string
+	requestHeaderCaFile    string
+	clientCaFile           string
+	redirectResources      []delegatingauthorizer.GroupVersionResourceVerb
+	fakeKubeletIPs         bool
 }
 
 // NewServer creates and installs a new Server.
@@ -113,7 +109,6 @@ func NewServer(ctx *options.ControllerContext, requestHeaderCaFile, clientCaFile
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +459,7 @@ func initAdmission(ctx context.Context, vConfig *rest.Config) (admission.Interfa
 	serviceResolver := aggregatorapiserver.NewClusterIPServiceResolver(
 		kubeInformerFactory.Core().V1().Services().Lister(),
 	)
-	authInfoResolverWrapper := func(resolver webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver {
+	authInfoResolverWrapper := func(_ webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver {
 		return &kubeConfigProvider{
 			vConfig: vConfig,
 		}

--- a/pkg/setup/enable_controllers_test.go
+++ b/pkg/setup/enable_controllers_test.go
@@ -16,17 +16,17 @@ import (
 
 func TestEnableControllers(t *testing.T) {
 	testTable := []struct {
-		desc           string
 		optsModifier   func(*options.VirtualClusterOptions)
+		desc           string
+		errSubString   string
 		expectEnabled  []string
 		expectDisabled []string
 		expectError    bool
-		errSubString   string
 		pause          bool
 	}{
 		{
 			desc:           "default case",
-			optsModifier:   func(v *options.VirtualClusterOptions) {},
+			optsModifier:   func(_ *options.VirtualClusterOptions) {},
 			expectEnabled:  sets.List(constants.DefaultEnabledControllers),
 			expectDisabled: sets.List(constants.ExistingControllers.Difference(constants.DefaultEnabledControllers)),
 			expectError:    false,
@@ -165,10 +165,10 @@ var csiNodeV1 = metav1.APIResource{
 
 func TestDisableMissingAPIs(t *testing.T) {
 	tests := []struct {
-		name             string
 		apis             map[string][]metav1.APIResource
 		expectedNotFound sets.Set[string]
 		expectedFound    sets.Set[string]
+		name             string
 	}{
 		{
 			name:             "K8s 1.21 or lower",

--- a/test/e2e_metrics_proxy/metricsProxy.go
+++ b/test/e2e_metrics_proxy/metricsProxy.go
@@ -23,7 +23,7 @@ var _ = ginkgo.Describe("Target Namespace", func() {
 	ginkgo.It("Make sure the metrics api service is registered and available", func() {
 		err := wait.PollUntilContextTimeout(f.Context, time.Second, time.Minute*1, false, func(ctx context.Context) (bool, error) {
 			apiRegistrationClient := apiregistrationv1clientset.NewForConfigOrDie(f.VclusterConfig)
-			apiService, err := apiRegistrationClient.APIServices().Get(f.Context, metricsapiservice.MetricsAPIServiceName, metav1.GetOptions{})
+			apiService, err := apiRegistrationClient.APIServices().Get(ctx, metricsapiservice.MetricsAPIServiceName, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("Target Namespace", func() {
 		err := wait.PollUntilContextTimeout(f.Context, time.Second, time.Minute*1, false, func(ctx context.Context) (bool, error) {
 			metricsClient := metricsv1beta1client.NewForConfigOrDie(f.VclusterConfig)
 
-			nodeMetricsList, err := metricsClient.NodeMetricses().List(f.Context, metav1.ListOptions{})
+			nodeMetricsList, err := metricsClient.NodeMetricses().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				fmt.Fprintf(ginkgo.GinkgoWriter, "error getting node metrics list %v", err)
 				return false, nil
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Target Namespace", func() {
 				return false, nil
 			}
 
-			podMetricsList, err := metricsClient.PodMetricses("kube-system").List(f.Context, metav1.ListOptions{})
+			podMetricsList, err := metricsClient.PodMetricses("kube-system").List(ctx, metav1.ListOptions{})
 			if err != nil {
 				fmt.Fprintf(ginkgo.GinkgoWriter, "error getting pod metrics list %v", err)
 				return false, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1499


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the vCluster generic sync would not detect whether a CRD has a status subresource on import.


**What else do we need to know?** 
