### PR TITLE
fix: resource already exists

### DIFF
--- a/pkg/controllers/syncer/translator/namespaced_translator.go
+++ b/pkg/controllers/syncer/translator/namespaced_translator.go
@@ -69,6 +69,10 @@ func (n *namespacedTranslator) SyncToHostCreate(ctx *context.SyncContext, vObj, 
 			ctx.Log.Debugf("error syncing %s %s/%s to physical cluster: %v", n.name, vObj.GetNamespace(), vObj.GetName(), err)
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
+		if kerrors.IsAlreadyExists(err) {
+			ctx.Log.Debugf("ignoring syncing %s %s/%s to physical cluster as it already exists", n.name, vObj.GetNamespace(), vObj.GetName())
+			return ctrl.Result{}, nil
+		}
 		ctx.Log.Infof("error syncing %s %s/%s to physical cluster: %v", n.name, vObj.GetNamespace(), vObj.GetName(), err)
 		n.eventRecorder.Eventf(vObj, "Warning", "SyncError", "Error syncing to physical cluster: %v", err)
 		return ctrl.Result{}, err


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

During syncing of virtual namespaces to physical, the default service account already exists, which leads to errors during syncing. In this fix we consume the error in case the physical resource already exists.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not sync due to already existing default service accounts

**What else do we need to know?** 

This is part of a collaborative work at Woven by Toyota with my colleagues @ajithcnambiar and @tauxi