### PR TITLE
feat: Adding option --use-kubeconfig in vcluster cli arguments,

### DIFF
--- a/cmd/vclusterctl/cmd/completion.go
+++ b/cmd/vclusterctl/cmd/completion.go
@@ -51,7 +51,7 @@ func wrapCompletionFuncWithTimeout(defaultDirective cobra.ShellCompDirective, co
 // It takes into account the namespace if specified by the --namespace flag.
 func newValidVClusterNameFunc(globalFlags *flags.GlobalFlags) completionFunc {
 	fn := func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		vclusters, err := find.ListVClusters(cmd.Context(), globalFlags.Context, "", globalFlags.Namespace, log.Default.ErrorStreamOnly())
+		vclusters, err := find.ListVClusters(cmd.Context(), globalFlags.UseKubeConfig, globalFlags.Context, "", globalFlags.Namespace, log.Default.ErrorStreamOnly())
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
 		}

--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -74,7 +74,6 @@ vcluster connect test -n test -- kubectl get ns
 
 	// platform
 	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The platform project the vCluster is in")
-
 	return cobraCmd
 }
 

--- a/pkg/cli/activate_platform.go
+++ b/pkg/cli/activate_platform.go
@@ -47,7 +47,7 @@ func ActivatePlatform(ctx context.Context, options *ActivateOptions, globalFlags
 	}
 
 	if globalFlags.Namespace == "" {
-		globalFlags.Namespace, err = GetVClusterNamespace(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
+		globalFlags.Namespace, err = GetVClusterNamespace(ctx, globalFlags.UseKubeConfig, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
 		if err != nil {
 			log.Warnf("Error retrieving vCluster namespace: %v", err)
 		}
@@ -68,13 +68,13 @@ func ActivatePlatform(ctx context.Context, options *ActivateOptions, globalFlags
 	return nil
 }
 
-func GetVClusterNamespace(ctx context.Context, context, name, namespace string, log log.Logger) (string, error) {
+func GetVClusterNamespace(ctx context.Context, kubeconfigPath, context, name, namespace string, log log.Logger) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("please specify a name")
 	}
 
 	// list virtual clusters
-	ossVClusters, err := find.ListOSSVClusters(ctx, context, name, namespace)
+	ossVClusters, err := find.ListOSSVClusters(ctx, kubeconfigPath, context, name, namespace)
 	if err != nil {
 		log.Warnf("Error retrieving vclusters: %v", err)
 		return "", err

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -79,7 +79,7 @@ func ConnectHelm(ctx context.Context, options *ConnectOptions, globalFlags *flag
 	}
 
 	// retrieve the vcluster
-	vCluster, err := find.GetVCluster(ctx, cmd.Context, vClusterName, cmd.Namespace, cmd.Log)
+	vCluster, err := find.GetVCluster(ctx, cmd.UseKubeConfig, cmd.Context, vClusterName, cmd.Namespace, cmd.Log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -55,7 +55,7 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 	}
 
 	// find vcluster
-	vCluster, err := find.GetVCluster(ctx, cmd.Context, vClusterName, cmd.Namespace, cmd.log)
+	vCluster, err := find.GetVCluster(ctx, cmd.UseKubeConfig, cmd.Context, vClusterName, cmd.Namespace, cmd.log)
 	if err != nil {
 		if !cmd.IgnoreNotFound {
 			return err
@@ -159,7 +159,7 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 	}
 
 	// check if there are any other vclusters in the namespace you are deleting vcluster in.
-	vClusters, err := find.ListVClusters(ctx, cmd.Context, "", cmd.Namespace, cmd.log)
+	vClusters, err := find.ListVClusters(ctx, cmd.UseKubeConfig, cmd.Context, "", cmd.Namespace, cmd.log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -6,12 +6,13 @@ import (
 
 // GlobalFlags is the flags that contains the global flags
 type GlobalFlags struct {
-	Silent    bool
-	Debug     bool
-	Config    string
-	Context   string
-	Namespace string
-	LogOutput string
+	Silent        bool
+	Debug         bool
+	Config        string
+	UseKubeConfig string
+	Context       string
+	Namespace     string
+	LogOutput     string
 }
 
 // SetGlobalFlags applies the global flags
@@ -19,6 +20,7 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	globalFlags := &GlobalFlags{}
 
 	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")
+	flags.StringVar(&globalFlags.UseKubeConfig, "use-kubeconfig", "", "The kubernetes config file path to use")
 	flags.StringVar(&globalFlags.Context, "context", "", "The kubernetes config context to use")
 	flags.StringVarP(&globalFlags.Namespace, "namespace", "n", "", "The kubernetes namespace to use")
 	flags.BoolVarP(&globalFlags.Silent, "silent", "s", false, "Run in silent mode and prevents any vcluster log output except panics & fatals")

--- a/pkg/cli/list_helm.go
+++ b/pkg/cli/list_helm.go
@@ -50,7 +50,7 @@ func ListHelm(ctx context.Context, options *ListOptions, globalFlags *flags.Glob
 		namespace = globalFlags.Namespace
 	}
 
-	vClusters, err := find.ListVClusters(ctx, globalFlags.Context, "", namespace, log.ErrorStreamOnly())
+	vClusters, err := find.ListVClusters(ctx, globalFlags.UseKubeConfig, globalFlags.Context, "", namespace, log.ErrorStreamOnly())
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func printVClusters(ctx context.Context, options *ListOptions, output []ListVClu
 			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			defer cancel()
 
-			vClusters, _ := find.ListVClusters(ctx, globalFlags.Context, "", "", log.Discard)
+			vClusters, _ := find.ListVClusters(ctx, globalFlags.UseKubeConfig, globalFlags.Context, "", "", log.Discard)
 			if len(vClusters) > 0 {
 				logger.Infof("You also have %d virtual clusters in your current kube-context.", len(vClusters))
 				logger.Info("If you want to see them, run: 'vcluster list --manager helm' or 'vcluster use manager helm' to change the default")

--- a/pkg/cli/pause_helm.go
+++ b/pkg/cli/pause_helm.go
@@ -20,7 +20,7 @@ type PauseOptions struct {
 
 func PauseHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	// find vcluster
-	vCluster, err := find.GetVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
+	vCluster, err := find.GetVCluster(ctx, globalFlags.UseKubeConfig, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/resume_helm.go
+++ b/pkg/cli/resume_helm.go
@@ -18,7 +18,7 @@ type ResumeOptions struct {
 }
 
 func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
-	vCluster, err := find.GetVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
+	vCluster, err := find.GetVCluster(ctx, globalFlags.UseKubeConfig, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
feat: Adding option --use-kubeconfig in vcluster cli arguments, which specify the kubeconfig file to be used for vcluster cli

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1724 


**Please provide a short message that should be published in the vcluster release notes**
according to the describtion of this issue ,  I try to work on this and add some code to impliment this feature
well, there is a slightly different thing which is that I use  `--use-kubeconfig` as the globalflag, because  `--kube-config` flag has already been defined in other subcommand,  for example  when execute 
```
$ vcluster connect -h 
. . . . . .
    --kube-config string                Writes the created kube config to this file (default "./kubeconfig.yaml")
. . . . . .

```

**What else do we need to know?** 
this `--use-kubeconfig`  flag support  user input  `relative file path and absolute path`
