### PR TITLE
fix: set control plane svc as cert secret owner

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
       - name: Setup GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
           version: latest
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
       - name: Setup GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           install-only: true
       - name: Build vcluster cli

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loft-sh/vcluster
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
@@ -16,7 +16,6 @@ require (
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.2
-	github.com/hashicorp/yamux v0.1.1
 	github.com/invopop/jsonschema v0.12.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/loft-sh/admin-apis v0.0.0-20240203010124-3600c1c582a8
@@ -26,10 +25,8 @@ require (
 	github.com/loft-sh/utils v0.0.29
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-testing-interface v1.0.0
 	github.com/moby/locker v1.0.1
 	github.com/moby/term v0.5.0
-	github.com/oklog/run v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
@@ -92,10 +89,13 @@ require (
 	github.com/google/cel-go v0.17.7 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
+	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 // indirect
 	github.com/loft-sh/apiserver v0.0.0-20240129130254-7b9a55ab1744 // indirect
 	github.com/loft-sh/jspolicy v0.2.2 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/oklog/run v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/otiai10/copy v1.11.0 // indirect
 	github.com/rivo/uniseg v0.4.6 // indirect
@@ -139,7 +139,7 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect

--- a/pkg/setup/config.go
+++ b/pkg/setup/config.go
@@ -76,12 +76,7 @@ func InitAndValidateConfig(ctx context.Context, vConfig *config.VirtualClusterCo
 	// set global owner for use in owner references
 	err = SetGlobalOwner(
 		ctx,
-		vConfig.WorkloadClient,
-		vConfig.Experimental.MultiNamespaceMode.Enabled,
-		vConfig.WorkloadNamespace,
-		vConfig.WorkloadTargetNamespace,
-		vConfig.Experimental.SyncSettings.SetOwner,
-		vConfig.WorkloadService,
+		vConfig,
 	)
 	if err != nil {
 		return errors.Wrap(err, "finding vcluster pod owner")
@@ -309,23 +304,23 @@ func updateSecretAnnotations(ctx context.Context, client kubernetes.Interface, n
 
 // SetGlobalOwner fetches the owning service and populates in translate.Owner if: the vcluster is configured to setOwner is,
 // and if the currentNamespace == targetNamespace (because cross namespace owner refs don't work).
-func SetGlobalOwner(ctx context.Context, currentNamespaceClient kubernetes.Interface, multins bool, currentNamespace, targetNamespace string, setOwner bool, serviceName string) error {
-	if !setOwner {
+func SetGlobalOwner(ctx context.Context, vConfig *config.VirtualClusterConfig) error {
+	if !vConfig.Experimental.SyncSettings.SetOwner {
 		return nil
 	}
 
-	if multins {
+	if vConfig.Experimental.MultiNamespaceMode.Enabled {
 		klog.Warningf("Skip setting owner, because multi namespace mode is enabled")
 		return nil
 	}
 
-	if currentNamespace != targetNamespace {
-		klog.Warningf("Skip setting owner, because current namespace %s != target namespace %s", currentNamespace, targetNamespace)
+	if vConfig.WorkloadNamespace != vConfig.WorkloadTargetNamespace {
+		klog.Warningf("Skip setting owner, because current namespace %s != target namespace %s", vConfig.WorkloadNamespace, vConfig.WorkloadTargetNamespace)
 
 		return nil
 	}
 
-	service, err := currentNamespaceClient.CoreV1().Services(currentNamespace).Get(ctx, serviceName, metav1.GetOptions{})
+	service, err := vConfig.WorkloadClient.CoreV1().Services(vConfig.WorkloadNamespace).Get(ctx, vConfig.WorkloadService, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "get vcluster service")
 	}

--- a/pkg/setup/initialize.go
+++ b/pkg/setup/initialize.go
@@ -88,7 +88,7 @@ func initialize(ctx context.Context, parentCtx context.Context, options *config.
 
 		// create certificates if they are not there yet
 		certificatesDir := "/data/k0s/pki"
-		err = GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options.Networking.Advanced.ClusterDomain)
+		err = GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func initialize(ctx context.Context, parentCtx context.Context, options *config.
 
 		// generate etcd certificates
 		certificatesDir := "/data/pki"
-		err = GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options.Networking.Advanced.ClusterDomain)
+		err = GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func initialize(ctx context.Context, parentCtx context.Context, options *config.
 		// try to generate k8s certificates
 		certificatesDir := filepath.Dir(options.VirtualClusterKubeConfig().ServerCACert)
 		if certificatesDir == "/data/pki" {
-			err := GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options.Networking.Advanced.ClusterDomain)
+			err := GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options)
 			if err != nil {
 				return err
 			}
@@ -223,7 +223,7 @@ func initialize(ctx context.Context, parentCtx context.Context, options *config.
 		certificatesDir := filepath.Dir(options.VirtualClusterKubeConfig().ServerCACert)
 		if certificatesDir == "/data/pki" {
 			// generate k8s certificates
-			err := GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options.Networking.Advanced.ClusterDomain)
+			err := GenerateCerts(ctx, options.ControlPlaneClient, options.Name, options.ControlPlaneNamespace, serviceCIDR, certificatesDir, options)
 			if err != nil {
 				return err
 			}
@@ -233,7 +233,8 @@ func initialize(ctx context.Context, parentCtx context.Context, options *config.
 	return nil
 }
 
-func GenerateCerts(ctx context.Context, currentNamespaceClient kubernetes.Interface, vClusterName, currentNamespace, serviceCIDR, certificatesDir, clusterDomain string) error {
+func GenerateCerts(ctx context.Context, currentNamespaceClient kubernetes.Interface, vClusterName, currentNamespace, serviceCIDR, certificatesDir string, options *config.VirtualClusterConfig) error {
+	clusterDomain := options.Networking.Advanced.ClusterDomain
 	// generate etcd server and peer sans
 	etcdService := vClusterName + "-etcd"
 	etcdSans := []string{
@@ -267,7 +268,7 @@ func GenerateCerts(ctx context.Context, currentNamespaceClient kubernetes.Interf
 	}
 
 	// generate certificates
-	err := certs.EnsureCerts(ctx, serviceCIDR, currentNamespace, currentNamespaceClient, vClusterName, certificatesDir, clusterDomain, etcdSans)
+	err := certs.EnsureCerts(ctx, serviceCIDR, currentNamespace, currentNamespaceClient, vClusterName, certificatesDir, etcdSans, options)
 	if err != nil {
 		return fmt.Errorf("ensure certs: %w", err)
 	}

--- a/test/commonValues.yaml
+++ b/test/commonValues.yaml
@@ -43,3 +43,7 @@ networking:
       to: default/test
     - from: test/nginx
       to: default/nginx
+      
+experimental:
+  syncSettings:
+    setOwner: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
When using isolated control plane, the owner for the cert should be the service in the control plane namespace.