### PR TITLE
now sets up the controller with the exportkubeconfig namespace if it is set

### DIFF
--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -103,9 +103,15 @@ func NewControllerContext(ctx context.Context, options *config.VirtualClusterCon
 
 func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	// is multi namespace mode?
-	var defaultNamespaces map[string]cache.Config
+	defaultNamespaces := make(map[string]cache.Config)
 	if !options.Experimental.MultiNamespaceMode.Enabled {
-		defaultNamespaces = map[string]cache.Config{options.WorkloadTargetNamespace: {}}
+		defaultNamespaces[options.WorkloadTargetNamespace] = cache.Config{}
+	}
+	// do we need access to another namespace to export the kubeconfig ?
+	// we will need access to all the objects that the vcluster usually has access to
+	// otherwise the controller will not start
+	if options.ExportKubeConfig.Secret.Namespace != "" {
+		defaultNamespaces[options.ExportKubeConfig.Secret.Namespace] = cache.Config{}
 	}
 
 	return cache.Options{DefaultNamespaces: defaultNamespaces}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of eng-3332


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster wouldn't be able to create the kubeconfig secret in another namespace 


**What else do we need to know?** 
