### PR TITLE
chore: rename activate flag to add and move to helm flags

### DIFF
--- a/pkg/cli/add_vcluster_helm.go
+++ b/pkg/cli/add_vcluster_helm.go
@@ -68,6 +68,6 @@ func AddVClusterHelm(
 		}
 	}
 
-	log.Donef("Successfully activated vCluster %s/%s", vCluster.Namespace, vCluster.Name)
+	log.Donef("Successfully added vCluster %s/%s", vCluster.Namespace, vCluster.Name)
 	return nil
 }

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -60,6 +60,7 @@ type CreateOptions struct {
 	CreateNamespace bool
 	UpdateCurrent   bool
 	BackgroundProxy bool
+	Add             bool
 	CreateContext   bool
 	SwitchContext   bool
 	Expose          bool
@@ -68,7 +69,6 @@ type CreateOptions struct {
 	Upgrade         bool
 
 	// Platform
-	Activate        bool
 	Project         string
 	Cluster         string
 	Template        string
@@ -276,8 +276,8 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	}
 
 	// create platform secret
-	if cmd.Activate {
-		err = cmd.activateVCluster(ctx, vClusterConfig)
+	if cmd.Add {
+		err = cmd.addVCluster(ctx, vClusterConfig)
 		if err != nil {
 			return err
 		}
@@ -339,7 +339,7 @@ func (cmd *createHelm) parseVClusterYAML(chartValues string) (*config.Config, er
 	return vClusterConfig, nil
 }
 
-func (cmd *createHelm) activateVCluster(ctx context.Context, vClusterConfig *config.Config) error {
+func (cmd *createHelm) addVCluster(ctx context.Context, vClusterConfig *config.Config) error {
 	if vClusterConfig.Platform.API.AccessKey != "" || vClusterConfig.Platform.API.SecretRef.Name != "" {
 		return nil
 	}
@@ -347,7 +347,7 @@ func (cmd *createHelm) activateVCluster(ctx context.Context, vClusterConfig *con
 	_, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
 	if err != nil {
 		if vClusterConfig.IsProFeatureEnabled() {
-			return fmt.Errorf("you have vCluster pro features activated, but seems like you are not logged in (%w). Please make sure to log into vCluster Platform to use vCluster pro features or run this command with --activate=false", err)
+			return fmt.Errorf("you have vCluster pro features enabled, but seems like you are not logged in (%w). Please make sure to log into vCluster Platform to use vCluster pro features or run this command with --add=false", err)
 		}
 
 		cmd.log.Debugf("create platform client: %v", err)

--- a/pkg/cli/flags/create/create.go
+++ b/pkg/cli/flags/create/create.go
@@ -36,6 +36,7 @@ func AddHelmFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 	cmd.Flags().StringVar(&options.LocalChartDir, "local-chart-dir", "", "The virtual cluster local chart dir to use")
 	cmd.Flags().BoolVar(&options.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service. Will be set to false and the passed value will be ignored if --expose is set to true.")
 	cmd.Flags().BoolVar(&options.BackgroundProxy, "background-proxy", true, "Try to use a background-proxy to access the vCluster. Only works if docker is installed and reachable")
+	cmd.Flags().BoolVar(&options.Add, "add", true, "Adds the virtual cluster automatically to the current vCluster platform when using helm driver")
 
 	_ = cmd.Flags().MarkHidden("local-chart-dir")
 	_ = cmd.Flags().MarkHidden("expose-local")
@@ -44,7 +45,6 @@ func AddHelmFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 func AddPlatformFlags(cmd *cobra.Command, options *cli.CreateOptions, prefixes ...string) {
 	prefix := strings.Join(prefixes, "")
 
-	cmd.Flags().BoolVar(&options.Activate, "activate", true, fmt.Sprintf("%sActivate the vCluster automatically when using helm driver", prefix))
 	cmd.Flags().StringVar(&options.Project, "project", "", fmt.Sprintf("%sThe vCluster platform project to use", prefix))
 	cmd.Flags().StringSliceVarP(&options.Labels, "labels", "l", []string{}, fmt.Sprintf("%sComma separated labels to apply to the virtualclusterinstance", prefix))
 	cmd.Flags().StringSliceVar(&options.Annotations, "annotations", []string{}, fmt.Sprintf("%sComma separated annotations to apply to the virtualclusterinstance", prefix))


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Renamed activate flag to add in vcluster create in order to be more consistent


**What else do we need to know?** 
Also moved the field to helm flags, otherwise it would appear also in `vcluster platform create vcluster` where a `--add=false` does not make sense?!