### PR TITLE
Improve binaries volume config

### DIFF
--- a/charts/eks/templates/syncer.yaml
+++ b/charts/eks/templates/syncer.yaml
@@ -101,11 +101,7 @@ spec:
           emptyDir: {}
         - name: certs
           emptyDir: {}
-      {{- if .Values.volumes }}
-{{ toYaml .Values.volumes | indent 8 }}
-      {{- end }}
-        - name: binaries
-          emptyDir: {}
+{{ toYaml .Values.syncer.storage.binariesVolume | indent 8 }}
       {{- if .Values.syncer.volumes }}
 {{ toYaml .Values.syncer.volumes | indent 8 }}
       {{- end }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -166,7 +166,7 @@ syncer:
       ephemeral-storage: 8Gi
       memory: 2Gi
     requests:
-      ephemeral-storage: 200Mi
+      ephemeral-storage: 300Mi
       cpu: 10m
       memory: 256Mi
   # Extra volumes

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -196,14 +196,19 @@ syncer:
   serviceAnnotations: {}
   # Storage settings for the vcluster
   storage:
-   # If this is disabled, vcluster will use an emptyDir instead
-   # of a PersistentVolumeClaim
-   persistence: true
-   # Size of the persistent volume claim
-   size: 5Gi
-   # Optional StorageClass used for the pvc
-   # if empty default StorageClass defined in your host cluster will be used
-   #className:
+    # If this is disabled, vcluster will use an emptyDir instead
+    # of a PersistentVolumeClaim
+    persistence: true
+    # Size of the persistent volume claim
+    size: 5Gi
+    # The binariesVolume is used to retrieve distro specific executables to be run by the syncer
+    # This volume doesn't need to be persistent 
+    binariesVolume:
+      - name: binaries
+        emptyDir: {}
+    # Optional StorageClass used for the pvc
+    # if empty default StorageClass defined in your host cluster will be used
+    #className:
 
 # Etcd settings
 etcd:

--- a/charts/k0s/templates/syncer.yaml
+++ b/charts/k0s/templates/syncer.yaml
@@ -79,8 +79,7 @@ spec:
           emptyDir: {}
         - name: run-k0s
           emptyDir: {}
-        - name: binaries
-          emptyDir: {}
+{{ toYaml .Values.syncer.storage.binariesVolume | indent 8 }}
       {{- if .Values.syncer.volumes }}
 {{ toYaml .Values.syncer.volumes | indent 8 }}
       {{- end }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -174,6 +174,11 @@ syncer:
     persistence: true
     # Size of the persistent volume claim
     size: 5Gi
+    # The binariesVolume is used to retrieve distro specific executables to be run by the syncer
+    # This volume doesn't need to be persistent 
+    binariesVolume:
+      - name: binaries
+        emptyDir: {}
     # Optional StorageClass used for the pvc
     # if empty default StorageClass defined in your host cluster will be used
     #className:

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -162,7 +162,7 @@ syncer:
       ephemeral-storage: 8Gi
       memory: 2Gi
     requests:
-      ephemeral-storage: 200Mi
+      ephemeral-storage: 250Mi
       cpu: 10m
       memory: 64Mi
   kubeConfigContextName: "my-vcluster"

--- a/charts/k3s/templates/syncer.yaml
+++ b/charts/k3s/templates/syncer.yaml
@@ -109,8 +109,7 @@ spec:
       {{- include "vcluster.plugins.volumes" . | indent 8 }}
         - name: helm-cache
           emptyDir: {}
-        - name: binaries
-          emptyDir: {}
+{{ toYaml .Values.syncer.storage.binariesVolume | indent 8 }}
         - name: tmp
           emptyDir: {}
         - name: config

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -174,6 +174,11 @@ syncer:
     persistence: true
     # Size of the persistent volume claim
     size: 5Gi
+    # The binariesVolume is used to retrieve distro specific executables to be run by the syncer
+    # This volume doesn't need to be persistent 
+    binariesVolume:
+      - name: binaries
+        emptyDir: {}
     # Optional StorageClass used for the pvc
     # if empty default StorageClass defined in your host cluster will be used
     #className:

--- a/charts/k8s/templates/syncer.yaml
+++ b/charts/k8s/templates/syncer.yaml
@@ -101,11 +101,7 @@ spec:
           emptyDir: {}
         - name: certs
           emptyDir: {}
-      {{- if .Values.volumes }}
-{{ toYaml .Values.volumes | indent 8 }}
-      {{- end }}
-        - name: binaries
-          emptyDir: {}
+{{ toYaml .Values.syncer.storage.binariesVolume | indent 8 }}
       {{- if .Values.syncer.volumes }}
 {{ toYaml .Values.syncer.volumes | indent 8 }}
       {{- end }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -170,7 +170,7 @@ syncer:
       cpu: 1000m
       memory: 2Gi
     requests:
-      ephemeral-storage: 200Mi
+      ephemeral-storage: 300Mi
       # ensure that cpu/memory requests are high enough.
       # for example gke wants minimum 10m/32Mi here!
       cpu: 20m

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -207,6 +207,11 @@ syncer:
     persistence: true
     # Size of the persistent volume claim
     size: 5Gi
+    # The binariesVolume is used to retrieve distro specific executables to be run by the syncer
+    # This volume doesn't need to be persistent 
+    binariesVolume:
+      - name: binaries
+        emptyDir: {}
     # Optional StorageClass used for the pvc
     # if empty default StorageClass defined in your host cluster will be used
     #className:

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/loft-sh/api/v3 v3.0.0-20240207094436-f23808d5a185
 	github.com/loft-sh/loftctl/v3 v3.0.0-20240207094551-f600825cc6f5
 	github.com/loft-sh/utils v0.0.29
-	github.com/loft-sh/vcluster-values v0.0.0-20240207093538-4bbb24e9f699
+	github.com/loft-sh/vcluster-values v0.0.0-20240618120001-334c9c814bc7
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/locker v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a h1:/gqqjKpcHEdFXIX41lx
 github.com/loft-sh/log v0.0.0-20230824104949-bd516c25712a/go.mod h1:YImeRjXH34Yf5E79T7UHBQpDZl9fIaaFRgyZ/bkY+UQ=
 github.com/loft-sh/utils v0.0.29 h1:P/MObccXToAZy2QoJSQDJ+OJx1qHitpFHEVj3QBSNJs=
 github.com/loft-sh/utils v0.0.29/go.mod h1:9hlX9cGpWHg3mNi/oBlv3X4ePGDMK66k8MbOZGFMDTI=
-github.com/loft-sh/vcluster-values v0.0.0-20240207093538-4bbb24e9f699 h1:lbbIlSpl/sz1iY/Tl/VUOU8NtFe31uwvlUbANK04mDM=
-github.com/loft-sh/vcluster-values v0.0.0-20240207093538-4bbb24e9f699/go.mod h1:J34xtWyMbjM+NRgVWxO0IVDB5XYUaX52jPQNqEAhu4M=
+github.com/loft-sh/vcluster-values v0.0.0-20240618120001-334c9c814bc7 h1:jx71rhB9wVag57JsF3+qBTzDSxs80Xg1TNT/5o31+/8=
+github.com/loft-sh/vcluster-values v0.0.0-20240618120001-334c9c814bc7/go.mod h1:46AgKZ6A9cP+tSWkPEyeyNe/BSwk56nETKfzV+9bux8=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/config/helmvalues/values_test.go
+++ b/pkg/config/helmvalues/values_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestValues(t *testing.T) {
+	// In case of any new fields defined in the values yaml,
+	// ensure they are also added to the go-structs in
+	// the github.com/loft.sh/vcluster-values repository
 	testCases := map[string]string{
 		"k0s": "../../../charts/k0s/values.yaml",
 		"k3s": "../../../charts/k3s/values.yaml",

--- a/vendor/github.com/loft-sh/vcluster-values/helmvalues/common.go
+++ b/vendor/github.com/loft-sh/vcluster-values/helmvalues/common.go
@@ -14,8 +14,9 @@ type EmbeddedEtcdValues struct {
 }
 
 type Storage struct {
-	Persistence bool   `json:"persistence,omitempty"`
-	Size        string `json:"size,omitempty"`
+	Persistence    bool                     `json:"persistence,omitempty"`
+	Size           string                   `json:"size,omitempty"`
+	BinariesVolume []map[string]interface{} `json:"binariesVolume,omitempty"`
 }
 
 type BaseHelm struct {
@@ -88,14 +89,14 @@ type SyncValues struct {
 	Endpoints              EnabledSwitch  `json:"endpoints,omitempty"`
 	Pods                   SyncPods       `json:"pods,omitempty"`
 	Events                 EnabledSwitch  `json:"events,omitempty"`
-	PersistentVolumeClaims EnabledSwitch  `json:"persistentVolumeClaims,omitempty"`
+	PersistentVolumeClaims EnabledSwitch  `json:"persistentvolumeclaims,omitempty"`
 	Ingresses              EnabledSwitch  `json:"ingresses,omitempty"`
 	Ingressclasses         EnabledSwitch  `json:"ingressclasses,omitempty"`
 	FakeNodes              EnabledSwitch  `json:"fake-nodes,omitempty"`
 	FakePersistentvolumes  EnabledSwitch  `json:"fake-persistentvolumes,omitempty"`
 	Nodes                  SyncNodes      `json:"nodes,omitempty"`
-	PersistentVolumes      EnabledSwitch  `json:"persistentVolumes,omitempty"`
-	StorageClasses         EnabledSwitch  `json:"storageClasses,omitempty"`
+	PersistentVolumes      EnabledSwitch  `json:"persistentvolumes,omitempty"`
+	StorageClasses         EnabledSwitch  `json:"storageclasses,omitempty"`
 	Hoststorageclasses     EnabledSwitch  `json:"hoststorageclasses,omitempty"`
 	Priorityclasses        EnabledSwitch  `json:"priorityclasses,omitempty"`
 	Networkpolicies        EnabledSwitch  `json:"networkpolicies,omitempty"`
@@ -188,7 +189,7 @@ type RBACClusterRoleValues struct {
 type RBACRoleValues struct {
 	Create               bool       `json:"create,omitempty"`
 	ExtraRules           []RBACRule `json:"extraRules,omitempty"`
-	ExcludedAPIResources []string   `json:"excludedAPIResources,omitempty"`
+	ExcludedAPIResources []string   `json:"excludedApiResources,omitempty"`
 }
 
 type RBACRule struct {
@@ -369,14 +370,14 @@ type TelemetryValues struct {
 
 type NoopSyncerValues struct {
 	Enabled        bool `json:"enabled,omitempty"`
-	Synck8sService bool `json:"synck8SService,omitempty"`
+	Synck8sService bool `json:"synck8sService,omitempty"`
 	Secret         struct {
 		ServerCaCert        string `json:"serverCaCert,omitempty"`
 		ServerCaKey         string `json:"serverCaKey,omitempty"`
 		ClientCaCert        string `json:"clientCaCert,omitempty"`
 		RequestHeaderCaCert string `json:"requestHeaderCaCert,omitempty"`
 		KubeConfig          string `json:"kubeConfig,omitempty"`
-	}
+	} `json:"secret,omitempty"`
 }
 
 type AdmissionValues struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -431,7 +431,7 @@ github.com/loft-sh/utils/pkg/command
 github.com/loft-sh/utils/pkg/downloader
 github.com/loft-sh/utils/pkg/downloader/commands
 github.com/loft-sh/utils/pkg/extract
-# github.com/loft-sh/vcluster-values v0.0.0-20240207093538-4bbb24e9f699
+# github.com/loft-sh/vcluster-values v0.0.0-20240618120001-334c9c814bc7
 ## explicit; go 1.21.5
 github.com/loft-sh/vcluster-values/helmvalues
 github.com/loft-sh/vcluster-values/values


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
There are cases where an emptyDir volume of sufficient size can not be provided, so users should be allowed to override the /binaries volume with an alternative.
Additionally, current ephemeral storage requests are no sufficient for some distros:
```
k0s
# du -h /binaries/*
203.2M	/binaries/k0s

k8s
# du -h /binaries/*
108.3M	/binaries/kube-apiserver
100.9M	/binaries/kube-controller-manager
69.4M	/binaries/vcluster

eks
# du -h /binaries/*
105.8M	/binaries/kube-apiserver
98.4M	/binaries/kube-controller-manager
69.4M	/binaries/vcluster
``` 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would request too little ephemeral storage.
Added .syncer.storage.binariesVolume helm chart value to allow overriding /binaries volume.