### PR TITLE
feat: add migration function

### DIFF
--- a/chart/tests/coredns-configmap_test.yaml
+++ b/chart/tests/coredns-configmap_test.yaml
@@ -88,7 +88,7 @@ tests:
                     rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
                     kubernetes cluster.local in-addr.arpa ip6.arpa {
                         pods insecure
-                        fallthrough cluster.local in-addr.arpa ip6.arpa
+                        fallthrough in-addr.arpa ip6.arpa
                     }
                     hosts /etc/NodeHosts {
                         ttl 60
@@ -96,7 +96,7 @@ tests:
                         fallthrough
                     }
                     prometheus :9153
-                    forward . {{.HOST_CLUSTER_DNS}}
+                    forward . /etc/resolv.conf
                     cache 30
                     loop
                     loadbalance
@@ -281,7 +281,7 @@ tests:
                 kubernetes cluster.local in-addr.arpa ip6.arpa {
                     kubeconfig /data/vcluster/admin.conf
                     pods insecure
-                    fallthrough cluster.local in-addr.arpa ip6.arpa
+                    fallthrough in-addr.arpa ip6.arpa
                 }
                 hosts /etc/NodeHosts {
                     ttl 60
@@ -289,7 +289,7 @@ tests:
                     fallthrough
                 }
                 prometheus :9153
-                forward . {{.HOST_CLUSTER_DNS}}
+                forward . /etc/resolv.conf
                 cache 30
                 loop
                 loadbalance

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -284,7 +284,9 @@
           "description": "Affinity is the affinity to apply to the pod."
         },
         "tolerations": {
-          "items": true,
+          "items": {
+            "type": "object"
+          },
           "type": "array",
           "description": "Tolerations are the tolerations to apply to the pod."
         },
@@ -1293,13 +1295,13 @@
           "type": "array",
           "description": "SyncLabels are labels that should get not rewritten when syncing from the virtual cluster."
         },
-        "localManagerMetricsBindAddress": {
+        "hostMetricsBindAddress": {
           "type": "string",
-          "description": "LocalManagerMetricsBindAddress is the bind address for the local manager"
+          "description": "HostMetricsBindAddress is the bind address for the local manager"
         },
-        "virtualManagerMetricsBindAddress": {
+        "virtualMetricsBindAddress": {
           "type": "string",
-          "description": "VirtualManagerMetricsBindAddress is the bind address for the virtual manager"
+          "description": "VirtualMetricsBindAddress is the bind address for the virtual manager"
         }
       },
       "additionalProperties": false,
@@ -1571,27 +1573,6 @@
           },
           "type": "array",
           "description": "ReversePatches are the patches to apply to host cluster objects\nafter it has been synced to the virtual cluster"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "LabelSelectorRequirement": {
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "key is the label key that the selector applies to."
-        },
-        "operator": {
-          "type": "string",
-          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist."
-        },
-        "values": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch."
         }
       },
       "additionalProperties": false,
@@ -2420,7 +2401,7 @@
           "description": "Quota are the quota options"
         },
         "scopeSelector": {
-          "$ref": "#/$defs/ScopeSelector",
+          "type": "object",
           "description": "ScopeSelector is the resource quota scope selector"
         },
         "scopes": {
@@ -2495,18 +2476,6 @@
           },
           "type": "array",
           "description": "Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.\nFor non-resource requests, this is the lowercase http verb.\nIf '*' is present, the length of the slice must be one.\nRequired.\n+listType=atomic"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ScopeSelector": {
