### PR TITLE
Add vcluster related commands under platform

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
@@ -46,7 +47,7 @@ vcluster connect test -n test -- kubectl get ns
 #######################################################
 	`,
 		Args:              nameValidator,
-		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Check for newer version
 			upgrade.PrintNewerVersionWarning()

--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/flags/connect"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
 	"github.com/loft-sh/vcluster/pkg/upgrade"
 	"github.com/spf13/cobra"
@@ -58,27 +59,8 @@ vcluster connect test -n test -- kubectl get ns
 
 	cobraCmd.Flags().StringVar(&cmd.Manager, "manager", "", "The manager to use for managing the virtual cluster, can be either helm or platform.")
 
-	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
-	cobraCmd.Flags().StringVar(&cmd.KubeConfig, "kube-config", "./kubeconfig.yaml", "Writes the created kube config to this file")
-	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
-	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "When enabled prints the context to stdout")
-	cobraCmd.Flags().StringVar(&cmd.PodName, "pod", "", "The pod to connect to")
-	cobraCmd.Flags().StringVar(&cmd.Server, "server", "", "The server to connect to")
-	cobraCmd.Flags().IntVar(&cmd.LocalPort, "local-port", 0, "The local port to forward the virtual cluster to. If empty, vCluster will use a random unused port")
-	cobraCmd.Flags().StringVar(&cmd.Address, "address", "", "The local address to start port forwarding under")
-	cobraCmd.Flags().StringVar(&cmd.ServiceAccount, "service-account", "", "If specified, vCluster will create a service account token to connect to the virtual cluster instead of using the default client cert / key. Service account must exist and can be used as namespace/name.")
-	cobraCmd.Flags().StringVar(&cmd.ServiceAccountClusterRole, "cluster-role", "", "If specified, vCluster will create the service account if it does not exist and also add a cluster role binding for the given cluster role to it. Requires --service-account to be set")
-	cobraCmd.Flags().IntVar(&cmd.ServiceAccountExpiration, "token-expiration", 0, "If specified, vCluster will create the service account token for the given duration in seconds. Defaults to eternal")
-	cobraCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "If specified, vCluster will create the kube config with insecure-skip-tls-verify")
-	cobraCmd.Flags().BoolVar(&cmd.BackgroundProxy, "background-proxy", false, "If specified, vCluster will create the background proxy in docker [its mainly used for vclusters with no nodeport service.]")
-
-	// platform
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The platform project the vCluster is in")
-
-	// deprecated
-	_ = cobraCmd.Flags().MarkDeprecated("kube-config", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
-	_ = cobraCmd.Flags().MarkDeprecated("kube-config-context-name", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
-	_ = cobraCmd.Flags().MarkDeprecated("update-current", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+	connect.AddCommonFlags(cobraCmd, &cmd.ConnectOptions)
+	connect.AddPlatformFlags(cobraCmd, &cmd.ConnectOptions, "[PLATFORM] ")
 
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -4,14 +4,13 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/flags/create"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
-	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/upgrade"
 	"github.com/spf13/cobra"
@@ -53,55 +52,12 @@ vcluster create test --namespace test
 		},
 	}
 
-	// generic flags
 	cobraCmd.Flags().StringVar(&cmd.Manager, "manager", "", "The manager to use for managing the virtual cluster, can be either helm or platform.")
-	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
-	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
-	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
-	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", constants.LoftChartRepo, "The virtual cluster chart repo to use")
-	cobraCmd.Flags().StringVar(&cmd.KubernetesVersion, "kubernetes-version", "", "The kubernetes version to use (e.g. v1.20). Patch versions are not supported")
-	cobraCmd.Flags().StringArrayVarP(&cmd.Values, "values", "f", []string{}, "Path where to load extra helm values from")
-	cobraCmd.Flags().StringArrayVar(&cmd.SetValues, "set", []string{}, "Set values for helm. E.g. --set 'persistence.enabled=true'")
-	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "If enabled, prints the context to the console")
 
-	cobraCmd.Flags().BoolVar(&cmd.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")
-	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
-	cobraCmd.Flags().BoolVar(&cmd.CreateContext, "create-context", true, "If the CLI should create a kube context for the space")
-	cobraCmd.Flags().BoolVar(&cmd.SwitchContext, "switch-context", true, "If the CLI should switch the current context to the new context")
-	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
-	cobraCmd.Flags().BoolVar(&cmd.Connect, "connect", true, "If true will run vcluster connect directly after the vcluster was created")
-	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "upgrade", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
+	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
+	create.AddHelmFlags(cobraCmd, &cmd.CreateOptions)
+	create.AddPlatformFlags(cobraCmd, &cmd.CreateOptions, "[PLATFORM] ")
 
-	// Platform flags
-	cobraCmd.Flags().BoolVar(&cmd.Activate, "activate", true, "[PLATFORM] Activate the vCluster automatically when using helm manager")
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The vCluster platform project to use")
-	cobraCmd.Flags().StringSliceVarP(&cmd.Labels, "labels", "l", []string{}, "[PLATFORM] Comma separated labels to apply to the virtualclusterinstance")
-	cobraCmd.Flags().StringSliceVar(&cmd.Annotations, "annotations", []string{}, "[PLATFORM] Comma separated annotations to apply to the virtualclusterinstance")
-	cobraCmd.Flags().StringVar(&cmd.Cluster, "cluster", "", "[PLATFORM] The vCluster platform connected cluster to use")
-	cobraCmd.Flags().StringVar(&cmd.Template, "template", "", "[PLATFORM] The vCluster platform template to use")
-	cobraCmd.Flags().StringVar(&cmd.TemplateVersion, "template-version", "", "[PLATFORM] The vCluster platform template version to use")
-	cobraCmd.Flags().StringArrayVar(&cmd.Links, "link", []string{}, "[PLATFORM] A link to add to the vCluster. E.g. --link 'prod=http://exampleprod.com'")
-	cobraCmd.Flags().StringVar(&cmd.Params, "params", "", "[PLATFORM] If a template is used, this can be used to use a file for the parameters. E.g. --params path/to/my/file.yaml")
-	cobraCmd.Flags().StringVar(&cmd.Params, "parameters", "", "[PLATFORM] If a template is used, this can be used to use a file for the parameters. E.g. --parameters path/to/my/file.yaml")
-	cobraCmd.Flags().StringArrayVar(&cmd.SetParams, "set-param", []string{}, "[PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'")
-	cobraCmd.Flags().StringArrayVar(&cmd.SetParams, "set-parameter", []string{}, "[PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'")
-	cobraCmd.Flags().StringVar(&cmd.Description, "description", "", "[PLATFORM] The description to show in the platform UI for this virtual cluster")
-	cobraCmd.Flags().StringVar(&cmd.DisplayName, "display-name", "", "[PLATFORM] The display name to show in the platform UI for this virtual cluster")
-	cobraCmd.Flags().StringVar(&cmd.Team, "team", "", "[PLATFORM] The team to create the space for")
-	cobraCmd.Flags().StringVar(&cmd.User, "user", "", "[PLATFORM] The user to create the space for")
-	cobraCmd.Flags().BoolVar(&cmd.UseExisting, "use", false, "[PLATFORM] If the platform should use the virtual cluster if its already there")
-	cobraCmd.Flags().BoolVar(&cmd.Recreate, "recreate", false, "[PLATFORM] If enabled and there already exists a virtual cluster with this name, it will be deleted first")
-	cobraCmd.Flags().BoolVar(&cmd.SkipWait, "skip-wait", false, "[PLATFORM] If true, will not wait until the virtual cluster is running")
-
-	// hidden / deprecated
-	cobraCmd.Flags().StringVar(&cmd.LocalChartDir, "local-chart-dir", "", "The virtual cluster local chart dir to use")
-	cobraCmd.Flags().BoolVar(&cmd.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service. Will be set to false and the passed value will be ignored if --expose is set to true.")
-	cobraCmd.Flags().StringVar(&cmd.Distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro to use for the virtual cluster. Allowed distros: %s", strings.Join(cli.AllowedDistros, ", ")))
-
-	_ = cobraCmd.Flags().MarkHidden("local-chart-dir")
-	_ = cobraCmd.Flags().MarkHidden("expose-local")
-	_ = cobraCmd.Flags().MarkHidden("distro")
-	_ = cobraCmd.Flags().MarkDeprecated("distro", fmt.Sprintf("please specify the distro by setting %q accordingly via values.yaml file.", "controlPlane.distro"))
 	return cobraCmd
 }
 

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
@@ -43,7 +44,7 @@ vcluster delete test --namespace test
 	`,
 		Args:              util.VClusterNameOnlyValidator,
 		Aliases:           []string{"rm"},
