### PR TITLE
fix: disable global owner for isolated control plane mode

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
       - name: Setup GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
           version: latest
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
       - name: Setup GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
       - name: Build vcluster cli

--- a/test/commonValues.yaml
+++ b/test/commonValues.yaml
@@ -43,3 +43,7 @@ networking:
       to: default/test
     - from: test/nginx
       to: default/nginx
+      
+experimental:
+  syncSettings:
+    setOwner: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

currently, owner is set in both control-plane and workload clusters, so this option should be disabled for isolated control plane.



**What else do we need to know?** 

No release not since it's not a released bug
