### PR TITLE
fix(vclusterctl): limit updating vCluster server address to local for OSS vClusters only

### DIFF
--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -573,9 +573,14 @@ func executeCommand(vKubeConfig clientcmdapi.Config, command []string, errorChan
 func getLocalVClusterConfig(vKubeConfig clientcmdapi.Config, options *ConnectOptions) clientcmdapi.Config {
 	// wait until we can access the virtual cluster
 	vKubeConfig = *vKubeConfig.DeepCopy()
-	for k := range vKubeConfig.Clusters {
-		vKubeConfig.Clusters[k].Server = "https://localhost:" + strconv.Itoa(options.LocalPort)
+
+	// update vCluster server address in case of OSS vClusters only
+	if options.LocalPort != 0 {
+		for k := range vKubeConfig.Clusters {
+			vKubeConfig.Clusters[k].Server = "https://localhost:" + strconv.Itoa(options.LocalPort)
+		}
 	}
+
 	return vKubeConfig
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3869


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fail to create a kubeconfig with ServiceAccount for platform vClusters