### PR TITLE
fix: parse driver error

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -99,7 +99,7 @@ func PrintDriverInfo(verb string, driver DriverType, log log.Logger) {
 
 func ParseDriverType(driver string) (DriverType, error) {
 	switch driver {
-	case "helm":
+	case "", "helm":
 		return HelmDriver, nil
 	case "platform":
 		return PlatformDriver, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster cli would error if no driver is selected
