### PR TITLE
 [backport]fix: set control plane svc as cert secret owner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loft-sh/vcluster
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/pkg/certs/ensure.go
+++ b/pkg/certs/ensure.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"github.com/loft-sh/vcluster/pkg/options"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,8 +29,8 @@ func EnsureCerts(
 	currentNamespaceClient kubernetes.Interface,
 	vClusterName string,
 	certificateDir string,
-	clusterDomain string,
 	etcdSans []string,
+	options *options.VirtualClusterOptions,
 ) error {
 	// we create a certificate for up to 20 etcd replicas, this should be sufficient for most use cases. Eventually we probably
 	// want to update this to the actual etcd number, but for now this is the easiest way to allow up and downscaling without
@@ -51,7 +51,7 @@ func EnsureCerts(
 
 		klog.Info("removing outdated certs")
 		// delete the certs and recreate them
-		cfg, err := createConfig(serviceCIDR, vClusterName, certificateDir, clusterDomain, etcdSans)
+		cfg, err := createConfig(serviceCIDR, vClusterName, certificateDir, options.ClusterDomain, etcdSans)
 		if err != nil {
 			return err
 		}
@@ -91,10 +91,30 @@ func EnsureCerts(
 	_, err = os.Stat(filepath.Join(certificateDir, CAKeyName))
 	if errors.Is(err, fs.ErrNotExist) {
 		// try to generate the certificates
-		err = generateCertificates(serviceCIDR, vClusterName, certificateDir, clusterDomain, etcdSans)
+		err = generateCertificates(serviceCIDR, vClusterName, certificateDir, options.ClusterDomain, etcdSans)
 		if err != nil {
 			return err
 		}
+	}
+
+	ownerRef := []metav1.OwnerReference{}
+	if options.SetOwner {
+		// options.ServiceName gets rewritten to the workload service name so we use options.Name as the v0.19.x chart
+		// directly uses the release name for the service name
+		controlPlaneService, err := currentNamespaceClient.CoreV1().Services(currentNamespace).Get(ctx, options.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get vcluster service: %w", err)
+		}
+		// client doesn't populate typemeta
+		controlPlaneService.TypeMeta.APIVersion = "v1"
+		controlPlaneService.TypeMeta.Kind = "Service"
+
+		ownerRef = append(ownerRef, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Service",
+			Name:       controlPlaneService.Name,
+			UID:        controlPlaneService.UID,
+		})
 	}
 
 	// build secret
@@ -102,7 +122,7 @@ func EnsureCerts(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            secretName,
 			Namespace:       currentNamespace,
-			OwnerReferences: translate.GetOwnerReference(nil),
+			OwnerReferences: ownerRef,
 		},
 		Data: map[string][]byte{},
 	}


### PR DESCRIPTION
- **fix: set control plane svc as cert secret owner**
- **fix: bump go version**

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

  backport of #1859 

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
When using isolated control plane, the owner for the cert should be the service in the control plane namespace.
