### PR TITLE
moved withinterceptor so it can catch the info from the context

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -353,7 +353,6 @@ func createCachedClient(ctx context.Context, config *rest.Config, namespace stri
 func (s *Server) buildHandlerChain(serverConfig *server.Config) http.Handler {
 	defaultHandler := DefaultBuildHandlerChain(s.handler, serverConfig)
 	defaultHandler = filters.WithNodeName(defaultHandler, s.currentNamespace, s.fakeKubeletIPs, s.cachedVirtualClient, s.currentNamespaceClient)
-	defaultHandler = plugin.DefaultManager.WithInterceptors(defaultHandler)
 	return defaultHandler
 }
 
@@ -424,6 +423,10 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *server.Config) http.Ha
 		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
 	}
 	handler = genericapifilters.WithLatencyTrackers(handler)
+
+	// this is for the plugins to be able to catch the requests with the info in the
+	// context
+	handler = plugin.DefaultManager.WithInterceptors(handler)
 	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
 	handler = genericapifilters.WithRequestReceivedTimestamp(handler)
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster plugins wouldn't get the context info because it's not there yet 


**What else do we need to know?** 
