### PR TITLE
BACKPORT v0.19 bugfix(chart): enable fallthrough for cluster.local queries only when fallbackHostDns is true

### DIFF
--- a/charts/k3s/templates/_coredns.tpl
+++ b/charts/k3s/templates/_coredns.tpl
@@ -18,7 +18,7 @@ Corefile: |-
           {{- end }}
           {{- end }}
           pods insecure
-          {{- if or (.Values.fallbackHostDns) (and .Values.coredns.integrated .Values.coredns.plugin.enabled) }}
+          {{- if .Values.fallbackHostDns }}
           fallthrough cluster.local in-addr.arpa ip6.arpa
           {{- else }}
           fallthrough in-addr.arpa ip6.arpa

--- a/charts/k3s/templates/_coredns.tpl
+++ b/charts/k3s/templates/_coredns.tpl
@@ -10,6 +10,9 @@ Corefile: |-
       errors
       health
       ready
+      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
+      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
+      {{- end }}
       rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
       kubernetes cluster.local in-addr.arpa ip6.arpa {
           {{- if .Values.pro }}
@@ -24,9 +27,6 @@ Corefile: |-
           fallthrough in-addr.arpa ip6.arpa
           {{- end }}
       }
-      {{- if and .Values.coredns.integrated .Values.coredns.plugin.enabled }}
-      vcluster {{ toYaml .Values.coredns.plugin.config | b64enc }}
-      {{- end }}
       hosts /etc/NodeHosts {
           ttl 60
           reload 15s


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-4127


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would fallback to hostDNS when coredns plugin is enabled

