### PR TITLE
docs(brew): Updated docs to reference loft homebrew tap

### DIFF
--- a/docs/pages/deploying-vclusters/high-availability.mdx
+++ b/docs/pages/deploying-vclusters/high-availability.mdx
@@ -13,8 +13,9 @@ You also need your kube config pointing to that cluster (you can connect and run
 If you’re on a Mac and using Homebrew, you can install the vCluster CLI with this command:
 
 ```
-brew install vcluster
+brew install loft-sh/tap/vcluster
 ```
+
 For other platforms, see [the installation instructions](../getting-started/setup.mdx).
 
 # 2. Understanding vCluster distros

--- a/docs/pages/fragments/install/cli.mdx
+++ b/docs/pages/fragments/install/cli.mdx
@@ -19,7 +19,7 @@ import TabItem from "@theme/TabItem";
 brew install loft-sh/tap/vcluster
 ```
 
-If you installed the CLI using `brew install vcluster`, you should `brew uninstall vcluster` and then install using the tap.
+If you installed the CLI using `brew install loft-sh/tap/vcluster`, you should `brew uninstall vcluster` and then install using the tap.
 The binaries in the tap are signed using the [Sigstore](https://docs.sigstore.dev/) framework for enhanced security.
 
 </TabItem>

--- a/docs/pages/help&tutorials/bootstrapping.mdx
+++ b/docs/pages/help&tutorials/bootstrapping.mdx
@@ -14,8 +14,9 @@ The only prerequisite is a Kubernetes cluster that you can run the virtual clust
 If you use a Mac with Homebrew, you can install the CLI with this command:
 
 ```
-brew install vcluster
+brew install loft-sh/tap/vcluster
 ```
+
 For other platforms, see [the installation docs](../getting-started/setup.mdx). The CLI is supported on macOS, Linux, and Windows.
 
 # Apply a manifest on initialization
@@ -49,7 +50,7 @@ init:
           - name: nginx
             image: nginx:1.25.1
             ports:
-            - containerPort: 80  
+            - containerPort: 80
 ```
 
 Let’s break down what’s happening here.

--- a/docs/pages/help&tutorials/helm-provisioning.mdx
+++ b/docs/pages/help&tutorials/helm-provisioning.mdx
@@ -13,7 +13,7 @@ For this tutorial, you will need:
 
 - A Kubernetes cluster to use as the host cluster and a kube context that points at it. vCluster works both with local and remote Kubernetes clusters.
 - The Helm Command Line Interface (CLI). You can find installation instructions [here](https://helm.sh/docs/intro/install/?_gl=1*158hplf*_ga*MjEzODEwMTQ1My4xNjY3MjA5OTgx*_ga_4RQQZ3WGE9*MTY5NjMyMTgwMy4xMzcuMS4xNjk2MzI0MDAzLjE2LjAuMA..*_gcl_au*MTYzMDM2NDc5NC4xNjkwMzczNjIyLjIwMTE4NTM2MTIuMTY5NTA0NjA0Ny4xNjk1MDQ2MDQ2/).
-- The vCluster CLI. If you use a Mac with Homebrew, you can install it with this command: brew install vcluster. For other platforms, see [the installation docs](../getting-started/setup.mdx).
+- The vCluster CLI. If you use a Mac with Homebrew, you can install it with this command: `brew install loft-sh/tap/vcluster`. For other platforms, see [the installation docs](../getting-started/setup.mdx).
 # 1. Provision a vCluster with Helm
 If you have previously used the vCluster CLI to create a virtual cluster, you may have noticed that the vcluster create command uses Helm. Here’s some example output:
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**Please provide a short message that should be published in the vcluster release notes**
I updated the docs to use the official Loft tap when installing vCluster via brew.