### PR TITLE
chore(vclusterctl): rename pro to platform

### DIFF
--- a/cmd/vclusterctl/cmd/platform/access_key.go
+++ b/cmd/vclusterctl/cmd/platform/access_key.go
@@ -43,14 +43,14 @@ func NewAccessKeyCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Aliases: []string{"token"},
 		Short:   "Prints the access token to a vCluster platform instance",
 		Long: `########################################################
-################## vcluster pro token ##################
+############# vcluster platform token ##################
 ########################################################
 
 Prints an access token to a vCluster platform instance. This
 can be used as an ExecAuthenticator for kubernetes
 
 Example:
-vcluster pro token
+vcluster platform token
 ########################################################
 	`,
 		Args: cobra.NoArgs,

--- a/cmd/vclusterctl/cmd/platform/connect/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/connect/cluster.go
@@ -54,7 +54,7 @@ func NewClusterCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 Connect a cluster to the vCluster platform instance.
 
 Example:
-vcluster pro connect cluster my-cluster
+vcluster platform connect cluster my-cluster
 ########################################################
 		`,
 		Args: cobra.ExactArgs(1),

--- a/cmd/vclusterctl/cmd/platform/connect/connect.go
+++ b/cmd/vclusterctl/cmd/platform/connect/connect.go
@@ -11,7 +11,7 @@ func NewConnectCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Use:   "connect",
 		Short: "Connects a cluster to vCluster platform",
 		Long: `#######################################################
-################ vcluster pro connect #################
+########### vcluster platform connect #################
 #######################################################
 		`,
 		Args: cobra.NoArgs,

--- a/cmd/vclusterctl/cmd/platform/reset.go
+++ b/cmd/vclusterctl/cmd/platform/reset.go
@@ -9,7 +9,7 @@ import (
 
 func NewResetCmd(loftctlGlobalFlags *loftctlflags.GlobalFlags) *cobra.Command {
 	description := `########################################################
-################## vcluster pro reset ##################
+############# vcluster platform reset ##################
 ########################################################
 	`
 	cmd := &cobra.Command{
@@ -31,13 +31,13 @@ func NewPasswordCmd(globalFlags *loftctlflags.GlobalFlags) *cobra.Command {
 	}
 
 	description := `########################################################
-############## vcluster pro reset password #############
+######### vcluster platform reset password #############
 ########################################################
 Resets the password of a user.
 
 Example:
-vcluster pro reset password
-vcluster pro reset password --user admin
+vcluster platform reset password
+vcluster platform reset password --user admin
 #######################################################
 	`
 

--- a/cmd/vclusterctl/cmd/platform/start.go
+++ b/cmd/vclusterctl/cmd/platform/start.go
@@ -31,7 +31,7 @@ func NewStartCmd(loftctlGlobalFlags *loftctlflags.GlobalFlags) (*cobra.Command, 
 		Use:   "start",
 		Short: "Start a vCluster platform instance and connect via port-forwarding",
 		Long: `########################################################
-################## vcluster pro start ##################
+############# vcluster platform start ##################
 ########################################################
 
 Starts a vCluster platform instance in your Kubernetes cluster


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would display deprecated pro cmd instead of platform.


**What else do we need to know?** 
