### PR TITLE
[backport] fix: disable global owner for isolated control plane mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loft-sh/vcluster
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

currently, owner is set in both control-plane and workload clusters, so this option should be disabled for isolated control plane.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

backport of https://github.com/loft-sh/vcluster/pull/1855