-		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	flagsdelete "github.com/loft-sh/vcluster/pkg/cli/flags/delete"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/spf13/cobra"
@@ -52,16 +53,9 @@ vcluster delete test --namespace test
 
 	cobraCmd.Flags().StringVar(&cmd.Manager, "manager", "", "The manager to use for managing the virtual cluster, can be either helm or platform.")
 
-	cobraCmd.Flags().BoolVar(&cmd.Wait, "wait", true, "If enabled, vcluster will wait until the vcluster is deleted")
-	cobraCmd.Flags().BoolVar(&cmd.DeleteConfigMap, "delete-configmap", false, "If enabled, vCluster will delete the ConfigMap of the vCluster")
-	cobraCmd.Flags().BoolVar(&cmd.KeepPVC, "keep-pvc", false, "If enabled, vcluster will not delete the persistent volume claim of the vcluster")
-	cobraCmd.Flags().BoolVar(&cmd.DeleteNamespace, "delete-namespace", false, "If enabled, vcluster will delete the namespace of the vcluster. In the case of multi-namespace mode, will also delete all other namespaces created by vcluster")
-	cobraCmd.Flags().BoolVar(&cmd.DeleteContext, "delete-context", true, "If the corresponding kube context should be deleted if there is any")
-	cobraCmd.Flags().BoolVar(&cmd.AutoDeleteNamespace, "auto-delete-namespace", true, "If enabled, vcluster will delete the namespace of the vcluster if it was created by vclusterctl. In the case of multi-namespace mode, will also delete all other namespaces created by vcluster")
-	cobraCmd.Flags().BoolVar(&cmd.IgnoreNotFound, "ignore-not-found", false, "If enabled, vcluster will not error out in case the target vcluster does not exist")
-
-	// Platform flags
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The vCluster platform project to use")
+	flagsdelete.AddCommonFlags(cobraCmd, &cmd.DeleteOptions)
+	flagsdelete.AddHelmFlags(cobraCmd, &cmd.DeleteOptions)
+	flagsdelete.AddPlatformFlags(cobraCmd, &cmd.DeleteOptions, "[PLATFORM] ")
 
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/pause.go
+++ b/cmd/vclusterctl/cmd/pause.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
@@ -49,7 +50,7 @@ vcluster pause test --namespace test
 #######################################################
 	`,
 		Args:              util.VClusterNameOnlyValidator,
-		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},

--- a/cmd/vclusterctl/cmd/platform/connect/connect.go
+++ b/cmd/vclusterctl/cmd/platform/connect/connect.go
@@ -11,7 +11,7 @@ import (
 func NewConnectCmd(globalFlags *flags.GlobalFlags, defaults *defaults.Defaults) *cobra.Command {
 	description := product.ReplaceWithHeader("connect", `
 
