### PR TITLE
BACKPORT v0.20 bugfix(chart): enable fallthrough for cluster.local queries only when .Values.networking.advanced.fallbackHostCluster is true

### DIFF
--- a/chart/templates/_coredns.tpl
+++ b/chart/templates/_coredns.tpl
@@ -21,7 +21,7 @@ Corefile: |-
           kubeconfig /data/vcluster/admin.conf
           {{- end }}
           pods insecure
-          {{- if or .Values.networking.advanced.fallbackHostCluster (and .Values.controlPlane.coredns.embedded .Values.networking.resolveDNS) }}
+          {{- if .Values.networking.advanced.fallbackHostCluster }}
           fallthrough cluster.local in-addr.arpa ip6.arpa
           {{- else }}
           fallthrough in-addr.arpa ip6.arpa


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fallback to hostDNS when a resolveDNS rule was specified

