### PR TITLE
chore(config): deprecate fields instead of removal

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1985,6 +1985,11 @@
     },
     "Platform": {
       "properties": {
+        "apiKey": {
+          "$ref": "#/$defs/PlatformAPIKey",
+          "description": "APIKey defines how vCluster can contact the platform api.\nDEPRECATED: TODO Remove with v0.20.0 GA",
+          "deprecated": true
+        },
         "api": {
           "$ref": "#/$defs/PlatformAPI",
           "description": "API defines how vCluster can contact the platform api."
@@ -2026,6 +2031,21 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "PlatformAPIKey": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Value specifies the access key as a regular text value."
+        },
+        "secretRef": {
+          "$ref": "#/$defs/PlatformAccessKeySecretReference",
+          "description": "SecretRef defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:\n* platform.api.accessKey\n* environment variable called LICENSE\n* secret specified under platform.api.secretRef.name\n* secret called \"vcluster-platform-api-key\" in the vCluster namespace"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "TODO Remove with v0.20.0 GA"
     },
     "PlatformAccessKeySecretReference": {
       "properties": {
@@ -2718,6 +2738,11 @@
         "enabled": {
           "type": "boolean",
           "description": "Enabled specifies if rewriting stateful set pods should be enabled."
+        },
+        "initContainerImage": {
+          "type": "string",
+          "description": "InitContainerImage is the image virtual cluster should use to rewrite this FQDN.\nDEPRECATED: TODO Remove with v0.20.0 GA",
+          "deprecated": true
         },
         "initContainer": {
           "$ref": "#/$defs/SyncRewriteHostsInitContainer",

--- a/config/config.go
+++ b/config/config.go
@@ -312,6 +312,10 @@ type SyncRewriteHosts struct {
 	// Enabled specifies if rewriting stateful set pods should be enabled.
 	Enabled bool `json:"enabled,omitempty"`
 
+	// InitContainerImage is the image virtual cluster should use to rewrite this FQDN.
+	// DEPRECATED: TODO Remove with v0.20.0 GA
+	InitContainerImage string `json:"initContainerImage,omitempty" jsonschema_extras:"deprecated=true"`
+
 	// InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 	InitContainer SyncRewriteHostsInitContainer `json:"initContainer,omitempty"`
 }
@@ -1632,6 +1636,10 @@ type ExperimentalDeployHelmChart struct {
 }
 
 type Platform struct {
+	// APIKey defines how vCluster can contact the platform api.
+	// DEPRECATED: TODO Remove with v0.20.0 GA
+	APIKey PlatformAPIKey `json:"apiKey,omitempty" jsonschema_extras:"deprecated=true"`
+
 	// API defines how vCluster can contact the platform api.
 	API PlatformAPI `json:"api,omitempty"`
 
@@ -1652,6 +1660,21 @@ type PlatformOwner struct {
 	// Team is the team id within the platform. This is mutually exclusive with user.
 	Team string `json:"team,omitempty"`
 }
+
+// TODO Remove with v0.20.0 GA
+type PlatformAPIKey struct {
+	// Value specifies the access key as a regular text value.
+	Value string `json:"value,omitempty"`
+
+	// SecretRef defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
+	// * platform.api.accessKey
+	// * environment variable called LICENSE
+	// * secret specified under platform.api.secretRef.name
+	// * secret called "vcluster-platform-api-key" in the vCluster namespace
+	SecretRef PlatformAccessKeySecretReference `json:"secretRef,omitempty"`
+}
+
+// TODO end
 
 type PlatformAPI struct {
 	// AccessKey specifies the access key as a regular text value.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of #ENG-3573


**Please provide a short message that should be published in the vcluster release notes**
Needed so we can do a strict unmarshal of the new config format. Otherwise this won't work because values obtained from 0.20.0-beta.1 virtual clusters cannot be unmarshaled because of missing keys.


**What else do we need to know?** 