-Activates a kube context for the given cluster / space / management.
+Activates a kube context for the given cluster / management / space / vcluster.
 	`)
 	connectCmd := &cobra.Command{
 		Use:   "connect",
@@ -23,5 +23,6 @@ Activates a kube context for the given cluster / space / management.
 	connectCmd.AddCommand(newClusterCmd(globalFlags))
 	connectCmd.AddCommand(newManagementCmd(globalFlags))
 	connectCmd.AddCommand(newSpaceCmd(globalFlags, defaults))
+	connectCmd.AddCommand(newVClusterCmd(globalFlags))
 	return connectCmd
 }

--- a/cmd/vclusterctl/cmd/platform/connect/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/connect/vcluster.go
@@ -1,0 +1,104 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/loft-sh/vcluster/pkg/upgrade"
+	"github.com/spf13/cobra"
+)
+
+// VClusterCmd holds the cmd flags
+type VClusterCmd struct {
+	Log log.Logger
+	*flags.GlobalFlags
+	cli.ConnectOptions
+}
+
+// newVClusterCmd creates a new command
+func newVClusterCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &VClusterCmd{
+		GlobalFlags: globalFlags,
+		Log:         log.GetInstance(),
+	}
+
+	useLine, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+
+	cobraCmd := &cobra.Command{
+		Use:   "vcluster" + useLine,
+		Short: "Connect to a virtual cluster",
+		Long: `#########################################################################
+################## vcluster platform connect vcluster ###################
+#########################################################################
+Connect to a virtual cluster
+
+Example:
+vcluster platform connect vcluster test --namespace test
+# Open a new bash with the vcluster KUBECONFIG defined
+vcluster platform connect vcluster test -n test -- bash
+vcluster platform connect vcluster test -n test -- kubectl get ns
+#########################################################################
+	`,
+		Args:              nameValidator,
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			// Check for newer version
+			upgrade.PrintNewerVersionWarning()
+
+			return cmd.Run(cobraCmd.Context(), args)
+		},
+	}
+
+	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
+	cobraCmd.Flags().StringVar(&cmd.KubeConfig, "kube-config", "./kubeconfig.yaml", "Writes the created kube config to this file")
+	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
+	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "When enabled prints the context to stdout")
+	cobraCmd.Flags().StringVar(&cmd.PodName, "pod", "", "The pod to connect to")
+	cobraCmd.Flags().StringVar(&cmd.Server, "server", "", "The server to connect to")
+	cobraCmd.Flags().IntVar(&cmd.LocalPort, "local-port", 0, "The local port to forward the virtual cluster to. If empty, vCluster will use a random unused port")
+	cobraCmd.Flags().StringVar(&cmd.Address, "address", "", "The local address to start port forwarding under")
+	cobraCmd.Flags().StringVar(&cmd.ServiceAccount, "service-account", "", "If specified, vCluster will create a service account token to connect to the virtual cluster instead of using the default client cert / key. Service account must exist and can be used as namespace/name.")
+	cobraCmd.Flags().StringVar(&cmd.ServiceAccountClusterRole, "cluster-role", "", "If specified, vCluster will create the service account if it does not exist and also add a cluster role binding for the given cluster role to it. Requires --service-account to be set")
+	cobraCmd.Flags().IntVar(&cmd.ServiceAccountExpiration, "token-expiration", 0, "If specified, vCluster will create the service account token for the given duration in seconds. Defaults to eternal")
+	cobraCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "If specified, vCluster will create the kube config with insecure-skip-tls-verify")
+	cobraCmd.Flags().BoolVar(&cmd.BackgroundProxy, "background-proxy", false, "If specified, vCluster will create the background proxy in docker [its mainly used for vclusters with no nodeport service.]")
+
+	// platform
+	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "The platform project the vCluster is in")
+
+	// deprecated
+	_ = cobraCmd.Flags().MarkDeprecated("kube-config", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+	_ = cobraCmd.Flags().MarkDeprecated("kube-config-context-name", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+	_ = cobraCmd.Flags().MarkDeprecated("update-current", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+
+	return cobraCmd
+}
+
+// Run executes the functionality
+func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
+	vClusterName := ""
+	if len(args) > 0 {
+		vClusterName = args[0]
+	}
+
+	// validate flags
+	err := cmd.validateFlags()
+	if err != nil {
+		return err
+	}
+
+	return cli.ConnectPlatform(ctx, &cmd.ConnectOptions, cmd.GlobalFlags, vClusterName, args[1:], cmd.Log)
+}
+
+func (cmd *VClusterCmd) validateFlags() error {
+	if cmd.ServiceAccountClusterRole != "" && cmd.ServiceAccount == "" {
+		return fmt.Errorf("expected --service-account to be defined as well")
+	}
+
+	return nil
+}

--- a/cmd/vclusterctl/cmd/platform/connect/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/connect/vcluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/flags/connect"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
 	"github.com/loft-sh/vcluster/pkg/upgrade"
 	"github.com/spf13/cobra"
@@ -54,27 +55,8 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 		},
 	}
 
-	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
-	cobraCmd.Flags().StringVar(&cmd.KubeConfig, "kube-config", "./kubeconfig.yaml", "Writes the created kube config to this file")
-	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
-	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "When enabled prints the context to stdout")
-	cobraCmd.Flags().StringVar(&cmd.PodName, "pod", "", "The pod to connect to")
-	cobraCmd.Flags().StringVar(&cmd.Server, "server", "", "The server to connect to")
-	cobraCmd.Flags().IntVar(&cmd.LocalPort, "local-port", 0, "The local port to forward the virtual cluster to. If empty, vCluster will use a random unused port")
-	cobraCmd.Flags().StringVar(&cmd.Address, "address", "", "The local address to start port forwarding under")
-	cobraCmd.Flags().StringVar(&cmd.ServiceAccount, "service-account", "", "If specified, vCluster will create a service account token to connect to the virtual cluster instead of using the default client cert / key. Service account must exist and can be used as namespace/name.")
-	cobraCmd.Flags().StringVar(&cmd.ServiceAccountClusterRole, "cluster-role", "", "If specified, vCluster will create the service account if it does not exist and also add a cluster role binding for the given cluster role to it. Requires --service-account to be set")
-	cobraCmd.Flags().IntVar(&cmd.ServiceAccountExpiration, "token-expiration", 0, "If specified, vCluster will create the service account token for the given duration in seconds. Defaults to eternal")
-	cobraCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "If specified, vCluster will create the kube config with insecure-skip-tls-verify")
-	cobraCmd.Flags().BoolVar(&cmd.BackgroundProxy, "background-proxy", false, "If specified, vCluster will create the background proxy in docker [its mainly used for vclusters with no nodeport service.]")
-
-	// platform
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "The platform project the vCluster is in")
-
-	// deprecated
-	_ = cobraCmd.Flags().MarkDeprecated("kube-config", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
-	_ = cobraCmd.Flags().MarkDeprecated("kube-config-context-name", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
-	_ = cobraCmd.Flags().MarkDeprecated("update-current", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+	connect.AddCommonFlags(cobraCmd, &cmd.ConnectOptions)
+	connect.AddPlatformFlags(cobraCmd, &cmd.ConnectOptions)
 
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/platform/create/create.go
+++ b/cmd/vclusterctl/cmd/platform/create/create.go
@@ -16,6 +16,7 @@ func NewCreateCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) 
 		Long:  description,
 		Args:  cobra.NoArgs,
 	}
-	c.AddCommand(NewSpaceCmd(globalFlags, defaults))
+	c.AddCommand(newSpaceCmd(globalFlags, defaults))
+	c.AddCommand(newVClusterCmd(globalFlags))
 	return c
 }

--- a/cmd/vclusterctl/cmd/platform/create/space.go
+++ b/cmd/vclusterctl/cmd/platform/create/space.go
@@ -67,8 +67,8 @@ type SpaceCmd struct {
 	Log log.Logger
 }
 
-// NewSpaceCmd creates a new command
-func NewSpaceCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
+// newSpaceCmd creates a new command
+func newSpaceCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
 	cmd := &SpaceCmd{
 		GlobalFlags: globalFlags,
 		Log:         log.GetInstance(),

--- a/cmd/vclusterctl/cmd/platform/create/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/create/vcluster.go
@@ -2,14 +2,12 @@ package create
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/flags/create"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
-	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/upgrade"
 	"github.com/spf13/cobra"
 )
@@ -50,54 +48,9 @@ vcluster platform create vcluster test --namespace test
 		},
 	}
 
-	// generic flags
-	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
-	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
-	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
-	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", constants.LoftChartRepo, "The virtual cluster chart repo to use")
-	cobraCmd.Flags().StringVar(&cmd.KubernetesVersion, "kubernetes-version", "", "The kubernetes version to use (e.g. v1.20). Patch versions are not supported")
-	cobraCmd.Flags().StringArrayVarP(&cmd.Values, "values", "f", []string{}, "Path where to load extra helm values from")
-	cobraCmd.Flags().StringArrayVar(&cmd.SetValues, "set", []string{}, "Set values for helm. E.g. --set 'persistence.enabled=true'")
-	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "If enabled, prints the context to the console")
+	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
+	create.AddPlatformFlags(cobraCmd, &cmd.CreateOptions)
 
-	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
-	cobraCmd.Flags().BoolVar(&cmd.CreateContext, "create-context", true, "If the CLI should create a kube context for the space")
-	cobraCmd.Flags().BoolVar(&cmd.SwitchContext, "switch-context", true, "If the CLI should switch the current context to the new context")
-	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
-	cobraCmd.Flags().BoolVar(&cmd.Connect, "connect", true, "If true will run vcluster connect directly after the vcluster was created")
-	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "upgrade", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
-	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "update", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
-
-	// Platform flags
-	cobraCmd.Flags().BoolVar(&cmd.Activate, "activate", true, "[PLATFORM] Activate the vCluster automatically when using helm manager")
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The vCluster platform project to use")
-	cobraCmd.Flags().StringSliceVarP(&cmd.Labels, "labels", "l", []string{}, "[PLATFORM] Comma separated labels to apply to the virtualclusterinstance")
-	cobraCmd.Flags().StringSliceVar(&cmd.Annotations, "annotations", []string{}, "[PLATFORM] Comma separated annotations to apply to the virtualclusterinstance")
-	cobraCmd.Flags().StringVar(&cmd.Cluster, "cluster", "", "[PLATFORM] The vCluster platform connected cluster to use")
-	cobraCmd.Flags().StringVar(&cmd.Template, "template", "", "[PLATFORM] The vCluster platform template to use")
-	cobraCmd.Flags().StringVar(&cmd.TemplateVersion, "template-version", "", "[PLATFORM] The vCluster platform template version to use")
-	cobraCmd.Flags().StringArrayVar(&cmd.Links, "link", []string{}, "[PLATFORM] A link to add to the vCluster. E.g. --link 'prod=http://exampleprod.com'")
-	cobraCmd.Flags().StringVar(&cmd.Params, "params", "", "[PLATFORM] If a template is used, this can be used to use a file for the parameters. E.g. --params path/to/my/file.yaml")
-	cobraCmd.Flags().StringVar(&cmd.Params, "parameters", "", "[PLATFORM] If a template is used, this can be used to use a file for the parameters. E.g. --parameters path/to/my/file.yaml")
-	cobraCmd.Flags().StringArrayVar(&cmd.SetParams, "set-param", []string{}, "[PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'")
-	cobraCmd.Flags().StringArrayVar(&cmd.SetParams, "set-parameter", []string{}, "[PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'")
-	cobraCmd.Flags().StringVar(&cmd.Description, "description", "", "[PLATFORM] The description to show in the platform UI for this virtual cluster")
-	cobraCmd.Flags().StringVar(&cmd.DisplayName, "display-name", "", "[PLATFORM] The display name to show in the platform UI for this virtual cluster")
-	cobraCmd.Flags().StringVar(&cmd.Team, "team", "", "[PLATFORM] The team to create the space for")
-	cobraCmd.Flags().StringVar(&cmd.User, "user", "", "[PLATFORM] The user to create the space for")
-	cobraCmd.Flags().BoolVar(&cmd.UseExisting, "use", false, "[PLATFORM] If the platform should use the virtual cluster if its already there")
-	cobraCmd.Flags().BoolVar(&cmd.Recreate, "recreate", false, "[PLATFORM] If enabled and there already exists a virtual cluster with this name, it will be deleted first")
-	cobraCmd.Flags().BoolVar(&cmd.SkipWait, "skip-wait", false, "[PLATFORM] If true, will not wait until the virtual cluster is running")
-
-	// hidden / deprecated
-	cobraCmd.Flags().StringVar(&cmd.LocalChartDir, "local-chart-dir", "", "The virtual cluster local chart dir to use")
-	cobraCmd.Flags().BoolVar(&cmd.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service. Will be set to false and the passed value will be ignored if --expose is set to true.")
-	cobraCmd.Flags().StringVar(&cmd.Distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro to use for the virtual cluster. Allowed distros: %s", strings.Join(cli.AllowedDistros, ", ")))
-
-	_ = cobraCmd.Flags().MarkHidden("local-chart-dir")
-	_ = cobraCmd.Flags().MarkHidden("expose-local")
-	_ = cobraCmd.Flags().MarkHidden("distro")
-	_ = cobraCmd.Flags().MarkDeprecated("distro", fmt.Sprintf("please specify the distro by setting %q accordingly via values.yaml file.", "controlPlane.distro"))
 	return cobraCmd
 }
 

--- a/cmd/vclusterctl/cmd/platform/create/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/create/vcluster.go
@@ -1,0 +1,107 @@
+package create
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/upgrade"
+	"github.com/spf13/cobra"
+)
+
+// VClusterCmd holds the login cmd flags
+type VClusterCmd struct {
+	*flags.GlobalFlags
+	cli.CreateOptions
+
+	log log.Logger
+}
+
+// newVClusterCmd creates a new command
+func newVClusterCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &VClusterCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "vcluster" + util.VClusterNameOnlyUseLine,
+		Short: "Creates a new virtual cluster",
+		Long: `#########################################################################
+################### vcluster platform create vcluster ###################
+#########################################################################
+Creates a new virtual cluster
+
+Example:
+vcluster platform create vcluster test --namespace test
+#########################################################################
+	`,
+		Args: util.VClusterNameOnlyValidator,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			// Check for newer version
+			upgrade.PrintNewerVersionWarning()
+
+			return cmd.Run(cobraCmd.Context(), args)
+		},
+	}
+
+	// generic flags
+	cobraCmd.Flags().StringVar(&cmd.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
+	cobraCmd.Flags().StringVar(&cmd.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
+	cobraCmd.Flags().StringVar(&cmd.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
+	cobraCmd.Flags().StringVar(&cmd.ChartRepo, "chart-repo", constants.LoftChartRepo, "The virtual cluster chart repo to use")
+	cobraCmd.Flags().StringVar(&cmd.KubernetesVersion, "kubernetes-version", "", "The kubernetes version to use (e.g. v1.20). Patch versions are not supported")
+	cobraCmd.Flags().StringArrayVarP(&cmd.Values, "values", "f", []string{}, "Path where to load extra helm values from")
+	cobraCmd.Flags().StringArrayVar(&cmd.SetValues, "set", []string{}, "Set values for helm. E.g. --set 'persistence.enabled=true'")
+	cobraCmd.Flags().BoolVar(&cmd.Print, "print", false, "If enabled, prints the context to the console")
+
+	cobraCmd.Flags().BoolVar(&cmd.UpdateCurrent, "update-current", true, "If true updates the current kube config")
+	cobraCmd.Flags().BoolVar(&cmd.CreateContext, "create-context", true, "If the CLI should create a kube context for the space")
+	cobraCmd.Flags().BoolVar(&cmd.SwitchContext, "switch-context", true, "If the CLI should switch the current context to the new context")
+	cobraCmd.Flags().BoolVar(&cmd.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
+	cobraCmd.Flags().BoolVar(&cmd.Connect, "connect", true, "If true will run vcluster connect directly after the vcluster was created")
+	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "upgrade", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
+	cobraCmd.Flags().BoolVar(&cmd.Upgrade, "update", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
+
+	// Platform flags
+	cobraCmd.Flags().BoolVar(&cmd.Activate, "activate", true, "[PLATFORM] Activate the vCluster automatically when using helm manager")
+	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The vCluster platform project to use")
+	cobraCmd.Flags().StringSliceVarP(&cmd.Labels, "labels", "l", []string{}, "[PLATFORM] Comma separated labels to apply to the virtualclusterinstance")
+	cobraCmd.Flags().StringSliceVar(&cmd.Annotations, "annotations", []string{}, "[PLATFORM] Comma separated annotations to apply to the virtualclusterinstance")
+	cobraCmd.Flags().StringVar(&cmd.Cluster, "cluster", "", "[PLATFORM] The vCluster platform connected cluster to use")
+	cobraCmd.Flags().StringVar(&cmd.Template, "template", "", "[PLATFORM] The vCluster platform template to use")
+	cobraCmd.Flags().StringVar(&cmd.TemplateVersion, "template-version", "", "[PLATFORM] The vCluster platform template version to use")
+	cobraCmd.Flags().StringArrayVar(&cmd.Links, "link", []string{}, "[PLATFORM] A link to add to the vCluster. E.g. --link 'prod=http://exampleprod.com'")
+	cobraCmd.Flags().StringVar(&cmd.Params, "params", "", "[PLATFORM] If a template is used, this can be used to use a file for the parameters. E.g. --params path/to/my/file.yaml")
+	cobraCmd.Flags().StringVar(&cmd.Params, "parameters", "", "[PLATFORM] If a template is used, this can be used to use a file for the parameters. E.g. --parameters path/to/my/file.yaml")
+	cobraCmd.Flags().StringArrayVar(&cmd.SetParams, "set-param", []string{}, "[PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'")
+	cobraCmd.Flags().StringArrayVar(&cmd.SetParams, "set-parameter", []string{}, "[PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'")
+	cobraCmd.Flags().StringVar(&cmd.Description, "description", "", "[PLATFORM] The description to show in the platform UI for this virtual cluster")
+	cobraCmd.Flags().StringVar(&cmd.DisplayName, "display-name", "", "[PLATFORM] The display name to show in the platform UI for this virtual cluster")
+	cobraCmd.Flags().StringVar(&cmd.Team, "team", "", "[PLATFORM] The team to create the space for")
+	cobraCmd.Flags().StringVar(&cmd.User, "user", "", "[PLATFORM] The user to create the space for")
+	cobraCmd.Flags().BoolVar(&cmd.UseExisting, "use", false, "[PLATFORM] If the platform should use the virtual cluster if its already there")
+	cobraCmd.Flags().BoolVar(&cmd.Recreate, "recreate", false, "[PLATFORM] If enabled and there already exists a virtual cluster with this name, it will be deleted first")
+	cobraCmd.Flags().BoolVar(&cmd.SkipWait, "skip-wait", false, "[PLATFORM] If true, will not wait until the virtual cluster is running")
+
+	// hidden / deprecated
+	cobraCmd.Flags().StringVar(&cmd.LocalChartDir, "local-chart-dir", "", "The virtual cluster local chart dir to use")
+	cobraCmd.Flags().BoolVar(&cmd.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service. Will be set to false and the passed value will be ignored if --expose is set to true.")
+	cobraCmd.Flags().StringVar(&cmd.Distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro to use for the virtual cluster. Allowed distros: %s", strings.Join(cli.AllowedDistros, ", ")))
+
+	_ = cobraCmd.Flags().MarkHidden("local-chart-dir")
+	_ = cobraCmd.Flags().MarkHidden("expose-local")
+	_ = cobraCmd.Flags().MarkHidden("distro")
+	_ = cobraCmd.Flags().MarkDeprecated("distro", fmt.Sprintf("please specify the distro by setting %q accordingly via values.yaml file.", "controlPlane.distro"))
+	return cobraCmd
+}
+
+// Run executes the functionality
+func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
+	return cli.CreatePlatform(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log)
+}

--- a/cmd/vclusterctl/cmd/platform/create/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/create/vcluster.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// VClusterCmd holds the login cmd flags
+// VClusterCmd holds the cmd flags
 type VClusterCmd struct {
 	*flags.GlobalFlags
 	cli.CreateOptions

--- a/cmd/vclusterctl/cmd/platform/delete/delete.go
+++ b/cmd/vclusterctl/cmd/platform/delete/delete.go
@@ -11,11 +11,13 @@ import (
 func NewDeleteCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
 	description := product.ReplaceWithHeader("delete", "")
 	c := &cobra.Command{
-		Use:   "delete",
-		Short: product.Replace("Deletes vCluster platform resources"),
-		Long:  description,
-		Args:  cobra.NoArgs,
+		Use:     "delete",
+		Short:   product.Replace("Deletes vCluster platform resources"),
+		Long:    description,
+		Aliases: []string{"rm"},
+		Args:    cobra.NoArgs,
 	}
-	c.AddCommand(NewSpaceCmd(globalFlags, defaults))
+	c.AddCommand(newSpaceCmd(globalFlags, defaults))
+	c.AddCommand(newVClusterCmd(globalFlags))
 	return c
 }

--- a/cmd/vclusterctl/cmd/platform/delete/space.go
+++ b/cmd/vclusterctl/cmd/platform/delete/space.go
@@ -32,8 +32,8 @@ type SpaceCmd struct {
 	Log log.Logger
 }
 
-// NewSpaceCmd creates a new command
-func NewSpaceCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
+// newSpaceCmd creates a new command
+func newSpaceCmd(globalFlags *flags.GlobalFlags, defaults *pdefaults.Defaults) *cobra.Command {
 	cmd := &SpaceCmd{
 		GlobalFlags: globalFlags,
 		Log:         log.GetInstance(),

--- a/cmd/vclusterctl/cmd/platform/delete/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/delete/vcluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	flagsdelete "github.com/loft-sh/vcluster/pkg/cli/flags/delete"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
 	"github.com/spf13/cobra"
 )
@@ -45,11 +46,8 @@ vcluster platform delete vcluster --namespace test
 		},
 	}
 
-	cobraCmd.Flags().BoolVar(&cmd.Wait, "wait", true, "If enabled, vcluster will wait until the vcluster is deleted")
-	cobraCmd.Flags().BoolVar(&cmd.DeleteContext, "delete-context", true, "If the corresponding kube context should be deleted if there is any")
-
-	// Platform flags
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "The vCluster platform project to use")
+	flagsdelete.AddCommonFlags(cobraCmd, &cmd.DeleteOptions)
+	flagsdelete.AddPlatformFlags(cobraCmd, &cmd.DeleteOptions)
 
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/platform/delete/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/delete/vcluster.go
@@ -1,0 +1,60 @@
+package deletecmd
+
+import (
+	"context"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/spf13/cobra"
+)
+
+// VClusterCmd holds the cmd flags
+type VClusterCmd struct {
+	*flags.GlobalFlags
+	cli.DeleteOptions
+
+	log log.Logger
+}
+
+// newVClusterCmd creates a new command
+func newVClusterCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &VClusterCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	cobraCmd := &cobra.Command{
+		Use:   "vcluster" + util.VClusterNameOnlyUseLine,
+		Short: "Deletes a virtual cluster",
+		Long: `#########################################################################
+################### vcluster platform delete vcluster ###################
+#########################################################################
+Deletes a virtual cluster
+
+Example:
+vcluster platform delete vcluster --namespace test
+#########################################################################
+	`,
+		Args:              util.VClusterNameOnlyValidator,
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(cobraCmd.Context(), args)
+		},
+	}
+
+	cobraCmd.Flags().BoolVar(&cmd.Wait, "wait", true, "If enabled, vcluster will wait until the vcluster is deleted")
+	cobraCmd.Flags().BoolVar(&cmd.DeleteContext, "delete-context", true, "If the corresponding kube context should be deleted if there is any")
+
+	// Platform flags
+	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "The vCluster platform project to use")
+
+	return cobraCmd
+}
+
+// Run executes the functionality
+func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
+	return cli.DeletePlatform(ctx, &cmd.DeleteOptions, cmd.LoadedConfig(cmd.log), args[0], cmd.log)
+}

--- a/cmd/vclusterctl/cmd/platform/sleep/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/sleep/vcluster.go
@@ -50,8 +50,8 @@ vcluster platform sleep vcluster test --namespace test
 	}
 
 	// Platform flags
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The vCluster platform project to use")
-	cobraCmd.Flags().Int64Var(&cmd.ForceDuration, "prevent-wakeup", -1, "[PLATFORM] The amount of seconds this vcluster should sleep until it can be woken up again (use 0 for infinite sleeping). During this time the space can only be woken up by `vcluster resume vcluster`, manually deleting the annotation on the namespace or through the loft UI")
+	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "The vCluster platform project to use")
+	cobraCmd.Flags().Int64Var(&cmd.ForceDuration, "prevent-wakeup", -1, "The amount of seconds this vcluster should sleep until it can be woken up again (use 0 for infinite sleeping). During this time the space can only be woken up by `vcluster resume vcluster`, manually deleting the annotation on the namespace or through the loft UI")
 
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/platform/wakeup/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/wakeup/vcluster.go
@@ -46,7 +46,7 @@ vcluster platform wakeup vcluster test --namespace test
 	}
 
 	// Platform flags
-	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "[PLATFORM] The vCluster platform project to use")
+	cobraCmd.Flags().StringVar(&cmd.Project, "project", "", "The vCluster platform project to use")
 
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/resume.go
+++ b/cmd/vclusterctl/cmd/resume.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
@@ -44,7 +45,7 @@ vcluster resume test --namespace test
 #######################################################
 	`,
 		Args:              util.VClusterNameOnlyValidator,
