### PR TITLE
fail early if kine can't start

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -43,7 +43,7 @@ func StartK8S(
 		}
 
 		// start embedded mode
-		eg.Go(func() error {
+		go func() {
 			args := []string{}
 			args = append(args, "/usr/local/bin/kine")
 			args = append(args, "--endpoint="+dataSource)
@@ -53,9 +53,12 @@ func StartK8S(
 			args = append(args, "--metrics-bind-address=0")
 			args = append(args, "--listen-address="+KineEndpoint)
 
-			// now start the api server
-			return RunCommand(ctx, args, "kine")
-		})
+			// now start kine
+			err := RunCommand(ctx, args, "kine")
+			if err != nil {
+				klog.Fatal("could not run kine", err)
+			}
+		}()
 
 		etcdEndpoints = KineEndpoint
 	} else if vConfig.ControlPlane.BackingStore.Database.External.Enabled {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would time out if kine wasn't found, now fails early and displays a message 


**What else do we need to know?** 
