### PR TITLE
refactor: combine IsManaged & IsManagedCluster

### DIFF
--- a/pkg/controllers/resources/csistoragecapacities/translator.go
+++ b/pkg/controllers/resources/csistoragecapacities/translator.go
@@ -23,10 +23,6 @@ func (s *csistoragecapacitySyncer) Resource() client.Object {
 	return &storagev1.CSIStorageCapacity{}
 }
 
-func (s *csistoragecapacitySyncer) IsManaged(context.Context, client.Object) (bool, error) {
-	return true, nil
-}
-
 // TranslateMetadata translates the object's metadata
 func (s *csistoragecapacitySyncer) TranslateMetadata(ctx context.Context, pObj client.Object) (client.Object, error) {
 	pName := mappings.CSIStorageCapacities().HostToVirtual(ctx, types.NamespacedName{Name: pObj.GetName(), Namespace: pObj.GetNamespace()}, pObj)

--- a/pkg/controllers/resources/events/syncer.go
+++ b/pkg/controllers/resources/events/syncer.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"context"
 	"fmt"
 
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
@@ -12,7 +11,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,10 +38,6 @@ func (s *eventSyncer) Resource() client.Object {
 
 func (s *eventSyncer) Name() string {
 	return "event"
-}
-
-func (s *eventSyncer) IsManaged(ctx context.Context, pObj client.Object) (bool, error) {
-	return mappings.Events().HostToVirtual(ctx, types.NamespacedName{Namespace: pObj.GetNamespace(), Name: pObj.GetName()}, pObj).Name != "", nil
 }
 
 var _ syncer.Syncer = &eventSyncer{}

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -249,10 +249,6 @@ func registerIndices(ctx *synccontext.RegisterContext) error {
 	})
 }
 