-		ValidArgsFunction: newValidVClusterNameFunc(globalFlags),
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},

--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/set"
 	cmdtelemetry "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/telemetry"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/use"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
@@ -147,7 +148,7 @@ func BuildRoot(log log.Logger) (*cobra.Command, error) {
 	rootCmd.AddCommand(credits.NewCreditsCmd())
 
 	// add completion command
-	err = rootCmd.RegisterFlagCompletionFunc("namespace", newNamespaceCompletionFunc(rootCmd.Context()))
+	err = rootCmd.RegisterFlagCompletionFunc("namespace", completion.NewNamespaceCompletionFunc(rootCmd.Context()))
 	if err != nil {
 		return rootCmd, fmt.Errorf("failed to register completion for namespace: %w", err)
 	}

--- a/pkg/cli/completion/completion.go
+++ b/pkg/cli/completion/completion.go
@@ -1,4 +1,4 @@
-package cmd
+package completion
 
 import (
 	"context"
@@ -17,39 +17,16 @@ const completionTimeout = time.Second * 3
 
 // defining as a type purely for readability purposes.
 // this is the type accepted by cobra.Command.ValidArgsFunc and cobra.Command.RegisterFlagCompletionFunc
-type completionFunc func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)
+type Func func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective)
 
 type completionResult struct {
 	completions []string
 	directive   cobra.ShellCompDirective
 }
 
