### PR TITLE
chore: upgrade to goreleaser v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,9 +56,10 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: "goreleaser/goreleaser-action@v5"
+      - uses: "goreleaser/goreleaser-action@v6"
         with:
           args: release --clean --timeout 60m
+          version: '~> v2'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           TELEMETRY_PRIVATE_KEY: ${{ secrets.VCLUSTER_TELEMETRY_PRIVATE_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: vcluster
 
 before:
@@ -138,7 +140,7 @@ brews:
     repository:
       owner: loft-sh
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     homepage: https://www.vcluster.com
     license: Apache-2.0
     description: "Creates fully functional virtual k8s cluster inside host k8s cluster's namespace"
@@ -161,7 +163,7 @@ brews:
     repository:
       owner: loft-sh
       name: homebrew-tap
-    folder: Formula
+    directory: Formula
     homepage: https://www.vcluster.com
     license: Apache-2.0
     description: "Creates fully functional virtual k8s cluster inside host k8s cluster's namespace"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
goreleaser v2 was [announced on June 4th](https://goreleaser.com/blog/goreleaser-v2/). When using v2 (e.g. locally) we cannot issue e.g. `just build-snapshot` anymore:
```bash
⨯ build failed after 0s                    error=only configurations files on  version: 2  are supported, yours is  version: 1 , please update your configuration
```