### PR TITLE
fix: ensure vcluster upgrade downloads correct binary

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -113,8 +113,14 @@ func NewerVersionAvailable() string {
 
 // Upgrade downloads the latest release from github and replaces vcluster if a new version is found
 func Upgrade(flagVersion string, log log.Logger) error {
+	updater, err := selfupdate.NewUpdater(selfupdate.Config{
+		Filters: []string{"vcluster"},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize updater: %w", err)
+	}
 	if flagVersion != "" {
-		release, found, err := selfupdate.DetectVersion(githubSlug, flagVersion)
+		release, found, err := updater.DetectVersion(githubSlug, flagVersion)
 		if err != nil {
 			return errors.Wrap(err, "find version")
 		} else if !found {
@@ -127,7 +133,7 @@ func Upgrade(flagVersion string, log log.Logger) error {
 		}
 
 		log.Infof("Downloading version %s...", flagVersion)
-		err = selfupdate.DefaultUpdater().UpdateTo(release, cmdPath)
+		err = updater.UpdateTo(release, cmdPath)
 		if err != nil {
 			return err
 		}
@@ -148,7 +154,7 @@ func Upgrade(flagVersion string, log log.Logger) error {
 	v := semver.MustParse(version)
 
 	log.Info("Downloading newest version...")
-	latest, err := selfupdate.UpdateSelf(v, githubSlug)
+	latest, err := updater.UpdateSelf(v, githubSlug)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-2833


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster upgrade download the wrong release asset


**What else do we need to know?** 
