### PR TITLE
[wip]: start informers for currentNamespaceCache

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -48,7 +48,7 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	// parse vCluster config
 	vConfig, err := config.ParseConfig(options.Config, os.Getenv("VCLUSTER_NAME"), options.SetValues)
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing vcluster config: %w", err)
 	}
 
 	// get current namespace
@@ -60,7 +60,7 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	// init config
 	err = setup.InitAndValidateConfig(ctx, vConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("validating vcluster config: %w", err)
 	}
 
 	// start telemetry

--- a/pkg/config/controller_context.go
+++ b/pkg/config/controller_context.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -20,6 +21,7 @@ type ControllerContext struct {
 	VirtualClusterVersion *version.Info
 
 	WorkloadNamespaceClient client.Client
+	WorkloadNamespaceCache  cache.Cache
 
 	AdditionalServerFilters []servertypes.Filter
 	Config                  *VirtualClusterConfig

--- a/pkg/controllers/resources/nodes/register.go
+++ b/pkg/controllers/resources/nodes/register.go
@@ -16,6 +16,7 @@ func New(ctx *synccontext.RegisterContext) (syncer.Object, error) {
 		return nil, err
 	}
 
+	// TODO(rohan): check if the currentNamespaceClient is used without informers
 	nodeService := nodeservice.NewNodeServiceProvider(ctx.Config.WorkloadService, ctx.CurrentNamespace, ctx.CurrentNamespaceClient, ctx.VirtualManager.GetClient(), uncachedVirtualClient)
 	if !ctx.Config.Sync.FromHost.Nodes.Enabled {
 		return NewFakeSyncer(ctx, nodeService)

--- a/pkg/controllers/resources/pods/translate.go
+++ b/pkg/controllers/resources/pods/translate.go
@@ -70,6 +70,7 @@ func (s *podSyncer) translateUpdate(ctx context.Context, pClient client.Client, 
 
 func (s *podSyncer) findKubernetesIP(ctx *synccontext.SyncContext) (string, error) {
 	pService := &corev1.Service{}
+	// TODO(rohan): client-used
 	err := ctx.CurrentNamespaceClient.Get(ctx.Context, types.NamespacedName{
 		Name:      s.serviceName,
 		Namespace: ctx.CurrentNamespace,

--- a/pkg/controllers/syncer/context/context.go
+++ b/pkg/controllers/syncer/context/context.go
@@ -6,6 +6,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,6 +19,8 @@ type SyncContext struct {
 
 	CurrentNamespace       string
 	CurrentNamespaceClient client.Client
+	// TODO: verify this is actually used, but I assume it it should be wherever the corresponding client is
+	CurrentNamespaceCache cache.Cache
 }
 
 type RegisterContext struct {
@@ -25,8 +28,10 @@ type RegisterContext struct {
 
 	Config *config.VirtualClusterConfig
 
-	CurrentNamespace       string
+	CurrentNamespace string
+	// TODO: check all the calls that use the client, but don't register a watch
 	CurrentNamespaceClient client.Client
+	CurrentNamespaceCache  cache.Cache
 
 	VirtualManager  ctrl.Manager
 	PhysicalManager ctrl.Manager
@@ -34,11 +39,13 @@ type RegisterContext struct {
 
 func ConvertContext(registerContext *RegisterContext, logName string) *SyncContext {
 	return &SyncContext{
-		Context:                registerContext.Context,
-		Log:                    loghelper.New(logName),
-		PhysicalClient:         registerContext.PhysicalManager.GetClient(),
-		VirtualClient:          registerContext.VirtualManager.GetClient(),
-		CurrentNamespace:       registerContext.CurrentNamespace,
+		Context:          registerContext.Context,
+		Log:              loghelper.New(logName),
+		PhysicalClient:   registerContext.PhysicalManager.GetClient(),
+		VirtualClient:    registerContext.VirtualManager.GetClient(),
+		CurrentNamespace: registerContext.CurrentNamespace,
+		// TODO(rohan)
 		CurrentNamespaceClient: registerContext.CurrentNamespaceClient,
+		CurrentNamespaceCache:  registerContext.CurrentNamespaceCache,
 	}
 }

--- a/pkg/controllers/syncer/fake_syncer.go
+++ b/pkg/controllers/syncer/fake_syncer.go
@@ -22,6 +22,7 @@ func RegisterFakeSyncer(ctx *synccontext.RegisterContext, syncer syncertypes.Fak
 		physicalClient: ctx.PhysicalManager.GetClient(),
 
 		currentNamespace:       ctx.CurrentNamespace,
+		// TODO(rohan): check if the currentNamespaceClient is used without informers
 		currentNamespaceClient: ctx.CurrentNamespaceClient,
 
 		virtualClient: ctx.VirtualManager.GetClient(),

--- a/pkg/controllers/syncer/syncer.go
+++ b/pkg/controllers/syncer/syncer.go
@@ -28,7 +28,7 @@ import (
 
 const hostObjectRequestPrefix = "host#"
 
-func NewSyncController(ctx *synccontext.RegisterContext, syncer syncertypes.Syncer) *SyncController {
+func 		NewSyncController(ctx *synccontext.RegisterContext, syncer syncertypes.Syncer) *SyncController {
 	options := &syncertypes.Options{}
 	optionsProvider, ok := syncer.(syncertypes.OptionsProvider)
 	if ok {
@@ -42,6 +42,7 @@ func NewSyncController(ctx *synccontext.RegisterContext, syncer syncertypes.Sync
 		physicalClient: ctx.PhysicalManager.GetClient(),
 
 		currentNamespace:       ctx.CurrentNamespace,
+		// TODO(rohan): check if the currentNamespaceClient is used without informers
 		currentNamespaceClient: ctx.CurrentNamespaceClient,
 
 		virtualClient: ctx.VirtualManager.GetClient(),

--- a/pkg/controllers/syncer/syncer_test.go
+++ b/pkg/controllers/syncer/syncer_test.go
@@ -274,7 +274,8 @@ func TestReconcile(t *testing.T) {
 			vEventRecorder: &testingutil.FakeEventRecorder{},
 			physicalClient: pClient,
 
-			currentNamespace:       fakeContext.CurrentNamespace,
+			currentNamespace: fakeContext.CurrentNamespace,
+			// TODO(rohan): check if the currentNamespaceClient is used without informers
 			currentNamespaceClient: fakeContext.CurrentNamespaceClient,
 
 			virtualClient: vClient,

--- a/pkg/controllers/syncer/testing/context.go
+++ b/pkg/controllers/syncer/testing/context.go
@@ -49,9 +49,10 @@ func FakeStartSyncer(t *testing.T, ctx *synccontext.RegisterContext, create func
 func NewFakeRegisterContext(pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *synccontext.RegisterContext {
 	translate.Default = translate.NewSingleNamespaceTranslator(DefaultTestTargetNamespace)
 	return &synccontext.RegisterContext{
-		Context:                context.Background(),
-		Config:                 NewFakeConfig(),
-		CurrentNamespace:       DefaultTestCurrentNamespace,
+		Context:          context.Background(),
+		Config:           NewFakeConfig(),
+		CurrentNamespace: DefaultTestCurrentNamespace,
+		// TODO: see if we need the currentnamespace cache here
 		CurrentNamespaceClient: pClient,
 		VirtualManager:         newFakeManager(vClient),
 		PhysicalManager:        newFakeManager(pClient),

--- a/pkg/pro/remote.go
+++ b/pkg/pro/remote.go
@@ -38,9 +38,12 @@ var AddRemoteNodePortSANs = func(_ context.Context, _, _ string, _ kubernetes.In
 }
 
 var ExchangeControlPlaneClient = func(controllerCtx *config.ControllerContext) (client.Client, error) {
+	// TODO(rohan): check that workloadnamespace client calls have the right informers set. Should we return the cache as well?
 	return controllerCtx.WorkloadNamespaceClient, nil
 }
 
 var SyncRemoteEndpoints = func(_ context.Context, _ types.NamespacedName, _ client.Client, _ types.NamespacedName, _ client.Client) error {
+	// TODO(rohan): check that workloadnamespace client calls have the right informers set. Should we return the cache as well?
+	// TODO: checkin pro
 	return NewFeatureError(string(licenseapi.VirtualClusterProDistroIsolatedControlPlane))
 }

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -14,7 +14,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/telemetry"
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
@@ -335,20 +334,20 @@ func newCurrentNamespaceCache(ctx context.Context, localManager ctrl.Manager, op
 			return nil, nil, err
 		}
 
-		_, err := currentNamespaceCache.GetInformer(ctx, &corev1.Service{}, cache.BlockUntilSynced(true))
-		if err != nil {
-			return nil, nil, fmt.Errorf("current namespace cache informer failed: %w", err)
-		}
+		// _, err := currentNamespaceCache.GetInformer(ctx, &corev1.Service{}, cache.BlockUntilSynced(true))
+		// if err != nil {
+		// 	return nil, nil, fmt.Errorf("current namespace cache informer failed: %w", err)
+		// }
 
-		// start cache now if it's not in the same namespace
-		go func() {
-			err := currentNamespaceCache.Start(ctx)
-			if err != nil {
-				panic(err)
-			}
-		}()
-		currentNamespaceCache.WaitForCacheSync(ctx)
 	}
+	// start cache now
+	go func() {
+		err := currentNamespaceCache.Start(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	currentNamespaceCache.WaitForCacheSync(ctx)
 
 	// create a current namespace client
 	currentNamespaceClient, err := blockingcacheclient.NewCacheClient(localManager.GetConfig(), client.Options{

--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -88,6 +88,7 @@ func StartControllers(controllerContext *config.ControllerContext) error {
 				Namespace: controllerContext.Config.WorkloadNamespace,
 				Name:      controllerContext.Config.WorkloadService,
 			},
+			// TODO(rohan)
 			controllerContext.WorkloadNamespaceClient,
 		)
 		if err != nil {
@@ -165,6 +166,7 @@ func ApplyCoreDNS(controllerContext *config.ControllerContext) {
 	})
 }
 
+// SetGlobalOwner sets the global Owner variable in the translate pkg
 func SetGlobalOwner(ctx context.Context, currentNamespaceClient client.Client, currentNamespace, targetNamespace string, setOwner bool, serviceName string) error {
 	if currentNamespace != targetNamespace {
 		if setOwner {

--- a/pkg/util/context/converter.go
+++ b/pkg/util/context/converter.go
@@ -13,6 +13,7 @@ func ToRegisterContext(ctx *config.ControllerContext) *synccontext.RegisterConte
 
 		CurrentNamespace:       ctx.Config.WorkloadNamespace,
 		CurrentNamespaceClient: ctx.WorkloadNamespaceClient,
+		CurrentNamespaceCache:  ctx.WorkloadNamespaceCache,
 
 		VirtualManager:  ctx.VirtualManager,
 		PhysicalManager: ctx.LocalManager,


### PR DESCRIPTION
This is currently WIP. I've enabled a cahce option that fails the `Reader` call when a call is made with no informer set. Going to retry the e2e till all calls pass with this option.
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
