### PR TITLE
feat: Added value to suppress creation of ClusterRole and ClusterRole…

### DIFF
--- a/charts/eks/templates/_helpers.tpl
+++ b/charts/eks/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Whether to create a cluster role or not
     .Values.proxy.metricsServer.nodes.enabled
     .Values.multiNamespaceMode.enabled
     .Values.coredns.plugin.enabled -}}
-{{- true -}}
+{{- .Values.suppressClusterRoleCreation | ternary "" "true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -333,6 +333,10 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Prevent Creation of ClusterRole and ClusterRoleBinding by setting this to true. If 
+# not set or false, a ClusterRole and ClsterRoleBinding will be created if needed
+suppressClusterRoleCreation: false
+
 # Service account that should be used by the pods synced by vcluster
 workloadServiceAccount:
   # This is not supported in multi-namespace mode

--- a/charts/k0s/templates/_helpers.tpl
+++ b/charts/k0s/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Whether to create a cluster role or not
     .Values.proxy.metricsServer.nodes.enabled
     .Values.multiNamespaceMode.enabled
     .Values.coredns.plugin.enabled -}}
-{{- true -}}
+{{- .Values.suppressClusterRoleCreation | ternary "" "true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -215,6 +215,10 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Prevent Creation of ClusterRole and ClusterRoleBinding by setting this to true. If 
+# not set or false, a ClusterRole and ClusterRoleBinding will be created if needed
+suppressClusterRoleCreation: false
+
 # Service account that should be used by the pods synced by vcluster
 workloadServiceAccount:
   # This is not supported in multi-namespace mode

--- a/charts/k3s/templates/_helpers.tpl
+++ b/charts/k3s/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Whether to create a cluster role or not
     .Values.proxy.metricsServer.nodes.enabled
     .Values.multiNamespaceMode.enabled
     .Values.coredns.plugin.enabled -}}
-{{- true -}}
+{{- .Values.suppressClusterRoleCreation | ternary "" "true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -235,6 +235,10 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Prevent Creation of ClusterRole and ClusterRoleBinding by setting this to true. If 
+# not set or false, a ClusterRole and ClusterRoleBinding will be created if needed
+suppressClusterRoleCreation: false
+
 # Service account that should be used by the pods synced by vcluster
 workloadServiceAccount:
   # This is not supported in multi-namespace mode

--- a/charts/k8s/templates/_helpers.tpl
+++ b/charts/k8s/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Whether to create a cluster role or not
     .Values.proxy.metricsServer.nodes.enabled
     .Values.multiNamespaceMode.enabled
     .Values.coredns.plugin.enabled -}}
-{{- true -}}
+{{- .Values.suppressClusterRoleCreation | ternary "" "true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -271,6 +271,10 @@ serviceAccount:
   # imagePullSecrets:
   #   - name: my-pull-secret
 
+# Prevent Creation of ClusterRole and ClusterRoleBinding by setting this to true. If 
+# not set or false, a ClusterRole and ClsterRoleBinding will be created if needed
+suppressClusterRoleCreation: false
+
 # Service account that should be used by the pods synced by vcluster
 workloadServiceAccount:
   # This is not supported in multi-namespace mode


### PR DESCRIPTION
We have users using vCluster who experience problems when trying to uses certain features implying the creation au a ClusterRole/ClusterRoleBinding, since those users don't habe enough rights to do this. Our solution is to provide them with a Service account that has all RBAC rights needed to run vCluster. However, the vCluster helm chart wants to create a ClusterRole, ClusterRoleBinding anyhow. Therefore I added a "flag" suppressClusterRoleCreation to values.yaml  to prevent the ClusterRole/ClusterRoleBinding from being created. If this flag  is not set or set to false, CLusterRole creation will happen as before.

**What issue type does this pull request address?** 

**What does this pull request do? Which issues does it resolve?**
Gives the option to suppress ClusterRole cration.

**Please provide a short message that should be published in the vcluster release notes**
Added a flag to values.yaml to optionally prevent the Creation auf a ClusterRole