-      "properties": {
-        "matchExpressions": {
-          "items": {
-            "$ref": "#/$defs/LabelSelectorRequirement"
-          },
-          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -412,7 +412,7 @@ networking:
   resolveDNS: []
   advanced:
     clusterDomain: "cluster.local"
-    fallbackHostCluster: true
+    fallbackHostCluster: false
     proxyKubelets:
       byHostname: true
       byIP: true

--- a/config/config.go
+++ b/config/config.go
@@ -995,7 +995,7 @@ type ControlPlaneScheduling struct {
 	Affinity map[string]interface{} `json:"affinity,omitempty"`
 
 	// Tolerations are the tolerations to apply to the pod.
-	Tolerations []interface{} `json:"tolerations,omitempty"`
+	Tolerations []map[string]interface{} `json:"tolerations,omitempty"`
 
 	// PriorityClassName is the priority class name for the the pod.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
@@ -1098,16 +1098,12 @@ type ResourceQuota struct {
 	Quota map[string]interface{} `json:"quota,omitempty"`
 
 	// ScopeSelector is the resource quota scope selector
-	ScopeSelector ScopeSelector `json:"scopeSelector,omitempty"`
+	ScopeSelector map[string]interface{} `json:"scopeSelector,omitempty"`
 
 	// Scopes are the resource quota scopes
 	Scopes []string `json:"scopes,omitempty"`
 
 	LabelsAndAnnotations `json:",inline"`
-}
-
-type ScopeSelector struct {
-	MatchExpressions []LabelSelectorRequirement `json:"matchExpressions,omitempty"`
 }
 
 type LabelSelectorRequirement struct {
@@ -1426,11 +1422,11 @@ type ExperimentalSyncSettings struct {
 	// SyncLabels are labels that should get not rewritten when syncing from the virtual cluster.
 	SyncLabels []string `json:"syncLabels,omitempty"`
 
-	// LocalManagerMetricsBindAddress is the bind address for the local manager
-	LocalManagerMetricsBindAddress string `json:"localManagerMetricsBindAddress,omitempty"`
+	// HostMetricsBindAddress is the bind address for the local manager
+	HostMetricsBindAddress string `json:"hostMetricsBindAddress,omitempty"`
 
-	// VirtualManagerMetricsBindAddress is the bind address for the virtual manager
-	VirtualManagerMetricsBindAddress string `json:"virtualManagerMetricsBindAddress,omitempty"`
+	// VirtualMetricsBindAddress is the bind address for the virtual manager
+	VirtualMetricsBindAddress string `json:"virtualMetricsBindAddress,omitempty"`
 }
 
 type ExperimentalDeploy struct {

--- a/config/diff.go
+++ b/config/diff.go
@@ -50,7 +50,7 @@ func diff(from, to any) any {
 	case map[string]interface{}:
 		toMap, ok := to.(map[string]interface{})
 		if !ok {
-			return to
+			return prune(to)
 		}
 
 		retMap := map[string]interface{}{}
@@ -88,9 +88,37 @@ func diff(from, to any) any {
 			}
 		}
 
-		return retMap
+		return prune(retMap)
 	default:
-		return to
+		return prune(to)
+	}
+}
+
+func prune(in interface{}) interface{} {
+	switch inType := in.(type) {
+	case []interface{}:
+		for i, v := range inType {
+			inType[i] = prune(v)
+		}
+		return in
+	case map[string]interface{}:
+		if len(inType) == 0 {
+			return nil
+		}
+
+		for k, v := range inType {
+			inType[k] = prune(v)
+			if inType[k] == nil {
+				delete(inType, k)
+			}
+		}
+
+		if len(inType) == 0 {
+			return nil
+		}
+		return inType
+	default:
+		return in
 	}
 }
 

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -412,7 +412,7 @@ networking:
   resolveDNS: []
   advanced:
     clusterDomain: "cluster.local"
-    fallbackHostCluster: true
+    fallbackHostCluster: false
     proxyKubelets:
       byHostname: true
       byIP: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,12 +4,17 @@ import (
 	"strings"
 
 	"github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/config/legacyconfig"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+)
+
+const (
+	DefaultHostsRewriteImage = "library/alpine:3.13.1"
 )
 
 // VirtualClusterConfig wraps the config and adds extra info such as name, serviceName and targetNamespace
@@ -116,7 +121,7 @@ func (v VirtualClusterConfig) VirtualClusterKubeConfig() config.VirtualClusterKu
 }
 
 // LegacyOptions converts the config to the legacy cluster options
-func (v VirtualClusterConfig) LegacyOptions() (*LegacyVirtualClusterOptions, error) {
+func (v VirtualClusterConfig) LegacyOptions() (*legacyconfig.LegacyVirtualClusterOptions, error) {
 	legacyPlugins := []string{}
 	for pluginName, plugin := range v.Plugin {
 		if plugin.Version != "" && !plugin.Optional {
@@ -136,8 +141,8 @@ func (v VirtualClusterConfig) LegacyOptions() (*LegacyVirtualClusterOptions, err
 		nodeSelector = strings.Join(selectors, ",")
 	}
 
-	return &LegacyVirtualClusterOptions{
-		ProOptions: LegacyVirtualClusterProOptions{
+	return &legacyconfig.LegacyVirtualClusterOptions{
+		ProOptions: legacyconfig.LegacyVirtualClusterProOptions{
 			RemoteKubeConfig:      v.Experimental.IsolatedControlPlane.KubeConfig,
 			RemoteNamespace:       v.Experimental.IsolatedControlPlane.Namespace,
 			RemoteServiceName:     v.Experimental.IsolatedControlPlane.Service,

--- a/pkg/config/legacyconfig/config.go
+++ b/pkg/config/legacyconfig/config.go
@@ -1,0 +1,433 @@
+package legacyconfig
+
+import "github.com/loft-sh/vcluster/config"
+
+type LegacyK0sAndK3s struct {
+	BaseHelm
+	AutoDeletePersistentVolumeClaims bool               `json:"autoDeletePersistentVolumeClaims,omitempty"`
+	K3sToken                         string             `json:"k3sToken,omitempty"`
+	VCluster                         VClusterValues     `json:"vcluster,omitempty"`
+	EmbeddedEtcd                     EmbeddedEtcdValues `json:"embeddedEtcd,omitempty"`
+	Syncer                           SyncerValues       `json:"syncer,omitempty"`
+	Storage                          Storage            `json:"storage,omitempty"`
+}
+
+type LegacyK8s struct {
+	BaseHelm
+	Syncer       K8sSyncerValues    `json:"syncer,omitempty"`
+	API          APIServerValues    `json:"api,omitempty"`
+	Controller   ControllerValues   `json:"controller,omitempty"`
+	Scheduler    SchedulerValues    `json:"scheduler,omitempty"`
+	Etcd         EtcdValues         `json:"etcd,omitempty"`
+	EmbeddedEtcd EmbeddedEtcdValues `json:"embeddedEtcd,omitempty"`
+	Storage      Storage            `json:"storage,omitempty"`
+}
+
+type K8sSyncerValues struct {
+	SyncerValues
+	CommonValues
+	SecurityContext    map[string]interface{} `json:"securityContext,omitempty"`
+	PodSecurityContext map[string]interface{} `json:"podSecurityContext,omitempty"`
+}
+
+type APIServerValues struct {
+	SyncerExORCommonValues
+	ControlPlaneCommonValues
+}
+
+type ControllerValues struct {
+	SyncerExORCommonValues
+	ControlPlaneCommonValues
+}
+
+type SchedulerValues struct {
+	SyncerExORCommonValues
+	ControlPlaneCommonValues
+	Disabled bool `json:"disabled,omitempty"`
+}
+
+type EtcdValues struct {
+	// Disabled is allowed for k8s & eks
+	Disabled bool `json:"disabled,omitempty"`
+	CommonValues
+	SyncerExORCommonValues
+	ControlPlaneCommonValues
+	SecurityContext                  map[string]interface{} `json:"securityContext,omitempty"`
+	ServiceAnnotations               map[string]string      `json:"serviceAnnotations,omitempty"`
+	AutoDeletePersistentVolumeClaims bool                   `json:"autoDeletePersistentVolumeClaims,omitempty"`
+	Replicas                         int                    `json:"replicas,omitempty"`
+	Labels                           map[string]string      `json:"labels,omitempty"`
+	Annotations                      map[string]string      `json:"annotations,omitempty"`
+	Storage                          Storage                `json:"storage,omitempty"`
+}
+
+type MonitoringValues struct {
+	ServiceMonitor ServiceMonitor `json:"serviceMonitor,omitempty"`
+}
+
+type ServiceMonitor struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+type EmbeddedEtcdValues struct {
+	Enabled         bool `json:"enabled,omitempty"`
+	MigrateFromEtcd bool `json:"migrateFromEtcd,omitempty"`
+}
+
+type Storage struct {
+	Persistence *bool  `json:"persistence,omitempty"`
+	Size        string `json:"size,omitempty"`
+	ClassName   string `json:"className,omitempty"`
+}
+
+type BaseHelm struct {
+	GlobalAnnotations    map[string]string        `json:"globalAnnotations,omitempty"`
+	Pro                  bool                     `json:"pro,omitempty"`
+	ProLicenseSecret     string                   `json:"proLicenseSecret,omitempty"`
+	Headless             bool                     `json:"headless,omitempty"`
+	DefaultImageRegistry string                   `json:"defaultImageRegistry,omitempty"`
+	Plugin               map[string]interface{}   `json:"plugin,omitempty"`
+	Sync                 SyncValues               `json:"sync,omitempty"`
+	FallbackHostDNS      bool                     `json:"fallbackHostDns,omitempty"`
+	MapServices          MapServices              `json:"mapServices,omitempty"`
+	Proxy                ProxyValues              `json:"proxy,omitempty"`
+	Volumes              []map[string]interface{} `json:"volumes,omitempty"`
+	ServiceAccount       struct {
+		Create           *bool                         `json:"create,omitempty"`
+		Name             string                        `json:"name,omitempty"`
+		ImagePullSecrets []config.LocalObjectReference `json:"imagePullSecrets"`
+	} `json:"serviceAccount,omitempty"`
+	WorkloadServiceAccount struct {
+		Annotations map[string]string `json:"annotations,omitempty"`
+	} `json:"workloadServiceAccount,omitempty"`
+	Rbac                RBACValues               `json:"rbac,omitempty"`
+	NodeSelector        map[string]interface{}   `json:"nodeSelector,omitempty"`
+	Affinity            map[string]interface{}   `json:"affinity,omitempty"`
+	PriorityClassName   string                   `json:"priorityClassName,omitempty"`
+	Tolerations         []map[string]interface{} `json:"tolerations,omitempty"`
+	Labels              map[string]string        `json:"labels,omitempty"`
+	PodLabels           map[string]string        `json:"podLabels,omitempty"`
+	Annotations         map[string]string        `json:"annotations,omitempty"`
+	PodAnnotations      map[string]string        `json:"podAnnotations,omitempty"`
+	PodDisruptionBudget PDBValues                `json:"podDisruptionBudget,omitempty"`
+	Service             ServiceValues            `json:"service,omitempty"`
+	Ingress             IngressValues            `json:"ingress,omitempty"`
+
+	SecurityContext    map[string]interface{} `json:"securityContext,omitempty"`
+	PodSecurityContext map[string]interface{} `json:"podSecurityContext,omitempty"`
+	Openshift          struct {
+		Enable bool `json:"enable,omitempty"`
+	} `json:"openshift,omitempty"`
+	Coredns            CoreDNSValues    `json:"coredns,omitempty"`
+	Isolation          IsolationValues  `json:"isolation,omitempty"`
+	Init               InitValues       `json:"init,omitempty"`
+	MultiNamespaceMode EnabledSwitch    `json:"multiNamespaceMode,omitempty"`
+	Telemetry          TelemetryValues  `json:"telemetry,omitempty"`
+	NoopSyncer         NoopSyncerValues `json:"noopSyncer,omitempty"`
+	Monitoring         MonitoringValues `json:"monitoring,omitempty"`
+	CentralAdmission   AdmissionValues  `json:"centralAdmission,omitempty"`
+}
+
+type SyncerValues struct {
+	ControlPlaneCommonValues
+	ExtraArgs             []string                 `json:"extraArgs,omitempty"`
+	Env                   []map[string]interface{} `json:"env,omitempty"`
+	LivenessProbe         EnabledSwitch            `json:"livenessProbe,omitempty"`
+	ReadinessProbe        EnabledSwitch            `json:"readinessProbe,omitempty"`
+	VolumeMounts          []map[string]interface{} `json:"volumeMounts,omitempty"`
+	ExtraVolumeMounts     []config.VolumeMount     `json:"extraVolumeMounts,omitempty"`
+	Resources             config.Resources         `json:"resources,omitempty"`
+	KubeConfigContextName string                   `json:"kubeConfigContextName,omitempty"`
+	ServiceAnnotations    map[string]string        `json:"serviceAnnotations,omitempty"`
+	Replicas              int32                    `json:"replicas,omitempty"`
+	Storage               Storage                  `json:"storage,omitempty"`
+	Labels                map[string]string        `json:"labels,omitempty"`
+	Annotations           map[string]string        `json:"annotations,omitempty"`
+}
+
+type SyncValues struct {
+	Services               EnabledSwitch  `json:"services,omitempty"`
+	Configmaps             SyncConfigMaps `json:"configmaps,omitempty"`
+	Secrets                SyncSecrets    `json:"secrets,omitempty"`
+	Endpoints              EnabledSwitch  `json:"endpoints,omitempty"`
+	Pods                   SyncPods       `json:"pods,omitempty"`
+	Events                 EnabledSwitch  `json:"events,omitempty"`
+	PersistentVolumeClaims EnabledSwitch  `json:"persistentvolumeclaims,omitempty"`
+	Ingresses              EnabledSwitch  `json:"ingresses,omitempty"`
+	Ingressclasses         EnabledSwitch  `json:"ingressclasses,omitempty"`
+	FakeNodes              EnabledSwitch  `json:"fake-nodes,omitempty"`
+	FakePersistentvolumes  EnabledSwitch  `json:"fake-persistentvolumes,omitempty"`
+	Nodes                  SyncNodes      `json:"nodes,omitempty"`
+	PersistentVolumes      EnabledSwitch  `json:"persistentvolumes,omitempty"`
+	StorageClasses         EnabledSwitch  `json:"storageclasses,omitempty"`
+	Hoststorageclasses     EnabledSwitch  `json:"hoststorageclasses,omitempty"`
+	Priorityclasses        EnabledSwitch  `json:"priorityclasses,omitempty"`
+	Networkpolicies        EnabledSwitch  `json:"networkpolicies,omitempty"`
+	Volumesnapshots        EnabledSwitch  `json:"volumesnapshots,omitempty"`
+	Poddisruptionbudgets   EnabledSwitch  `json:"poddisruptionbudgets,omitempty"`
+	Serviceaccounts        EnabledSwitch  `json:"serviceaccounts,omitempty"`
+	Generic                SyncGeneric    `json:"generic,omitempty"`
+}
+
+type SyncConfigMaps struct {
+	Enabled *bool `json:"enabled,omitempty"`
+	All     bool  `json:"all,omitempty"`
+}
+
+type SyncSecrets struct {
+	Enabled *bool `json:"enabled,omitempty"`
+	All     bool  `json:"all,omitempty"`
+}
+
+type SyncPods struct {
+	Enabled             *bool `json:"enabled,omitempty"`
+	EphemeralContainers *bool `json:"ephemeralContainers,omitempty"`
+	Status              *bool `json:"status,omitempty"`
+}
+
+type SyncNodes struct {
+	Enabled *bool `json:"enabled,omitempty"`
+
+	FakeKubeletIPs  *bool  `json:"fakeKubeletIPs,omitempty"`
+	SyncAllNodes    *bool  `json:"syncAllNodes,omitempty"`
+	NodeSelector    string `json:"nodeSelector,omitempty"`
+	EnableScheduler *bool  `json:"enableScheduler,omitempty"`
+	SyncNodeChanges *bool  `json:"syncNodeChanges,omitempty"`
+}
+
+type SyncGeneric struct {
+	Config string `json:"config,omitempty"`
+}
+
+type EnabledSwitch struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type MapServices struct {
+	FromVirtual []config.ServiceMapping `json:"fromVirtual,omitempty"`
+	FromHost    []config.ServiceMapping `json:"fromHost,omitempty"`
+}
+
+type ProxyValues struct {
+	MetricsServer MetricsProxyServerConfig `json:"metricsServer,omitempty"`
+}
+
+type MetricsProxyServerConfig struct {
+	Nodes EnabledSwitch `json:"nodes,omitempty"`
+	Pods  EnabledSwitch `json:"pods,omitempty"`
+}
+
+type VClusterValues struct {
+	Image             string                   `json:"image,omitempty"`
+	ImagePullPolicy   string                   `json:"imagePullPolicy,omitempty"`
+	Command           []string                 `json:"command,omitempty"`
+	BaseArgs          []string                 `json:"baseArgs,omitempty"`
+	ExtraArgs         []string                 `json:"extraArgs,omitempty"`
+	ExtraVolumeMounts []config.VolumeMount     `json:"extraVolumeMounts,omitempty"`
+	VolumeMounts      []map[string]interface{} `json:"volumeMounts,omitempty"`
+	Env               []map[string]interface{} `json:"env,omitempty"`
+	Resources         map[string]interface{}   `json:"resources,omitempty"`
+
+	// this is only provided in context of k0s right now
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+}
+
+// These should be remove from the chart first as they are deprecated there
+type RBACValues struct {
+	ClusterRole RBACClusterRoleValues `json:"clusterRole,omitempty"`
+	Role        RBACRoleValues        `json:"role,omitempty"`
+}
+
+type RBACClusterRoleValues struct {
+	Create     *bool                    `json:"create,omitempty"`
+	ExtraRules []map[string]interface{} `json:"extraRules,omitempty"`
+}
+
+type RBACRoleValues struct {
+	Create               *bool                    `json:"create,omitempty"`
+	ExtraRules           []map[string]interface{} `json:"extraRules,omitempty"`
+	ExcludedAPIResources []string                 `json:"excludedApiResources,omitempty"`
+}
+
+type RBACRule struct {
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
+	// APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+	// the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+	// +optional
+	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,2,rep,name=apiGroups"`
+	// Resources is a list of resources this rule applies to. '*' represents all resources.
+	// +optional
+	Resources []string `json:"resources,omitempty" protobuf:"bytes,3,rep,name=resources"`
+	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	// +optional
+	ResourceNames []string `json:"resourceNames,omitempty" protobuf:"bytes,4,rep,name=resourceNames"`
+	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+	// +optional
+	NonResourceURLs []string `json:"nonResourceURLs,omitempty" protobuf:"bytes,5,rep,name=nonResourceURLs"`
+}
+
+type PDBValues struct {
+	Enabled        bool        `json:"enabled,omitempty"`
+	MinAvailable   interface{} `json:"minAvailable,omitempty"`
+	MaxUnavailable interface{} `json:"maxUnavailable,omitempty"`
+}
+
+type ServiceValues struct {
+	Type                     string            `json:"type,omitempty"`
+	ExternalIPs              []string          `json:"externalIPs,omitempty"`
+	ExternalTrafficPolicy    string            `json:"externalTrafficPolicy,omitempty"`
+	LoadBalancerIP           string            `json:"loadBalancerIP,omitempty"`
+	LoadBalancerSourceRanges []string          `json:"loadBalancerSourceRanges,omitempty"`
+	LoadBalancerClass        string            `json:"loadBalancerClass,omitempty"`
+	LoadBalancerAnnotation   map[string]string `json:"loadBalancerAnnotations,omitempty"`
+}
+
+type IngressValues struct {
+	Enabled          bool              `json:"enabled,omitempty"`
+	PathType         string            `json:"pathType,omitempty"`
+	IngressClassName string            `json:"ingressClassName,omitempty"`
+	Host             string            `json:"host,omitempty"`
+	Annotations      map[string]string `json:"annotations,omitempty"`
+	TLS              []interface{}     `json:"tls,omitempty"`
+}
+
+type CoreDNSValues struct {
+	Enabled        *bool                `json:"enabled,omitempty"`
+	Integrated     bool                 `json:"integrated,omitempty"`
+	Fallback       string               `json:"fallback,omitempty"`
+	Plugin         CoreDNSPluginValues  `json:"plugin,omitempty"`
+	Replicas       int                  `json:"replicas,omitempty"`
+	NodeSelector   map[string]string    `json:"nodeSelector,omitempty"`
+	Image          string               `json:"image,omitempty"`
+	Config         string               `json:"config,omitempty"`
+	Service        CoreDNSServiceValues `json:"service,omitempty"`
+	Resources      *config.Resources    `json:"resources,omitempty"`
+	Manifests      string               `json:"manifests,omitempty"`
+	PodAnnotations map[string]string    `json:"podAnnotations,omitempty"`
+	PodLabels      map[string]string    `json:"podLabels,omitempty"`
+}
+
+type CoreDNSPluginValues struct {
+	Enabled bool          `json:"enabled,omitempty"`
+	Config  []DNSMappings `json:"config,omitempty"`
+}
+
+type DNSMappings struct {
+	Record    Record       `json:"record,omitempty"`
+	Target    Target       `json:"target,omitempty"`
+	AllowedOn []FilterSpec `json:"allowedOn,omitempty"`
+	ExceptOn  []FilterSpec `json:"exceptOn,omitempty"`
+}
+
+type Record struct {
+	RecordType RecordType `json:"recordType,omitempty"`
+	FQDN       *string    `json:"fqdn,omitempty"`
+	Service    *string    `json:"service,omitempty"`
+	Namespace  *string    `json:"namespace,omitempty"`
+}
+
+type RecordType string
+type TargetMode string
+
+type Target struct {
+	Mode      TargetMode `json:"mode,omitempty"`
+	VCluster  *string    `json:"vcluster,omitempty"`
+	URL       *string    `json:"url,omitempty"`
+	Service   *string    `json:"service,omitempty"`
+	Namespace *string    `json:"namespace,omitempty"`
+}
+
+type FilterSpec struct {
+	Name      string   `json:"name,omitempty"`
+	Namespace string   `json:"namespace,omitempty"`
+	Labels    []string `json:"labels,omitempty"`
+}
+
+type CoreDNSServiceValues struct {
+	Type                  string            `json:"type,omitempty"`
+	ExternalIPs           []string          `json:"externalIPs,omitempty"`
+	ExternalTrafficPolicy string            `json:"externalTrafficPolicy,omitempty"`
+	Annotations           map[string]string `json:"annotations,omitempty"`
+}
+
+type IsolationValues struct {
+	Enabled             bool          `json:"enabled,omitempty"`
+	Namespace           *string       `json:"namespace,omitempty"`
+	PodSecurityStandard string        `json:"podSecurityStandard,omitempty"`
+	NodeProxyPermission EnabledSwitch `json:"nodeProxyPermission,omitempty"`
+
+	ResourceQuota struct {
+		Enabled       *bool                  `json:"enabled,omitempty"`
+		Quota         map[string]interface{} `json:"quota,omitempty"`
+		ScopeSelector map[string]interface{} `json:"scopeSelector,omitempty"`
+		Scopes        []string               `json:"scopes,omitempty"`
+	} `json:"resourceQuota,omitempty"`
+
+	LimitRange    IsolationLimitRangeValues `json:"limitRange,omitempty"`
+	NetworkPolicy NetworkPolicyValues       `json:"networkPolicy,omitempty"`
+}
+
+type IsolationLimitRangeValues struct {
+	Enabled        *bool                  `json:"enabled,omitempty"`
+	Default        map[string]interface{} `json:"default,omitempty"`
+	DefaultRequest map[string]interface{} `json:"defaultRequest,omitempty"`
+}
+
+type NetworkPolicyValues struct {
+	Enabled             *bool                      `json:"enabled,omitempty"`
+	OutgoingConnections config.OutgoingConnections `json:"outgoingConnections,omitempty"`
+}
+
+type InitValues struct {
+	Manifests         string                          `json:"manifests,omitempty"`
+	ManifestsTemplate string                          `json:"manifestsTemplate,omitempty"`
+	Helm              []config.ExperimentalDeployHelm `json:"helm,omitempty"`
+}
+
+type TelemetryValues struct {
+	Disabled           config.StrBool `json:"disabled,omitempty"`
+	InstanceCreator    string         `json:"instanceCreator,omitempty"`
+	PlatformUserID     string         `json:"platformUserID,omitempty"`
+	PlatformInstanceID string         `json:"platformInstanceID,omitempty"`
+	MachineID          string         `json:"machineID,omitempty"`
+}
+
+type NoopSyncerValues struct {
+	Enabled        bool `json:"enabled,omitempty"`
+	Synck8sService bool `json:"synck8sService,omitempty"`
+	Secret         struct {
+		ServerCaCert        string `json:"serverCaCert,omitempty"`
+		ServerCaKey         string `json:"serverCaKey,omitempty"`
+		ClientCaCert        string `json:"clientCaCert,omitempty"`
+		RequestHeaderCaCert string `json:"requestHeaderCaCert,omitempty"`
+		KubeConfig          string `json:"kubeConfig,omitempty"`
+	} `json:"secret,omitempty"`
+}
+
+type AdmissionValues struct {
+	ValidatingWebhooks []config.ValidatingWebhookConfiguration `json:"validatingWebhooks,omitempty"`
+	MutatingWebhooks   []config.MutatingWebhookConfiguration   `json:"mutatingWebhooks,omitempty"`
+}
+
+type ControlPlaneCommonValues struct {
+	Image           string `json:"image,omitempty"`
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+}
+
+type SyncerExORCommonValues struct {
+	ExtraArgs []string          `json:"extraArgs,omitempty"`
+	Resources *config.Resources `json:"resources,omitempty"`
+}
+
+type CommonValues struct {
+	Volumes           []map[string]interface{} `json:"volumes,omitempty"`
+	PriorityClassName string                   `json:"priorityClassName,omitempty"`
+	NodeSelector      map[string]interface{}   `json:"nodeSelector,omitempty"`
+	Affinity          map[string]interface{}   `json:"affinity,omitempty"`
+	Tolerations       []map[string]interface{} `json:"tolerations,omitempty"`
+	PodAnnotations    map[string]string        `json:"podAnnotations,omitempty"`
+	PodLabels         map[string]string        `json:"podLabels,omitempty"`
+}

--- a/pkg/config/legacyconfig/migrate.go
+++ b/pkg/config/legacyconfig/migrate.go
@@ -1,0 +1,1118 @@
+package legacyconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/loft-sh/vcluster/config"
+)
+
+func MigrateLegacyConfig(distro, oldValues string) (string, error) {
+	fromConfig, err := config.NewDefaultConfig()
+	if err != nil {
+		return "", err
+	}
+	toConfig, err := config.NewDefaultConfig()
+	if err != nil {
+		return "", err
+	}
+
+	switch distro {
+	case config.K0SDistro, config.K3SDistro:
+		err = migrateK3sAndK0s(distro, oldValues, toConfig)
+		if err != nil {
+			return "", fmt.Errorf("migrate legacy %s values: %w", distro, err)
+		}
+	case config.K8SDistro, config.EKSDistro:
+		err = migrateK8sAndEKS(distro, oldValues, toConfig)
+		if err != nil {
+			return "", fmt.Errorf("migrate legacy %s values: %w", distro, err)
+		}
+	default:
+		return "", fmt.Errorf("migrating distro %s is not supported", distro)
+	}
+
+	return config.Diff(fromConfig, toConfig)
+}
+
+func migrateK8sAndEKS(distro, oldValues string, newConfig *config.Config) error {
+	// unmarshal legacy config
+	oldConfig := &LegacyK8s{}
+	err := yaml.Unmarshal([]byte(oldValues), oldConfig)
+	if err != nil {
+		return fmt.Errorf("unmarshal legacy config: %w", err)
+	}
+
+	// k8s specific
+	if distro == config.K8SDistro {
+		newConfig.ControlPlane.Distro.K8S.Enabled = true
+		convertAPIValues(oldConfig.API, &newConfig.ControlPlane.Distro.K8S.APIServer)
+		convertControllerValues(oldConfig.Controller, &newConfig.ControlPlane.Distro.K8S.ControllerManager)
+		convertSchedulerValues(oldConfig.Scheduler, &newConfig.ControlPlane.Distro.K8S.Scheduler)
+	} else if distro == config.EKSDistro {
+		newConfig.ControlPlane.Distro.EKS.Enabled = true
+		convertAPIValues(oldConfig.API, &newConfig.ControlPlane.Distro.EKS.APIServer)
+		convertControllerValues(oldConfig.Controller, &newConfig.ControlPlane.Distro.EKS.ControllerManager)
+		convertSchedulerValues(oldConfig.Scheduler, &newConfig.ControlPlane.Distro.EKS.Scheduler)
+	}
+
+	// convert etcd
+	err = convertEtcd(oldConfig.Etcd, newConfig)
+	if err != nil {
+		return err
+	}
+
+	// default ordered ready
+	newConfig.ControlPlane.StatefulSet.Scheduling.PodManagementPolicy = "OrderedReady"
+
+	// storage config
+	applyStorage(oldConfig.Storage, newConfig)
+
+	// syncer config
+	err = convertK8sSyncerConfig(oldConfig.Syncer, newConfig)
+	if err != nil {
+		return fmt.Errorf("error converting syncer config: %w", err)
+	}
+
+	// migrate embedded etcd
+	convertEmbeddedEtcd(oldConfig.EmbeddedEtcd, newConfig)
+
+	// convert the rest
+	err = convertBaseValues(oldConfig.BaseHelm, newConfig)
+	if err != nil {
+		return err
+	}
+
+	// make default storage deployed etcd
+	if !newConfig.ControlPlane.BackingStore.Database.External.Enabled && !newConfig.ControlPlane.BackingStore.Database.Embedded.Enabled && !newConfig.ControlPlane.BackingStore.Etcd.Embedded.Enabled {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.Enabled = true
+	}
+
+	return nil
+}
+
+func migrateK3sAndK0s(distro, oldValues string, newConfig *config.Config) error {
+	// unmarshal legacy config
+	oldConfig := &LegacyK0sAndK3s{}
+	err := yaml.Unmarshal([]byte(oldValues), oldConfig)
+	if err != nil {
+		return fmt.Errorf("unmarshal legacy config: %w", err)
+	}
+
+	// distro specific
+	if distro == config.K0SDistro {
+		newConfig.ControlPlane.Distro.K0S.Enabled = true
+
+		// vcluster config
+		err = convertVClusterConfig(oldConfig.VCluster, &newConfig.ControlPlane.Distro.K0S.DistroCommon, &newConfig.ControlPlane.Distro.K0S.DistroContainer, newConfig)
+		if err != nil {
+			return fmt.Errorf("error converting vcluster config: %w", err)
+		}
+	} else if distro == config.K3SDistro {
+		newConfig.ControlPlane.Distro.K3S.Enabled = true
+		newConfig.ControlPlane.Distro.K3S.Token = oldConfig.K3sToken
+
+		// vcluster config
+		err = convertVClusterConfig(oldConfig.VCluster, &newConfig.ControlPlane.Distro.K3S.DistroCommon, &newConfig.ControlPlane.Distro.K3S.DistroContainer, newConfig)
+		if err != nil {
+			return fmt.Errorf("error converting vcluster config: %w", err)
+		}
+	}
+
+	// general things to update
+	newConfig.ControlPlane.StatefulSet.Scheduling.PodManagementPolicy = "OrderedReady"
+	if oldConfig.AutoDeletePersistentVolumeClaims {
+		newConfig.ControlPlane.StatefulSet.Persistence.VolumeClaim.RetentionPolicy = "Delete"
+	}
+
+	// storage config
+	applyStorage(oldConfig.Storage, newConfig)
+
+	// syncer config
+	err = convertSyncerConfig(oldConfig.Syncer, newConfig)
+	if err != nil {
+		return fmt.Errorf("error converting syncer config: %w", err)
+	}
+
+	// migrate embedded etcd
+	convertEmbeddedEtcd(oldConfig.EmbeddedEtcd, newConfig)
+
+	// convert the rest
+	return convertBaseValues(oldConfig.BaseHelm, newConfig)
+}
+
+func convertEtcd(oldConfig EtcdValues, newConfig *config.Config) error {
+	if oldConfig.Disabled {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Enabled = false
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.Service.Enabled = false
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.HeadlessService.Enabled = false
+	}
+	if oldConfig.ImagePullPolicy != "" {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.ImagePullPolicy = oldConfig.ImagePullPolicy
+	}
+	if oldConfig.Image != "" {
+		convertImage(oldConfig.Image, &newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Image)
+	}
+	newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.ExtraArgs = oldConfig.ExtraArgs
+	if oldConfig.Resources != nil {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Resources = *oldConfig.Resources
+	}
+	newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Persistence.AddVolumes = oldConfig.Volumes
+	if oldConfig.PriorityClassName != "" {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Scheduling.PriorityClassName = oldConfig.PriorityClassName
+	}
+	if len(oldConfig.NodeSelector) > 0 {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Scheduling.NodeSelector = oldConfig.NodeSelector
+	}
+	if len(oldConfig.Affinity) > 0 {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Scheduling.Affinity = oldConfig.Affinity
+	}
+	if len(oldConfig.Tolerations) > 0 {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Scheduling.Tolerations = oldConfig.Tolerations
+	}
+	newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Pods.Annotations = oldConfig.PodAnnotations
+	newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Pods.Labels = oldConfig.PodLabels
+	if len(oldConfig.SecurityContext) > 0 {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Security.ContainerSecurityContext = oldConfig.SecurityContext
+	}
+	if len(oldConfig.ServiceAnnotations) > 0 {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.Service.Annotations = oldConfig.ServiceAnnotations
+	}
+	if oldConfig.AutoDeletePersistentVolumeClaims {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Persistence.VolumeClaim.RetentionPolicy = "Delete"
+	}
+	if oldConfig.Replicas > 0 {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.HighAvailability.Replicas = oldConfig.Replicas
+	}
+	newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Labels = oldConfig.Labels
+	newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Annotations = oldConfig.Annotations
+
+	if oldConfig.Storage.Persistence != nil {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Persistence.VolumeClaim.Enabled = *oldConfig.Storage.Persistence
+	}
+	if oldConfig.Storage.Size != "" {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Persistence.VolumeClaim.Size = oldConfig.Storage.Size
+	}
+	if oldConfig.Storage.ClassName != "" {
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Persistence.VolumeClaim.StorageClass = oldConfig.Storage.ClassName
+	}
+
+	return nil
+}
+
+func convertAPIValues(oldConfig APIServerValues, newContainer *config.DistroContainerEnabled) {
+	if oldConfig.ImagePullPolicy != "" {
+		newContainer.ImagePullPolicy = oldConfig.ImagePullPolicy
+	}
+	if oldConfig.Image != "" {
+		convertImage(oldConfig.Image, &newContainer.Image)
+	}
+	newContainer.ExtraArgs = oldConfig.ExtraArgs
+}
+
+func convertControllerValues(oldConfig ControllerValues, newContainer *config.DistroContainerEnabled) {
+	if oldConfig.ImagePullPolicy != "" {
+		newContainer.ImagePullPolicy = oldConfig.ImagePullPolicy
+	}
+	if oldConfig.Image != "" {
+		convertImage(oldConfig.Image, &newContainer.Image)
+	}
+	newContainer.ExtraArgs = oldConfig.ExtraArgs
+}
+
+func convertSchedulerValues(oldConfig SchedulerValues, newContainer *config.DistroContainer) {
+	if oldConfig.ImagePullPolicy != "" {
+		newContainer.ImagePullPolicy = oldConfig.ImagePullPolicy
+	}
+	if oldConfig.Image != "" {
+		convertImage(oldConfig.Image, &newContainer.Image)
+	}
+	newContainer.ExtraArgs = oldConfig.ExtraArgs
+}
+
+func convertBaseValues(oldConfig BaseHelm, newConfig *config.Config) error {
+	newConfig.ControlPlane.Advanced.GlobalMetadata.Annotations = oldConfig.GlobalAnnotations
+	newConfig.Pro = oldConfig.Pro
+	if strings.Contains(oldConfig.ProLicenseSecret, "/") {
+		splitted := strings.Split(oldConfig.ProLicenseSecret, "/")
+		newConfig.Platform.APIKey.SecretRef.Namespace = splitted[0]
+		newConfig.Platform.APIKey.SecretRef.Name = splitted[1]
+	} else {
+		newConfig.Platform.APIKey.SecretRef.Name = oldConfig.ProLicenseSecret
+	}
+
+	newConfig.Experimental.IsolatedControlPlane.Headless = oldConfig.Headless
+	newConfig.ControlPlane.Advanced.DefaultImageRegistry = oldConfig.DefaultImageRegistry
+
+	if len(oldConfig.Plugin) > 0 {
+		err := convertObject(oldConfig.Plugin, &newConfig.Plugin)
+		if err != nil {
+			return err
+		}
+	}
+
+	newConfig.Networking.Advanced.FallbackHostCluster = oldConfig.FallbackHostDNS
+	newConfig.ControlPlane.StatefulSet.Labels = oldConfig.Labels
+	newConfig.ControlPlane.StatefulSet.Annotations = oldConfig.Annotations
+	newConfig.ControlPlane.StatefulSet.Pods.Labels = oldConfig.PodLabels
+	newConfig.ControlPlane.StatefulSet.Pods.Annotations = oldConfig.PodAnnotations
+	newConfig.ControlPlane.StatefulSet.Scheduling.Tolerations = oldConfig.Tolerations
+	newConfig.ControlPlane.StatefulSet.Scheduling.NodeSelector = oldConfig.NodeSelector
+	newConfig.ControlPlane.StatefulSet.Scheduling.Affinity = oldConfig.Affinity
+	newConfig.ControlPlane.StatefulSet.Scheduling.PriorityClassName = oldConfig.PriorityClassName
+
+	newConfig.Networking.ReplicateServices.FromHost = oldConfig.MapServices.FromHost
+	newConfig.Networking.ReplicateServices.ToHost = oldConfig.MapServices.FromVirtual
+
+	if oldConfig.Proxy.MetricsServer.Pods.Enabled != nil {
+		newConfig.Observability.Metrics.Proxy.Pods = *oldConfig.Proxy.MetricsServer.Pods.Enabled
+	}
+	if oldConfig.Proxy.MetricsServer.Nodes.Enabled != nil {
+		newConfig.Observability.Metrics.Proxy.Nodes = *oldConfig.Proxy.MetricsServer.Nodes.Enabled
+	}
+
+	if len(oldConfig.Volumes) > 0 {
+		newConfig.ControlPlane.StatefulSet.Persistence.AddVolumes = oldConfig.Volumes
+	}
+
+	if oldConfig.ServiceAccount.Create != nil {
+		newConfig.ControlPlane.Advanced.ServiceAccount.Enabled = *oldConfig.ServiceAccount.Create
+	}
+	if oldConfig.ServiceAccount.Name != "" {
+		newConfig.ControlPlane.Advanced.ServiceAccount.Name = oldConfig.ServiceAccount.Name
+	}
+	if len(oldConfig.ServiceAccount.ImagePullSecrets) > 0 {
+		newConfig.ControlPlane.Advanced.ServiceAccount.ImagePullSecrets = oldConfig.ServiceAccount.ImagePullSecrets
+	}
+	if len(oldConfig.WorkloadServiceAccount.Annotations) > 0 {
+		newConfig.ControlPlane.Advanced.WorkloadServiceAccount.Annotations = oldConfig.WorkloadServiceAccount.Annotations
+	}
+
+	newConfig.Policies.CentralAdmission.MutatingWebhooks = oldConfig.CentralAdmission.MutatingWebhooks
+	newConfig.Policies.CentralAdmission.ValidatingWebhooks = oldConfig.CentralAdmission.ValidatingWebhooks
+
+	if oldConfig.Telemetry.Disabled == "true" {
+		newConfig.Telemetry.Enabled = false
+	}
+
+	if oldConfig.MultiNamespaceMode.Enabled != nil {
+		newConfig.Experimental.MultiNamespaceMode.Enabled = *oldConfig.MultiNamespaceMode.Enabled
+	}
+
+	if len(oldConfig.SecurityContext) > 0 {
+		if newConfig.ControlPlane.StatefulSet.Security.ContainerSecurityContext == nil {
+			newConfig.ControlPlane.StatefulSet.Security.ContainerSecurityContext = map[string]interface{}{}
+		}
+		for k, v := range oldConfig.SecurityContext {
+			newConfig.ControlPlane.StatefulSet.Security.ContainerSecurityContext[k] = v
+		}
+	}
+	if len(oldConfig.PodSecurityContext) > 0 {
+		if newConfig.ControlPlane.StatefulSet.Security.PodSecurityContext == nil {
+			newConfig.ControlPlane.StatefulSet.Security.PodSecurityContext = map[string]interface{}{}
+		}
+		for k, v := range oldConfig.PodSecurityContext {
+			newConfig.ControlPlane.StatefulSet.Security.PodSecurityContext[k] = v
+		}
+	}
+
+	if oldConfig.Openshift.Enable {
+		newConfig.RBAC.Role.ExtraRules = append(newConfig.RBAC.Role.ExtraRules, map[string]interface{}{
+			"apiGroups": []string{""},
+			"resources": []string{"endpoints/restricted"},
+			"verbs":     []string{"create"},
+		})
+	}
+
+	newConfig.ControlPlane.ServiceMonitor.Enabled = oldConfig.Monitoring.ServiceMonitor.Enabled
+
+	if len(oldConfig.Rbac.Role.ExtraRules) > 0 {
+		newConfig.RBAC.Role.ExtraRules = append(newConfig.RBAC.Role.ExtraRules, oldConfig.Rbac.Role.ExtraRules...)
+	}
+	if oldConfig.Rbac.Role.Create != nil {
+		newConfig.RBAC.Role.Enabled = *oldConfig.Rbac.Role.Create
+	}
+	if len(oldConfig.Rbac.Role.ExcludedAPIResources) > 0 {
+		return fmt.Errorf("rbac.role.excludedAPIResources is not supported anymore, please use rbac.role.overwriteRules instead")
+	}
+
+	if len(oldConfig.Rbac.ClusterRole.ExtraRules) > 0 {
+		newConfig.RBAC.ClusterRole.ExtraRules = append(newConfig.RBAC.ClusterRole.ExtraRules, oldConfig.Rbac.ClusterRole.ExtraRules...)
+	}
+	if oldConfig.Rbac.ClusterRole.Create != nil && *oldConfig.Rbac.ClusterRole.Create {
+		newConfig.RBAC.ClusterRole.Enabled = "true"
+	}
+
+	if oldConfig.NoopSyncer.Enabled {
+		newConfig.Experimental.SyncSettings.DisableSync = true
+		if oldConfig.NoopSyncer.Secret.KubeConfig != "" {
+			newConfig.Experimental.VirtualClusterKubeConfig.KubeConfig = oldConfig.NoopSyncer.Secret.KubeConfig
+		}
+		if oldConfig.NoopSyncer.Secret.ClientCaCert != "" {
+			newConfig.Experimental.VirtualClusterKubeConfig.ClientCACert = oldConfig.NoopSyncer.Secret.ClientCaCert
+		}
+		if oldConfig.NoopSyncer.Secret.ServerCaKey != "" {
+			newConfig.Experimental.VirtualClusterKubeConfig.ServerCAKey = oldConfig.NoopSyncer.Secret.ServerCaKey
+		}
+		if oldConfig.NoopSyncer.Secret.ServerCaCert != "" {
+			newConfig.Experimental.VirtualClusterKubeConfig.ServerCACert = oldConfig.NoopSyncer.Secret.ServerCaCert
+		}
+		if oldConfig.NoopSyncer.Secret.RequestHeaderCaCert != "" {
+			newConfig.Experimental.VirtualClusterKubeConfig.RequestHeaderCACert = oldConfig.NoopSyncer.Secret.RequestHeaderCaCert
+		}
+		newConfig.Experimental.SyncSettings.RewriteKubernetesService = oldConfig.NoopSyncer.Synck8sService
+	}
+
+	newConfig.Experimental.Deploy.Manifests = oldConfig.Init.Manifests
+	newConfig.Experimental.Deploy.ManifestsTemplate = oldConfig.Init.ManifestsTemplate
+	newConfig.Experimental.Deploy.Helm = oldConfig.Init.Helm
+
+	if oldConfig.Isolation.Enabled {
+		if oldConfig.Isolation.NetworkPolicy.Enabled != nil {
+			newConfig.Policies.NetworkPolicy.Enabled = *oldConfig.Isolation.NetworkPolicy.Enabled
+		} else {
+			newConfig.Policies.NetworkPolicy.Enabled = true
+		}
+		if oldConfig.Isolation.ResourceQuota.Enabled != nil {
+			newConfig.Policies.ResourceQuota.Enabled = *oldConfig.Isolation.ResourceQuota.Enabled
+		} else {
+			newConfig.Policies.ResourceQuota.Enabled = true
+		}
+		if oldConfig.Isolation.LimitRange.Enabled != nil {
+			newConfig.Policies.LimitRange.Enabled = *oldConfig.Isolation.LimitRange.Enabled
+		} else {
+			newConfig.Policies.LimitRange.Enabled = true
+		}
+		if oldConfig.Isolation.PodSecurityStandard == "" {
+			newConfig.Policies.PodSecurityStandard = "baseline"
+		} else {
+			newConfig.Policies.PodSecurityStandard = oldConfig.Isolation.PodSecurityStandard
+		}
+
+		if oldConfig.Isolation.NetworkPolicy.OutgoingConnections.IPBlock.CIDR != "" {
+			newConfig.Policies.NetworkPolicy.OutgoingConnections.IPBlock.CIDR = oldConfig.Isolation.NetworkPolicy.OutgoingConnections.IPBlock.CIDR
+		}
+		if len(oldConfig.Isolation.NetworkPolicy.OutgoingConnections.IPBlock.Except) > 0 {
+			newConfig.Policies.NetworkPolicy.OutgoingConnections.IPBlock.Except = oldConfig.Isolation.NetworkPolicy.OutgoingConnections.IPBlock.Except
+		}
+
+		if len(oldConfig.Isolation.LimitRange.Default) > 0 {
+			newConfig.Policies.LimitRange.Default = oldConfig.Isolation.LimitRange.Default
+		}
+		if len(oldConfig.Isolation.LimitRange.DefaultRequest) > 0 {
+			newConfig.Policies.LimitRange.DefaultRequest = oldConfig.Isolation.LimitRange.DefaultRequest
+		}
+		if len(oldConfig.Isolation.ResourceQuota.Quota) > 0 {
+			newConfig.Policies.ResourceQuota.Quota = oldConfig.Isolation.ResourceQuota.Quota
+		}
+		if len(oldConfig.Isolation.ResourceQuota.Scopes) > 0 {
+			newConfig.Policies.ResourceQuota.Scopes = oldConfig.Isolation.ResourceQuota.Scopes
+		}
+		if len(oldConfig.Isolation.ResourceQuota.ScopeSelector) > 0 {
+			newConfig.Policies.ResourceQuota.ScopeSelector = oldConfig.Isolation.ResourceQuota.ScopeSelector
+		}
+
+		if oldConfig.Isolation.Namespace != nil {
+			return fmt.Errorf("isolation.namespace is no longer supported, use experimental.syncSettings.targetNamespace instead")
+		}
+		if oldConfig.Isolation.NodeProxyPermission.Enabled != nil {
+			return fmt.Errorf("isolation.nodeProxyPermission.enabled is no longer supported, use rbac.clusterRole.overwriteRules instead")
+		}
+	}
+
+	if oldConfig.Coredns.Enabled != nil {
+		newConfig.ControlPlane.CoreDNS.Enabled = *oldConfig.Coredns.Enabled
+	}
+	if oldConfig.Coredns.Fallback != "" {
+		newConfig.Policies.NetworkPolicy.FallbackDNS = oldConfig.Coredns.Fallback
+	}
+
+	newConfig.ControlPlane.CoreDNS.Embedded = oldConfig.Coredns.Integrated
+	if oldConfig.Coredns.Replicas > 0 {
+		newConfig.ControlPlane.CoreDNS.Deployment.Replicas = oldConfig.Coredns.Replicas
+	}
+	newConfig.ControlPlane.CoreDNS.Deployment.NodeSelector = oldConfig.Coredns.NodeSelector
+	if oldConfig.Coredns.Image != "" {
+		newConfig.ControlPlane.CoreDNS.Deployment.Image = oldConfig.Coredns.Image
+	}
+	if oldConfig.Coredns.Config != "" {
+		newConfig.ControlPlane.CoreDNS.OverwriteConfig = oldConfig.Coredns.Config
+	}
+	if oldConfig.Coredns.Manifests != "" {
+		newConfig.ControlPlane.CoreDNS.OverwriteManifests = oldConfig.Coredns.Manifests
+	}
+	newConfig.ControlPlane.CoreDNS.Deployment.Pods.Labels = oldConfig.Coredns.PodLabels
+	newConfig.ControlPlane.CoreDNS.Deployment.Pods.Annotations = oldConfig.Coredns.PodAnnotations
+	if oldConfig.Coredns.Resources != nil {
+		newConfig.ControlPlane.CoreDNS.Deployment.Resources = *oldConfig.Coredns.Resources
+	}
+	if oldConfig.Coredns.Plugin.Enabled {
+		if len(oldConfig.Coredns.Plugin.Config) > 0 {
+			return fmt.Errorf("please manually upgrade coredns.plugin.config to networking.resolvedDNS")
+		}
+	}
+
+	if len(oldConfig.Coredns.Service.Annotations) > 0 {
+		newConfig.ControlPlane.CoreDNS.Service.Annotations = oldConfig.Coredns.Service.Annotations
+	}
+	if oldConfig.Coredns.Service.Type != "" {
+		if newConfig.ControlPlane.CoreDNS.Service.Spec == nil {
+			newConfig.ControlPlane.CoreDNS.Service.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.CoreDNS.Service.Spec["type"] = oldConfig.Coredns.Service.Type
+	}
+	if oldConfig.Coredns.Service.ExternalTrafficPolicy != "" {
+		if newConfig.ControlPlane.CoreDNS.Service.Spec == nil {
+			newConfig.ControlPlane.CoreDNS.Service.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.CoreDNS.Service.Spec["externalTrafficPolicy"] = oldConfig.Coredns.Service.ExternalTrafficPolicy
+	}
+	if len(oldConfig.Coredns.Service.ExternalIPs) > 0 {
+		if newConfig.ControlPlane.CoreDNS.Service.Spec == nil {
+			newConfig.ControlPlane.CoreDNS.Service.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.CoreDNS.Service.Spec["externalIPs"] = oldConfig.Coredns.Service.ExternalIPs
+	}
+
+	// ingress
+	if oldConfig.Ingress.Enabled {
+		newConfig.ControlPlane.Ingress.Enabled = true
+	}
+	if oldConfig.Ingress.PathType != "" {
+		newConfig.ControlPlane.Ingress.PathType = oldConfig.Ingress.PathType
+	}
+	if oldConfig.Ingress.IngressClassName != "" {
+		if newConfig.ControlPlane.Ingress.Spec == nil {
+			newConfig.ControlPlane.Ingress.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.Ingress.Spec["ingressClassName"] = oldConfig.Ingress.IngressClassName
+	}
+	if oldConfig.Ingress.Host != "" {
+		newConfig.ControlPlane.Ingress.Host = oldConfig.Ingress.Host
+	}
+	if len(oldConfig.Ingress.Annotations) > 0 {
+		if newConfig.ControlPlane.Ingress.Annotations == nil {
+			newConfig.ControlPlane.Ingress.Annotations = nil
+		}
+		for k, v := range oldConfig.Ingress.Annotations {
+			newConfig.ControlPlane.Ingress.Annotations[k] = v
+		}
+	}
+	if len(oldConfig.Ingress.TLS) > 0 {
+		if newConfig.ControlPlane.Ingress.Spec == nil {
+			newConfig.ControlPlane.Ingress.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.Ingress.Spec["tls"] = oldConfig.Ingress.TLS
+	}
+
+	// service
+	if oldConfig.Service.Type != "" {
+		if newConfig.ControlPlane.Service.Spec == nil {
+			newConfig.ControlPlane.Service.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.Service.Spec["type"] = oldConfig.Service.Type
+	}
+	if len(oldConfig.Service.ExternalIPs) > 0 {
+		if newConfig.ControlPlane.Service.Spec == nil {
+			newConfig.ControlPlane.Service.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.Service.Spec["externalIPs"] = oldConfig.Service.ExternalIPs
+	}
+	if oldConfig.Service.ExternalTrafficPolicy != "" {
+		if newConfig.ControlPlane.Service.Spec == nil {
+			newConfig.ControlPlane.Service.Spec = map[string]interface{}{}
+		}
+		newConfig.ControlPlane.Service.Spec["externalTrafficPolicy"] = oldConfig.Service.ExternalTrafficPolicy
+	}
+
+	// sync
+	if oldConfig.Sync.Services.Enabled != nil {
+		newConfig.Sync.ToHost.Services.Enabled = *oldConfig.Sync.Services.Enabled
+	}
+	if oldConfig.Sync.Configmaps.Enabled != nil {
+		newConfig.Sync.ToHost.ConfigMaps.Enabled = *oldConfig.Sync.Configmaps.Enabled
+	}
+	if oldConfig.Sync.Configmaps.All {
+		newConfig.Sync.ToHost.ConfigMaps.All = oldConfig.Sync.Configmaps.All
+	}
+	if oldConfig.Sync.Secrets.Enabled != nil {
+		newConfig.Sync.ToHost.Secrets.Enabled = *oldConfig.Sync.Secrets.Enabled
+	}
+	if oldConfig.Sync.Secrets.All {
+		newConfig.Sync.ToHost.Secrets.All = oldConfig.Sync.Secrets.All
+	}
+	if oldConfig.Sync.Endpoints.Enabled != nil {
+		newConfig.Sync.ToHost.Endpoints.Enabled = *oldConfig.Sync.Endpoints.Enabled
+	}
+	if oldConfig.Sync.Pods.Enabled != nil {
+		newConfig.Sync.ToHost.Pods.Enabled = *oldConfig.Sync.Pods.Enabled
+	}
+	if oldConfig.Sync.Events.Enabled != nil {
+		newConfig.Sync.FromHost.Events.Enabled = *oldConfig.Sync.Events.Enabled
+	}
+	if oldConfig.Sync.PersistentVolumeClaims.Enabled != nil {
+		newConfig.Sync.ToHost.PersistentVolumeClaims.Enabled = *oldConfig.Sync.PersistentVolumeClaims.Enabled
+	}
+	if oldConfig.Sync.Ingresses.Enabled != nil {
+		newConfig.Sync.ToHost.Ingresses.Enabled = *oldConfig.Sync.Ingresses.Enabled
+	}
+	if oldConfig.Sync.Ingressclasses.Enabled != nil {
+		newConfig.Sync.FromHost.IngressClasses.Enabled = *oldConfig.Sync.Ingressclasses.Enabled
+	}
+	if oldConfig.Sync.FakeNodes.Enabled != nil && *oldConfig.Sync.FakeNodes.Enabled {
+		newConfig.Sync.FromHost.Nodes.Enabled = false
+	}
+	if oldConfig.Sync.FakePersistentvolumes.Enabled != nil && *oldConfig.Sync.FakePersistentvolumes.Enabled {
+		newConfig.Sync.ToHost.PersistentVolumes.Enabled = false
+	}
+	if oldConfig.Sync.Nodes.Enabled != nil {
+		newConfig.Sync.FromHost.Nodes.Enabled = *oldConfig.Sync.Nodes.Enabled
+	}
+	if oldConfig.Sync.Nodes.FakeKubeletIPs != nil {
+		newConfig.Networking.Advanced.ProxyKubelets.ByIP = *oldConfig.Sync.Nodes.FakeKubeletIPs
+	}
+	if oldConfig.Sync.Nodes.SyncAllNodes != nil {
+		newConfig.Sync.FromHost.Nodes.Selector.All = *oldConfig.Sync.Nodes.SyncAllNodes
+	}
+	if oldConfig.Sync.Nodes.NodeSelector != "" {
+		newConfig.Sync.FromHost.Nodes.Selector.Labels = mergeIntoMap(make(map[string]string), strings.Split(oldConfig.Sync.Nodes.NodeSelector, ","))
+	}
+	if oldConfig.Sync.Nodes.EnableScheduler != nil {
+		newConfig.ControlPlane.Advanced.VirtualScheduler.Enabled = *oldConfig.Sync.Nodes.EnableScheduler
+	}
+	if oldConfig.Sync.Nodes.SyncNodeChanges != nil {
+		newConfig.Sync.FromHost.Nodes.SyncBackChanges = *oldConfig.Sync.Nodes.SyncNodeChanges
+	}
+	if oldConfig.Sync.PersistentVolumes.Enabled != nil {
+		newConfig.Sync.ToHost.PersistentVolumes.Enabled = *oldConfig.Sync.PersistentVolumes.Enabled
+	}
+	if oldConfig.Sync.StorageClasses.Enabled != nil {
+		newConfig.Sync.ToHost.StorageClasses.Enabled = *oldConfig.Sync.StorageClasses.Enabled
+	}
+	if oldConfig.Sync.Hoststorageclasses.Enabled != nil {
+		newConfig.Sync.FromHost.StorageClasses.Enabled = *oldConfig.Sync.Hoststorageclasses.Enabled
+	}
+	if oldConfig.Sync.Priorityclasses.Enabled != nil {
+		newConfig.Sync.ToHost.PriorityClasses.Enabled = *oldConfig.Sync.Priorityclasses.Enabled
+	}
+	if oldConfig.Sync.Networkpolicies.Enabled != nil {
+		newConfig.Sync.ToHost.NetworkPolicies.Enabled = *oldConfig.Sync.Networkpolicies.Enabled
+	}
+	if oldConfig.Sync.Volumesnapshots.Enabled != nil {
+		newConfig.Sync.ToHost.VolumeSnapshots.Enabled = *oldConfig.Sync.Volumesnapshots.Enabled
+	}
+	if oldConfig.Sync.Poddisruptionbudgets.Enabled != nil {
+		newConfig.Sync.ToHost.PodDisruptionBudgets.Enabled = *oldConfig.Sync.Poddisruptionbudgets.Enabled
+	}
+	if oldConfig.Sync.Serviceaccounts.Enabled != nil {
+		newConfig.Sync.ToHost.ServiceAccounts.Enabled = *oldConfig.Sync.Serviceaccounts.Enabled
+	}
+	if oldConfig.Sync.Generic.Config != "" {
+		genericSyncConfig := &config.ExperimentalGenericSync{}
+		err := yaml.Unmarshal([]byte(oldConfig.Sync.Generic.Config), genericSyncConfig)
+		if err != nil {
+			return fmt.Errorf("decode sync.generic.config: %w", err)
+		}
+
+		newConfig.Experimental.GenericSync = *genericSyncConfig
+	}
+
+	return nil
+}
+
+func convertEmbeddedEtcd(oldConfig EmbeddedEtcdValues, newConfig *config.Config) {
+	if oldConfig.Enabled {
+		newConfig.ControlPlane.BackingStore.Etcd.Embedded.Enabled = true
+		newConfig.ControlPlane.BackingStore.Etcd.Deploy.Enabled = false
+		newConfig.ControlPlane.BackingStore.Database.Embedded.Enabled = false
+		newConfig.ControlPlane.BackingStore.Database.External.Enabled = false
+	}
+	if oldConfig.MigrateFromEtcd {
+		newConfig.ControlPlane.BackingStore.Etcd.Embedded.MigrateFromDeployedEtcd = true
+	}
+}
+
+func convertK8sSyncerConfig(oldConfig K8sSyncerValues, newConfig *config.Config) error {
+	newConfig.ControlPlane.StatefulSet.Persistence.AddVolumes = oldConfig.Volumes
+	if oldConfig.PriorityClassName != "" {
+		newConfig.ControlPlane.StatefulSet.Scheduling.PriorityClassName = oldConfig.PriorityClassName
+	}
+	newConfig.ControlPlane.StatefulSet.Scheduling.NodeSelector = oldConfig.NodeSelector
+	newConfig.ControlPlane.StatefulSet.Scheduling.Affinity = oldConfig.Affinity
+	if len(oldConfig.Tolerations) > 0 {
+		newConfig.ControlPlane.StatefulSet.Scheduling.Tolerations = oldConfig.Tolerations
+	}
+	newConfig.ControlPlane.StatefulSet.Pods.Annotations = oldConfig.PodAnnotations
+	newConfig.ControlPlane.StatefulSet.Pods.Labels = oldConfig.PodLabels
+	if len(oldConfig.PodSecurityContext) > 0 {
+		newConfig.ControlPlane.StatefulSet.Security.PodSecurityContext = oldConfig.PodSecurityContext
+	}
+	if len(oldConfig.SecurityContext) > 0 {
+		newConfig.ControlPlane.StatefulSet.Security.ContainerSecurityContext = oldConfig.SecurityContext
+	}
+
+	return convertSyncerConfig(oldConfig.SyncerValues, newConfig)
+}
+
+func convertSyncerConfig(oldConfig SyncerValues, newConfig *config.Config) error {
+	convertImage(oldConfig.Image, &newConfig.ControlPlane.StatefulSet.Image)
+	if oldConfig.ImagePullPolicy != "" {
+		newConfig.ControlPlane.StatefulSet.ImagePullPolicy = oldConfig.ImagePullPolicy
+	}
+
+	newConfig.ControlPlane.StatefulSet.Env = append(newConfig.ControlPlane.StatefulSet.Env, oldConfig.Env...)
+
+	if oldConfig.LivenessProbe.Enabled != nil {
+		newConfig.ControlPlane.StatefulSet.Probes.LivenessProbe.Enabled = *oldConfig.LivenessProbe.Enabled
+	}
+	if oldConfig.ReadinessProbe.Enabled != nil {
+		newConfig.ControlPlane.StatefulSet.Probes.StartupProbe.Enabled = *oldConfig.ReadinessProbe.Enabled
+	}
+	if oldConfig.ReadinessProbe.Enabled != nil {
+		newConfig.ControlPlane.StatefulSet.Probes.ReadinessProbe.Enabled = *oldConfig.ReadinessProbe.Enabled
+	}
+
+	newConfig.ControlPlane.StatefulSet.Persistence.AddVolumeMounts = append(newConfig.ControlPlane.StatefulSet.Persistence.AddVolumeMounts, oldConfig.ExtraVolumeMounts...)
+
+	if len(oldConfig.VolumeMounts) > 0 {
+		return fmt.Errorf("syncer.volumeMounts is not allowed anymore, please remove this field or use syncer.extraVolumeMounts")
+	}
+	if len(oldConfig.Resources.Limits) > 0 || len(oldConfig.Resources.Requests) > 0 {
+		newConfig.ControlPlane.StatefulSet.Resources = oldConfig.Resources
+	}
+
+	newConfig.ControlPlane.Service.Annotations = oldConfig.ServiceAnnotations
+	if oldConfig.Replicas > 0 {
+		newConfig.ControlPlane.StatefulSet.HighAvailability.Replicas = oldConfig.Replicas
+	}
+	if oldConfig.KubeConfigContextName != "" {
+		newConfig.ExportKubeConfig.Context = oldConfig.KubeConfigContextName
+	}
+	applyStorage(oldConfig.Storage, newConfig)
+
+	if len(oldConfig.Annotations) > 0 {
+		newConfig.ControlPlane.StatefulSet.Annotations = oldConfig.Annotations
+	}
+	if len(oldConfig.Labels) > 0 {
+		newConfig.ControlPlane.StatefulSet.Labels = oldConfig.Labels
+	}
+
+	return convertSyncerExtraArgs(oldConfig.ExtraArgs, newConfig)
+}
+
+func convertSyncerExtraArgs(extraArgs []string, newConfig *config.Config) error {
+	var err error
+	var flag, value string
+
+	for {
+		flag, value, extraArgs, err = nextFlagValue(extraArgs)
+		if err != nil {
+			return err
+		} else if flag == "" {
+			break
+		}
+
+		err = migrateFlag(flag, value, newConfig)
+		if err != nil {
+			return fmt.Errorf("migrate extra syncer flag --%s: %w", flag, err)
+		}
+	}
+
+	return nil
+}
+
+func migrateFlag(key, value string, newConfig *config.Config) error {
+	switch key {
+	case "pro-license-secret":
+		return fmt.Errorf("cannot be used directly, use proLicenseSecret value")
+	case "remote-kube-config":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.IsolatedControlPlane.Enabled = true
+		newConfig.Experimental.IsolatedControlPlane.KubeConfig = value
+	case "remote-namespace":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.IsolatedControlPlane.Namespace = value
+	case "remote-service-name":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.IsolatedControlPlane.Service = value
+	case "integrated-coredns":
+		return fmt.Errorf("cannot be used directly")
+	case "use-coredns-plugin":
+		return fmt.Errorf("cannot be used directly")
+	case "noop-syncer":
+		return fmt.Errorf("cannot be used directly")
+	case "sync-k8s-service":
+		return fmt.Errorf("cannot be used directly")
+	case "etcd-embedded":
+		return fmt.Errorf("cannot be used directly")
+	case "migrate-from":
+		return fmt.Errorf("cannot be used directly")
+	case "etcd-replicas":
+		return fmt.Errorf("cannot be used directly")
+	case "enforce-validating-hook":
+		return fmt.Errorf("cannot be used directly")
+	case "enforce-mutating-hook":
+		return fmt.Errorf("cannot be used directly")
+	case "kube-config-context-name":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.ExportKubeConfig.Context = value
+	case "sync":
+		return fmt.Errorf("cannot be used directly, use the sync.*.enabled options instead")
+	case "request-header-ca-cert":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.VirtualClusterKubeConfig.RequestHeaderCACert = value
+	case "client-ca-cert":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.VirtualClusterKubeConfig.ClientCACert = value
+	case "server-ca-cert":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.VirtualClusterKubeConfig.ServerCACert = value
+	case "server-ca-key":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.VirtualClusterKubeConfig.ServerCAKey = value
+	case "kube-config":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.VirtualClusterKubeConfig.KubeConfig = value
+	case "tls-san":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.ControlPlane.Proxy.ExtraSANs = append(newConfig.ControlPlane.Proxy.ExtraSANs, strings.Split(value, ",")...)
+	case "out-kube-config-secret":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.ExportKubeConfig.Secret.Name = value
+	case "out-kube-config-secret-namespace":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.ExportKubeConfig.Secret.Namespace = value
+	case "out-kube-config-server":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.ExportKubeConfig.Server = value
+	case "target-namespace":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.Experimental.SyncSettings.TargetNamespace = value
+	case "service-name":
+		return fmt.Errorf("this is not supported anymore, the service needs to be the vCluster name")
+	case "name":
+		return fmt.Errorf("this is not supported anymore, the name needs to be the helm release name")
+	case "set-owner":
+		if value == "false" {
+			newConfig.Experimental.SyncSettings.SetOwner = false
+		}
+	case "bind-address":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.ControlPlane.Proxy.BindAddress = value
+	case "port":
+		return fmt.Errorf("this is not supported anymore, the port needs to be 8443")
+	case "sync-all-nodes":
+		if value == "" || value == "true" {
+			newConfig.Sync.FromHost.Nodes.Selector.All = true
+		} else if value == "false" {
+			newConfig.Sync.FromHost.Nodes.Selector.All = false
+		}
+	case "enable-scheduler":
+		if value == "" || value == "true" {
+			newConfig.ControlPlane.Advanced.VirtualScheduler.Enabled = true
+		} else if value == "false" {
+			newConfig.ControlPlane.Advanced.VirtualScheduler.Enabled = false
+		}
+	case "disable-fake-kubelets":
+		if value == "" || value == "true" {
+			newConfig.Networking.Advanced.ProxyKubelets.ByHostname = false
+			newConfig.Networking.Advanced.ProxyKubelets.ByIP = false
+		}
+	case "fake-kubelet-ips":
+		if value == "" || value == "true" {
+			newConfig.Networking.Advanced.ProxyKubelets.ByIP = true
+		} else if value == "false" {
+			newConfig.Networking.Advanced.ProxyKubelets.ByIP = false
+		}
+	case "node-clear-image-status":
+		if value == "" || value == "true" {
+			newConfig.Sync.FromHost.Nodes.ClearImageStatus = true
+		} else if value == "false" {
+			newConfig.Sync.FromHost.Nodes.ClearImageStatus = false
+		}
+	case "translate-image":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.Sync.ToHost.Pods.TranslateImage = mergeIntoMap(newConfig.Sync.ToHost.Pods.TranslateImage, strings.Split(value, ","))
+	case "enforce-node-selector":
+		if value == "false" {
+			return fmt.Errorf("this is not supported anymore, node selector will from now on always be enforced")
+		}
+	case "enforce-toleration":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.Sync.ToHost.Pods.EnforceTolerations = append(newConfig.Sync.ToHost.Pods.EnforceTolerations, strings.Split(value, ",")...)
+	case "node-selector":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.Sync.FromHost.Nodes.Enabled = true
+		newConfig.Sync.FromHost.Nodes.Selector.Labels = mergeIntoMap(newConfig.Sync.FromHost.Nodes.Selector.Labels, strings.Split(value, ","))
+	case "service-account":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.ControlPlane.Advanced.WorkloadServiceAccount.Enabled = false
+		newConfig.ControlPlane.Advanced.WorkloadServiceAccount.Name = value
+	case "override-hosts":
+		if value == "" || value == "true" {
+			newConfig.Sync.ToHost.Pods.RewriteHosts.Enabled = true
+		} else if value == "false" {
+			newConfig.Sync.ToHost.Pods.RewriteHosts.Enabled = false
+		}
+	case "override-hosts-container-image":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.Sync.ToHost.Pods.RewriteHosts.InitContainerImage = value
+	case "cluster-domain":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+
+		newConfig.Networking.Advanced.ClusterDomain = value
+	case "leader-elect":
+		return fmt.Errorf("cannot be used directly")
+	case "lease-duration":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		i, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		newConfig.ControlPlane.StatefulSet.HighAvailability.LeaseDuration = i
+	case "renew-deadline":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		i, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		newConfig.ControlPlane.StatefulSet.HighAvailability.RenewDeadline = i
+	case "retry-period":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		i, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		newConfig.ControlPlane.StatefulSet.HighAvailability.RetryPeriod = i
+	case "disable-plugins":
+		return fmt.Errorf("this is not supported anymore")
+	case "plugin-listen-address":
+		return fmt.Errorf("this is not supported anymore")
+	case "default-image-registry":
+		return fmt.Errorf("shouldn't be used directly, use defaultImageRegistry instead")
+	case "enforce-pod-security-standard":
+		return fmt.Errorf("shouldn't be used directly, use isolation.podSecurityStandard instead")
+	case "plugins":
+		return fmt.Errorf("shouldn't be used directly")
+	case "sync-labels":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.SyncSettings.SyncLabels = append(newConfig.Experimental.SyncSettings.SyncLabels, strings.Split(value, ",")...)
+	case "map-virtual-service":
+		return fmt.Errorf("shouldn't be used directly")
+	case "map-host-service":
+		return fmt.Errorf("shouldn't be used directly")
+	case "host-metrics-bind-address":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.SyncSettings.HostMetricsBindAddress = value
+	case "virtual-metrics-bind-address":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.SyncSettings.VirtualMetricsBindAddress = value
+	case "mount-physical-host-paths":
+		if value == "" || value == "true" {
+			newConfig.ControlPlane.HostPathMapper.Enabled = true
+		}
+	case "multi-namespace-mode":
+		if value == "" || value == "true" {
+			newConfig.Experimental.MultiNamespaceMode.Enabled = true
+		}
+	case "namespace-labels":
+		if value == "" {
+			return fmt.Errorf("value is missing")
+		}
+		newConfig.Experimental.MultiNamespaceMode.NamespaceLabels = mergeIntoMap(newConfig.Experimental.MultiNamespaceMode.NamespaceLabels, strings.Split(value, ","))
+	case "sync-all-configmaps":
+		if value == "" || value == "true" {
+			newConfig.Sync.ToHost.ConfigMaps.All = true
+		}
+	case "sync-all-secrets":
+		if value == "" || value == "true" {
+			newConfig.Sync.ToHost.Secrets.All = true
+		}
+	case "proxy-metrics-server":
+		if value == "" || value == "true" {
+			newConfig.Observability.Metrics.Proxy.Pods = true
+			newConfig.Observability.Metrics.Proxy.Nodes = true
+		}
+	case "service-account-token-secrets":
+		if value == "" || value == "true" {
+			newConfig.Sync.ToHost.Pods.UseSecretsForSATokens = true
+		}
+	case "sync-node-changes":
+		if value == "" || value == "true" {
+			newConfig.Sync.FromHost.Nodes.SyncBackChanges = true
+		}
+	default:
+		return fmt.Errorf("flag %s does not exist", key)
+	}
+
+	return nil
+}
+
+func applyStorage(oldConfig Storage, newConfig *config.Config) {
+	if oldConfig.Persistence != nil {
+		newConfig.ControlPlane.StatefulSet.Persistence.VolumeClaim.Enabled = config.StrBool(strconv.FormatBool(*oldConfig.Persistence))
+	}
+	if oldConfig.Size != "" {
+		newConfig.ControlPlane.StatefulSet.Persistence.VolumeClaim.Size = oldConfig.Size
+	}
+	if oldConfig.ClassName != "" {
+		newConfig.ControlPlane.StatefulSet.Persistence.VolumeClaim.StorageClass = oldConfig.ClassName
+	}
+}
+
+func convertVClusterConfig(oldConfig VClusterValues, retDistroCommon *config.DistroCommon, retDistroContainer *config.DistroContainer, newConfig *config.Config) error {
+	retDistroCommon.Env = oldConfig.Env
+	convertImage(oldConfig.Image, &retDistroContainer.Image)
+	if len(oldConfig.Resources) > 0 {
+		retDistroCommon.Resources = oldConfig.Resources
+	}
+	retDistroContainer.ExtraArgs = append(retDistroContainer.ExtraArgs, oldConfig.ExtraArgs...)
+	if oldConfig.ImagePullPolicy != "" {
+		retDistroContainer.ImagePullPolicy = oldConfig.ImagePullPolicy
+	}
+
+	if len(oldConfig.BaseArgs) > 0 {
+		return fmt.Errorf("vcluster.baseArgs is not supported anymore, please use controlPlane.distro.k3s.command or controlPlane.distro.k3s.extraArgs instead")
+	}
+	if len(oldConfig.Command) > 0 {
+		return fmt.Errorf("vcluster.command is not supported anymore, please use controlPlane.distro.k3s.command or controlPlane.distro.k3s.extraArgs instead")
+	}
+	if oldConfig.PriorityClassName != "" {
+		return fmt.Errorf("vcluster.priorityClassName is not supported anymore, please manually upgrade this field")
+	}
+
+	newConfig.ControlPlane.StatefulSet.Persistence.AddVolumeMounts = append(newConfig.ControlPlane.StatefulSet.Persistence.AddVolumeMounts, oldConfig.ExtraVolumeMounts...)
+	newConfig.ControlPlane.StatefulSet.Persistence.AddVolumes = append(newConfig.ControlPlane.StatefulSet.Persistence.AddVolumes, oldConfig.VolumeMounts...)
+	return nil
+}
+
+func convertImage(image string, into *config.Image) {
+	if image == "" {
+		return
+	}
+
+	imageSplitted := strings.Split(image, ":")
+	if len(imageSplitted) == 1 {
+		return
+	}
+
+	into.Repository = strings.Join(imageSplitted[:len(imageSplitted)-1], ":")
+	into.Tag = imageSplitted[len(imageSplitted)-1]
+}
+
+func mergeIntoMap(retMap map[string]string, arr []string) map[string]string {
+	if retMap == nil {
+		retMap = map[string]string{}
+	}
+
+	for _, value := range arr {
+		splitValue := strings.SplitN(strings.TrimSpace(value), "=", 2)
+		if len(splitValue) != 2 {
+			continue
+		}
+
+		retMap[splitValue[0]] = splitValue[1]
+	}
+
+	return retMap
+}
+
+func nextFlagValue(args []string) (string, string, []string, error) {
+	if len(args) == 0 {
+		return "", "", nil, nil
+	} else if !strings.HasPrefix(args[0], "--") {
+		return "", "", nil, fmt.Errorf("unexpected extra argument %s", args[0])
+	}
+
+	flagName := strings.TrimPrefix(args[0], "--")
+	args = args[1:]
+
+	// check if flag has value
+	if strings.Contains(flagName, "=") {
+		splittedFlag := strings.SplitN(flagName, "=", 2)
+		return splittedFlag[0], splittedFlag[1], args, nil
+	} else if len(args) > 0 && !strings.HasPrefix(args[0], "--") {
+		value := args[0]
+		args = args[1:]
+		return flagName, value, args, nil
+	}
+
+	return flagName, "", args, nil
+}
+
+func convertObject(from, to interface{}) error {
+	out, err := json.Marshal(from)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(out, to)
+}

--- a/pkg/config/legacyconfig/migrate_test.go
+++ b/pkg/config/legacyconfig/migrate_test.go
@@ -1,0 +1,324 @@
+package legacyconfig
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type TestCaseMigration struct {
+	Name string
+
+	Distro string
+	In     string
+
+	Expected    string
+	ExpectedErr string
+}
+
+func TestMigration(t *testing.T) {
+	testCases := []TestCaseMigration{
+		{
+			Name:   "Simple k3s",
+			Distro: "k3s",
+			Expected: `controlPlane:
+  distro:
+    k3s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+		{
+			Name:   "Simple k0s",
+			Distro: "k0s",
+			Expected: `controlPlane:
+  distro:
+    k0s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+		{
+			Name:   "Plugin k3s",
+			Distro: "k3s",
+			In: `plugin:
+  test:
+    version: v2`,
+			Expected: `controlPlane:
+  distro:
+    k3s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+plugin:
+  test:
+    version: v2`,
+		},
+		{
+			Name:   "Simple k8s",
+			Distro: "k8s",
+			In: `sync:
+  ingresses:
+    enabled: true`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+sync:
+  toHost:
+    ingresses:
+      enabled: true`,
+		},
+		{
+			Name:   "Simple eks",
+			Distro: "eks",
+			In: `sync:
+  ingresses:
+    enabled: true`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    eks:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+sync:
+  toHost:
+    ingresses:
+      enabled: true`,
+		},
+		{
+			Name:   "generic sync example",
+			Distro: "k3s",
+			In: `multiNamespaceMode:
+  enabled: true
+sync:
+  generic:
+    role:
+      extraRules:
+        - apiGroups: ["cert-manager.io"]
+          resources: ["issuers", "certificates"]
+          verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+    clusterRole:
+      extraRules:
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources: ["customresourcedefinitions"]
+          verbs: ["get", "list", "watch"]
+    config: |-
+      version: v1beta1
+      export:
+        - apiVersion: cert-manager.io/v1
+          kind: Issuer
+        - apiVersion: cert-manager.io/v1
+          kind: Certificate
+      import:
+        - kind: Secret
+          apiVersion: v1`,
+			Expected: `controlPlane:
+  distro:
+    k3s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+experimental:
+  genericSync:
+    export:
+    - apiVersion: cert-manager.io/v1
+      kind: Issuer
+    - apiVersion: cert-manager.io/v1
+      kind: Certificate
+    import:
+    - apiVersion: v1
+      kind: Secret
+    version: v1beta1
+  multiNamespaceMode:
+    enabled: true`,
+		},
+		{
+			Name:   "persistence false",
+			Distro: "k3s",
+			In: `syncer:
+  storage:
+    persistence: false`,
+			Expected: `controlPlane:
+  distro:
+    k3s:
+      enabled: true
+  statefulSet:
+    persistence:
+      volumeClaim:
+        enabled: false
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+		{
+			Name:   "vcluster env",
+			Distro: "k3s",
+			In: `vcluster:
+  env:
+  - name: K3S_DATASTORE_ENDPOINT
+    value: postgres://username:password@hostname:5432/k3s`,
+			Expected: `controlPlane:
+  distro:
+    k3s:
+      enabled: true
+      env:
+      - name: K3S_DATASTORE_ENDPOINT
+        value: postgres://username:password@hostname:5432/k3s
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+		{
+			Name:   "high availability",
+			Distro: "k8s",
+			In: `syncer:
+  replicas: 3
+etcd:
+  replicas: 3
+coredns:
+  replicas: 3`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+        statefulSet:
+          highAvailability:
+            replicas: 3
+  coredns:
+    deployment:
+      replicas: 3
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    highAvailability:
+      replicas: 3
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+		{
+			Name:   "fallback host dns",
+			Distro: "k0s",
+			In: `fallbackHostDns: true
+pro: true`,
+			Expected: `controlPlane:
+  distro:
+    k0s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+networking:
+  advanced:
+    fallbackHostCluster: true
+pro: true`,
+		},
+		{
+			Name:   "isolated mode",
+			Distro: "k0s",
+			In: `isolation:
+  enabled: true
+  podSecurityStandard: baseline
+  resourceQuota:
+    enabled: true
+  limitRange:
+    enabled: true
+  networkPolicy:
+    enabled: false`,
+			Expected: `controlPlane:
+  distro:
+    k0s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+policies:
+  limitRange:
+    enabled: true
+  podSecurityStandard: baseline
+  resourceQuota:
+    enabled: true`,
+		},
+		{
+			Name:   "convert flags",
+			Distro: "k0s",
+			In: `syncer:
+  extraArgs:
+  - --tls-san=my-vcluster.example.com
+  - --service-account-token-secrets=true
+  - --mount-physical-host-paths=true
+  - --sync-all-nodes`,
+			Expected: `controlPlane:
+  distro:
+    k0s:
+      enabled: true
+  hostPathMapper:
+    enabled: true
+  proxy:
+    extraSANs:
+    - my-vcluster.example.com
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+sync:
+  fromHost:
+    nodes:
+      selector:
+        all: true
+  toHost:
+    pods:
+      useSecretsForSATokens: true`,
+		},
+		{
+			Name:   "embedded etcd",
+			Distro: "k8s",
+			In: `embeddedEtcd:
+  enabled: true`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      embedded:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		out, err := MigrateLegacyConfig(testCase.Distro, testCase.In)
+		if err != nil {
+			if testCase.ExpectedErr != "" && testCase.ExpectedErr == err.Error() {
+				continue
+			}
+
+			t.Fatalf("Test case %s failed with: %v", testCase.Name, err)
+		}
+
+		if strings.TrimSpace(testCase.Expected) != strings.TrimSpace(out) {
+			t.Log(out)
+		}
+		assert.Equal(t, strings.TrimSpace(testCase.Expected), strings.TrimSpace(out), testCase.Name)
+	}
+}

--- a/pkg/config/legacyconfig/options.go
+++ b/pkg/config/legacyconfig/options.go
@@ -1,8 +1,4 @@
-package config
-
-const (
-	DefaultHostsRewriteImage = "library/alpine:3.13.1"
-)
+package legacyconfig
 
 // LegacyVirtualClusterOptions holds the cmd flags
 type LegacyVirtualClusterOptions struct {

--- a/pkg/plugin/v1/plugin.go
+++ b/pkg/plugin/v1/plugin.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/config/legacyconfig"
 	plugintypes "github.com/loft-sh/vcluster/pkg/plugin/types"
 	"github.com/loft-sh/vcluster/pkg/util/kubeconfig"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
@@ -166,7 +166,7 @@ func (m *Manager) Start(
 	virtualKubeConfig *rest.Config,
 	physicalKubeConfig *rest.Config,
 	syncerConfig *clientcmdapi.Config,
-	options *config.LegacyVirtualClusterOptions,
+	options *legacyconfig.LegacyVirtualClusterOptions,
 ) error {
 	// set if we have plugins
 	m.hasPlugins.Store(len(options.Plugins) > 0)
@@ -239,7 +239,7 @@ func (m *Manager) Start(
 	return m.waitForPlugins(ctx, options)
 }
 
-func (m *Manager) waitForPlugins(ctx context.Context, options *config.LegacyVirtualClusterOptions) error {
+func (m *Manager) waitForPlugins(ctx context.Context, options *legacyconfig.LegacyVirtualClusterOptions) error {
 	for _, plugin := range options.Plugins {
 		klog.Infof("Waiting for plugin %s to register...", plugin)
 		err := wait.PollUntilContextTimeout(ctx, time.Millisecond*100, time.Minute*10, true, func(context.Context) (done bool, err error) {

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -52,14 +52,14 @@ func NewControllerContext(ctx context.Context, options *config.VirtualClusterCon
 
 	// local manager bind address
 	localManagerMetrics := "0"
-	if options.Experimental.SyncSettings.LocalManagerMetricsBindAddress != "" {
-		localManagerMetrics = options.Experimental.SyncSettings.LocalManagerMetricsBindAddress
+	if options.Experimental.SyncSettings.HostMetricsBindAddress != "" {
+		localManagerMetrics = options.Experimental.SyncSettings.HostMetricsBindAddress
 	}
 
 	// virtual manager bind address
 	virtualManagerMetrics := "0"
-	if options.Experimental.SyncSettings.VirtualManagerMetricsBindAddress != "" {
-		virtualManagerMetrics = options.Experimental.SyncSettings.VirtualManagerMetricsBindAddress
+	if options.Experimental.SyncSettings.VirtualMetricsBindAddress != "" {
+		virtualManagerMetrics = options.Experimental.SyncSettings.VirtualMetricsBindAddress
 	}
 
 	// create physical manager


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

Resolves ENG-3085

**What does it do?**
* This PR adds a migration function that is able to convert the old helm `values.yaml` into the new `vcluster.yaml` format.
* Changes the default value of `fallbackHostDns` back to `false`, which was a mistake introduced when changing the `values.yaml` format