### PR TITLE
Check pre 0.20 values vclusterctl

### DIFF
--- a/.github/workflows/sync-config.yaml
+++ b/.github/workflows/sync-config.yaml
@@ -21,6 +21,11 @@ jobs:
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Clone and update
         run: |
           git clone --single-branch https://github.com/loft-sh/vcluster-config.git
@@ -32,6 +37,10 @@ jobs:
 
           # We have to replace our config dependency so that we do not introduce vcluster as a whole as transitive dependecy.
           find ./config/legacyconfig -type f -exec sed -i "s#github.com/loft-sh/vcluster/config#github.com/loft-sh/vcluster-config/config#g" {} +
+
+          # Align deps, if there have been any relevant changes in vcluster.
+          go mod tidy
+          go mod vendor
 
           # Checkout new branch
           git add --all

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,10 @@ func (c *Config) UnmarshalYAMLStrict(data []byte) error {
 	return UnmarshalYAMLStrict(data, c)
 }
 
+func (c *Config) MarshalYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
 // BackingStoreType returns the backing store type of the vCluster.
 // If no backing store is enabled, it returns StoreTypeUnknown.
 func (c *Config) BackingStoreType() StoreType {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,17 +1,15 @@
 package config
 
 import (
-	"bytes"
 	_ "embed"
-	"io"
 	"testing"
 
 	"gotest.tools/assert"
 )
 
-func TestConfig_DecodeYAML(t *testing.T) {
+func TestConfig_UnmarshalYAMLStrict(t *testing.T) {
 	type args struct {
-		r io.Reader
+		data []byte
 	}
 	tests := []struct {
 		name    string
@@ -21,30 +19,30 @@ func TestConfig_DecodeYAML(t *testing.T) {
 		{
 			name: "Invalid: yaml",
 			args: args{
-				r: bytes.NewReader([]byte(`
+				data: []byte(`
 foo:
   bar: baz
-`)),
+`),
 			},
 			wantErr: true,
 		},
 		{
 			name: "Invalid: json",
 			args: args{
-				r: bytes.NewReader([]byte(`
+				data: []byte(`
 {
   "foo": {
     "bar": "baz"
   }
 }
-`)),
+`),
 			},
 			wantErr: true,
 		},
 		{
 			name: "Invalid: Old values format",
 			args: args{
-				r: bytes.NewReader([]byte(`
+				data: []byte(`
 api:
   image: registry.k8s.io/kube-apiserver:v1.29.0
 controller:
@@ -61,26 +59,26 @@ sync:
    enabled: true
 telemetry:
   disabled: false
-`)),
+`),
 			},
 			wantErr: true,
 		},
 		{
 			name: "Success: New values format",
 			args: args{
-				r: bytes.NewReader([]byte(`
+				data: []byte(`
 controlPlane:
   distro:
     k8s:
       enabled: true
-`)),
+`),
 			},
 			wantErr: false,
 		},
 		{
 			name: "Success: New values format (json)",
 			args: args{
-				r: bytes.NewReader([]byte(`
+				data: []byte(`
 {
   "controlPlane": {
     "distro": {
@@ -90,7 +88,7 @@ controlPlane:
     }
   }
 }
-`)),
+`),
 			},
 			wantErr: false,
 		},
@@ -98,8 +96,8 @@ controlPlane:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Config{}
-			if err := c.DecodeYAML(tt.args.r); (err != nil) != tt.wantErr {
-				t.Errorf("Config.DecodeYAML() error = %v, wantErr %v", err, tt.wantErr)
+			if err := c.UnmarshalYAMLStrict(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("Config.UnmarshalYAMLStrict() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/config/diff.go
+++ b/config/diff.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // ErrUnsupportedType is returned if the type is not implemented

--- a/config/legacyconfig/config.go
+++ b/config/legacyconfig/config.go
@@ -1,6 +1,14 @@
 package legacyconfig
 
-import "github.com/loft-sh/vcluster/config"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/ghodss/yaml"
+	"github.com/loft-sh/vcluster/config"
+)
 
 type LegacyK0sAndK3s struct {
 	BaseHelm
@@ -12,6 +20,28 @@ type LegacyK0sAndK3s struct {
 	Storage                          Storage            `json:"storage,omitempty"`
 }
 
+func (c *LegacyK0sAndK3s) DecodeYAML(r io.Reader) error {
+	o, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	j, err := yaml.YAMLToJSON(o)
+	if err != nil {
+		return err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.DisallowUnknownFields()
+
+	err = dec.Decode(c)
+	if err != nil {
+		return fmt.Errorf("%w: %w", config.ErrInvalidFileFormat, err)
+	}
+
+	return nil
+}
+
 type LegacyK8s struct {
 	BaseHelm
 	Syncer       K8sSyncerValues    `json:"syncer,omitempty"`
@@ -21,6 +51,28 @@ type LegacyK8s struct {
 	Etcd         EtcdValues         `json:"etcd,omitempty"`
 	EmbeddedEtcd EmbeddedEtcdValues `json:"embeddedEtcd,omitempty"`
 	Storage      Storage            `json:"storage,omitempty"`
+}
+
+func (c *LegacyK8s) DecodeYAML(r io.Reader) error {
+	o, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	j, err := yaml.YAMLToJSON(o)
+	if err != nil {
+		return err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.DisallowUnknownFields()
+
+	err = dec.Decode(c)
+	if err != nil {
+		return fmt.Errorf("%w: %w", config.ErrInvalidFileFormat, err)
+	}
+
+	return nil
 }
 
 type K8sSyncerValues struct {

--- a/config/legacyconfig/config.go
+++ b/config/legacyconfig/config.go
@@ -175,6 +175,7 @@ type BaseHelm struct {
 	Init               InitValues       `json:"init,omitempty"`
 	MultiNamespaceMode EnabledSwitch    `json:"multiNamespaceMode,omitempty"`
 	Telemetry          TelemetryValues  `json:"telemetry,omitempty"`
+	ServiceCIDR        string           `json:"serviceCIDR,omitempty"`
 	NoopSyncer         NoopSyncerValues `json:"noopSyncer,omitempty"`
 	Monitoring         MonitoringValues `json:"monitoring,omitempty"`
 	CentralAdmission   AdmissionValues  `json:"centralAdmission,omitempty"`
@@ -251,6 +252,7 @@ type SyncNodes struct {
 }
 
 type SyncGeneric struct {
+	RBACValues
 	Config string `json:"config,omitempty"`
 }
 

--- a/config/legacyconfig/config.go
+++ b/config/legacyconfig/config.go
@@ -1,12 +1,6 @@
 package legacyconfig
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-
-	"github.com/ghodss/yaml"
 	"github.com/loft-sh/vcluster/config"
 )
 
@@ -20,26 +14,8 @@ type LegacyK0sAndK3s struct {
 	Storage                          Storage            `json:"storage,omitempty"`
 }
 
-func (c *LegacyK0sAndK3s) DecodeYAML(r io.Reader) error {
-	o, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
-	j, err := yaml.YAMLToJSON(o)
-	if err != nil {
-		return err
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(j))
-	dec.DisallowUnknownFields()
-
-	err = dec.Decode(c)
-	if err != nil {
-		return fmt.Errorf("%w: %w", config.ErrInvalidFileFormat, err)
-	}
-
-	return nil
+func (c *LegacyK0sAndK3s) UnmarshalYAMLStrict(data []byte) error {
+	return config.UnmarshalYAMLStrict(data, c)
 }
 
 type LegacyK8s struct {
@@ -53,26 +29,8 @@ type LegacyK8s struct {
 	Storage      Storage            `json:"storage,omitempty"`
 }
 
-func (c *LegacyK8s) DecodeYAML(r io.Reader) error {
-	o, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
-	j, err := yaml.YAMLToJSON(o)
-	if err != nil {
-		return err
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(j))
-	dec.DisallowUnknownFields()
-
-	err = dec.Decode(c)
-	if err != nil {
-		return fmt.Errorf("%w: %w", config.ErrInvalidFileFormat, err)
-	}
-
-	return nil
+func (c *LegacyK8s) UnmarshalYAMLStrict(data []byte) error {
+	return config.UnmarshalYAMLStrict(data, c)
 }
 
 type K8sSyncerValues struct {

--- a/config/legacyconfig/config.go
+++ b/config/legacyconfig/config.go
@@ -1,8 +1,28 @@
 package legacyconfig
 
 import (
+	_ "embed"
+
 	"github.com/loft-sh/vcluster/config"
+	"sigs.k8s.io/yaml"
 )
+
+//go:embed values_k3s.yaml
+var k3sValues string
+
+//go:embed values_k8s.yaml
+var k8sValues string
+
+// NewDefaultK3sLegacyConfig creates a new k3s legacy config based on the legacy_values.yaml, including all default values.
+func NewDefaultK3sLegacyConfig() (*LegacyK0sAndK3s, error) {
+	retConfig := &LegacyK0sAndK3s{}
+	err := yaml.Unmarshal([]byte(k3sValues), retConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return retConfig, nil
+}
 
 type LegacyK0sAndK3s struct {
 	BaseHelm
@@ -18,6 +38,21 @@ func (c *LegacyK0sAndK3s) UnmarshalYAMLStrict(data []byte) error {
 	return config.UnmarshalYAMLStrict(data, c)
 }
 
+func (c *LegacyK0sAndK3s) MarshalYAML() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// NewDefaultK8sLegacyConfig creates a new k8s legacy config based on the legacy_values.yaml, including all default values.
+func NewDefaultK8sLegacyConfig() (*LegacyK8s, error) {
+	retConfig := &LegacyK8s{}
+	err := yaml.Unmarshal([]byte(k8sValues), retConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return retConfig, nil
+}
+
 type LegacyK8s struct {
 	BaseHelm
 	Syncer       K8sSyncerValues    `json:"syncer,omitempty"`
@@ -31,6 +66,10 @@ type LegacyK8s struct {
 
 func (c *LegacyK8s) UnmarshalYAMLStrict(data []byte) error {
 	return config.UnmarshalYAMLStrict(data, c)
+}
+
+func (c *LegacyK8s) MarshalYAML() ([]byte, error) {
+	return yaml.Marshal(c)
 }
 
 type K8sSyncerValues struct {

--- a/config/legacyconfig/config_test.go
+++ b/config/legacyconfig/config_test.go
@@ -1,0 +1,159 @@
+package legacyconfig
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestLegacyK0sAndK3s_DecodeYAML(t *testing.T) {
+	type args struct {
+		r io.Reader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Valid: k3s",
+			args: args{
+				r: strings.NewReader(`
+sync:
+  nodes:
+   enabled: true
+telemetry:
+  disabled: false
+`),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid: k8s",
+			args: args{
+				r: strings.NewReader(`
+api:
+  image: registry.k8s.io/kube-apiserver:v1.29.0
+controller:
+  image: registry.k8s.io/kube-controller-manager:v1.29.0
+etcd:
+  image: registry.k8s.io/etcd:3.5.10-0
+scheduler:
+  image: registry.k8s.io/kube-scheduler:v1.29.0
+service:
+  type: NodePort
+serviceCIDR: 10.96.0.0/16
+sync:
+  nodes:
+   enabled: true
+telemetry:
+  disabled: false
+`),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &LegacyK0sAndK3s{}
+			if err := c.DecodeYAML(tt.args.r); (err != nil) != tt.wantErr {
+				t.Errorf("LegacyK0sAndK3s.DecodeYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLegacyK8s_DecodeYAML(t *testing.T) {
+	type args struct {
+		r io.Reader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Valid: k8s",
+			args: args{
+				r: strings.NewReader(`
+api:
+  image: registry.k8s.io/kube-apiserver:v1.29.0
+controller:
+  image: registry.k8s.io/kube-controller-manager:v1.29.0
+etcd:
+  image: registry.k8s.io/etcd:3.5.10-0
+scheduler:
+  image: registry.k8s.io/kube-scheduler:v1.29.0
+service:
+  type: NodePort
+sync:
+  nodes:
+   enabled: true
+telemetry:
+  disabled: false
+`),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid: eks",
+			args: args{
+				r: strings.NewReader(`
+api:
+  image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.28.2-eks-1-28-6
+controller:
+  image: public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.28.2-eks-1-28-6
+coredns:
+  image: public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-28-6
+etcd:
+  image: public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.9-eks-1-28-6
+service:
+  type: NodePort
+sync:
+  nodes:
+    enabled: true
+telemetry:
+  disabled: false
+`),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid: k3s",
+			args: args{
+				r: strings.NewReader(`
+sync:
+  nodes:
+   enabled: true
+k3sToken: foo
+telemetry:
+  disabled: false
+`),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid: k0s",
+			args: args{
+				r: strings.NewReader(`
+sync:
+  nodes:
+   enabled: true
+vcluster:
+  image: k0sproject/k0s:v1.29.1-k0s.0
+telemetry:
+  disabled: false
+`),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &LegacyK8s{}
+			if err := c.DecodeYAML(tt.args.r); (err != nil) != tt.wantErr {
+				t.Errorf("LegacyK8s.DecodeYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/config/legacyconfig/config_test.go
+++ b/config/legacyconfig/config_test.go
@@ -1,14 +1,12 @@
 package legacyconfig
 
 import (
-	"io"
-	"strings"
 	"testing"
 )
 
-func TestLegacyK0sAndK3s_DecodeYAML(t *testing.T) {
+func TestLegacyK0sAndK3s_UnmarshalYAMLStrict(t *testing.T) {
 	type args struct {
-		r io.Reader
+		data []byte
 	}
 	tests := []struct {
 		name    string
@@ -18,7 +16,7 @@ func TestLegacyK0sAndK3s_DecodeYAML(t *testing.T) {
 		{
 			name: "Valid: k3s",
 			args: args{
-				r: strings.NewReader(`
+				data: []byte(`
 sync:
   nodes:
    enabled: true
@@ -31,7 +29,7 @@ telemetry:
 		{
 			name: "Invalid: k8s",
 			args: args{
-				r: strings.NewReader(`
+				data: []byte(`
 api:
   image: registry.k8s.io/kube-apiserver:v1.29.0
 controller:
@@ -56,16 +54,16 @@ telemetry:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &LegacyK0sAndK3s{}
-			if err := c.DecodeYAML(tt.args.r); (err != nil) != tt.wantErr {
-				t.Errorf("LegacyK0sAndK3s.DecodeYAML() error = %v, wantErr %v", err, tt.wantErr)
+			if err := c.UnmarshalYAMLStrict(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("LegacyK0sAndK3s.UnmarshalYAMLStrict() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestLegacyK8s_DecodeYAML(t *testing.T) {
+func TestLegacyK8s_UnmarshalYAMLStrict(t *testing.T) {
 	type args struct {
-		r io.Reader
+		data []byte
 	}
 	tests := []struct {
 		name    string
@@ -75,7 +73,7 @@ func TestLegacyK8s_DecodeYAML(t *testing.T) {
 		{
 			name: "Valid: k8s",
 			args: args{
-				r: strings.NewReader(`
+				data: []byte(`
 api:
   image: registry.k8s.io/kube-apiserver:v1.29.0
 controller:
@@ -98,7 +96,7 @@ telemetry:
 		{
 			name: "Valid: eks",
 			args: args{
-				r: strings.NewReader(`
+				data: []byte(`
 api:
   image: public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.28.2-eks-1-28-6
 controller:
@@ -121,7 +119,7 @@ telemetry:
 		{
 			name: "Invalid: k3s",
 			args: args{
-				r: strings.NewReader(`
+				data: []byte(`
 sync:
   nodes:
    enabled: true
@@ -135,7 +133,7 @@ telemetry:
 		{
 			name: "Invalid: k0s",
 			args: args{
-				r: strings.NewReader(`
+				data: []byte(`
 sync:
   nodes:
    enabled: true
@@ -151,8 +149,8 @@ telemetry:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &LegacyK8s{}
-			if err := c.DecodeYAML(tt.args.r); (err != nil) != tt.wantErr {
-				t.Errorf("LegacyK8s.DecodeYAML() error = %v, wantErr %v", err, tt.wantErr)
+			if err := c.UnmarshalYAMLStrict(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("LegacyK8s.UnmarshalYAMLStrict() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/config/legacyconfig/migrate.go
+++ b/config/legacyconfig/migrate.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/loft-sh/vcluster/config"
+	"sigs.k8s.io/yaml"
 )
 
 func MigrateLegacyConfig(distro, oldValues string) (string, error) {

--- a/config/legacyconfig/migrate.go
+++ b/config/legacyconfig/migrate.go
@@ -41,7 +41,7 @@ func MigrateLegacyConfig(distro, oldValues string) (string, error) {
 func migrateK8sAndEKS(distro, oldValues string, newConfig *config.Config) error {
 	// unmarshal legacy config
 	oldConfig := &LegacyK8s{}
-	err := yaml.Unmarshal([]byte(oldValues), oldConfig)
+	err := oldConfig.DecodeYAML(strings.NewReader(oldValues))
 	if err != nil {
 		return fmt.Errorf("unmarshal legacy config: %w", err)
 	}
@@ -97,7 +97,7 @@ func migrateK8sAndEKS(distro, oldValues string, newConfig *config.Config) error 
 func migrateK3sAndK0s(distro, oldValues string, newConfig *config.Config) error {
 	// unmarshal legacy config
 	oldConfig := &LegacyK0sAndK3s{}
-	err := yaml.Unmarshal([]byte(oldValues), oldConfig)
+	err := oldConfig.DecodeYAML(strings.NewReader(oldValues))
 	if err != nil {
 		return fmt.Errorf("unmarshal legacy config: %w", err)
 	}

--- a/config/legacyconfig/migrate.go
+++ b/config/legacyconfig/migrate.go
@@ -41,7 +41,7 @@ func MigrateLegacyConfig(distro, oldValues string) (string, error) {
 func migrateK8sAndEKS(distro, oldValues string, newConfig *config.Config) error {
 	// unmarshal legacy config
 	oldConfig := &LegacyK8s{}
-	err := oldConfig.DecodeYAML(strings.NewReader(oldValues))
+	err := oldConfig.UnmarshalYAMLStrict([]byte(oldValues))
 	if err != nil {
 		return fmt.Errorf("unmarshal legacy config: %w", err)
 	}
@@ -97,7 +97,7 @@ func migrateK8sAndEKS(distro, oldValues string, newConfig *config.Config) error 
 func migrateK3sAndK0s(distro, oldValues string, newConfig *config.Config) error {
 	// unmarshal legacy config
 	oldConfig := &LegacyK0sAndK3s{}
-	err := oldConfig.DecodeYAML(strings.NewReader(oldValues))
+	err := oldConfig.UnmarshalYAMLStrict([]byte(oldValues))
 	if err != nil {
 		return fmt.Errorf("unmarshal legacy config: %w", err)
 	}

--- a/config/legacyconfig/migrate_test.go
+++ b/config/legacyconfig/migrate_test.go
@@ -31,6 +31,20 @@ func TestMigration(t *testing.T) {
       podManagementPolicy: OrderedReady`,
 		},
 		{
+			Name:   "k3s with deprecated serviceCIDR",
+			Distro: "k3s",
+			In: `
+serviceCIDR: 10.96.0.0/16
+`,
+			Expected: `controlPlane:
+  distro:
+    k3s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady`,
+		},
+		{
 			Name:   "Simple k0s",
 			Distro: "k0s",
 			Expected: `controlPlane:

--- a/config/legacyconfig/values_k3s.yaml
+++ b/config/legacyconfig/values_k3s.yaml
@@ -1,0 +1,525 @@
+# These annotations will be applied to all objects created in this chart
+globalAnnotations: {}
+
+# If vCluster.Pro is enabled
+pro: false
+
+# Defines where vCluster should search for a license secret. If you are using the vCluster.Pro control-plane,
+# this is optional. vCluster by default will lookout for a secret called vc-VCLUSTER_NAME-license and if found use that.
+# You can also use a secret within another namespace by using the format NAMESPACE/NAME. If the secret is in another
+# namespace, please enable clusterRole.create and define an extra clusterRole.extraRules to allow vCluster to retrieve
+# secrets within the cluster.
+proLicenseSecret: ""
+
+# If true, will deploy vcluster in headless mode, which means no deployment
+# or statefulset is created.
+headless: false
+
+monitoring:
+  serviceMonitor:
+    enabled: false
+
+# DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
+# images within the vcluster will not be rewritten.
+defaultImageRegistry: ""
+
+# Plugins that should get loaded. Usually you want to apply those via 'vcluster create ... -f https://.../plugin.yaml'
+plugin: {}
+# Manually configure a plugin called test
+# test:
+#   image: ...
+#   env: ...
+#   rbac:
+#     clusterRole:
+#       extraRules: ...
+#     role:
+#       extraRules: ...
+
+# Resource syncers that should be enabled/disabled.
+# Enabling syncers will impact RBAC Role and ClusterRole permissions.
+# To disable a syncer set "enabled: false".
+# See docs for details - https://www.vcluster.com/docs/architecture/synced-resources
+sync:
+  services:
+    enabled: true
+  configmaps:
+    enabled: true
+    all: false
+  secrets:
+    all: false
+    enabled: true
+  endpoints:
+    enabled: true
+  pods:
+    enabled: true
+    ephemeralContainers: false
+    status: false
+  events:
+    enabled: true
+  persistentvolumeclaims:
+    enabled: true
+  ingresses:
+    enabled: false
+  ingressclasses: {}
+    # By default IngressClasses sync is enabled when the Ingress sync is enabled
+    # but it can be explicitly disabled by setting:
+    # enabled: false
+  fake-nodes:
+    enabled: true # will be ignored if nodes.enabled = true
+  fake-persistentvolumes:
+    enabled: true # will be ignored if persistentvolumes.enabled = true
+  nodes:
+    fakeKubeletIPs: true
+    enabled: false
+    # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster
+    # will sync all nodes instead of only the ones where some pods are running.
+    syncAllNodes: false
+    # nodeSelector is used to limit which nodes get synced to the vcluster,
+    # and which nodes are used to run vcluster pods.
+    # A valid string representation of a label selector must be used.
+    nodeSelector: ""
+    # if true, vcluster will run with a scheduler and node changes are possible
+    # from within the virtual cluster. This is useful if you would like to
+    # taint, drain and label nodes from within the virtual cluster
+    enableScheduler: false
+    # DEPRECATED: use enable scheduler instead
+    # syncNodeChanges allows vcluster user edits of the nodes to be synced down to the host nodes.
+    # Write permissions on node resource will be given to the vcluster.
+    syncNodeChanges: false
+  persistentvolumes:
+    enabled: false
+  storageclasses:
+    enabled: false
+  # formerly named - "legacy-storageclasses"
+  hoststorageclasses:
+    enabled: false
+  priorityclasses:
+    enabled: false
+  networkpolicies:
+    enabled: false
+  volumesnapshots:
+    enabled: false
+  poddisruptionbudgets:
+    enabled: false
+  serviceaccounts:
+    enabled: false
+  # generic CRD configuration
+  generic:
+    config: |-
+      ---
+
+# If enabled, will fallback to host dns for resolving domains. This
+# is useful if using istio or dapr in the host cluster and sidecar
+# containers cannot connect to the central instance. Its also useful
+# if you want to access host cluster services from within the vcluster.
+fallbackHostDns: false
+
+# Map Services between host and virtual cluster
+mapServices:
+  # Services that should get mapped from the
+  # virtual cluster to the host cluster.
+  # vcluster will make sure to sync the service
+  # ip to the host cluster automatically as soon
+  # as the service exists.
+  # For example:
+  # fromVirtual:
+  #   - from: my-namespace/name
+  #     to: host-service
+  fromVirtual: []
+  # Same as from virtual, but instead sync services
+  # from the host cluster into the virtual cluster.
+  # If the namespace does not exist, vcluster will
+  # also create the namespace for the service.
+  fromHost: []
+
+# Proxy metrics server from host to virtual
+proxy:
+  metricsServer:
+    nodes:
+      enabled: false
+    pods:
+      enabled: false
+
+# Syncer configuration
+syncer:
+  replicas: 1
+  # Image to use for the syncer
+  # image: ghcr.io/loft-sh/vcluster
+  extraArgs: []
+  imagePullPolicy: ""
+  env: []
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
+  extraVolumeMounts:
+    - mountPath: /data
+      name: data
+      # readOnly: true
+  resources:
+    limits:
+      ephemeral-storage: 8Gi
+      memory: 2Gi
+    requests:
+      ephemeral-storage: 200Mi
+      cpu: 200m
+      memory: 256Mi
+  kubeConfigContextName: "my-vcluster"
+  serviceAnnotations: {}
+  # Storage settings for the vcluster
+  storage:
+    # If this is disabled, vcluster will use an emptyDir instead
+    # of a PersistentVolumeClaim
+    persistence: true
+    # Size of the persistent volume claim
+    size: 5Gi
+    # Optional StorageClass used for the pvc
+    # if empty default StorageClass defined in your host cluster will be used
+    #className:
+
+# Virtual Cluster (k3s) configuration
+vcluster:
+  # Image to use for the virtual cluster
+  image: rancher/k3s:v1.29.0-k3s1
+  imagePullPolicy: ""
+  extraArgs: []
+  # Deprecated: Use syncer.extraVolumeMounts instead
+  extraVolumeMounts: []
+  # Deprecated: Use syncer.volumeMounts instead
+  volumeMounts: []
+  # Deprecated: Use syncer.env instead
+  env: []
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 40m
+      memory: 64Mi
+
+# Embedded etcd settings
+embeddedEtcd:
+  # If embedded etcd should be enabled, this is a PRO only feature
+  enabled: false
+
+# list of {validating/mutating}webhooks that the syncer should proxy.
+# This is a PRO only feature.
+centralAdmission:
+  validatingWebhooks: []
+  mutatingWebhooks: []
+
+
+# Extra volumes that should be created for the StatefulSet
+volumes: []
+
+# Service account that should be used by the vcluster
+serviceAccount:
+  create: true
+  # Optional name of the service account to use
+  # name: default
+  # Optional pull secrets
+  # imagePullSecrets:
+  #   - name: my-pull-secret
+
+# Service account that should be used by the pods synced by vcluster
+workloadServiceAccount:
+  # This is not supported in multi-namespace mode
+  annotations: {}
+
+# Roles & ClusterRoles for the vcluster
+rbac:
+  clusterRole:
+    # You don't need to toggle this as necessary cluster roles are created based on the enabled syncers (.sync.*.enabled).
+    # This only makes sense to enable if you want to use the extraRules below.
+    create: false
+    # Extra Rules for the cluster role
+    extraRules: []
+  role:
+    # Disable this only if you don't want vCluster to create a role. This will break most functionality if disabled.
+    create: true
+    # Extra Rules for the role
+    extraRules: []
+    # all entries in excludedApiResources will be excluded from the Role created for vcluster
+    excludedApiResources:
+      # - pods/exec
+
+# If vCluster persistent volume claims should get deleted automatically.
+autoDeletePersistentVolumeClaims: false
+
+# NodeSelector used to schedule the vcluster
+nodeSelector: {}
+
+# Affinity to apply to the vcluster statefulset
+affinity: {}
+
+# PriorityClassName to apply to the vcluster statefulset
+priorityClassName: ""
+
+# Tolerations to apply to the vcluster statefulset
+tolerations: []
+
+# Extra Labels for the stateful set
+labels: {}
+podLabels: {}
+
+# Extra Annotations for the stateful set
+annotations: {}
+podAnnotations: {}
+
+# The k3s token to use. If empty will generate one automatically
+k3sToken: ""
+
+# Service configurations
+service:
+  type: ClusterIP
+
+  # Optional configuration
+  # A list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+  # These IPs are not managed by Kubernetes; e.g., an external load balancer.
+  externalIPs: []
+
+  # Optional configuration for LoadBalancer & NodePort service types
+  # Route external traffic to node-local or cluster-wide endpoints [ Local | Cluster ]
+  externalTrafficPolicy: ""
+
+  # Optional configuration for LoadBalancer service type
+  # Specify IP of load balancer to be created
+  loadBalancerIP: ""
+  # CIDR block(s) for the service allowlist
+  loadBalancerSourceRanges: []
+  # Set the loadBalancerClass if using an external load balancer controller
+  loadBalancerClass: ""
+  # Set loadBalancer specific annotations on the Kubernetes service
+  loadBalancerAnnotations: {}
+
+# Configure the ingress resource that allows you to access the vcluster
+ingress:
+  # Enable ingress record generation
+  enabled: false
+  # Ingress path type
+  pathType: ImplementationSpecific
+  ingressClassName: ""
+  host: vcluster.local
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  # Ingress TLS configuration
+  tls: []
+    # - secretName: tls-vcluster.local
+    #   hosts:
+    #     - vcluster.local
+
+# Configure SecurityContext of the containers in the VCluster pod
+securityContext:
+  allowPrivilegeEscalation: false
+  # capabilities:
+  #  drop:
+  #  - all
+  # readOnlyRootFilesystem will be set to true by default at a later release
+  # currently leaving it undefined for backwards compatibility with older vcluster cli versions
+  # readOnlyRootFilesystem: true
+
+  # To run vcluster pod as non-root uncomment runAsUser and runAsNonRoot values.
+  # Update the runAsUser value if your cluster has limitations on user UIDs.
+  # For installation on OpenShift leave the runAsUser undefined (commented out).
+  # runAsUser: 12345
+  # runAsNonRoot: true
+  runAsUser: 0
+  runAsGroup: 0
+
+# PodSecurityContext holds pod-level security attributes and common container settings for the vCluster pod
+podSecurityContext: {}
+
+# Set "enable" to true when running vcluster in an OpenShift host
+# This will add an extra rule to the deployed role binding in order
+# to manage service endpoints
+openshift:
+  enable: false
+
+# If enabled will deploy the coredns configmap
+coredns:
+  # If CoreDns is enabled
+  enabled: true
+  # Pro only feature
+  integrated: false
+  # only used if isolation is enabled
+  fallback: 8.8.8.8
+  plugin:
+    enabled: false
+    config: []
+    # example configuration for plugin syntax, will be documented in detail
+    # - record:
+    #     fqdn: google.com
+    #   target:
+    #     mode: url
+    #     url: google.co.in
+    # - record:
+    #     service: my-namespace/my-svc    # dns-test/nginx-svc
+    #   target:
+    #     mode: host
+    #     service: dns-test/nginx-svc
+    # - record:
+    #     service: my-namespace-lb/my-svc-lb
+    #   target:
+    #     mode: host
+    #     service: dns-test-exposed-lb/nginx-svc-exposed-lb
+    # - record:
+    #     service: my-ns-external-name/my-svc-external-name
+    #   target:
+    #     mode: host
+    #     service: dns-test-external-name/nginx-svc-external-name
+    # - record:
+    #     service: my-ns-in-vcluster/my-svc-vcluster
+    #   target:
+    #     mode: vcluster              # can be tested only manually for now
+    #     vcluster: test-vcluster-ns/test-vcluster
+    #     service: dns-test-in-vcluster-ns/test-in-vcluster-service
+    # - record:
+    #     service: my-ns-in-vcluster-mns/my-svc-mns
+    #   target:
+    #     mode: vcluster              # can be tested only manually for now
+    #     service: dns-test-in-vcluster-mns/test-in-vcluster-svc-mns
+    #     vcluster: test-vcluster-ns-mns/test-vcluster-mns
+    # - record:
+    #     service: my-self-vc-ns/my-self-vc-svc
+    #   target:
+    #     mode: self
+    #     service: dns-test/nginx-svc
+  replicas: 1
+  # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
+  # nodeSelector:
+  #   kubernetes.io/arch: arm64
+  # image: my-core-dns-image:latest
+  # config: |-
+  #   .:1053 {
+  #      ...
+  # CoreDNS service configurations
+  service:
+    type: ClusterIP
+    # Configuration for LoadBalancer service type
+    externalIPs: []
+    externalTrafficPolicy: ""
+    # Extra Annotations
+    annotations: {}
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 170Mi
+    requests:
+      cpu: 3m
+      memory: 16Mi
+# if below option is configured, it will override the coredns manifests with the following string
+#  manifests: |-
+#    apiVersion: ...
+#    ...
+  podAnnotations: {}
+  podLabels: {}
+
+# If enabled will deploy vcluster in an isolated mode with pod security
+# standards, limit ranges and resource quotas
+isolation:
+  enabled: false
+  namespace: null
+
+  podSecurityStandard: baseline
+
+  # If enabled will add node/proxy permission to the cluster role
+  # in isolation mode
+  nodeProxyPermission:
+    enabled: false
+
+  resourceQuota:
+    enabled: true
+    quota:
+      requests.cpu: 10
+      requests.memory: 20Gi
+      requests.storage: "100Gi"
+      requests.ephemeral-storage: 60Gi
+      limits.cpu: 20
+      limits.memory: 40Gi
+      limits.ephemeral-storage: 160Gi
+      services.nodeports: 0
+      services.loadbalancers: 1
+      count/endpoints: 40
+      count/pods: 20
+      count/services: 20
+      count/secrets: 100
+      count/configmaps: 100
+      count/persistentvolumeclaims: 20
+    scopeSelector:
+      matchExpressions:
+    scopes:
+
+  limitRange:
+    enabled: true
+    default:
+      ephemeral-storage: 8Gi
+      memory: 512Mi
+      cpu: "1"
+    defaultRequest:
+      ephemeral-storage: 3Gi
+      memory: 128Mi
+      cpu: 100m
+
+  networkPolicy:
+    enabled: true
+    outgoingConnections:
+      ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+          - 100.64.0.0/10
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+
+# manifests to setup when initializing a vcluster
+init:
+  manifests: |-
+    ---
+  # The contents of manifests-template will be templated using helm
+  # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
+  manifestsTemplate: ''
+  helm: []
+    # - bundle: <string> - base64-encoded .tar.gz file content (optional - overrides chart.repo)
+    #   chart:
+    #     name: <string>  REQUIRED
+    #     version: <string>  REQUIRED
+    #     repo: <string>  (optional when bundle is used)
+    #     username: <string>   (if required for repo)
+    #     password: <string>   (if required for repo)
+    #     insecure: boolean    (if required for repo)
+    #   release:
+    #     name: <string> REQUIRED
+    #     namespace: <string> REQUIRED
+    #     timeout: number
+    #   values: |-  string YAML object
+    #     foo: bar
+    #   valuesTemplate: |-  string YAML object
+    #     foo: {{ .Release.Name }}
+
+multiNamespaceMode:
+  enabled: false
+
+telemetry:
+  disabled: false
+  instanceCreator: "helm"
+  platformUserID: ""
+  platformInstanceID: ""
+  machineID: ""
+
+noopSyncer:
+  enabled: false
+  synck8sService: false
+
+  # Secret containing remote cluster configuration
+  # (should have the following keys defined)
+  #   serverCaCert: <server-ca-cert of the remote cluster>
+  #   serverCaKey: <server-ca-key of the remote cluster>
+  #   clientCaCert: <client-ca-cert of the remote cluster>
+  #   requestHeaderCaCert: <request-header-ca-cert of the remote cluster>
+  #   kubeConfig: <kubeconfig of the remote cluster>
+  #
+  #secret: ""
+

--- a/config/legacyconfig/values_k8s.yaml
+++ b/config/legacyconfig/values_k8s.yaml
@@ -1,0 +1,524 @@
+# DefaultImageRegistry will be prepended to all deployed vcluster images, such as the vcluster pod, coredns etc.. Deployed
+# images within the vcluster will not be rewritten.
+defaultImageRegistry: ""
+
+# Global annotations to add to all objects
+globalAnnotations: {}
+
+# If vCluster.Pro is enabled
+pro: false
+
+# Defines where vCluster should search for a license secret. If you are using the vCluster.Pro control-plane,
+# this is optional. vCluster by default will lookout for a secret called vc-VCLUSTER_NAME-license and if found use that.
+# You can also use a secret within another namespace by using the format NAMESPACE/NAME. If the secret is in another
+# namespace, please enable clusterRole.create and define an extra clusterRole.extraRules to allow vCluster to retrieve
+# secrets within the cluster.
+proLicenseSecret: ""
+
+# Embedded etcd settings
+embeddedEtcd:
+  # If embedded etcd should be enabled, this is a PRO only feature
+  enabled: false
+  # To use if embeddedEtcd is enabled and you want to migrate the data
+  # from the external etcd
+  migrateFromEtcd: false
+
+# If true, will deploy vcluster in headless mode, which means no deployment
+# or statefulset is created.
+headless: false
+
+monitoring:
+  serviceMonitor:
+    enabled: false
+
+# Plugins that should get loaded. Usually you want to apply those via 'vcluster create ... -f https://.../plugin.yaml'
+plugin: {}
+# Manually configure a plugin called test
+# test:
+#   image: ...
+#   env: ...
+#   rbac:
+#     clusterRole:
+#       extraRules: ...
+#     role:
+#       extraRules: ...
+
+# Extra Annotations for the stateful set
+annotations: {}
+podAnnotations: {}
+
+# Resource syncers that should be enabled/disabled.
+# Enabling syncers will impact RBAC Role and ClusterRole permissions.
+# To disable a syncer set "enabled: false".
+# See docs for details - https://www.vcluster.com/docs/architecture/synced-resources
+sync:
+  services:
+    enabled: true
+  configmaps:
+    enabled: true
+    all: false
+  secrets:
+    enabled: true
+    all: false
+  endpoints:
+    enabled: true
+  pods:
+    enabled: true
+    ephemeralContainers: false
+    status: false
+  events:
+    enabled: true
+  persistentvolumeclaims:
+    enabled: true
+  ingresses:
+    enabled: false
+  ingressclasses: {}
+    # By default IngressClasses sync is enabled when the Ingress sync is enabled
+    # but it can be explicitly disabled by setting:
+    # enabled: false
+  fake-nodes:
+    enabled: true # will be ignored if nodes.enabled = true
+  fake-persistentvolumes:
+    enabled: true # will be ignored if persistentvolumes.enabled = true
+  nodes:
+    fakeKubeletIPs: true
+    enabled: false
+    # If nodes sync is enabled, and syncAllNodes = true, the virtual cluster
+    # will sync all nodes instead of only the ones where some pods are running.
+    syncAllNodes: false
+    # nodeSelector is used to limit which nodes get synced to the vcluster,
+    # and which nodes are used to run vcluster pods.
+    # A valid string representation of a label selector must be used.
+    nodeSelector: ""
+    # if true, vcluster will run with a scheduler and node changes are possible
+    # from within the virtual cluster. This is useful if you would like to
+    # taint, drain and label nodes from within the virtual cluster
+    enableScheduler: false
+    # DEPRECATED: use enable scheduler instead
+    # syncNodeChanges allows vcluster user edits of the nodes to be synced down to the host nodes.
+    # Write permissions on node resource will be given to the vcluster.
+    syncNodeChanges: false
+  persistentvolumes:
+    enabled: false
+  storageclasses:
+    enabled: false
+  # formerly named - "legacy-storageclasses"
+  hoststorageclasses:
+    enabled: false
+  priorityclasses:
+    enabled: false
+  networkpolicies:
+    enabled: false
+  volumesnapshots:
+    enabled: false
+  poddisruptionbudgets:
+    enabled: false
+  serviceaccounts:
+    enabled: false
+  # generic CRD configuration
+  generic:
+    config: |-
+      ---
+
+# If enabled, will fallback to host dns for resolving domains. This
+# is useful if using istio or dapr in the host cluster and sidecar
+# containers cannot connect to the central instance. Its also useful
+# if you want to access host cluster services from within the vcluster.
+fallbackHostDns: false
+
+# Map Services between host and virtual cluster
+mapServices:
+  # Services that should get mapped from the
+  # virtual cluster to the host cluster.
+  # vcluster will make sure to sync the service
+  # ip to the host cluster automatically as soon
+  # as the service exists.
+  # For example:
+  # fromVirtual:
+  #   - from: my-namespace/name
+  #     to: host-service
+  fromVirtual: []
+  # Same as from virtual, but instead sync services
+  # from the host cluster into the virtual cluster.
+  # If the namespace does not exist, vcluster will
+  # also create the namespace for the service.
+  fromHost: []
+
+proxy:
+  metricsServer:
+    nodes:
+      enabled: false
+    pods:
+      enabled: false
+
+# Syncer configuration
+syncer:
+  # Image to use for the syncer
+  # image: ghcr.io/loft-sh/vcluster
+  imagePullPolicy: ""
+  extraArgs: []
+  volumeMounts: []
+  extraVolumeMounts: []
+  env: []
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
+  resources:
+    limits:
+      ephemeral-storage: 8Gi
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      ephemeral-storage: 200Mi
+      # ensure that cpu/memory requests are high enough.
+      # for example gke wants minimum 10m/32Mi here!
+      cpu: 20m
+      memory: 256Mi
+  # Extra volumes
+  volumes: []
+  # The amount of replicas to run the deployment with
+  replicas: 1
+  # NodeSelector used to schedule the syncer
+  nodeSelector: {}
+  # Affinity to apply to the syncer deployment
+  affinity: {}
+  # Tolerations to apply to the syncer deployment
+  tolerations: []
+  # Extra Labels for the syncer deployment
+  labels: {}
+  # Extra Annotations for the syncer deployment
+  annotations: {}
+  podAnnotations: {}
+  podLabels: {}
+  priorityClassName: ""
+  kubeConfigContextName: "my-vcluster"
+  # Security context configuration
+  securityContext:
+    allowPrivilegeEscalation: false
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  serviceAnnotations: {}
+  # Storage settings for the vcluster
+  storage:
+    # If this is disabled, vcluster will use an emptyDir instead
+    # of a PersistentVolumeClaim
+    persistence: true
+    # Size of the persistent volume claim
+    size: 5Gi
+    # Optional StorageClass used for the pvc
+    # if empty default StorageClass defined in your host cluster will be used
+    #className:
+
+# Etcd settings
+etcd:
+  image: registry.k8s.io/etcd:3.5.10-0
+  imagePullPolicy: ""
+  # The amount of replicas to run
+  replicas: 1
+  # NodeSelector used
+  nodeSelector: {}
+  # Affinity to apply
+  affinity: {}
+  # Tolerations to apply
+  tolerations: []
+  # Extra Labels
+  labels: {}
+  # Extra Annotations
+  annotations: {}
+  podAnnotations: {}
+  podLabels: {}
+  resources:
+    requests:
+      cpu: 20m
+      memory: 150Mi
+  # Storage settings for the etcd
+  storage:
+    # If this is disabled, vcluster will use an emptyDir instead
+    # of a PersistentVolumeClaim
+    persistence: true
+    # Size of the persistent volume claim
+    size: 5Gi
+    # Optional StorageClass used for the pvc
+    # if empty default StorageClass defined in your host cluster will be used
+    #className:
+  priorityClassName: ""
+  securityContext: {}
+  serviceAnnotations: {}
+  autoDeletePersistentVolumeClaims: false
+
+# Kubernetes Controller Manager settings
+controller:
+  image: registry.k8s.io/kube-controller-manager:v1.29.0
+  imagePullPolicy: ""
+
+# Kubernetes Scheduler settings. Only enabled if sync.nodes.enableScheduler is true
+scheduler:
+  image: registry.k8s.io/kube-scheduler:v1.29.0
+  imagePullPolicy: ""
+  disabled: true
+
+# Kubernetes API Server settings
+api:
+  image: registry.k8s.io/kube-apiserver:v1.29.0
+  imagePullPolicy: ""
+  extraArgs: []
+
+# Service account that should be used by the vcluster
+serviceAccount:
+  create: true
+  # Optional name of the service account to use
+  # name: default
+  # Optional pull secrets
+  # imagePullSecrets:
+  #   - name: my-pull-secret
+
+# Service account that should be used by the pods synced by vcluster
+workloadServiceAccount:
+  # This is not supported in multi-namespace mode
+  annotations: {}
+
+# Roles & ClusterRoles for the vcluster
+rbac:
+  clusterRole:
+    # You don't need to toggle this as necessary cluster roles are created based on the enabled syncers (.sync.*.enabled).
+    # This only makes sense to enable if you want to use the extraRules below.
+    create: false
+    # Extra Rules for the cluster role
+    extraRules: []
+  role:
+    # Disable this only if you don't want vCluster to create a role. This will break most functionality if disabled.
+    create: true
+    # Extra Rules for the role
+    extraRules: []
+    # all entries in excludedApiResources will be excluded from the Role created for vcluster
+    excludedApiResources:
+    # - pods/exec
+
+# Syncer service configurations
+service:
+  type: ClusterIP
+
+  # Optional configuration
+  # A list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+  # These IPs are not managed by Kubernetes; e.g., an external load balancer.
+  externalIPs: []
+
+  # Optional configuration for LoadBalancer & NodePort service types
+  # Route external traffic to node-local or cluster-wide endpoints [ Local | Cluster ]
+  externalTrafficPolicy: ""
+
+  # Optional configuration for LoadBalancer service type
+  # Specify IP of load balancer to be created
+  loadBalancerIP: ""
+  # CIDR block(s) for the service allowlist
+  loadBalancerSourceRanges: []
+  # Set the loadBalancerClass if using an external load balancer controller
+  loadBalancerClass: ""
+  # Set loadBalancer specific annotations on the Kubernetes service
+  loadBalancerAnnotations: {}
+
+# Configure the ingress resource that allows you to access the vcluster
+ingress:
+  # Enable ingress record generation
+  enabled: false
+  # Ingress path type
+  pathType: ImplementationSpecific
+  ingressClassName: ""
+  host: vcluster.local
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  # Ingress TLS configuration
+  tls: []
+    # - secretName: tls-vcluster.local
+    #   hosts:
+    #     - vcluster.local
+
+# Set "enable" to true when running vcluster in an OpenShift host
+# This will add an extra rule to the deployed role binding in order
+# to manage service endpoints
+openshift:
+  enable: false
+
+# If enabled will deploy the coredns configmap
+coredns:
+  # If CoreDns is enabled
+  enabled: true
+  # Pro only feature
+  integrated: false
+  # only used if isolation is enabled
+  fallback: 8.8.8.8
+  plugin:
+    enabled: false
+    config: []
+    # example configuration for plugin syntax, will be documented in detail
+    # - record:
+    #     fqdn: google.com
+    #   target:
+    #     mode: url
+    #     url: google.co.in
+    # - record:
+    #     service: my-namespace/my-svc    # dns-test/nginx-svc
+    #   target:
+    #     mode: host
+    #     service: dns-test/nginx-svc
+    # - record:
+    #     service: my-namespace-lb/my-svc-lb
+    #   target:
+    #     mode: host
+    #     service: dns-test-exposed-lb/nginx-svc-exposed-lb
+    # - record:
+    #     service: my-ns-external-name/my-svc-external-name
+    #   target:
+    #     mode: host
+    #     service: dns-test-external-name/nginx-svc-external-name
+    # - record:
+    #     service: my-ns-in-vcluster/my-svc-vcluster
+    #   target:
+    #     mode: vcluster              # can be tested only manually for now
+    #     vcluster: test-vcluster-ns/test-vcluster
+    #     service: dns-test-in-vcluster-ns/test-in-vcluster-service
+    # - record:
+    #     service: my-ns-in-vcluster-mns/my-svc-mns
+    #   target:
+    #     mode: vcluster              # can be tested only manually for now
+    #     service: dns-test-in-vcluster-mns/test-in-vcluster-svc-mns
+    #     vcluster: test-vcluster-ns-mns/test-vcluster-mns
+    # - record:
+    #     service: my-self-vc-ns/my-self-vc-svc
+    #   target:
+    #     mode: self
+    #     service: dns-test/nginx-svc
+  replicas: 1
+  # The nodeSelector example below specifices that coredns should only be scheduled to nodes with the arm64 label
+  # nodeSelector:
+  #   kubernetes.io/arch: arm64
+  # image: my-core-dns-image:latest
+  # config: |-
+  #   .:1053 {
+  #      ...
+  # CoreDNS service configurations
+  service:
+    type: ClusterIP
+    # Configuration for LoadBalancer service type
+    externalIPs: []
+    externalTrafficPolicy: ""
+    # Extra Annotations
+    annotations: {}
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 170Mi
+    requests:
+      cpu: 3m
+      memory: 16Mi
+# if below option is configured, it will override the coredns manifests with the following string
+#  manifests: |-
+#    apiVersion: ...
+#    ...
+  podAnnotations: {}
+  podLabels: {}
+
+# If enabled will deploy vcluster in an isolated mode with pod security
+# standards, limit ranges and resource quotas
+isolation:
+  enabled: false
+  namespace: null
+
+  podSecurityStandard: baseline
+
+  # If enabled will add node/proxy permission to the cluster role
+  # in isolation mode
+  nodeProxyPermission:
+    enabled: false
+
+  resourceQuota:
+    enabled: true
+    quota:
+      requests.cpu: 10
+      requests.memory: 20Gi
+      requests.storage: "100Gi"
+      requests.ephemeral-storage: 60Gi
+      limits.cpu: 20
+      limits.memory: 40Gi
+      limits.ephemeral-storage: 160Gi
+      services.nodeports: 0
+      services.loadbalancers: 1
+      count/endpoints: 40
+      count/pods: 20
+      count/services: 20
+      count/secrets: 100
+      count/configmaps: 100
+      count/persistentvolumeclaims: 20
+    scopeSelector:
+      matchExpressions:
+    scopes:
+
+  limitRange:
+    enabled: true
+    default:
+      ephemeral-storage: 8Gi
+      memory: 512Mi
+      cpu: "1"
+    defaultRequest:
+      ephemeral-storage: 3Gi
+      memory: 128Mi
+      cpu: 100m
+
+  networkPolicy:
+    enabled: true
+    outgoingConnections:
+      ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+          - 100.64.0.0/10
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+
+# manifests to setup when initializing a vcluster
+init:
+  manifests: |-
+    ---
+  # The contents of manifests-template will be templated using helm
+  # this allows you to use helm values inside, e.g.: {{ .Release.Name }}
+  manifestsTemplate: ''
+  helm: []
+    # - bundle: <string> - base64-encoded .tar.gz file content (optional - overrides chart.repo)
+    #   chart:
+    #     name: <string>  REQUIRED
+    #     version: <string>  REQUIRED
+    #     repo: <string>  (optional when bundle is used)
+    #     username: <string>   (if required for repo)
+    #     password: <string>   (if required for repo)
+    #     insecure: boolean    (if required for repo)
+    #   release:
+    #     name: <string> REQUIRED
+    #     namespace: <string> REQUIRED
+    #     timeout: number
+    #   values: |-  string YAML object
+    #     foo: bar
+    #   valuesTemplate: |-  string YAML object
+    #     foo: {{ .Release.Name }}
+
+multiNamespaceMode:
+  enabled: false
+
+
+# list of {validating/mutating}webhooks that the syncer should proxy.
+# This is a PRO only feature.
+centralAdmission:
+  validatingWebhooks: []
+  mutatingWebhooks: []
+
+telemetry:
+  disabled: false
+  instanceCreator: "helm"
+  platformUserID: ""
+  platformInstanceID: ""
+  machineID: ""
+

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -205,11 +206,16 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 			_ = f.Close()
 		}()
 
+		data, err := io.ReadAll(f)
+		if err != nil {
+			return err
+		}
+
 		// parse config
 		cfg := &config.Config{}
-		err = cfg.DecodeYAML(f)
+		err = cfg.UnmarshalYAMLStrict(data)
 		if err != nil {
-			if errors.Is(err, config.ErrInvalidFileFormat) {
+			if errors.Is(err, config.ErrInvalidConfig) {
 				cmd.log.Infof("If you are using the old values format, consider using %q to convert it to the new v0.20 format", "vcluster convert config")
 			}
 			return err

--- a/pkg/setup/config.go
+++ b/pkg/setup/config.go
@@ -1,7 +1,6 @@
 package setup
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -136,7 +135,7 @@ func CheckUsingHelm(ctx context.Context, client kubernetes.Interface, name, name
 	// Try parsing as 0.20 values
 	if success, err := func() (bool, error) {
 		previousConfig := vclusterconfig.Config{}
-		if err := previousConfig.DecodeYAML(bytes.NewReader(previousConfigRaw)); err != nil {
+		if err := previousConfig.UnmarshalYAMLStrict(previousConfigRaw); err != nil {
 			return false, nil
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves ENG-3573


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
Currently based on https://github.com/loft-sh/vcluster/pull/1727
Will rebase onto main after merge.

I had to adjust our default 0.19.5 `values_k3s.yaml` to the following in order to be able to unmarshal it, as we don't allow those fields anymore.
<img width="687" alt="Screenshot 2024-05-02 at 14 40 20" src="https://github.com/loft-sh/vcluster/assets/3787730/cbd5b5d7-7b9f-4534-8959-3dc07afbaa35">