### PR TITLE
chore(vclusterctl): add --config to global flags

### DIFF
--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -34,6 +34,14 @@ func NewRootCmd(log log.Logger) *cobra.Command {
 			} else {
 				log.SetLevel(logrus.InfoLevel)
 			}
+
+			if globalFlags.Config == "" {
+				var err error
+				globalFlags.Config, err = platform.ConfigFilePath()
+				if err != nil {
+					log.Fatalf("failed to get vcluster configuration file path: %w", err)
+				}
+			}
 		},
 		Long: `vcluster root command`,
 	}
@@ -76,7 +84,7 @@ func Execute() {
 func BuildRoot(log log.Logger) (*cobra.Command, error) {
 	rootCmd := NewRootCmd(log)
 	persistentFlags := rootCmd.PersistentFlags()
-	globalFlags = flags.SetGlobalFlags(persistentFlags)
+	globalFlags = flags.SetGlobalFlags(persistentFlags, log)
 
 	// Set version for --version flag
 	rootCmd.Version = upgrade.GetVersion()

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -1,6 +1,8 @@
 package flags
 
 import (
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/platform"
 	flag "github.com/spf13/pflag"
 )
 
@@ -15,10 +17,16 @@ type GlobalFlags struct {
 }
 
 // SetGlobalFlags applies the global flags
-func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
+func SetGlobalFlags(flags *flag.FlagSet, log log.Logger) *GlobalFlags {
 	globalFlags := &GlobalFlags{}
 
+	defaultConfigPath, err := platform.ConfigFilePath()
+	if err != nil {
+		log.Fatalf("failed to get vcluster configuration file path: %w", err)
+	}
+
 	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")
+	flags.StringVar(&globalFlags.Config, "config", defaultConfigPath, "The vcluster platform config to use (will be created if it does not exist)")
 	flags.StringVar(&globalFlags.Context, "context", "", "The kubernetes config context to use")
 	flags.StringVarP(&globalFlags.Namespace, "namespace", "n", "", "The kubernetes namespace to use")
 	flags.BoolVarP(&globalFlags.Silent, "silent", "s", false, "Run in silent mode and prevents any vcluster log output except panics & fatals")

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	VClusterProFolder = "pro"
+	ConfigDirName = "platform"
 )
 
 // ConfigFilePath returns the path to the loft config file
@@ -22,7 +22,7 @@ func ConfigFilePath() (string, error) {
 		return "", fmt.Errorf("failed to open vCluster platform configuration file, unable to detect $HOME directory, falling back to default configuration, following error occurred: %w", err)
 	}
 
-	return filepath.Join(home, constants.VClusterFolder, VClusterProFolder, constants.ConfigFileName), nil
+	return filepath.Join(home, constants.VClusterFolder, ConfigDirName, constants.ConfigFileName), nil
 }
 
 func managerFilePath() (string, error) {
@@ -31,7 +31,7 @@ func managerFilePath() (string, error) {
 		return "", fmt.Errorf("failed to open vCluster platform manager file, unable to detect $HOME directory, falling back to default configuration, following error occurred: %w", err)
 	}
 
-	return filepath.Join(home, constants.VClusterFolder, VClusterProFolder, constants.ManagerFileName), nil
+	return filepath.Join(home, constants.VClusterFolder, ConfigDirName, constants.ManagerFileName), nil
 }
 
 func PrintManagerInfo(verb string, manager ManagerType, log log.Logger) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3722


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not offer a global flag to store its config file.


**What else do we need to know?** 
For now passes-through the global flags to loftctl commands, which we currently still depend on. This part will be removed in future PRs that remove the dependency to loftctl.
Futhermore, renamed the `pro` config sub dir to `platform`.