### PR TITLE
fix(vclusterctl): use platform client instead of loftctl client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.2
+	github.com/hashicorp/yamux v0.1.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/loft-sh/admin-apis v0.0.0-20240203010124-3600c1c582a8
@@ -25,8 +26,10 @@ require (
 	github.com/loft-sh/utils v0.0.29
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/term v0.5.0
+	github.com/oklog/run v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
@@ -89,13 +92,10 @@ require (
 	github.com/google/cel-go v0.17.7 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
-	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 // indirect
 	github.com/loft-sh/apiserver v0.0.0-20240129130254-7b9a55ab1744 // indirect
 	github.com/loft-sh/jspolicy v0.2.2 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/oklog/run v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/otiai10/copy v1.11.0 // indirect
 	github.com/rivo/uniseg v0.4.6 // indirect
@@ -139,7 +139,7 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/protobuf v1.5.3
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect

--- a/pkg/cli/start/login.go
+++ b/pkg/cli/start/login.go
@@ -12,7 +12,7 @@ import (
 
 	types "github.com/loft-sh/api/v4/pkg/auth"
 	"github.com/loft-sh/api/v4/pkg/product"
-	"github.com/loft-sh/loftctl/v4/pkg/client"
+	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/mgutz/ansi"
 	"github.com/sirupsen/logrus"
 	"github.com/skratchdot/open-golang/open"
@@ -89,13 +89,9 @@ func (l *LoftStarter) loginViaCLI(url string) error {
 	}
 
 	// log into loft
-	loader, err := client.NewClientFromPath(l.Config)
-	if err != nil {
-		return err
-	}
-
+	loginClient := platform.NewLoginClientFromConfig(l.LoadedConfig(l.Log))
 	url = strings.TrimSuffix(url, "/")
-	err = loader.LoginWithAccessKey(url, accessKey.AccessKey, true)
+	err = loginClient.LoginWithAccessKey(url, accessKey.AccessKey, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/start/success.go
+++ b/pkg/cli/start/success.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/loft-sh/admin-apis/pkg/licenseapi"
 	"github.com/loft-sh/api/v4/pkg/product"
-	"github.com/loft-sh/loftctl/v4/pkg/client"
 	"github.com/loft-sh/loftctl/v4/pkg/clihelper"
 	"github.com/loft-sh/loftctl/v4/pkg/config"
 	"github.com/loft-sh/loftctl/v4/pkg/printhelper"
 	"github.com/loft-sh/log/survey"
+	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -178,8 +178,8 @@ func (l *LoftStarter) successLocal() error {
 func (l *LoftStarter) isLoggedIn(url string) bool {
 	url = strings.TrimPrefix(url, "https://")
 
-	c, err := client.NewClientFromPath(l.Config)
-	return err == nil && strings.TrimPrefix(strings.TrimSuffix(c.Config().Host, "/"), "https://") == strings.TrimSuffix(url, "/")
+	c := platform.NewClientFromConfig(l.LoadedConfig(l.Log))
+	return strings.TrimPrefix(strings.TrimSuffix(c.Config().Platform.Host, "/"), "https://") == strings.TrimSuffix(url, "/")
 }
 
 func (l *LoftStarter) successRemote(ctx context.Context, host string) error {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3846


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform start would use old client to write config.


**What else do we need to know?** 
