### PR TITLE
Revert "chore(vclusterctl): add loftctl flags to vcluster connect (#1823)

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -71,10 +71,7 @@ vcluster connect test -n test -- kubectl get ns
 	cobraCmd.Flags().BoolVar(&cmd.BackgroundProxy, "background-proxy", false, "If specified, vCluster will create the background proxy in docker [its mainly used for vclusters with no nodeport service.]")
 
 	// platform
-	cobraCmd.Flags().StringVar(&cmd.Cluster, "cluster", "", "[PLATFORM] The cluster to use")
 	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The platform project the vCluster is in")
-	cobraCmd.Flags().StringVar(&cmd.User, "user", "", "[PLATFORM] The user to share the space with. The user needs to have access to the cluster")
-	cobraCmd.Flags().StringVar(&cmd.Team, "team", "", "[PLATFORM] The team to share the space with. The team needs to have access to the cluster")
 
 	// deprecated
 	_ = cobraCmd.Flags().MarkDeprecated("kube-config", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -53,10 +53,7 @@ type ConnectOptions struct {
 	BackgroundProxy           bool
 	Insecure                  bool
 
-	Cluster string
 	Project string
-	User    string
-	Team    string
 }
 
 type connectHelm struct {

--- a/pkg/cli/connect_platform.go
+++ b/pkg/cli/connect_platform.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	agentstoragev1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/storage/v1"
 	"github.com/loft-sh/loftctl/v4/pkg/vcluster"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
-	"github.com/loft-sh/vcluster/pkg/projectutil"
 	"github.com/loft-sh/vcluster/pkg/util/clihelper"
-	"github.com/mgutz/ansi"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -28,12 +24,6 @@ type connectPlatform struct {
 
 func ConnectPlatform(ctx context.Context, options *ConnectOptions, globalFlags *flags.GlobalFlags, vClusterName string, command []string, log log.Logger) error {
 	platformClient, err := platform.InitClientFromConfig(ctx, globalFlags.LoadedConfig(log))
-	if err != nil {
-		return err
-	}
-
-	// determine project & cluster name
-	options.Cluster, options.Project, err = platform.SelectProjectOrCluster(ctx, platformClient, options.Cluster, options.Project, false, log)
 	if err != nil {
 		return err
 	}
@@ -67,32 +57,6 @@ func ConnectPlatform(ctx context.Context, options *ConnectOptions, globalFlags *
 	vCluster.VirtualCluster, err = vcluster.WaitForVirtualClusterInstance(ctx, managementClient, vCluster.VirtualCluster.Namespace, vCluster.VirtualCluster.Name, true, log)
 	if err != nil {
 		return err
-	}
-
-	accessRule := agentstoragev1.InstanceAccessRule{
-		ClusterRole: options.ServiceAccountClusterRole,
-	}
-	if options.User != "" {
-		accessRule.Users = append(accessRule.Users, options.User)
-	}
-	if options.Team != "" {
-		accessRule.Teams = append(accessRule.Teams, options.Team)
-	}
-	vCluster.VirtualCluster.Spec.ExtraAccessRules = append(vCluster.VirtualCluster.Spec.ExtraAccessRules, accessRule)
-	if vCluster.VirtualCluster.Spec.TemplateRef != nil {
-		vCluster.VirtualCluster.Spec.TemplateRef.SyncOnce = true
-	}
-	_, err = managementClient.Loft().ManagementV1().VirtualClusterInstances(projectutil.ProjectNamespace(cmd.Project)).Update(ctx, vCluster.VirtualCluster, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	if cmd.User != "" {
-		cmd.log.Donef("Successfully granted user %s access to vcluster %s", ansi.Color(cmd.User, "white+b"), ansi.Color(vClusterName, "white+b"))
-		cmd.log.Infof("The user can access the virtual cluster now via: %s", ansi.Color(fmt.Sprintf("vcluster connect %s --project %s", vClusterName, cmd.Project), "white+b"))
-	} else {
-		cmd.log.Donef("Successfully granted team %s access to vcluster %s", ansi.Color(cmd.Team, "white+b"), ansi.Color(vClusterName, "white+b"))
-		cmd.log.Infof("The team can access the space now via: %s", ansi.Color(fmt.Sprintf("vcluster connect %s --project %s", vClusterName, cmd.Project), "white+b"))
 	}
 
 	// retrieve vCluster kube config


### PR DESCRIPTION
This reverts commit f8e61acb54c7c4319392eda201b2bf186783f210.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where "vcluster connect --manager=platform" contained functionality of "vcluster platform share vcluster"


**What else do we need to know?** 
