### PR TITLE
fix: NetworkPolicies of Control-Planes

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -30,7 +30,7 @@ spec:
     - ports:
         - port: 443
         - port: 8443
-      to:
+    - to:
         - podSelector:
             matchLabels:
               release: {{ .Release.Name }}
@@ -78,21 +78,25 @@ spec:
     matchLabels:
       release: {{ .Release.Name }}
   egress:
-    # Allows outgoing connections to all pods with
-    # port 443, 8443 or 6443. This is needed for host Kubernetes
-    # access
+    # Allows outgoing connections to all necessary pods with
+    # port 443, 8443 or 6443 or system dns. This is needed for
+    # host Kubernetes access.
     - ports:
         - port: 443
         - port: 8443
         - port: 6443
-    # Allows outgoing connections to all vcluster workloads
-    # or kube system dns server
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
     - to:
-        - podSelector: {}
+        - podSelector:
+            matchLabels:
+              release: {{ .Release.Name }}
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: 'kube-system'
-          podSelector:
+        - podSelector:
             matchLabels:
               k8s-app: kube-dns
   policyTypes:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

This pull request will fix networkpolicies of control-planes. Since from v0.19.x, the control-plane will pack into single
pod. The issue is not obvious. 

**Please provide a short message that should be published in the vcluster release notes**

We encounter a issue with v0.18.x + k8s. After some investigation from our team, we found
the rule to system's host-dns is missing.

And we look into several version, we think the networkpolicies should be fixed.


**What else do we need to know?** 
