### PR TITLE
[bug] Fix indentation of statefulset pod annotations

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
   template:
     metadata:
       annotations:
-       vClusterConfigHash: {{ .Values | toYaml | b64enc | sha256sum | quote }}
+        vClusterConfigHash: {{ .Values | toYaml | b64enc | sha256sum | quote }}
       {{- if .Values.controlPlane.statefulSet.pods.annotations }}
 {{ toYaml .Values.controlPlane.statefulSet.pods.annotations | indent 8 }}
       {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves # n/a


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where when `controlPlane.statefulSet.pods.annotations` is set helm gives the error `Error: UPGRADE FAILED: YAML parse error on vcluster/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 32: did not find expected key` due to the `vClusterConfigHash` key being indented one space instead of two.


**What else do we need to know?** 

vcluster chart version: `0.20.0-beta.11`
