### PR TITLE
Fix goversion for devpod

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.21-bullseye
+FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?** 

Using devpod with this repo was not working because go version was not updated. Go version is already updated for the vcluster code but its not updated in dev container dockerfile.

**Please provide a short message that should be published in the vcluster release notes**
Fix golang version for devpod

**What else do we need to know?** 
NA