-func (s *nodeSyncer) IsManaged(_ context.Context, _ client.Object) (bool, error) {
-	return true, nil
-}
-
 var _ syncertypes.Syncer = &nodeSyncer{}
 
 func (s *nodeSyncer) SyncToHost(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -193,7 +193,7 @@ func modifyController(ctx *synccontext.RegisterContext, nodeServiceProvider node
 	}()
 
 	bld = bld.WatchesRawSource(source.Kind(ctx.PhysicalManager.GetCache(), &corev1.Pod{}, handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, pod *corev1.Pod) []reconcile.Request {
-		if pod == nil || !translate.Default.IsManaged(pod) || pod.Spec.NodeName == "" {
+		if pod == nil || !translate.Default.IsManaged(ctx, pod) || pod.Spec.NodeName == "" {
 			return []reconcile.Request{}
 		}
 
@@ -231,7 +231,7 @@ func (s *nodeSyncer) RegisterIndices(ctx *synccontext.RegisterContext) error {
 func registerIndices(ctx *synccontext.RegisterContext) error {
 	err := ctx.PhysicalManager.GetFieldIndexer().IndexField(ctx, &corev1.Pod{}, constants.IndexByAssigned, func(rawObj client.Object) []string {
 		pod := rawObj.(*corev1.Pod)
-		if !translate.Default.IsManaged(pod) || pod.Spec.NodeName == "" {
+		if !translate.Default.IsManaged(ctx, pod) || pod.Spec.NodeName == "" {
 			return nil
 		}
 		return []string{pod.Spec.NodeName}

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -188,7 +188,7 @@ func (s *nodeSyncer) translateUpdateStatus(ctx *synccontext.SyncContext, pNode *
 				klog.Errorf("Error listing pods: %v", err)
 			} else {
 				for _, pod := range podList.Items {
-					if !translate.Default.IsManaged(&pod) {
+					if !translate.Default.IsManaged(ctx, &pod) {
 						// count pods that are not synced by this vcluster
 						nonVClusterPods++
 					}

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -85,7 +85,7 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx context.Context, v
 	}
 
 	// check storage class. Do not copy the name, if it was created on virtual.
-	if !translate.Default.IsManagedCluster(pPv) {
+	if !translate.Default.IsManaged(ctx, pPv) {
 		if !equality.Semantic.DeepEqual(vPv.Spec.StorageClassName, translatedSpec.StorageClassName) && !isStorageClassCreatedOnVirtual {
 			updated = translator.NewIfNil(updated, vPv)
 			updated.Spec.StorageClassName = translatedSpec.StorageClassName

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer.go
@@ -203,7 +203,7 @@ func (s *volumeSnapshotContentSyncer) shouldSync(ctx context.Context, pObj *volu
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			return false, nil, err
-		} else if translate.Default.IsManagedCluster(pObj) {
+		} else if translate.Default.IsManaged(ctx, pObj) {
 			return true, vVS, nil
 		}
 		return false, nil, nil

--- a/pkg/controllers/syncer/translator/generic_translator.go
+++ b/pkg/controllers/syncer/translator/generic_translator.go
@@ -92,10 +92,6 @@ func (n *genericTranslator) SyncToHostUpdate(ctx *context.SyncContext, vObj, pOb
 	return ctrl.Result{}, nil
 }
 
-func (n *genericTranslator) IsManaged(ctx context2.Context, pObj client.Object) (bool, error) {
-	return translate.Default.IsManaged(ctx, pObj), nil
-}
-
 func (n *genericTranslator) TranslateMetadata(ctx context2.Context, vObj client.Object) client.Object {
 	pObj, err := translate.Default.SetupMetadataWithName(vObj, n.Mapper.VirtualToHost(ctx, types.NamespacedName{Name: vObj.GetName(), Namespace: vObj.GetNamespace()}, vObj))
 	if err != nil {

--- a/pkg/controllers/syncer/translator/generic_translator.go
+++ b/pkg/controllers/syncer/translator/generic_translator.go
@@ -92,12 +92,8 @@ func (n *genericTranslator) SyncToHostUpdate(ctx *context.SyncContext, vObj, pOb
 	return ctrl.Result{}, nil
 }
 
-func (n *genericTranslator) IsManaged(_ context2.Context, pObj client.Object) (bool, error) {
-	if pObj.GetNamespace() == "" {
-		return translate.Default.IsManagedCluster(pObj), nil
-	}
-
-	return translate.Default.IsManaged(pObj), nil
+func (n *genericTranslator) IsManaged(ctx context2.Context, pObj client.Object) (bool, error) {
+	return translate.Default.IsManaged(ctx, pObj), nil
 }
 
 func (n *genericTranslator) TranslateMetadata(ctx context2.Context, vObj client.Object) client.Object {

--- a/pkg/controllers/syncer/translator/mirror_translator.go
+++ b/pkg/controllers/syncer/translator/mirror_translator.go
@@ -47,7 +47,3 @@ func (n *mirrorPhysicalTranslator) TranslateMetadataUpdate(_ context.Context, vO
 	updatedLabels := pObj.GetLabels()
 	return !equality.Semantic.DeepEqual(updatedAnnotations, vObj.GetAnnotations()) || !equality.Semantic.DeepEqual(updatedLabels, vObj.GetLabels()), updatedAnnotations, updatedLabels
 }
-
-func (n *mirrorPhysicalTranslator) IsManaged(context.Context, client.Object) (bool, error) {
-	return true, nil
-}

--- a/pkg/controllers/syncer/types/syncer.go
+++ b/pkg/controllers/syncer/types/syncer.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
+	"github.com/loft-sh/vcluster/pkg/mappings"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -24,7 +25,7 @@ type Exporter interface {
 
 type Syncer interface {
 	Object
-	ObjectManager
+	mappings.Mapper
 
 	// SyncToHost is called when a virtual object was created and needs to be synced down to the physical cluster
 	SyncToHost(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error)

--- a/pkg/controllers/syncer/types/translator.go
+++ b/pkg/controllers/syncer/types/translator.go
@@ -12,18 +12,9 @@ import (
 
 // Translator is used to translate names as well as metadata between virtual and physical objects
 type Translator interface {
-	Resource() client.Object
-	Name() string
-	ObjectManager
-	MetadataTranslator
-}
-
-// ObjectManager is used to convert virtual to physical names and vice versa
-type ObjectManager interface {
+	Object
 	mappings.Mapper
-
-	// IsManaged determines if a physical object is managed by the vcluster
-	IsManaged(context.Context, client.Object) (bool, error)
+	MetadataTranslator
 }
 
 // MetadataTranslator is used to convert metadata between virtual and physical objects and vice versa

--- a/pkg/mappings/generic/mapper.go
+++ b/pkg/mappings/generic/mapper.go
@@ -109,3 +109,7 @@ func (n *mapper) HostToVirtual(ctx context2.Context, req types.NamespacedName, p
 		Name:      vObj.GetName(),
 	}
 }
+
+func (n *mapper) IsManaged(ctx context2.Context, pObj client.Object) (bool, error) {
+	return translate.Default.IsManaged(ctx, pObj), nil
+}

--- a/pkg/mappings/generic/mirror.go
+++ b/pkg/mappings/generic/mirror.go
@@ -64,3 +64,7 @@ func (n *mirrorMapper) HostToVirtual(_ context.Context, req types.NamespacedName
 		Name: req.Name,
 	}
 }
+
+func (n *mirrorMapper) IsManaged(context.Context, client.Object) (bool, error) {
+	return true, nil
+}

--- a/pkg/mappings/resources/csistoragecapacities.go
+++ b/pkg/mappings/resources/csistoragecapacities.go
@@ -64,3 +64,7 @@ func (s *csiStorageCapacitiesMapper) VirtualToHost(ctx context.Context, req type
 		Name:      pObj.GetName(),
 	}
 }
+
+func (s *csiStorageCapacitiesMapper) IsManaged(context.Context, client.Object) (bool, error) {
+	return true, nil
+}

--- a/pkg/mappings/resources/events.go
+++ b/pkg/mappings/resources/events.go
@@ -69,6 +69,10 @@ func (s *eventMapper) HostToVirtual(ctx context.Context, req types.NamespacedNam
 	}
 }
 
+func (s *eventMapper) IsManaged(ctx context.Context, pObj client.Object) (bool, error) {
+	return s.HostToVirtual(ctx, types.NamespacedName{Namespace: pObj.GetNamespace(), Name: pObj.GetName()}, pObj).Name != "", nil
+}
+
 func HostEventNameToVirtual(hostName string, hostInvolvedObjectName, virtualInvolvedObjectName string) string {
 	// replace name of object
 	if strings.HasPrefix(hostName, hostInvolvedObjectName) {

--- a/pkg/mappings/types.go
+++ b/pkg/mappings/types.go
@@ -29,6 +29,9 @@ type Mapper interface {
 
 	// HostToVirtual translates a physical name to a virtual name
 	HostToVirtual(ctx context.Context, req types.NamespacedName, pObj client.Object) types.NamespacedName
+
+	// IsManaged determines if a physical object is managed by the vCluster
+	IsManaged(context.Context, client.Object) (bool, error)
 }
 
 func Has(gvk schema.GroupVersionKind) bool {

--- a/pkg/util/translate/types.go
+++ b/pkg/util/translate/types.go
@@ -1,8 +1,9 @@
 package translate
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -20,11 +21,8 @@ type Translator interface {
 	// SingleNamespaceTarget signals if we sync all objects into a single namespace
 	SingleNamespaceTarget() bool
 
-	// IsManaged checks if the object is managed by vcluster
-	IsManaged(obj runtime.Object) bool
-
-	// IsManagedCluster checks if the cluster scoped object is managed by vcluster
-	IsManagedCluster(obj runtime.Object) bool
+	// IsManaged checks if the host object is managed by vCluster
+	IsManaged(ctx context.Context, pObj client.Object) bool
 
 	// IsTargetedNamespace checks if the provided namespace is a sync target for vcluster
 	IsTargetedNamespace(ns string) bool
@@ -68,10 +66,6 @@ type Translator interface {
 
 	// SetupMetadataWithName is similar to ApplyMetadata with a custom name translator and doesn't apply annotations and labels
 	SetupMetadataWithName(vObj client.Object, name types.NamespacedName) (client.Object, error)
-
-	// LegacyGetTargetNamespace returns in the case of a single namespace the target namespace, but fails
-	// if vcluster is syncing to multiple namespaces.
-	LegacyGetTargetNamespace() (string, error)
 
 	ConvertLabelKey(string) string
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

PR Changes:
* Combine IsManaged & IsManagedCluster
* Get rid of LegacyTargetNamespace()
* Move IsManaged into mapper so that we can centrally control what objects should be managed by vCluster