### PR TITLE
Omit OSS vCluster that were imported into pro vClusters.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/evanphx/json-patch v5.8.1+incompatible
+	github.com/evanphx/json-patch v5.8.1+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect


### PR DESCRIPTION
**What issue type does this pull request address?** 

**What does this pull request do? Which issues does it resolve?**  
resolves #ENG-3822

**Please provide a short message that should be published in the vcluster release notes**
Omits OSS clusters where the name/namespace matches pro clusters with the `loft.sh/imported-by-agent` annotation.

