### PR TITLE
ENG-3736 | FIX: make list command support undefined (default) vcluster version

### DIFF
--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -156,6 +156,13 @@ func proToVClusters(vClusters []procli.VirtualClusterInstanceProject, currentCon
 			status = "Pending"
 		}
 
+		version := ""
+		if vCluster.VirtualCluster.Status.VirtualCluster != nil && vCluster.VirtualCluster.Status.VirtualCluster.HelmRelease.Chart.Version != "" {
+			version = vCluster.VirtualCluster.Status.VirtualCluster.HelmRelease.Chart.Version
+		} else if vCluster.VirtualCluster.Spec.Template != nil && vCluster.VirtualCluster.Spec.Template.HelmRelease.Chart.Version != "" {
+			version = vCluster.VirtualCluster.Spec.Template.HelmRelease.Chart.Version
+		}
+
 		connected := strings.HasPrefix(currentContext, "vcluster-pro_"+vCluster.VirtualCluster.Name+"_"+vCluster.Project.Name)
 		vClusterOutput := VCluster{
 			Name:       vCluster.VirtualCluster.Spec.ClusterRef.VirtualCluster,
@@ -166,7 +173,7 @@ func proToVClusters(vClusters []procli.VirtualClusterInstanceProject, currentCon
 			AgeSeconds: int(time.Since(vCluster.VirtualCluster.CreationTimestamp.Time).Round(time.Second).Seconds()),
 			Status:     status,
 			Pro:        true,
-			Version:    vCluster.VirtualCluster.Status.VirtualCluster.HelmRelease.Chart.Version,
+			Version:    version,
 		}
 		output = append(output, vClusterOutput)
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-3736


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster list` command failed when one of vclusters had undefined version. 
