### PR TITLE
fix(vclusterctl): limit updating vCluster server address to local for OSS vClusters only

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -770,9 +770,14 @@ func (cmd *ConnectCmd) executeCommand(vKubeConfig clientcmdapi.Config, command [
 func (cmd *ConnectCmd) getLocalVClusterConfig(vKubeConfig clientcmdapi.Config) clientcmdapi.Config {
 	// wait until we can access the virtual cluster
 	vKubeConfig = *vKubeConfig.DeepCopy()
-	for k := range vKubeConfig.Clusters {
-		vKubeConfig.Clusters[k].Server = "https://localhost:" + strconv.Itoa(cmd.LocalPort)
+
+	// update vCluster server address in case of OSS vClusters only
+	if cmd.LocalPort != 0 {
+		for k := range vKubeConfig.Clusters {
+			vKubeConfig.Clusters[k].Server = "https://localhost:" + strconv.Itoa(cmd.LocalPort)
+		}
 	}
+
 	return vKubeConfig
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3850


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fail to create a kubeconfig with ServiceAccount for platform vClusters


**What else do we need to know?** 
