### PR TITLE
fix: don't rerun e2e when PR text/title edited

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,6 @@ on:
   release:
     types: [created]
   pull_request:
-    types: [opened, synchronize, reopened, edited]
     branches:
       - main
     paths:


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

`By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened`

No need to rerun when edited.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

