### PR TITLE
Update platform version to v4.0.0-alpha.18

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.0.0-alpha.6"
+	MinimumVersionTag = "v4.0.0-alpha.18"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...

Update the default platform version to `v4.0.0-alpha.18`

