### PR TITLE
feat: add "migrate values" command to migrate to new values format

### DIFF
--- a/cmd/vclusterctl/cmd/migrate/migrate.go
+++ b/cmd/vclusterctl/cmd/migrate/migrate.go
@@ -1,0 +1,22 @@
+package migrate
+
+import (
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
+	"github.com/spf13/cobra"
+)
+
+func NewMigrateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	migrateCmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate vcluster configuration",
+		Long: `
+#######################################################
+################## vcluster migrate ###################
+#######################################################
+	`,
+		Args: cobra.NoArgs,
+	}
+
+	migrateCmd.AddCommand(migrateValues(globalFlags))
+	return migrateCmd
+}

--- a/cmd/vclusterctl/cmd/migrate/values.go
+++ b/cmd/vclusterctl/cmd/migrate/values.go
@@ -38,10 +38,9 @@ func migrateValues(globalFlags *flags.GlobalFlags) *cobra.Command {
 Migrates values for a vcluster to the new format
 
 Examples:
-vcluster migrate values -f /my/k8s/values.yaml
-vcluster migrate values --distro k3s -f /my/k3s/values.yaml
-vcluster migrate values --distro k0s < /my/k0s/values.yaml
-cat /my/k8s/values.yaml | vcluster migrate values --distro k8s
+vcluster migrate values --distro k8s -f /my/k8s/values.yaml
+vcluster migrate values --distro k3s < /my/k3s/values.yaml
+cat /my/k0s/values.yaml | vcluster migrate values --distro k0s
 #######################################################
 	`,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -49,7 +48,7 @@ cat /my/k8s/values.yaml | vcluster migrate values --distro k8s
 		}}
 
 	cobraCmd.Flags().StringVarP(&c.filePath, "file", "f", "", "Path to the input file")
-	cobraCmd.Flags().StringVar(&c.distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro of the values. Allowed distros: %s", strings.Join([]string{"k8s", "k3s", "k0s", "eks"}, ", ")))
+	cobraCmd.Flags().StringVar(&c.distro, "distro", "", fmt.Sprintf("Kubernetes distro of the values. Allowed distros: %s", strings.Join([]string{"k8s", "k3s", "k0s", "eks"}, ", ")))
 	cobraCmd.Flags().StringVarP(&c.format, "output", "o", "yaml", "Prints the output in the specified format. Allowed values: yaml, json")
 
 	return cobraCmd
@@ -60,6 +59,10 @@ func (cmd *valuesCmd) Run() error {
 		migratedConfig string
 		err            error
 	)
+
+	if cmd.distro == "" {
+		return fmt.Errorf("no distro given: please set \"--distro\" (IMPORTANT: distro must match the given values)")
+	}
 
 	if cmd.filePath != "" {
 		file, err := os.Open(cmd.filePath)

--- a/cmd/vclusterctl/cmd/migrate/values.go
+++ b/cmd/vclusterctl/cmd/migrate/values.go
@@ -35,7 +35,7 @@ func migrateValues(globalFlags *flags.GlobalFlags) *cobra.Command {
 #######################################################
 ############### vcluster migrate values ###############
 #######################################################
-Migrates values for a vcluster to the new format
+Migrates values for a vcluster to the 0.20 format
 
 Examples:
 vcluster migrate values --distro k8s -f /my/k8s/values.yaml

--- a/cmd/vclusterctl/cmd/migrate/values.go
+++ b/cmd/vclusterctl/cmd/migrate/values.go
@@ -1,0 +1,109 @@
+package migrate
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
+	"github.com/loft-sh/vcluster/pkg/config/legacyconfig"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type valuesCmd struct {
+	*flags.GlobalFlags
+	log      log.Logger
+	distro   string
+	filePath string
+	format   string
+}
+
+func migrateValues(globalFlags *flags.GlobalFlags) *cobra.Command {
+	c := &valuesCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "values",
+		Short: "Migrates current cluster values",
+		Long: `
+#######################################################
+############### vcluster migrate values ###############
+#######################################################
+Migrates values for a vcluster to the new format
+
+Examples:
+vcluster migrate values -f /my/k8s/values.yaml
+vcluster migrate values --distro k3s -f /my/k3s/values.yaml
+vcluster migrate values --distro k0s < /my/k0s/values.yaml
+cat /my/k8s/values.yaml | vcluster migrate values --distro k8s
+#######################################################
+	`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.Run()
+		}}
+
+	cobraCmd.Flags().StringVarP(&c.filePath, "file", "f", "", "Path to the input file")
+	cobraCmd.Flags().StringVar(&c.distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro of the values. Allowed distros: %s", strings.Join([]string{"k8s", "k3s", "k0s", "eks"}, ", ")))
+	cobraCmd.Flags().StringVarP(&c.format, "output", "o", "yaml", "Prints the output in the specified format. Allowed values: yaml, json")
+
+	return cobraCmd
+}
+
+func (cmd *valuesCmd) Run() error {
+	var (
+		migratedConfig string
+		err            error
+	)
+
+	if cmd.filePath != "" {
+		file, err := os.Open(cmd.filePath)
+		if err != nil {
+			return err
+		}
+		migratedConfig, err = migrate(cmd.distro, file)
+		if err != nil {
+			return fmt.Errorf("unable to migrate config values: %w", err)
+		}
+		defer file.Close()
+	} else {
+		// If no files provided, read from stdin
+		migratedConfig, err = migrate(cmd.distro, os.Stdin)
+		if err != nil {
+			return fmt.Errorf("unable to migrate config values: %w", err)
+		}
+	}
+
+	var out string
+	switch cmd.format {
+	case "json":
+		j, err := yaml.ToJSON([]byte(migratedConfig))
+		if err != nil {
+			return err
+		}
+		out = string(j)
+	case "yaml":
+		out = migratedConfig
+	default:
+		fmt.Fprintf(os.Stderr, "unsupported output format: %s. falling back to yaml\n", cmd.format)
+		out = migratedConfig
+	}
+
+	cmd.log.WriteString(logrus.InfoLevel, out)
+
+	return nil
+}
+
+func migrate(distro string, r io.Reader) (string, error) {
+	content, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+
+	return legacyconfig.MigrateLegacyConfig(distro, string(content))
+}

--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/get"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/migrate"
 	cmdpro "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/pro"
 	cmdtelemetry "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/telemetry"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
@@ -89,6 +90,7 @@ func BuildRoot(log log.Logger) (*cobra.Command, error) {
 	rootCmd.AddCommand(NewDisconnectCmd(globalFlags))
 	rootCmd.AddCommand(NewUpgradeCmd())
 	rootCmd.AddCommand(get.NewGetCmd(globalFlags))
+	rootCmd.AddCommand(migrate.NewMigrateCmd(globalFlags))
 	rootCmd.AddCommand(cmdtelemetry.NewTelemetryCmd())
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(NewInfoCmd())


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves ENG-3274


**Please provide a short message that should be published in the vcluster release notes**
Add "migrate values" command to vcluster in order to convert the old values format to the new format introduced with 0.20


**What else do we need to know?** 
Current caveat is that the passed in values actually match`--distro`. Otherwise the `MigrateLegacyConfig` currently will simply create new default values for the given distro in the new format. So I made `--distro` mandatory with a warning that it should exactly match the provided values.