### PR TITLE
fix: add coredns version map with key equales to 1.26 item

### DIFF
--- a/pkg/constants/coredns.go
+++ b/pkg/constants/coredns.go
@@ -2,6 +2,7 @@ package constants
 
 var CoreDNSVersionMap = map[string]string{
 	"1.27": "coredns/coredns:1.10.1",
+	"1.26": "coredns/coredns:1.9.3",
 	"1.25": "coredns/coredns:1.9.3",
 	"1.24": "coredns/coredns:1.8.7",
 	"1.23": "coredns/coredns:1.8.6",


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
fix: add coredns version map with kubernetes version equales to 1.26 item

**What else do we need to know?** 
According to https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md
when instsall kubernetes version 1.26,  it is supposed to install coredns/coredns:1.9.3 respectively
so I add this bug fix
