### PR TITLE
chore(config): also enable hpm when using deprecated flag

### DIFF
--- a/config/legacyconfig/migrate.go
+++ b/config/legacyconfig/migrate.go
@@ -989,7 +989,7 @@ func migrateFlag(key, value string, newConfig *config.Config) error {
 			return fmt.Errorf("value is missing")
 		}
 		newConfig.Experimental.SyncSettings.VirtualMetricsBindAddress = value
-	case "mount-physical-host-paths":
+	case "mount-physical-host-paths", "rewrite-host-paths":
 		if value == "" || value == "true" {
 			newConfig.ControlPlane.HostPathMapper.Enabled = true
 		}

--- a/config/legacyconfig/migrate_test.go
+++ b/config/legacyconfig/migrate_test.go
@@ -308,6 +308,24 @@ sync:
       useSecretsForSATokens: true`,
 		},
 		{
+			Name:   "convert deprecated host-path-mapper flag",
+			Distro: "k0s",
+			In: `syncer:
+  extraArgs:
+  - --rewrite-host-paths=true
+`,
+			Expected: `controlPlane:
+  distro:
+    k0s:
+      enabled: true
+  hostPathMapper:
+    enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+`,
+		},
+		{
 			Name:   "embedded etcd",
 			Distro: "k8s",
 			In: `embeddedEtcd:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Part of ENG-3708


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster did not convert a legacy config with a deprecated HPM flag.


**What else do we need to know?** 