-// wrapper to add a timeout to completionFuncs
-func wrapCompletionFuncWithTimeout(defaultDirective cobra.ShellCompDirective, compFunc completionFunc) completionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// initialize a buffered channel to receive results
-		resultChan := make(chan completionResult, 1)
-
-		// run completion function in the background and send result to resultChan
-		go func(c chan completionResult) {
-			completions, directive := compFunc(cmd, args, toComplete)
-			r := completionResult{completions: completions, directive: directive}
-			c <- r
-		}(resultChan)
-
-		// wait for results or timeout
-		select {
-		case result := <-resultChan:
-			return result.completions, result.directive
-		case <-time.After(completionTimeout):
-			return []string{}, defaultDirective | cobra.ShellCompDirectiveError
-		}
-	}
-}
-
-// newValidVClusterNameFunc returns a function that handles shell completion when the argument is vcluster_name
+// NewValidVClusterNameFunc returns a function that handles shell completion when the argument is vcluster_name
 // It takes into account the namespace if specified by the --namespace flag.
-func newValidVClusterNameFunc(globalFlags *flags.GlobalFlags) completionFunc {
+func NewValidVClusterNameFunc(globalFlags *flags.GlobalFlags) Func {
 	fn := func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		vclusters, err := find.ListVClusters(cmd.Context(), globalFlags.Context, "", globalFlags.Namespace, log.Default.ErrorStreamOnly())
 		if err != nil {
@@ -64,8 +41,8 @@ func newValidVClusterNameFunc(globalFlags *flags.GlobalFlags) completionFunc {
 	return wrapCompletionFuncWithTimeout(cobra.ShellCompDirectiveNoFileComp, fn)
 }
 
-// newNamespaceCompletionFunc handles shell completions for the namespace flag
-func newNamespaceCompletionFunc(ctx context.Context) completionFunc {
+// NewNamespaceCompletionFunc handles shell completions for the namespace flag
+func NewNamespaceCompletionFunc(ctx context.Context) Func {
 	fn := func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		restConfig, err := config.GetConfig()
 		if err != nil {
@@ -90,4 +67,27 @@ func newNamespaceCompletionFunc(ctx context.Context) completionFunc {
 		return names, cobra.ShellCompDirectiveNoFileComp
 	}
 	return wrapCompletionFuncWithTimeout(cobra.ShellCompDirectiveNoFileComp, fn)
+}
+
+// wrapper to add a timeout to completionFuncs
+func wrapCompletionFuncWithTimeout(defaultDirective cobra.ShellCompDirective, compFunc Func) Func {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// initialize a buffered channel to receive results
+		resultChan := make(chan completionResult, 1)
+
+		// run completion function in the background and send result to resultChan
+		go func(c chan completionResult) {
+			completions, directive := compFunc(cmd, args, toComplete)
+			r := completionResult{completions: completions, directive: directive}
+			c <- r
+		}(resultChan)
+
+		// wait for results or timeout
+		select {
+		case result := <-resultChan:
+			return result.completions, result.directive
+		case <-time.After(completionTimeout):
+			return []string{}, defaultDirective | cobra.ShellCompDirectiveError
+		}
+	}
 }

--- a/pkg/cli/flags/connect/connect.go
+++ b/pkg/cli/flags/connect/connect.go
@@ -1,0 +1,36 @@
+package connect
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+func AddCommonFlags(cmd *cobra.Command, options *cli.ConnectOptions) {
+	cmd.Flags().StringVar(&options.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
+	cmd.Flags().StringVar(&options.KubeConfig, "kube-config", "./kubeconfig.yaml", "Writes the created kube config to this file")
+	cmd.Flags().BoolVar(&options.UpdateCurrent, "update-current", true, "If true updates the current kube config")
+	cmd.Flags().BoolVar(&options.Print, "print", false, "When enabled prints the context to stdout")
+	cmd.Flags().StringVar(&options.PodName, "pod", "", "The pod to connect to")
+	cmd.Flags().StringVar(&options.Server, "server", "", "The server to connect to")
+	cmd.Flags().IntVar(&options.LocalPort, "local-port", 0, "The local port to forward the virtual cluster to. If empty, vCluster will use a random unused port")
+	cmd.Flags().StringVar(&options.Address, "address", "", "The local address to start port forwarding under")
+	cmd.Flags().StringVar(&options.ServiceAccount, "service-account", "", "If specified, vCluster will create a service account token to connect to the virtual cluster instead of using the default client cert / key. Service account must exist and can be used as namespace/name.")
+	cmd.Flags().StringVar(&options.ServiceAccountClusterRole, "cluster-role", "", "If specified, vCluster will create the service account if it does not exist and also add a cluster role binding for the given cluster role to it. Requires --service-account to be set")
+	cmd.Flags().IntVar(&options.ServiceAccountExpiration, "token-expiration", 0, "If specified, vCluster will create the service account token for the given duration in seconds. Defaults to eternal")
+	cmd.Flags().BoolVar(&options.Insecure, "insecure", false, "If specified, vCluster will create the kube config with insecure-skip-tls-verify")
+	cmd.Flags().BoolVar(&options.BackgroundProxy, "background-proxy", false, "If specified, vCluster will create the background proxy in docker [its mainly used for vclusters with no nodeport service.]")
+
+	// deprecated
+	_ = cmd.Flags().MarkDeprecated("kube-config", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+	_ = cmd.Flags().MarkDeprecated("kube-config-context-name", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+	_ = cmd.Flags().MarkDeprecated("update-current", fmt.Sprintf("please use %q to write the kubeconfig of the virtual cluster to stdout.", "vcluster connect --print"))
+}
+
+func AddPlatformFlags(cmd *cobra.Command, options *cli.ConnectOptions, prefixes ...string) {
+	prefix := strings.Join(prefixes, "")
+
+	cmd.Flags().StringVar(&options.Project, "project", "", fmt.Sprintf("%sThe platform project the vCluster is in", prefix))
+}

--- a/pkg/cli/flags/create/create.go
+++ b/pkg/cli/flags/create/create.go
@@ -25,7 +25,6 @@ func AddCommonFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 	cmd.Flags().BoolVar(&options.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
 	cmd.Flags().BoolVar(&options.Connect, "connect", true, "If true will run vcluster connect directly after the vcluster was created")
 	cmd.Flags().BoolVar(&options.Upgrade, "upgrade", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
-	cmd.Flags().BoolVar(&options.Upgrade, "update", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
 	cmd.Flags().StringVar(&options.Distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro to use for the virtual cluster. Allowed distros: %s", strings.Join(cli.AllowedDistros, ", ")))
 
 	_ = cmd.Flags().MarkHidden("distro")

--- a/pkg/cli/flags/create/create.go
+++ b/pkg/cli/flags/create/create.go
@@ -1,0 +1,66 @@
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/upgrade"
+	"github.com/spf13/cobra"
+)
+
+func AddCommonFlags(cmd *cobra.Command, options *cli.CreateOptions) {
+	cmd.Flags().StringVar(&options.KubeConfigContextName, "kube-config-context-name", "", "If set, will override the context name of the generated virtual cluster kube config with this name")
+	cmd.Flags().StringVar(&options.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
+	cmd.Flags().StringVar(&options.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
+	cmd.Flags().StringVar(&options.ChartRepo, "chart-repo", constants.LoftChartRepo, "The virtual cluster chart repo to use")
+	cmd.Flags().StringVar(&options.KubernetesVersion, "kubernetes-version", "", "The kubernetes version to use (e.g. v1.20). Patch versions are not supported")
+	cmd.Flags().StringArrayVarP(&options.Values, "values", "f", []string{}, "Path where to load extra helm values from")
+	cmd.Flags().StringArrayVar(&options.SetValues, "set", []string{}, "Set values for helm. E.g. --set 'persistence.enabled=true'")
+	cmd.Flags().BoolVar(&options.Print, "print", false, "If enabled, prints the context to the console")
+	cmd.Flags().BoolVar(&options.UpdateCurrent, "update-current", true, "If true updates the current kube config")
+	cmd.Flags().BoolVar(&options.CreateContext, "create-context", true, "If the CLI should create a kube context for the space")
+	cmd.Flags().BoolVar(&options.SwitchContext, "switch-context", true, "If the CLI should switch the current context to the new context")
+	cmd.Flags().BoolVar(&options.Expose, "expose", false, "If true will create a load balancer service to expose the vcluster endpoint")
+	cmd.Flags().BoolVar(&options.Connect, "connect", true, "If true will run vcluster connect directly after the vcluster was created")
+	cmd.Flags().BoolVar(&options.Upgrade, "upgrade", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
+	cmd.Flags().BoolVar(&options.Upgrade, "update", false, "If true will try to upgrade the vcluster instead of failing if it already exists")
+	cmd.Flags().StringVar(&options.Distro, "distro", "k8s", fmt.Sprintf("Kubernetes distro to use for the virtual cluster. Allowed distros: %s", strings.Join(cli.AllowedDistros, ", ")))
+
+	_ = cmd.Flags().MarkHidden("distro")
+	_ = cmd.Flags().MarkDeprecated("distro", fmt.Sprintf("please specify the distro by setting %q accordingly via values.yaml file.", "controlPlane.distro"))
+}
+
+func AddHelmFlags(cmd *cobra.Command, options *cli.CreateOptions) {
+	cmd.Flags().BoolVar(&options.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")
+	cmd.Flags().StringVar(&options.LocalChartDir, "local-chart-dir", "", "The virtual cluster local chart dir to use")
+	cmd.Flags().BoolVar(&options.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service. Will be set to false and the passed value will be ignored if --expose is set to true.")
+
+	_ = cmd.Flags().MarkHidden("local-chart-dir")
+	_ = cmd.Flags().MarkHidden("expose-local")
+}
+
+func AddPlatformFlags(cmd *cobra.Command, options *cli.CreateOptions, prefixes ...string) {
+	prefix := strings.Join(prefixes, "")
+
+	cmd.Flags().BoolVar(&options.Activate, "activate", true, fmt.Sprintf("%sActivate the vCluster automatically when using helm manager", prefix))
+	cmd.Flags().StringVar(&options.Project, "project", "", fmt.Sprintf("%sThe vCluster platform project to use", prefix))
+	cmd.Flags().StringSliceVarP(&options.Labels, "labels", "l", []string{}, fmt.Sprintf("%sComma separated labels to apply to the virtualclusterinstance", prefix))
+	cmd.Flags().StringSliceVar(&options.Annotations, "annotations", []string{}, fmt.Sprintf("%sComma separated annotations to apply to the virtualclusterinstance", prefix))
+	cmd.Flags().StringVar(&options.Cluster, "cluster", "", fmt.Sprintf("%sThe vCluster platform connected cluster to use", prefix))
+	cmd.Flags().StringVar(&options.Template, "template", "", fmt.Sprintf("%sThe vCluster platform template to use", prefix))
+	cmd.Flags().StringVar(&options.TemplateVersion, "template-version", "", fmt.Sprintf("%sThe vCluster platform template version to use", prefix))
+	cmd.Flags().StringArrayVar(&options.Links, "link", []string{}, fmt.Sprintf("%sA link to add to the vCluster. E.g. --link 'prod=http://exampleprod.com'", prefix))
+	cmd.Flags().StringVar(&options.Params, "params", "", fmt.Sprintf("%sIf a template is used, this can be used to use a file for the parameters. E.g. --params path/to/my/file.yaml", prefix))
+	cmd.Flags().StringVar(&options.Params, "parameters", "", fmt.Sprintf("%sIf a template is used, this can be used to use a file for the parameters. E.g. --parameters path/to/my/file.yaml", prefix))
+	cmd.Flags().StringArrayVar(&options.SetParams, "set-param", []string{}, fmt.Sprintf("%sIf a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'", prefix))
+	cmd.Flags().StringArrayVar(&options.SetParams, "set-parameter", []string{}, fmt.Sprintf("%sIf a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'", prefix))
+	cmd.Flags().StringVar(&options.Description, "description", "", fmt.Sprintf("%sThe description to show in the platform UI for this virtual cluster", prefix))
+	cmd.Flags().StringVar(&options.DisplayName, "display-name", "", fmt.Sprintf("%sThe display name to show in the platform UI for this virtual cluster", prefix))
+	cmd.Flags().StringVar(&options.Team, "team", "", fmt.Sprintf("%sThe team to create the space for", prefix))
+	cmd.Flags().StringVar(&options.User, "user", "", fmt.Sprintf("%sThe user to create the space for", prefix))
+	cmd.Flags().BoolVar(&options.UseExisting, "use", false, fmt.Sprintf("%sIf the platform should use the virtual cluster if its already there", prefix))
+	cmd.Flags().BoolVar(&options.Recreate, "recreate", false, fmt.Sprintf("%sIf enabled and there already exists a virtual cluster with this name, it will be deleted first", prefix))
+	cmd.Flags().BoolVar(&options.SkipWait, "skip-wait", false, fmt.Sprintf("%sIf true, will not wait until the virtual cluster is running", prefix))
+}

--- a/pkg/cli/flags/delete/delete.go
+++ b/pkg/cli/flags/delete/delete.go
@@ -1,0 +1,28 @@
+package delete
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+func AddCommonFlags(cmd *cobra.Command, options *cli.DeleteOptions) {
+	cmd.Flags().BoolVar(&options.Wait, "wait", true, "If enabled, vcluster will wait until the vcluster is deleted")
+	cmd.Flags().BoolVar(&options.DeleteContext, "delete-context", true, "If the corresponding kube context should be deleted if there is any")
+}
+
+func AddHelmFlags(cmd *cobra.Command, options *cli.DeleteOptions) {
+	cmd.Flags().BoolVar(&options.DeleteConfigMap, "delete-configmap", false, "If enabled, vCluster will delete the ConfigMap of the vCluster")
+	cmd.Flags().BoolVar(&options.KeepPVC, "keep-pvc", false, "If enabled, vcluster will not delete the persistent volume claim of the vcluster")
+	cmd.Flags().BoolVar(&options.DeleteNamespace, "delete-namespace", false, "If enabled, vcluster will delete the namespace of the vcluster. In the case of multi-namespace mode, will also delete all other namespaces created by vcluster")
+	cmd.Flags().BoolVar(&options.AutoDeleteNamespace, "auto-delete-namespace", true, "If enabled, vcluster will delete the namespace of the vcluster if it was created by vclusterctl. In the case of multi-namespace mode, will also delete all other namespaces created by vcluster")
+	cmd.Flags().BoolVar(&options.IgnoreNotFound, "ignore-not-found", false, "If enabled, vcluster will not error out in case the target vcluster does not exist")
+}
+
+func AddPlatformFlags(cmd *cobra.Command, options *cli.DeleteOptions, prefixes ...string) {
+	prefix := strings.Join(prefixes, "")
+
+	cmd.Flags().StringVar(&options.Project, "project", "", fmt.Sprintf("%sThe vCluster platform project to use", prefix))
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3874


**Please provide a short message that should be published in the vcluster release notes**
Provide `vcluster platform connect/create/delete vcluster` commands


**What else do we need to know?**
I moved the common/platform/helm related flags to respective packages, in order to not duplicate them in two places. The `--manager` flag was removed from the `platform` sub commands, as it does not make sense there.