### PR TITLE
[backport] fix: Use workload client when setting global owner

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -108,7 +108,7 @@ func ExecuteStart(ctx context.Context, options *options.VirtualClusterOptions) e
 	// // set global owner for use in owner references
 	err = SetGlobalOwner(
 		ctx,
-		controlPlaneClient,
+		workloadClient,
 		options.MultiNamespaceMode,
 		controlPlaneNamespace,
 		options.TargetNamespace,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
