### PR TITLE
Use correct access token when trigerring runme

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/github-script@v6
         continue-on-error: true
         with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           script: |
             const version = '${{ steps.get_version.outputs.release_version }}';
             const response = await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves issue with access to vcluster-docs repo from CI

