### PR TITLE
fix/refactor: remove need to pass cli.Config to subcommands

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/cluster.go
@@ -16,7 +16,6 @@ import (
 
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
@@ -31,7 +30,6 @@ import (
 type ClusterCmd struct {
 	Log log.Logger
 	*flags.GlobalFlags
-	Cfg              *config.CLI
 	Namespace        string
 	ServiceAccount   string
 	DisplayName      string
@@ -90,7 +88,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	// Get clusterName from command argument
 	clusterName := args[0]
 
-	platformClient, err := platform.InitClientFromConfig(ctx, cmd.Cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.Log))
 	if err != nil {
 		return fmt.Errorf("new client from path: %w", err)
 	}

--- a/cmd/vclusterctl/cmd/platform/backup/backup.go
+++ b/cmd/vclusterctl/cmd/platform/backup/backup.go
@@ -1,13 +1,12 @@
 package backup
 
 import (
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/spf13/cobra"
 )
 
 // NewAddCmd creates a new command
-func NewBackupCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func NewBackupCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	addCmd := &cobra.Command{
 		Use:   "backup",
 		Short: "Backup subcommands",
@@ -18,6 +17,6 @@ func NewBackupCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Comman
 		Args: cobra.NoArgs,
 	}
 
-	addCmd.AddCommand(newManagementCmd(globalFlags, cfg))
+	addCmd.AddCommand(newManagementCmd(globalFlags))
 	return addCmd
 }

--- a/cmd/vclusterctl/cmd/platform/backup/management.go
+++ b/cmd/vclusterctl/cmd/platform/backup/management.go
@@ -8,7 +8,6 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/survey"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/backup"
@@ -35,15 +34,13 @@ type ManagementCmd struct {
 	Namespace string
 	Filename  string
 	Skip      []string
-	cfg       *config.CLI
 }
 
 // newManagementCmd creates a new command for backing up the management plane
-func newManagementCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newManagementCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ManagementCmd{
 		GlobalFlags: globalFlags,
 		Log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 
 	description := product.ReplaceWithHeader("backup management", `
@@ -61,7 +58,7 @@ vcluster platform backup management
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			// we need to set the project namespace prefix correctly here
-			_, err := platform.InitClientFromConfig(cobraCmd.Context(), cmd.cfg)
+			_, err := platform.InitClientFromConfig(cobraCmd.Context(), cmd.LoadedConfig(cmd.Log))
 			if err != nil {
 				return fmt.Errorf("create vCluster platform client: %w", err)
 			}

--- a/cmd/vclusterctl/cmd/platform/connect/connect.go
+++ b/cmd/vclusterctl/cmd/platform/connect/connect.go
@@ -2,13 +2,12 @@ package connect
 
 import (
 	"github.com/loft-sh/api/v4/pkg/product"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/spf13/cobra"
 )
 
 // NewConnectCmd creates a new cobra command
-func NewConnectCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func NewConnectCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	description := product.ReplaceWithHeader("connect", `
 
 Activates a kube context for the given cluster / space / vcluster / management.
@@ -21,7 +20,7 @@ Activates a kube context for the given cluster / space / vcluster / management.
 	}
 
 	connectCmd.AddCommand(newClusterCmd(globalFlags))
-	connectCmd.AddCommand(newManagementCmd(globalFlags, cfg))
 	connectCmd.AddCommand(newVClusterCmd(globalFlags))
+	connectCmd.AddCommand(newManagementCmd(globalFlags))
 	return connectCmd
 }

--- a/cmd/vclusterctl/cmd/platform/connect/management.go
+++ b/cmd/vclusterctl/cmd/platform/connect/management.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/kubeconfig"
@@ -17,20 +16,16 @@ import (
 // ManagementCmd holds the cmd flags
 type ManagementCmd struct {
 	*flags.GlobalFlags
-
-	Print bool
-
 	log log.Logger
 
-	cfg *config.CLI
+	Print bool
 }
 
 // NewManagementCmd creates a new command
-func newManagementCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newManagementCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ManagementCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 
 	description := product.ReplaceWithHeader("connect management", `
@@ -60,7 +55,7 @@ vcluster platform connect management
 }
 
 func (cmd *ManagementCmd) run(cobraCmd *cobra.Command) error {
-	platformClient, err := platform.InitClientFromConfig(cobraCmd.Context(), cmd.cfg)
+	platformClient, err := platform.InitClientFromConfig(cobraCmd.Context(), cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/get/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/get/cluster.go
@@ -9,7 +9,7 @@ import (
 
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	"github.com/loft-sh/loftctl/v4/pkg/config"
-	cliconfig "github.com/loft-sh/vcluster/pkg/cli/config"
+	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/projectutil"
@@ -26,13 +26,12 @@ var (
 
 type clusterCmd struct {
 	*flags.GlobalFlags
-	cfg *cliconfig.CLI
+	log log.Logger
 }
 
-func newClusterCmd(globalFlags *flags.GlobalFlags, cfg *cliconfig.CLI) *cobra.Command {
+func newClusterCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &clusterCmd{
 		GlobalFlags: globalFlags,
-		cfg:         cfg,
 	}
 
 	return &cobra.Command{
@@ -61,7 +60,7 @@ func (c *clusterCmd) Run(ctx context.Context, _ []string) error {
 
 	isProject, projectName := isProjectContext(cluster)
 	if isProject {
-		platformClient, err := platform.InitClientFromConfig(ctx, c.cfg)
+		platformClient, err := platform.InitClientFromConfig(ctx, c.LoadedConfig(c.log))
 		if err != nil {
 			return err
 		}

--- a/cmd/vclusterctl/cmd/platform/get/cluster_access_key.go
+++ b/cmd/vclusterctl/cmd/platform/get/cluster_access_key.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	util "github.com/loft-sh/vcluster/pkg/platform/loftutils"
@@ -22,16 +21,14 @@ import (
 type ClusterTokenCmd struct {
 	*flags.GlobalFlags
 
-	cfg    *config.CLI
 	log    log.Logger
 	Output string
 }
 
-func newClusterAccessKeyCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newClusterAccessKeyCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ClusterTokenCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 	description := product.ReplaceWithHeader("get cluster-access-key", `
 Returns the Network Peer Cluster Token
@@ -61,7 +58,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 func (cmd *ClusterTokenCmd) Run(ctx context.Context, args []string) error {
 	clusterName := args[0]
 
-	platformClient, err := platform.InitClientFromConfig(ctx, cmd.cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return fmt.Errorf("new client from path: %w", err)
 	}

--- a/cmd/vclusterctl/cmd/platform/get/get.go
+++ b/cmd/vclusterctl/cmd/platform/get/get.go
@@ -2,14 +2,13 @@ package get
 
 import (
 	"github.com/loft-sh/api/v4/pkg/product"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/spf13/cobra"
 )
 
 // NewGetCmd creates a new cobra command for the sub command
-func NewGetCmd(globalFlags *flags.GlobalFlags, defaults *defaults.Defaults, cfg *config.CLI) *cobra.Command {
+func NewGetCmd(globalFlags *flags.GlobalFlags, defaults *defaults.Defaults) *cobra.Command {
 	description := product.ReplaceWithHeader("get", "")
 
 	cmd := &cobra.Command{
@@ -19,9 +18,9 @@ func NewGetCmd(globalFlags *flags.GlobalFlags, defaults *defaults.Defaults, cfg 
 		Args:  cobra.NoArgs,
 	}
 
-	cmd.AddCommand(newClusterCmd(globalFlags, cfg))
-	cmd.AddCommand(newClusterAccessKeyCmd(globalFlags, cfg))
-	cmd.AddCommand(newSecretCmd(globalFlags, defaults, cfg))
-	cmd.AddCommand(newUserCmd(globalFlags, cfg))
+	cmd.AddCommand(newClusterCmd(globalFlags))
+	cmd.AddCommand(newClusterAccessKeyCmd(globalFlags))
+	cmd.AddCommand(newSecretCmd(globalFlags, defaults))
+	cmd.AddCommand(newUserCmd(globalFlags))
 	return cmd
 }

--- a/cmd/vclusterctl/cmd/platform/get/secret.go
+++ b/cmd/vclusterctl/cmd/platform/get/secret.go
@@ -11,7 +11,6 @@ import (
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/survey"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/set"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	pdefaults "github.com/loft-sh/vcluster/pkg/platform/defaults"
@@ -38,16 +37,13 @@ type SecretCmd struct {
 	Project   string
 	Output    string
 	All       bool
-
-	cfg *config.CLI
 }
 
 // newSecretCmd creates a new command
-func newSecretCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults, cfg *config.CLI) *cobra.Command {
+func newSecretCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
 	cmd := &SecretCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 	description := product.ReplaceWithHeader("get secret", `
 Returns the key value of a project / shared secret.
@@ -78,7 +74,7 @@ vcluster platform get secret test-secret.key --project myproject
 
 // RunUsers executes the functionality
 func (cmd *SecretCmd) Run(ctx context.Context, args []string) error {
-	platformClient, err := platform.InitClientFromConfig(ctx, cmd.cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/get/user.go
+++ b/cmd/vclusterctl/cmd/platform/get/user.go
@@ -11,7 +11,6 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/table"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/spf13/cobra"
@@ -31,7 +30,7 @@ const (
 )
 
 // newUserCmd creates a new command
-func newUserCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newUserCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &UserCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
@@ -49,7 +48,7 @@ vcluster platform get current-user
 		Long:  description,
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
-			return cmd.Run(cobraCmd.Context(), cfg)
+			return cmd.Run(cobraCmd.Context())
 		},
 	}
 
@@ -59,8 +58,8 @@ vcluster platform get current-user
 }
 
 // RunUsers executes the functionality
-func (cmd *UserCmd) Run(ctx context.Context, cfg *config.CLI) error {
-	baseClient, err := platform.InitClientFromConfig(ctx, cfg)
+func (cmd *UserCmd) Run(ctx context.Context) error {
+	baseClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/list/clusters.go
+++ b/cmd/vclusterctl/cmd/platform/list/clusters.go
@@ -7,7 +7,6 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/table"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/spf13/cobra"
@@ -20,15 +19,13 @@ type ClustersCmd struct {
 	*flags.GlobalFlags
 
 	log log.Logger
-	cfg *config.CLI
 }
 
 // newClustersCmd creates a new spaces command
-func newClustersCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newClustersCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ClustersCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 	description := product.ReplaceWithHeader("list clusters", `
 List the vcluster platform clusters you have access to
@@ -52,7 +49,7 @@ vcluster platform list clusters
 
 // RunClusters executes the functionality
 func (cmd *ClustersCmd) RunClusters(ctx context.Context) error {
-	platformClient, err := platform.InitClientFromConfig(ctx, cmd.cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/list/list.go
+++ b/cmd/vclusterctl/cmd/platform/list/list.go
@@ -3,13 +3,12 @@ package list
 import (
 	"github.com/loft-sh/api/v4/pkg/product"
 
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/spf13/cobra"
 )
 
 // NewListCmd creates a new cobra command
-func NewListCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func NewListCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	description := product.ReplaceWithHeader("list", "")
 	listCmd := &cobra.Command{
 		Use:   "list",
@@ -18,9 +17,9 @@ func NewListCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command 
 		Args:  cobra.NoArgs,
 	}
 
-	listCmd.AddCommand(newClustersCmd(globalFlags, cfg))
-	listCmd.AddCommand(newSharedSecretsCmd(globalFlags, cfg))
-	listCmd.AddCommand(newTeamsCmd(globalFlags, cfg))
+	listCmd.AddCommand(newClustersCmd(globalFlags))
+	listCmd.AddCommand(newSharedSecretsCmd(globalFlags))
+	listCmd.AddCommand(newTeamsCmd(globalFlags))
 	listCmd.AddCommand(newVClustersCmd(globalFlags))
 	return listCmd
 }

--- a/cmd/vclusterctl/cmd/platform/list/secrets.go
+++ b/cmd/vclusterctl/cmd/platform/list/secrets.go
@@ -9,7 +9,6 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/table"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/kube"
@@ -30,7 +29,7 @@ type SharedSecretsCmd struct {
 }
 
 // newSharedSecretsCmd creates a new command
-func newSharedSecretsCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newSharedSecretsCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &SharedSecretsCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
@@ -48,7 +47,7 @@ vcluster platform list secrets
 		Long:  description,
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
-			return cmd.Run(cobraCmd, cfg)
+			return cmd.Run(cobraCmd)
 		},
 	}
 
@@ -60,8 +59,8 @@ vcluster platform list secrets
 }
 
 // Run executes the functionality
-func (cmd *SharedSecretsCmd) Run(command *cobra.Command, cfg *config.CLI) error {
-	platformClient, err := platform.InitClientFromConfig(command.Context(), cfg)
+func (cmd *SharedSecretsCmd) Run(command *cobra.Command) error {
+	platformClient, err := platform.InitClientFromConfig(command.Context(), cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/list/teams.go
+++ b/cmd/vclusterctl/cmd/platform/list/teams.go
@@ -6,7 +6,6 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/table"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
@@ -19,14 +18,12 @@ type TeamsCmd struct {
 	*flags.GlobalFlags
 
 	log log.Logger
-	cfg *config.CLI
 }
 
-func newTeamsCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) *cobra.Command {
+func newTeamsCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &TeamsCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 	description := product.ReplaceWithHeader("list teams", `
 List the vCluster platform teams you are a member of
@@ -49,7 +46,7 @@ vcluster platform list teams
 }
 
 func (cmd *TeamsCmd) Run(ctx context.Context) error {
-	platformClient, err := platform.InitClientFromConfig(ctx, cmd.cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/platform.go
+++ b/cmd/vclusterctl/cmd/platform/platform.go
@@ -15,14 +15,13 @@ import (
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/share"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/sleep"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/wakeup"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
-func NewPlatformCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) (*cobra.Command, error) {
+func NewPlatformCmd(globalFlags *flags.GlobalFlags) (*cobra.Command, error) {
 	platformCmd := &cobra.Command{
 		Use:   "platform",
 		Short: "vCluster platform subcommands",
@@ -54,11 +53,11 @@ func NewPlatformCmd(globalFlags *flags.GlobalFlags, cfg *config.CLI) (*cobra.Com
 	platformCmd.AddCommand(add.NewAddCmd(globalFlags))
 	platformCmd.AddCommand(NewAccessKeyCmd(globalFlags))
 	platformCmd.AddCommand(vimport.NewImportCmd(globalFlags))
-	platformCmd.AddCommand(get.NewGetCmd(globalFlags, defaults, cfg))
-	platformCmd.AddCommand(connect.NewConnectCmd(globalFlags, cfg))
-	platformCmd.AddCommand(list.NewListCmd(globalFlags, cfg))
-	platformCmd.AddCommand(set.NewSetCmd(globalFlags, defaults, cfg))
-	platformCmd.AddCommand(backup.NewBackupCmd(globalFlags, cfg))
+	platformCmd.AddCommand(get.NewGetCmd(globalFlags, defaults))
+	platformCmd.AddCommand(connect.NewConnectCmd(globalFlags))
+	platformCmd.AddCommand(list.NewListCmd(globalFlags))
+	platformCmd.AddCommand(set.NewSetCmd(globalFlags, defaults))
+	platformCmd.AddCommand(backup.NewBackupCmd(globalFlags))
 	platformCmd.AddCommand(wakeup.NewWakeupCmd(globalFlags))
 	platformCmd.AddCommand(sleep.NewSleepCmd(globalFlags))
 	platformCmd.AddCommand(share.NewShareCmd(globalFlags))

--- a/cmd/vclusterctl/cmd/platform/pro.go
+++ b/cmd/vclusterctl/cmd/platform/pro.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/connect"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/spf13/cobra"
+)
+
+func NewProCmd(globalFlags *flags.GlobalFlags) (*cobra.Command, error) {
+	proCmd := &cobra.Command{
+		Use:   "pro",
+		Short: "vCluster platform subcommands",
+		Long: `#######################################################
+#################### vcluster pro #####################
+#######################################################
+
+Deprecated, please use vcluster platform instead
+		`,
+		Args: cobra.NoArgs,
+	}
+
+	startCmd := NewStartCmd(globalFlags)
+
+	proCmd.AddCommand(startCmd)
+	proCmd.AddCommand(NewResetCmd(globalFlags))
+	proCmd.AddCommand(connect.NewConnectCmd(globalFlags))
+	proCmd.AddCommand(NewAccessKeyCmd(globalFlags))
+
+	return proCmd, nil
+}

--- a/cmd/vclusterctl/cmd/platform/set/secret.go
+++ b/cmd/vclusterctl/cmd/platform/set/secret.go
@@ -10,7 +10,6 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/survey"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	pdefaults "github.com/loft-sh/vcluster/pkg/platform/defaults"
@@ -39,17 +38,14 @@ type SecretCmd struct {
 	*flags.GlobalFlags
 	Namespace string
 	Project   string
-
-	cfg *config.CLI
-	log log.Logger
+	log       log.Logger
 }
 
 // NewSecretCmd creates a new command
-func NewSecretCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults, cfg *config.CLI) *cobra.Command {
+func NewSecretCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
 	cmd := &SecretCmd{
 		GlobalFlags: globalFlags,
 		log:         log.GetInstance(),
-		cfg:         cfg,
 	}
 	description := product.ReplaceWithHeader("set secret", `
 Sets the key value of a project / shared secret.
@@ -78,7 +74,7 @@ vcluster platform set secret test-secret.key value --project myproject
 	return c
 }
 func (cmd *SecretCmd) Run(cobraCmd *cobra.Command, args []string) error {
-	platformClient, err := platform.InitClientFromConfig(cobraCmd.Context(), cmd.cfg)
+	platformClient, err := platform.InitClientFromConfig(cobraCmd.Context(), cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/set/set.go
+++ b/cmd/vclusterctl/cmd/platform/set/set.go
@@ -2,14 +2,13 @@ package set
 
 import (
 	"github.com/loft-sh/api/v4/pkg/product"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	pdefaults "github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/spf13/cobra"
 )
 
 // NewSetCmd creates a new cobra command
-func NewSetCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults, cfg *config.CLI) *cobra.Command {
+func NewSetCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
 	description := product.ReplaceWithHeader("set", "")
 	c := &cobra.Command{
 		Use:   "set",
@@ -18,6 +17,6 @@ func NewSetCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults, cfg
 		Args:  cobra.NoArgs,
 	}
 
-	c.AddCommand(NewSecretCmd(globalFlags, defaults, cfg))
+	c.AddCommand(NewSecretCmd(globalFlags, defaults))
 	return c
 }

--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -90,7 +90,6 @@ func BuildRoot(log log.Logger) (*cobra.Command, error) {
 	rootCmd := NewRootCmd(log)
 	persistentFlags := rootCmd.PersistentFlags()
 	globalFlags = flags.SetGlobalFlags(persistentFlags, log)
-	cfg := globalFlags.LoadedConfig(log)
 	home, err := homedir.Dir()
 	if err != nil {
 		return nil, err
@@ -119,10 +118,10 @@ func BuildRoot(log log.Logger) (*cobra.Command, error) {
 	rootCmd.AddCommand(cmdtelemetry.NewTelemetryCmd(globalFlags))
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(NewInfoCmd(globalFlags))
-	rootCmd.AddCommand(set.NewSetCmd(globalFlags, defaults, cfg))
+	rootCmd.AddCommand(set.NewSetCmd(globalFlags, defaults))
 
 	// add platform commands
-	platformCmd, err := cmdplatform.NewPlatformCmd(globalFlags, cfg)
+	platformCmd, err := cmdplatform.NewPlatformCmd(globalFlags)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create platform command: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.2
-	github.com/hashicorp/yamux v0.1.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/loft-sh/admin-apis v0.0.0-20240203010124-3600c1c582a8
@@ -26,10 +25,8 @@ require (
 	github.com/loft-sh/utils v0.0.29
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/term v0.5.0
-	github.com/oklog/run v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
@@ -92,10 +89,13 @@ require (
 	github.com/google/cel-go v0.17.7 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
+	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 // indirect
 	github.com/loft-sh/apiserver v0.0.0-20240129130254-7b9a55ab1744 // indirect
 	github.com/loft-sh/jspolicy v0.2.2 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/oklog/run v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/otiai10/copy v1.11.0 // indirect
 	github.com/rivo/uniseg v0.4.6 // indirect
@@ -139,7 +139,7 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect


### PR DESCRIPTION
Earlier, `vcluster platform add cluster` had an uninitialized config.

I think generating from GlobalFlags reduces the need to drill down another var

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

