### PR TITLE
fix(vclusterctl): info messages for connect when sharing

### DIFF
--- a/cmd/vclusterctl/cmd/platform/share/space.go
+++ b/cmd/vclusterctl/cmd/platform/share/space.go
@@ -119,10 +119,10 @@ func (cmd *SpaceCmd) shareSpace(ctx context.Context, platformClient platform.Cli
 
 	if cmd.User != "" {
 		cmd.Log.Donef("Successfully granted user %s access to space %s", ansi.Color(cmd.User, "white+b"), ansi.Color(spaceName, "white+b"))
-		cmd.Log.Infof("The user can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("loft use space %s --project %s"), spaceName, cmd.Project), "white+b"))
+		cmd.Log.Infof("The user can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("vcluster platform connect space %s --project %s"), spaceName, cmd.Project), "white+b"))
 	} else {
 		cmd.Log.Donef("Successfully granted team %s access to space %s", ansi.Color(cmd.Team, "white+b"), ansi.Color(spaceName, "white+b"))
-		cmd.Log.Infof("The team can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("loft use space %s --project %s"), spaceName, cmd.Project), "white+b"))
+		cmd.Log.Infof("The team can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("vcluster platform connect space %s --project %s"), spaceName, cmd.Project), "white+b"))
 	}
 
 	return nil

--- a/cmd/vclusterctl/cmd/platform/share/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/share/vcluster.go
@@ -40,7 +40,7 @@ func NewVClusterCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Use:   "vcluster" + util.VClusterNameOnlyUseLine,
 		Short: "Shares a vcluster with another Platform user or team",
 		Long: `##########################################################################
-#################### vcluster platform list vclusters ####################
+#################### vcluster platform share vcluster ####################
 ##########################################################################
 Shares a vcluster with another Platform user or team
 
@@ -110,10 +110,10 @@ func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
 
 	if cmd.User != "" {
 		cmd.Log.Donef("Successfully granted user %s access to vcluster %s", ansi.Color(cmd.User, "white+b"), ansi.Color(vClusterName, "white+b"))
-		cmd.Log.Infof("The user can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("loft use vcluster %s --project %s"), vClusterName, cmd.Project), "white+b"))
+		cmd.Log.Infof("The user can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("vcluster connect %s --project %s"), vClusterName, cmd.Project), "white+b"))
 	} else {
 		cmd.Log.Donef("Successfully granted team %s access to vcluster %s", ansi.Color(cmd.Team, "white+b"), ansi.Color(vClusterName, "white+b"))
-		cmd.Log.Infof("The team can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("loft use vcluster %s --project %s"), vClusterName, cmd.Project), "white+b"))
+		cmd.Log.Infof("The team can access the space now via: %s", ansi.Color(fmt.Sprintf(product.Replace("vcluster connect %s --project %s"), vClusterName, cmd.Project), "white+b"))
 	}
 
 	return nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would print out wrong info messages when sharing vclusters/spaces


**What else do we need to know?** 
