### PR TITLE
fix(vclusterctl): select default project when only cluster flag is given

### DIFF
--- a/cmd/vclusterctl/cmd/platform/create/space.go
+++ b/cmd/vclusterctl/cmd/platform/create/space.go
@@ -134,7 +134,7 @@ func (cmd *SpaceCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// determine cluster name
-	cmd.Cluster, cmd.Project, err = platform.SelectProjectOrCluster(ctx, platformClient, cmd.Cluster, cmd.Project, true, cmd.Log)
+	cmd.Cluster, cmd.Project, err = platform.SelectProjectOrCluster(ctx, platformClient, cmd.Cluster, cmd.Project, false, cmd.Log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3900


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster platform create space` would not work when only the --cluster flag was provided.


**What else do we need to know?** 
Passing true (allowClusterOnly) to the helper func returned an empty string for project, which won't qualify as the default project in subsequent functions calls (e.g. ListTemplates).