### PR TITLE
Adds enableServiceLinks to the STS config for controlPlane and controlPlane.backingStore

### DIFF
--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -132,6 +132,7 @@ spec:
       securityContext:
 {{ toYaml $externalEtcd.security.podSecurityContext | indent 8 }}
       {{- end }}
+      enableServiceLinks: {{ .Values.controlPlane.backingStore.etcd.deploy.statefulSet.enableServiceLinks }}
       containers:
       - name: etcd
         image: '{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" $externalEtcd.image.registry "repository" $externalEtcd.image.repository "tag" $externalEtcd.image.tag) }}'

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -129,6 +129,7 @@ spec:
       initContainers:
 {{ include "vcluster.initContainers" . | indent 8 }}
       {{- end }}
+      enableServiceLinks: {{ .Values.controlPlane.statefulSet.enableServiceLinks }}
       containers:
         - name: syncer
           image: {{ include "vcluster.controlPlane.image" . | quote }}

--- a/chart/tests/etcd-statefulset_test.yaml
+++ b/chart/tests/etcd-statefulset_test.yaml
@@ -40,6 +40,23 @@ tests:
           path: spec.template.spec.containers[0].image
           value: fabi.com/etcd:123
 
+  - it: disables serviceLinks for backingStore etcd pod
+    set:
+      controlPlane:
+        backingStore:
+          etcd:
+            deploy:
+              enabled: true
+              statefulSet:
+                enabled: true
+                enableServiceLinks: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: false
+
   - it: change image registry
     set:
       controlPlane:

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -75,6 +75,16 @@ tests:
           path: spec.template.spec.initContainers[0].image
           value: k0s:123
 
+  - it: disables serviceLinks for sts etcd pod
+    set:
+      controlPlane:
+        statefulSet:
+          enableServiceLinks: false
+    asserts:
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: false
+
   - it: custom init container
     set:
       controlPlane:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -421,7 +421,7 @@
         },
         "enableServiceLinks": {
           "type": "boolean",
-          "description": "EnableServiceLinks for the sts pod"
+          "description": "EnableServiceLinks for the StatefulSet pod"
         },
         "annotations": {
           "additionalProperties": {
@@ -1013,7 +1013,7 @@
         },
         "enableServiceLinks": {
           "type": "boolean",
-          "description": "EnableServiceLinks for the sts pod"
+          "description": "EnableServiceLinks for the StatefulSet pod"
         },
         "image": {
           "$ref": "#/$defs/Image",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -419,6 +419,10 @@
           "$ref": "#/$defs/ControlPlanePersistence",
           "description": "Persistence defines options around persistence for the statefulSet."
         },
+        "enableServiceLinks": {
+          "type": "boolean",
+          "description": "EnableServiceLinks for the sts pod"
+        },
         "annotations": {
           "additionalProperties": {
             "type": "string"
@@ -1006,6 +1010,10 @@
         "enabled": {
           "type": "boolean",
           "description": "Enabled defines if the statefulSet should be deployed"
+        },
+        "enableServiceLinks": {
+          "type": "boolean",
+          "description": "EnableServiceLinks for the sts pod"
         },
         "image": {
           "$ref": "#/$defs/Image",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -358,6 +358,8 @@ controlPlane:
         statefulSet:
           # Enabled defines if the statefulSet should be deployed
           enabled: true
+          # EnableServiceLinks for the sts pod
+          enableServiceLinks: true
           annotations: {}
           labels: {}
           # Image is the image to use for the external etcd statefulSet
@@ -602,6 +604,8 @@ controlPlane:
       addVolumeMounts: []
       # AddVolumes defines extra volumes for the pod
       addVolumes: []
+    # EnableServiceLinks for the sts pod
+    enableServiceLinks: true
     # Scheduling holds options related to scheduling.
     scheduling:
       # PodManagementPolicy is the statefulSet pod management policy.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -358,7 +358,7 @@ controlPlane:
         statefulSet:
           # Enabled defines if the statefulSet should be deployed
           enabled: true
-          # EnableServiceLinks for the sts pod
+          # EnableServiceLinks for the StatefulSet pod
           enableServiceLinks: true
           annotations: {}
           labels: {}
@@ -604,7 +604,7 @@ controlPlane:
       addVolumeMounts: []
       # AddVolumes defines extra volumes for the pod
       addVolumes: []
-    # EnableServiceLinks for the sts pod
+    # EnableServiceLinks for the StatefulSet pod
     enableServiceLinks: true
     # Scheduling holds options related to scheduling.
     scheduling:

--- a/config/config.go
+++ b/config/config.go
@@ -620,7 +620,7 @@ type ControlPlaneStatefulSet struct {
 	// Persistence defines options around persistence for the statefulSet.
 	Persistence ControlPlanePersistence `json:"persistence,omitempty"`
 
-	// EnableServiceLinks for the sts pod
+	// EnableServiceLinks for the StatefulSet pod
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
 
 	LabelsAndAnnotations `json:",inline"`
@@ -883,7 +883,7 @@ type EtcdDeployStatefulSet struct {
 	// Enabled defines if the statefulSet should be deployed
 	Enabled bool `json:"enabled,omitempty"`
 
-	// EnableServiceLinks for the sts pod
+	// EnableServiceLinks for the StatefulSet pod
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
 
 	// Image is the image to use for the external etcd statefulSet

--- a/config/config.go
+++ b/config/config.go
@@ -620,6 +620,9 @@ type ControlPlaneStatefulSet struct {
 	// Persistence defines options around persistence for the statefulSet.
 	Persistence ControlPlanePersistence `json:"persistence,omitempty"`
 
+	// EnableServiceLinks for the sts pod
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
+
 	LabelsAndAnnotations `json:",inline"`
 
 	// Additional labels or annotations for the statefulSet pods.
@@ -879,6 +882,9 @@ type EtcdDeployHeadlessService struct {
 type EtcdDeployStatefulSet struct {
 	// Enabled defines if the statefulSet should be deployed
 	Enabled bool `json:"enabled,omitempty"`
+
+	// EnableServiceLinks for the sts pod
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty"`
 
 	// Image is the image to use for the external etcd statefulSet
 	Image Image `json:"image,omitempty"`

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -202,6 +202,7 @@ controlPlane:
         enabled: false
         statefulSet:
           enabled: true
+          enableServiceLinks: true
           annotations: {}
           labels: {}
           image:
@@ -351,6 +352,8 @@ controlPlane:
       volumeClaimTemplates: []
       addVolumeMounts: []
       addVolumes: []
+
+    enableServiceLinks: true
 
     scheduling:
       podManagementPolicy: Parallel


### PR DESCRIPTION

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind test

**What does this pull request do? Which issues does it resolve?** 
resolves ENG-3500
resolves #1708 


**Please provide a short message that should be published in the vcluster release notes**
Added the ability to disable service links for the etcd STS as they can cause problems in a cluster with thousands of services.


**What else do we need to know?** 
vcluster.yaml docs should be updated as well.

👇 Demo showing creating one vCluster for each of the new `enableServiceLinks` config options.  Then getting the STS yaml, and parsing out the value that should, and does, read false in both cases:
![gh1708-demo](https://github.com/loft-sh/vcluster/assets/100507/84f81c95-8ff9-4a97-b473-258f74b7ba37)
