### PR TITLE
refactor: make syncer generic

### DIFF
--- a/pkg/controllers/resources/configmaps/syncer_test.go
+++ b/pkg/controllers/resources/configmaps/syncer_test.go
@@ -78,7 +78,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*configMapSyncer).SyncToHost(syncCtx, baseConfigMap)
+				_, err := syncer.(*configMapSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(baseConfigMap))
 				assert.NilError(t, err)
 			},
 		},
@@ -95,7 +95,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*configMapSyncer).SyncToHost(syncCtx, baseConfigMap)
+				_, err := syncer.(*configMapSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(baseConfigMap))
 				assert.NilError(t, err)
 			},
 		},
@@ -115,7 +115,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*configMapSyncer).Sync(syncCtx, syncedConfigMap, updatedConfigMap)
+				_, err := syncer.(*configMapSyncer).Sync(syncCtx, synccontext.NewSyncEvent(syncedConfigMap, updatedConfigMap))
 				assert.NilError(t, err)
 			},
 		},
@@ -132,7 +132,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*configMapSyncer).Sync(syncCtx, syncedConfigMap, updatedConfigMap)
+				_, err := syncer.(*configMapSyncer).Sync(syncCtx, synccontext.NewSyncEvent(syncedConfigMap, updatedConfigMap))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/csidrivers/syncer_test.go
+++ b/pkg/controllers/resources/csidrivers/syncer_test.go
@@ -108,7 +108,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csidriverSyncer).SyncToVirtual(syncCtx, pObj)
+				_, err := syncer.(*csidriverSyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -119,7 +119,7 @@ func TestSync(t *testing.T) {
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csidriverSyncer).SyncToHost(syncCtx, vObj)
+				_, err := syncer.(*csidriverSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -135,7 +135,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csidriverSyncer).Sync(syncCtx, pObjUpdated, vObj)
+				_, err := syncer.(*csidriverSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObjUpdated, vObj))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/csinodes/syncer_test.go
+++ b/pkg/controllers/resources/csinodes/syncer_test.go
@@ -111,7 +111,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csinodeSyncer).SyncToVirtual(syncCtx, pObj)
+				_, err := syncer.(*csinodeSyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -122,7 +122,7 @@ func TestSync(t *testing.T) {
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csinodeSyncer).SyncToHost(syncCtx, vObj)
+				_, err := syncer.(*csinodeSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -138,7 +138,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csinodeSyncer).Sync(syncCtx, pObjUpdated, vObj)
+				_, err := syncer.(*csinodeSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObjUpdated, vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -155,7 +155,7 @@ func TestSync(t *testing.T) {
 
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*csinodeSyncer).Sync(syncCtx, pObjUpdated, vObj)
+				_, err := syncer.(*csinodeSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObjUpdated, vObj))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/csistoragecapacities/syncer_test.go
+++ b/pkg/controllers/resources/csistoragecapacities/syncer_test.go
@@ -9,6 +9,7 @@ import (
 	syncer "github.com/loft-sh/vcluster/pkg/syncer/types"
 	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/storageclasses"
 	"gotest.tools/assert"
@@ -111,7 +112,7 @@ func TestSyncHostStorageClass(t *testing.T) {
 				ctx.Config.Sync.FromHost.StorageClasses.Enabled = "true"
 				ctx.Config.Sync.ToHost.StorageClasses.Enabled = false
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, pObj)
+				_, err := sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -124,7 +125,7 @@ func TestSyncHostStorageClass(t *testing.T) {
 				ctx.Config.Sync.FromHost.StorageClasses.Enabled = "true"
 				ctx.Config.Sync.ToHost.StorageClasses.Enabled = false
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := sync.(*csistoragecapacitySyncer).SyncToHost(syncCtx, vObj)
+				_, err := sync.(*csistoragecapacitySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -142,7 +143,7 @@ func TestSyncHostStorageClass(t *testing.T) {
 				ctx.Config.Sync.FromHost.StorageClasses.Enabled = "true"
 				ctx.Config.Sync.ToHost.StorageClasses.Enabled = false
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := sync.(*csistoragecapacitySyncer).Sync(syncCtx, pObjUpdated, vObj)
+				_, err := sync.(*csistoragecapacitySyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObjUpdated, vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -257,13 +258,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, pObj)
+				_, err = sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -284,13 +285,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, pObj)
+				_, err = sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -311,13 +312,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, pObj)
+				_, err = sync.(*csistoragecapacitySyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -333,13 +334,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).SyncToHost(syncCtx, vObj)
+				_, err = sync.(*csistoragecapacitySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -360,13 +361,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).Sync(syncCtx, pObjUpdated, vObj)
+				_, err = sync.(*csistoragecapacitySyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObjUpdated, vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -387,13 +388,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).Sync(syncCtx, pObj, vObj)
+				_, err = sync.(*csistoragecapacitySyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObj, vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -414,13 +415,13 @@ func TestSyncStorageClass(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				var err error
 				syncCtx, sync := syncertesting.FakeStartSyncer(t, ctx, storageclasses.New)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCa)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCa))
 				assert.NilError(t, err)
-				_, err = sync.(syncer.Syncer).SyncToHost(syncCtx, vSCb)
+				_, err = sync.(syncer.Syncer).Syncer().SyncToHost(syncCtx, synccontext.NewSyncToHostEvent[client.Object](vSCb))
 				assert.NilError(t, err)
 
 				syncCtx, sync = syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err = sync.(*csistoragecapacitySyncer).Sync(syncCtx, pObj, vObj)
+				_, err = sync.(*csistoragecapacitySyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObj, vObj))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/endpoints/syncer_test.go
+++ b/pkg/controllers/resources/endpoints/syncer_test.go
@@ -186,7 +186,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*endpointsSyncer).SyncToHost(syncCtx, baseEndpoints)
+				_, err := syncer.(*endpointsSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(baseEndpoints))
 				assert.NilError(t, err)
 			},
 		},
@@ -205,7 +205,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*endpointsSyncer).Sync(syncCtx, syncedEndpoints, updatedEndpoints)
+				_, err := syncer.(*endpointsSyncer).Sync(syncCtx, synccontext.NewSyncEvent(syncedEndpoints, updatedEndpoints))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/events/syncer_test.go
+++ b/pkg/controllers/resources/events/syncer_test.go
@@ -93,7 +93,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(registerContext *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, registerContext)
-				_, err := syncer.SyncToVirtual(syncContext, pEvent)
+				_, err := syncer.SyncToVirtual(syncContext, synccontext.NewSyncToVirtualEvent(pEvent))
 				assert.NilError(t, err)
 			},
 		},
@@ -115,7 +115,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(registerContext *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, registerContext)
-				_, err := syncer.Sync(syncContext, pEventUpdated, vEvent)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(pEventUpdated, vEvent))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/ingressclasses/syncer.go
+++ b/pkg/controllers/resources/ingressclasses/syncer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/patcher"
+	"github.com/loft-sh/vcluster/pkg/syncer"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
@@ -38,36 +39,38 @@ func (i *ingressClassSyncer) Resource() client.Object {
 	return &networkingv1.IngressClass{}
 }
 
-var _ syncertypes.ToVirtualSyncer = &ingressClassSyncer{}
 var _ syncertypes.Syncer = &ingressClassSyncer{}
 
-func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, pObj client.Object) (ctrl.Result, error) {
-	vObj := translate.CopyObjectWithName(pObj.(*networkingv1.IngressClass), types.NamespacedName{Name: pObj.GetName(), Namespace: pObj.GetNamespace()}, false)
+func (i *ingressClassSyncer) Syncer() syncertypes.Sync[client.Object] {
+	return syncer.ToGenericSyncer[*networkingv1.IngressClass](i)
+}
+
+func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*networkingv1.IngressClass]) (ctrl.Result, error) {
+	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 	ctx.Log.Infof("create ingress class %s, because it does not exist in virtual cluster", vObj.Name)
 	return ctrl.Result{}, ctx.VirtualClient.Create(ctx, vObj)
 }
 
-func (i *ingressClassSyncer) Sync(ctx *synccontext.SyncContext, pObj, vObj client.Object) (_ ctrl.Result, retErr error) {
-	patch, err := patcher.NewSyncerPatcher(ctx, pObj, vObj)
+func (i *ingressClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*networkingv1.IngressClass]) (_ ctrl.Result, retErr error) {
+	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
 	}
 	defer func() {
-		if err := patch.Patch(ctx, pObj, vObj); err != nil {
+		if err := patch.Patch(ctx, event.Host, event.Virtual); err != nil {
 			retErr = utilerrors.NewAggregate([]error{retErr, err})
 		}
 	}()
 
 	// cast objects
-	pIngressClass, vIngressClass, _, _ := synccontext.Cast[*networkingv1.IngressClass](ctx, pObj, vObj)
-	vIngressClass.Annotations = pIngressClass.Annotations
-	vIngressClass.Labels = pIngressClass.Labels
-	vIngressClass.Spec.Controller = pIngressClass.Spec.Controller
-	vIngressClass.Spec.Parameters = pIngressClass.Spec.Parameters
+	event.Virtual.Annotations = event.Host.Annotations
+	event.Virtual.Labels = event.Host.Labels
+	event.Virtual.Spec.Controller = event.Host.Spec.Controller
+	event.Virtual.Spec.Parameters = event.Host.Spec.Parameters
 	return ctrl.Result{}, nil
 }
 
-func (i *ingressClassSyncer) SyncToHost(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {
-	ctx.Log.Infof("delete virtual ingress class %s, because physical object is missing", vObj.GetName())
-	return ctrl.Result{}, ctx.VirtualClient.Delete(ctx, vObj)
+func (i *ingressClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*networkingv1.IngressClass]) (ctrl.Result, error) {
+	ctx.Log.Infof("delete virtual ingress class %s, because physical object is missing", event.Virtual.Name)
+	return ctrl.Result{}, ctx.VirtualClient.Delete(ctx, event.Virtual)
 }

--- a/pkg/controllers/resources/ingressclasses/syncer_test.go
+++ b/pkg/controllers/resources/ingressclasses/syncer_test.go
@@ -94,7 +94,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*ingressClassSyncer).SyncToVirtual(syncCtx, pObj)
+				_, err := syncer.(*ingressClassSyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -105,7 +105,7 @@ func TestSync(t *testing.T) {
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*ingressClassSyncer).SyncToHost(syncCtx, vObj)
+				_, err := syncer.(*ingressClassSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vObj))
 				assert.NilError(t, err)
 			},
 		},
@@ -121,7 +121,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*ingressClassSyncer).Sync(syncCtx, pObjUpdated, vObj)
+				_, err := syncer.(*ingressClassSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObjUpdated, vObj))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/ingresses/syncer_test.go
+++ b/pkg/controllers/resources/ingresses/syncer_test.go
@@ -169,7 +169,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(registerContext *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, registerContext, NewSyncer)
-				_, err := syncer.(*ingressSyncer).SyncToHost(syncCtx, baseIngress.DeepCopy())
+				_, err := syncer.(*ingressSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(baseIngress.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -203,10 +203,10 @@ func TestSync(t *testing.T) {
 				}
 				pIngress.ResourceVersion = "999"
 
-				_, err := syncer.(*ingressSyncer).Sync(syncCtx, pIngress, &networkingv1.Ingress{
+				_, err := syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pIngress, &networkingv1.Ingress{
 					ObjectMeta: vObjectMeta,
 					Spec:       *vBaseSpec.DeepCopy(),
-				})
+				}))
 				assert.NilError(t, err)
 			},
 		},
@@ -225,7 +225,7 @@ func TestSync(t *testing.T) {
 				vIngress := noUpdateIngress.DeepCopy()
 				vIngress.ResourceVersion = "999"
 
-				_, err := syncer.(*ingressSyncer).Sync(syncCtx, createdIngress.DeepCopy(), vIngress)
+				_, err := syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdIngress.DeepCopy(), vIngress))
 				assert.NilError(t, err)
 			},
 		},
@@ -245,8 +245,7 @@ func TestSync(t *testing.T) {
 				vIngress := baseIngress.DeepCopy()
 				vIngress.ResourceVersion = "999"
 
-				syncCtx.EventSource = synccontext.EventSourceHost
-				_, err := syncer.(*ingressSyncer).Sync(syncCtx, backwardUpdateIngress, vIngress)
+				_, err := syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(backwardUpdateIngress, vIngress, synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 
 				err = syncCtx.VirtualClient.Get(syncCtx, types.NamespacedName{Namespace: vIngress.Namespace, Name: vIngress.Name}, vIngress)
@@ -255,7 +254,7 @@ func TestSync(t *testing.T) {
 				err = syncCtx.PhysicalClient.Get(syncCtx, types.NamespacedName{Namespace: backwardUpdateIngress.Namespace, Name: backwardUpdateIngress.Name}, backwardUpdateIngress)
 				assert.NilError(t, err)
 
-				_, err = syncer.(*ingressSyncer).Sync(syncCtx, backwardUpdateIngress, vIngress)
+				_, err = syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(backwardUpdateIngress, vIngress, synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 
 				err = syncCtx.VirtualClient.Get(syncCtx, types.NamespacedName{Namespace: vIngress.Namespace, Name: vIngress.Name}, vIngress)
@@ -264,7 +263,7 @@ func TestSync(t *testing.T) {
 				err = syncCtx.PhysicalClient.Get(syncCtx, types.NamespacedName{Namespace: backwardUpdateIngress.Namespace, Name: backwardUpdateIngress.Name}, backwardUpdateIngress)
 				assert.NilError(t, err)
 
-				_, err = syncer.(*ingressSyncer).Sync(syncCtx, backwardUpdateIngress, vIngress)
+				_, err = syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(backwardUpdateIngress, vIngress, synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 			},
 		},
@@ -283,7 +282,7 @@ func TestSync(t *testing.T) {
 				pIngress.ResourceVersion = "999"
 
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, registerContext, NewSyncer)
-				_, err := syncer.(*ingressSyncer).Sync(syncCtx, pIngress, baseIngress.DeepCopy())
+				_, err := syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pIngress, baseIngress.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -357,7 +356,7 @@ func TestSync(t *testing.T) {
 				err = syncCtx.PhysicalClient.Get(syncCtx, types.NamespacedName{Name: createdIngress.Name, Namespace: createdIngress.Namespace}, pIngress)
 				assert.NilError(t, err)
 
-				_, err = syncer.(*ingressSyncer).Sync(syncCtx, pIngress, vIngress)
+				_, err = syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pIngress, vIngress))
 				assert.NilError(t, err)
 			},
 		},
@@ -434,7 +433,7 @@ func TestSync(t *testing.T) {
 				err = syncCtx.PhysicalClient.Get(syncCtx, types.NamespacedName{Name: createdIngress.Name, Namespace: createdIngress.Namespace}, pIngress)
 				assert.NilError(t, err)
 
-				_, err = syncer.(*ingressSyncer).Sync(syncCtx, pIngress, vIngress)
+				_, err = syncer.(*ingressSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pIngress, vIngress))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/networkpolicies/syncer_test.go
+++ b/pkg/controllers/resources/networkpolicies/syncer_test.go
@@ -227,7 +227,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vBaseNetworkPolicy.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vBaseNetworkPolicy.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -242,7 +242,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyNoPodSelector.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyNoPodSelector.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -273,10 +273,10 @@ func TestSync(t *testing.T) {
 				}
 				pNetworkPolicy.ResourceVersion = "999"
 
-				_, err := syncer.(*networkPolicySyncer).Sync(syncCtx, pNetworkPolicy, &networkingv1.NetworkPolicy{
+				_, err := syncer.(*networkPolicySyncer).Sync(syncCtx, synccontext.NewSyncEvent(pNetworkPolicy, &networkingv1.NetworkPolicy{
 					ObjectMeta: vObjectMeta,
 					Spec:       vBaseSpec,
-				})
+				}))
 				assert.NilError(t, err)
 			},
 		},
@@ -295,7 +295,7 @@ func TestSync(t *testing.T) {
 				vNetworkPolicy := vBaseNetworkPolicy.DeepCopy()
 				vNetworkPolicy.ResourceVersion = "999"
 
-				_, err := syncer.(*networkPolicySyncer).Sync(syncCtx, pBaseNetworkPolicy.DeepCopy(), vNetworkPolicy)
+				_, err := syncer.(*networkPolicySyncer).Sync(syncCtx, synccontext.NewSyncEvent(pBaseNetworkPolicy.DeepCopy(), vNetworkPolicy))
 				assert.NilError(t, err)
 			},
 		},
@@ -310,7 +310,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyWithIPBlock.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyWithIPBlock.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -325,7 +325,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyWithPodSelectorNoNs.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyWithPodSelectorNoNs.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -340,7 +340,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyWithPodSelectorEmptyNs.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyWithPodSelectorEmptyNs.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -355,7 +355,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyWithPodSelectorNsSelector.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyWithPodSelectorNsSelector.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -370,7 +370,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyWithMatchExpressions.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyWithMatchExpressions.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -385,7 +385,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, vnetworkPolicyEgressWithPodSelectorNoNs.DeepCopy())
+				_, err := syncer.(*networkPolicySyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vnetworkPolicyEgressWithPodSelectorNoNs.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/nodes/syncer_test.go
+++ b/pkg/controllers/resources/nodes/syncer_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 var (
-	baseName types.NamespacedName = types.NamespacedName{
+	baseName = types.NamespacedName{
 		Name: "mynode",
 	}
-	basePod corev1.Pod = corev1.Pod{
+	basePod = corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mypod",
 		},
@@ -31,7 +31,7 @@ var (
 		},
 	}
 
-	baseNode corev1.Node = corev1.Node{
+	baseNode = corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: baseName.Name,
 		},
@@ -43,7 +43,7 @@ var (
 			},
 		},
 	}
-	baseVNode corev1.Node = corev1.Node{
+	baseVNode = corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: baseName.Name,
 		},
@@ -101,7 +101,7 @@ func TestSyncToVirtual(t *testing.T) {
 				Sync: func(ctx *synccontext.RegisterContext) {
 					ctx.Config.Networking.Advanced.ProxyKubelets.ByIP = false
 					syncCtx, syncer := newFakeSyncer(t, ctx)
-					_, err := syncer.SyncToVirtual(syncCtx, baseNode.DeepCopy())
+					_, err := syncer.SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(baseNode.DeepCopy()))
 					assert.NilError(t, err)
 				},
 			}
@@ -321,7 +321,7 @@ func TestSyncBothExist(t *testing.T) {
 			registerContext.Config.Sync.FromHost.Nodes.Selector.Labels = tC.syncFromHostLabel
 
 			syncCtx, syncer := newFakeSyncer(t, registerContext)
-			_, err := syncer.Sync(syncCtx, physical, initialVNode.DeepCopy())
+			_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(physical, initialVNode.DeepCopy()))
 			assert.NilError(t, err)
 
 			test.Validate(t)

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
@@ -148,7 +148,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*persistentVolumeClaimSyncer).SyncToHost(syncCtx, basePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(basePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -164,7 +164,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*persistentVolumeClaimSyncer).SyncToHost(syncCtx, deletePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(deletePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -180,7 +180,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, createdPvc.DeepCopy(), updatePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdPvc.DeepCopy(), updatePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -196,7 +196,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, createdPvc.DeepCopy(), basePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdPvc.DeepCopy(), basePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -212,7 +212,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, createdPvc.DeepCopy(), deletePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdPvc.DeepCopy(), deletePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -228,7 +228,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, backwardUpdateAnnotationsPvc.DeepCopy(), basePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, synccontext.NewSyncEvent(backwardUpdateAnnotationsPvc.DeepCopy(), basePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -245,7 +245,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
 				syncer.(*persistentVolumeClaimSyncer).useFakePersistentVolumes = true
-				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, backwardUpdateStatusPvc.DeepCopy(), basePvc.DeepCopy())
+				_, err := syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, synccontext.NewSyncEvent(backwardUpdateStatusPvc.DeepCopy(), basePvc.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -305,7 +305,7 @@ func TestSync(t *testing.T) {
 				}, pPVC)
 				assert.NilError(t, err)
 
-				_, err = syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, pPVC.DeepCopy(), vPVC.DeepCopy())
+				_, err = syncer.(*persistentVolumeClaimSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pPVC.DeepCopy(), vPVC.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/persistentvolumes/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer_test.go
@@ -202,7 +202,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.SyncToVirtual(syncContext, basePPv)
+				_, err := syncer.SyncToVirtual(syncContext, synccontext.NewSyncToVirtualEvent(basePPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -219,7 +219,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.SyncToVirtual(syncContext, wrongNsPPv)
+				_, err := syncer.SyncToVirtual(syncContext, synccontext.NewSyncToVirtualEvent(wrongNsPPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -236,7 +236,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.SyncToVirtual(syncContext, noPvcPPv)
+				_, err := syncer.SyncToVirtual(syncContext, synccontext.NewSyncToVirtualEvent(noPvcPPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -255,7 +255,7 @@ func TestSync(t *testing.T) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				backwardUpdatePPv := backwardUpdatePPv.DeepCopy()
 				baseVPv := baseVPv.DeepCopy()
-				_, err := syncer.Sync(syncContext, backwardUpdatePPv, baseVPv)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(backwardUpdatePPv, baseVPv))
 				assert.NilError(t, err)
 
 				err = syncContext.VirtualClient.Get(ctx, types.NamespacedName{Name: baseVPv.Name}, baseVPv)
@@ -264,7 +264,7 @@ func TestSync(t *testing.T) {
 				err = syncContext.PhysicalClient.Get(ctx, types.NamespacedName{Name: backwardUpdatePPv.Name}, backwardUpdatePPv)
 				assert.NilError(t, err)
 
-				_, err = syncer.Sync(syncContext, backwardUpdatePPv, baseVPv)
+				_, err = syncer.Sync(syncContext, synccontext.NewSyncEvent(backwardUpdatePPv, baseVPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -281,7 +281,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncContext, noPvcPPv, baseVPv)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(noPvcPPv, baseVPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -298,7 +298,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncContext, basePPv, baseVPv)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(basePPv, baseVPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -371,8 +371,7 @@ func TestSync(t *testing.T) {
 				err = syncContext.PhysicalClient.Get(ctx, types.NamespacedName{Name: basePPv.Name}, pPv)
 				assert.NilError(t, err)
 
-				syncContext.EventSource = synccontext.EventSourceHost
-				_, err = syncer.Sync(syncContext, pPv, vPv)
+				_, err = syncer.Sync(syncContext, synccontext.NewSyncEventWithSource(pPv, vPv, synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 			},
 		},
@@ -390,7 +389,7 @@ func TestSync(t *testing.T) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				backwardRetainPPv := backwardRetainPPv.DeepCopy()
 				backwardRetainInitialVPv := backwardRetainInitialVPv.DeepCopy()
-				_, err := syncer.Sync(syncContext, backwardRetainPPv, backwardRetainInitialVPv)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(backwardRetainPPv, backwardRetainInitialVPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -408,7 +407,7 @@ func TestSync(t *testing.T) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				backwardDeletePPv := backwardDeletePPv.DeepCopy()
 				backwardDeleteVPv := backwardDeleteVPv.DeepCopy()
-				_, err := syncer.Sync(syncContext, backwardDeletePPv, backwardDeleteVPv)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(backwardDeletePPv, backwardDeleteVPv))
 				assert.NilError(t, err)
 			},
 		},
@@ -426,7 +425,7 @@ func TestSync(t *testing.T) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				backwardDeletePPv := backwardDeletePPv.DeepCopy()
 				backwardDeleteVPvwithDelTS := backwardDeleteVPvwithDelTS.DeepCopy()
-				_, err := syncer.Sync(syncContext, backwardDeletePPv, backwardDeleteVPvwithDelTS)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(backwardDeletePPv, backwardDeleteVPvwithDelTS))
 				assert.NilError(t, err)
 			},
 		},
@@ -444,7 +443,7 @@ func TestSync(t *testing.T) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
 				vPVforDeletePVWithoutClaim := vPVforDeletePVWithoutClaim.DeepCopy()
 				pPVforDeletePVWithoutClaim := pPVforDeletePVWithoutClaim.DeepCopy()
-				_, err := syncer.Sync(syncContext, pPVforDeletePVWithoutClaim, vPVforDeletePVWithoutClaim)
+				_, err := syncer.Sync(syncContext, synccontext.NewSyncEvent(pPVforDeletePVWithoutClaim, vPVforDeletePVWithoutClaim))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/poddisruptionbudgets/syncer_test.go
+++ b/pkg/controllers/resources/poddisruptionbudgets/syncer_test.go
@@ -93,7 +93,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*pdbSyncer).SyncToHost(syncCtx, vclusterPDB.DeepCopy())
+				_, err := syncer.(*pdbSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vclusterPDB.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -113,7 +113,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*pdbSyncer).Sync(syncCtx, hostClusterSyncedPDB.DeepCopy(), vclusterUpdatedPDB.DeepCopy())
+				_, err := syncer.(*pdbSyncer).Sync(syncCtx, synccontext.NewSyncEvent(hostClusterSyncedPDB.DeepCopy(), vclusterUpdatedPDB.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -133,7 +133,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*pdbSyncer).Sync(syncCtx, hostClusterSyncedPDB.DeepCopy(), vclusterUpdatedSelectorPDB.DeepCopy())
+				_, err := syncer.(*pdbSyncer).Sync(syncCtx, synccontext.NewSyncEvent(hostClusterSyncedPDB.DeepCopy(), vclusterUpdatedSelectorPDB.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -440,7 +440,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).Sync(syncCtx, pPodWithNodeName.DeepCopy(), vPodWithNodeName)
+				_, err := syncer.(*podSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pPodWithNodeName.DeepCopy(), vPodWithNodeName))
 				assert.NilError(t, err)
 			},
 		},
@@ -459,7 +459,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Sync.FromHost.Nodes.Selector.Labels = nodeSelectorOption
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, vPodWithNodeSelector.DeepCopy())
+				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPodWithNodeSelector.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -475,7 +475,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, vPodPSS.DeepCopy())
+				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPodPSS.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -492,7 +492,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Policies.PodSecurityStandard = string(api.LevelPrivileged)
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, vPodPSS.DeepCopy())
+				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPodPSS.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -509,7 +509,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Policies.PodSecurityStandard = string(api.LevelRestricted)
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, vPodPSSR.DeepCopy())
+				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPodPSSR.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -525,8 +525,8 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.ControlPlane.HostPathMapper.Enabled = true
-				synccontext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).SyncToHost(synccontext, vHostPathPod.DeepCopy())
+				syncContext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).SyncToHost(syncContext, synccontext.NewSyncToHostEvent(vHostPathPod.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -538,8 +538,8 @@ func TestSync(t *testing.T) {
 				corev1.SchemeGroupVersion.WithKind("Pod"): {vNotInjectedPod.DeepCopy()},
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
-				synccontext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).Sync(synccontext, pInjectedPod.DeepCopy(), vNotInjectedPod.DeepCopy())
+				syncContext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).Sync(syncContext, synccontext.NewSyncEvent(pInjectedPod.DeepCopy(), vNotInjectedPod.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -558,7 +558,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Experimental.SyncSettings.SyncLabels = []string{syncLabelsWildcard}
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, vPodWithLabels.DeepCopy())
+				_, err := syncer.(*podSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPodWithLabels.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -8,14 +8,14 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/syncer/translator"
-	"github.com/loft-sh/vcluster/pkg/syncer/types"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func New(ctx *synccontext.RegisterContext) (types.Object, error) {
+func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	mapper, err := ctx.Mappings.ByGVK(mappings.PriorityClasses())
 	if err != nil {
 		return nil, err
@@ -27,43 +27,49 @@ func New(ctx *synccontext.RegisterContext) (types.Object, error) {
 }
 
 type priorityClassSyncer struct {
-	types.GenericTranslator
+	syncertypes.GenericTranslator
 }
 
-var _ types.Syncer = &priorityClassSyncer{}
+var _ syncertypes.Syncer = &priorityClassSyncer{}
 
-func (s *priorityClassSyncer) SyncToHost(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error) {
-	if ctx.IsDelete {
-		return syncer.DeleteVirtualObject(ctx, vObj, "host object was deleted")
+func (s *priorityClassSyncer) Syncer() syncertypes.Sync[client.Object] {
+	return syncer.ToGenericSyncer[*schedulingv1.PriorityClass](s)
+}
+
+func (s *priorityClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*schedulingv1.PriorityClass]) (ctrl.Result, error) {
+	if event.IsDelete() {
+		return syncer.DeleteVirtualObject(ctx, event.Virtual, "host object was deleted")
 	}
 
-	newPriorityClass := s.translate(ctx, vObj.(*schedulingv1.PriorityClass))
+	newPriorityClass := s.translate(ctx, event.Virtual)
 	ctx.Log.Infof("create physical priority class %s", newPriorityClass.Name)
 	err := ctx.PhysicalClient.Create(ctx, newPriorityClass)
 	if err != nil {
-		ctx.Log.Infof("error syncing %s to physical cluster: %v", vObj.GetName(), err)
+		ctx.Log.Infof("error syncing %s to physical cluster: %v", event.Virtual.Name, err)
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (s *priorityClassSyncer) Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj client.Object) (_ ctrl.Result, retErr error) {
+func (s *priorityClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*schedulingv1.PriorityClass]) (_ ctrl.Result, retErr error) {
 	// patch objects
-	patch, err := patcher.NewSyncerPatcher(ctx, pObj, vObj)
+	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
 	}
 	defer func() {
-		if err := patch.Patch(ctx, pObj, vObj); err != nil {
+		if err := patch.Patch(ctx, event.Host, event.Virtual); err != nil {
 			retErr = utilerrors.NewAggregate([]error{retErr, err})
 		}
 	}()
 
-	// cast objects
-	pPriorityClass, vPriorityClass, sourceObject, targetObject := synccontext.Cast[*schedulingv1.PriorityClass](ctx, pObj, vObj)
-
 	// did the priority class change?
-	s.translateUpdate(ctx, pPriorityClass, vPriorityClass, sourceObject, targetObject)
+	s.translateUpdate(ctx, event.Host, event.Virtual, event.SourceObject(), event.TargetObject())
 	return ctrl.Result{}, nil
+}
+
+func (s *priorityClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*schedulingv1.PriorityClass]) (_ ctrl.Result, retErr error) {
+	// virtual object is not here anymore, so we delete
+	return syncer.DeleteHostObject(ctx, event.Host, "virtual object was deleted")
 }

--- a/pkg/controllers/resources/secrets/syncer_test.go
+++ b/pkg/controllers/resources/secrets/syncer_test.go
@@ -91,7 +91,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.(*secretSyncer).SyncToHost(syncContext, baseSecret)
+				_, err := syncer.(*secretSyncer).SyncToHost(syncContext, synccontext.NewSyncToHostEvent(baseSecret))
 				assert.NilError(t, err)
 			},
 		},
@@ -109,7 +109,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Experimental.SyncSettings.SyncLabels = []string{testLabel}
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.(*secretSyncer).SyncToHost(syncContext, baseSecret)
+				_, err := syncer.(*secretSyncer).SyncToHost(syncContext, synccontext.NewSyncToHostEvent(baseSecret))
 				assert.NilError(t, err)
 			},
 		},
@@ -130,7 +130,7 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Experimental.SyncSettings.SyncLabels = []string{testLabel}
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.(*secretSyncer).Sync(syncContext, syncedSecret, updatedSecret)
+				_, err := syncer.(*secretSyncer).Sync(syncContext, synccontext.NewSyncEvent(syncedSecret, updatedSecret))
 				assert.NilError(t, err)
 			},
 		},
@@ -147,7 +147,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncContext, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.(*secretSyncer).Sync(syncContext, syncedSecret, updatedSecret)
+				_, err := syncer.(*secretSyncer).Sync(syncContext, synccontext.NewSyncEvent(syncedSecret, updatedSecret))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/serviceaccounts/syncer_test.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer_test.go
@@ -63,7 +63,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceAccountSyncer).SyncToHost(syncCtx, vSA)
+				_, err := syncer.(*serviceAccountSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vSA))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/services/syncer_test.go
+++ b/pkg/controllers/resources/services/syncer_test.go
@@ -318,7 +318,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).SyncToHost(syncCtx, baseService)
+				_, err := syncer.(*serviceSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(baseService))
 				assert.NilError(t, err)
 			},
 		},
@@ -334,8 +334,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				syncCtx.EventSource = synccontext.EventSourceHost
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, pServicePorts1.DeepCopy(), vServicePorts1.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(pServicePorts1.DeepCopy(), vServicePorts1.DeepCopy(), synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 			},
 		},
@@ -351,7 +350,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, pServicePorts2.DeepCopy(), vServicePorts1.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pServicePorts2.DeepCopy(), vServicePorts1.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -367,7 +366,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, createdByServerService.DeepCopy(), updateForwardService.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdByServerService.DeepCopy(), updateForwardService.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -383,7 +382,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, createdService.DeepCopy(), baseService.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdService.DeepCopy(), baseService.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -401,8 +400,7 @@ func TestSync(t *testing.T) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
 				baseService := baseService.DeepCopy()
 				updateBackwardSpecService := updateBackwardSpecService.DeepCopy()
-				syncCtx.EventSource = synccontext.EventSourceHost
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, updateBackwardSpecService, baseService)
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(updateBackwardSpecService, baseService, synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 
 				err = ctx.VirtualManager.GetClient().Get(ctx, types.NamespacedName{Namespace: baseService.Namespace, Name: baseService.Name}, baseService)
@@ -412,7 +410,7 @@ func TestSync(t *testing.T) {
 				assert.NilError(t, err)
 
 				baseService.Spec.ExternalName = updateBackwardSpecService.Spec.ExternalName
-				_, err = syncer.(*serviceSyncer).Sync(syncCtx, updateBackwardSpecService.DeepCopy(), baseService.DeepCopy())
+				_, err = syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(updateBackwardSpecService.DeepCopy(), baseService.DeepCopy(), synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 			},
 		},
@@ -430,7 +428,7 @@ func TestSync(t *testing.T) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
 				baseService := baseService.DeepCopy()
 				updateBackwardSpecRecreateService := updateBackwardSpecRecreateService.DeepCopy()
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, updateBackwardSpecRecreateService, baseService)
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(updateBackwardSpecRecreateService, baseService))
 				assert.NilError(t, err)
 
 				err = ctx.VirtualManager.GetClient().Get(ctx, types.NamespacedName{Namespace: baseService.Namespace, Name: baseService.Name}, baseService)
@@ -439,9 +437,8 @@ func TestSync(t *testing.T) {
 				err = ctx.PhysicalManager.GetClient().Get(ctx, types.NamespacedName{Namespace: updateBackwardSpecRecreateService.Namespace, Name: updateBackwardSpecRecreateService.Name}, updateBackwardSpecRecreateService)
 				assert.NilError(t, err)
 
-				syncCtx.EventSource = synccontext.EventSourceHost
 				baseService.Spec.ExternalName = updateBackwardSpecService.Spec.ExternalName
-				_, err = syncer.(*serviceSyncer).Sync(syncCtx, updateBackwardSpecRecreateService.DeepCopy(), baseService.DeepCopy())
+				_, err = syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEventWithSource(updateBackwardSpecRecreateService.DeepCopy(), baseService.DeepCopy(), synccontext.SyncEventSourceHost))
 				assert.NilError(t, err)
 			},
 		},
@@ -457,7 +454,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, updateBackwardStatusService.DeepCopy(), baseService.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(updateBackwardStatusService.DeepCopy(), baseService.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -473,7 +470,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, createdService.DeepCopy(), baseService.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(createdService.DeepCopy(), baseService.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -561,7 +558,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, pServiceExternal.DeepCopy(), vServiceClusterIPFromExternal.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pServiceExternal.DeepCopy(), vServiceClusterIPFromExternal.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -577,7 +574,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*serviceSyncer).Sync(syncCtx, pServiceExternal.DeepCopy(), vServiceNodePortFromExternal.DeepCopy())
+				_, err := syncer.(*serviceSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pServiceExternal.DeepCopy(), vServiceNodePortFromExternal.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/storageclasses/syncer_test.go
+++ b/pkg/controllers/resources/storageclasses/syncer_test.go
@@ -82,7 +82,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*storageClassSyncer).SyncToHost(syncCtx, vObject.DeepCopy())
+				_, err := syncer.(*storageClassSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vObject.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*storageClassSyncer).Sync(syncCtx, pObject.DeepCopy(), vObjectUpdated.DeepCopy())
+				_, err := syncer.(*storageClassSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pObject.DeepCopy(), vObjectUpdated.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotclasses/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotclasses/syncer_test.go
@@ -21,7 +21,6 @@ func TestSync(t *testing.T) {
 
 	vObjectMeta := metav1.ObjectMeta{
 		Name:            "testclass",
-		Namespace:       "test",
 		ResourceVersion: "999",
 	}
 	vBaseVSC := &volumesnapshotv1.VolumeSnapshotClass{
@@ -49,7 +48,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotClassSyncer).SyncToVirtual(syncCtx, vBaseVSC.DeepCopy())
+				_, err := syncer.(*volumeSnapshotClassSyncer).SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(vBaseVSC.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -65,7 +64,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotClassSyncer).Sync(syncCtx, vMoreParamsVSC.DeepCopy(), vBaseVSC.DeepCopy())
+				_, err := syncer.(*volumeSnapshotClassSyncer).Sync(syncCtx, synccontext.NewSyncEvent(vMoreParamsVSC.DeepCopy(), vBaseVSC.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -81,7 +80,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotClassSyncer).Sync(syncCtx, vBaseVSC.DeepCopy(), vMoreParamsVSC.DeepCopy())
+				_, err := syncer.(*volumeSnapshotClassSyncer).Sync(syncCtx, synccontext.NewSyncEvent(vBaseVSC.DeepCopy(), vMoreParamsVSC.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -93,7 +92,7 @@ func TestSync(t *testing.T) {
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotClassSyncer).SyncToHost(syncCtx, vBaseVSC.DeepCopy())
+				_, err := syncer.(*volumeSnapshotClassSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vBaseVSC.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshotcontents/syncer_test.go
@@ -176,7 +176,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.SyncToVirtual(syncCtx, pDynamic.DeepCopy())
+				_, err := syncer.SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(pDynamic.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -192,7 +192,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.SyncToHost(syncCtx, vPreProvisioned.DeepCopy())
+				_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPreProvisioned.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -208,7 +208,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pDynamic.DeepCopy(), vDynamic.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pDynamic.DeepCopy(), vDynamic.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -224,7 +224,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pDynamic.DeepCopy(), vInvalidMutation.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pDynamic.DeepCopy(), vInvalidMutation.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -240,7 +240,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pWithStatus.DeepCopy(), vWithGCFinalizer.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pWithStatus.DeepCopy(), vWithGCFinalizer.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -256,7 +256,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pModifiedDeletionPolicy.DeepCopy(), vModifiedDeletionPolicy.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pModifiedDeletionPolicy.DeepCopy(), vModifiedDeletionPolicy.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -271,7 +271,7 @@ func TestSync(t *testing.T) {
 				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {}},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pPreProvisioned.DeepCopy(), vDeleting.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pPreProvisioned.DeepCopy(), vDeleting.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -286,7 +286,7 @@ func TestSync(t *testing.T) {
 				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {}},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.SyncToHost(syncCtx, vDeletingWithGCFinalizer.DeepCopy())
+				_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vDeletingWithGCFinalizer.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -301,7 +301,7 @@ func TestSync(t *testing.T) {
 				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDeletingWithOneFinalizer.DeepCopy()}},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pDeletingWithOneFinalizer.DeepCopy(), vDeletingWithMoreFinalizers.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pDeletingWithOneFinalizer.DeepCopy(), vDeletingWithMoreFinalizers.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -316,7 +316,7 @@ func TestSync(t *testing.T) {
 				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent"): {pDeletingWithStatus.DeepCopy()}},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := newFakeSyncer(t, ctx)
-				_, err := syncer.Sync(syncCtx, pDeletingWithStatus.DeepCopy(), vDeletingWithOneFinalizer.DeepCopy())
+				_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(pDeletingWithStatus.DeepCopy(), vDeletingWithOneFinalizer.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/volumesnapshots/volumesnapshots/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshots/volumesnapshots/syncer_test.go
@@ -119,7 +119,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).SyncToHost(syncCtx, vPVSourceSnapshot.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPVSourceSnapshot.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -135,7 +135,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).SyncToHost(syncCtx, vVSCSourceSnapshot.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vVSCSourceSnapshot.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -151,7 +151,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, pPVSourceSnapshot.DeepCopy(), vVSCSourceSnapshot.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pPVSourceSnapshot.DeepCopy(), vVSCSourceSnapshot.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -167,7 +167,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, pWithNilClass.DeepCopy(), vPVSourceSnapshot.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pWithNilClass.DeepCopy(), vPVSourceSnapshot.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -183,7 +183,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, pWithNilClass.DeepCopy(), vWithNilClass.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pWithNilClass.DeepCopy(), vWithNilClass.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -199,7 +199,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, pWithFinalizers, vPVSourceSnapshot.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pWithFinalizers, vPVSourceSnapshot.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -215,7 +215,7 @@ func TestSync(t *testing.T) {
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, pWithStatus, vPVSourceSnapshot.DeepCopy())
+				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pWithStatus, vPVSourceSnapshot.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},
@@ -230,7 +230,7 @@ func TestSync(t *testing.T) {
 				volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshot"): {}},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
-				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, pPVSourceSnapshot.DeepCopy(), vDeletingSnapshot)
+				_, err := syncer.(*volumeSnapshotSyncer).Sync(syncCtx, synccontext.NewSyncEvent(pPVSourceSnapshot.DeepCopy(), vDeletingSnapshot))
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/syncer/synccontext/context.go
+++ b/pkg/syncer/synccontext/context.go
@@ -12,13 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type EventSource string
-
-const (
-	EventSourceHost    EventSource = "Host"
-	EventSourceVirtual EventSource = "Virtual"
-)
-
 type ControllerContext struct {
 	context.Context
 
@@ -59,9 +52,6 @@ type SyncContext struct {
 
 	CurrentNamespace       string
 	CurrentNamespaceClient client.Client
-
-	EventSource EventSource
-	IsDelete    bool
 }
 
 type RegisterContext struct {
@@ -81,47 +71,6 @@ type RegisterContext struct {
 type Filter func(http.Handler, *ControllerContext) http.Handler
 
 type Hook func(ctx *ControllerContext) error
-
-func SyncSourceTarget[T any](ctx *SyncContext, pObj, vObj T) (source T, target T) {
-	if ctx.EventFromHost() {
-		// sourceObj (Host), targetObj
-		return pObj, vObj
-	}
-	// sourceObj (Virtual), targetObj
-	return vObj, pObj
-}
-
-// Cast returns the given objects as types as well as
-func Cast[T any](ctx *SyncContext, pObj, vObj client.Object) (physical T, virtual T, source T, target T) {
-	if pObj == nil || vObj == nil {
-		panic("pObj or vObj is nil")
-	}
-
-	castedPhysical, ok := pObj.(T)
-	if !ok {
-		panic("Cannot cast physical object")
-	}
-
-	castedVirtual, ok := vObj.(T)
-	if !ok {
-		panic("Cannot cast virtual object")
-	}
-
-	if ctx.EventFromHost() {
-		// vObj, pObj, sourceObj (Host), targetObj
-		return castedPhysical, castedVirtual, castedPhysical, castedVirtual
-	}
-	// vObj, pObj, sourceObj (Virtual), targetObj
-	return castedPhysical, castedVirtual, castedVirtual, castedPhysical
-}
-
-func (s *SyncContext) EventFromHost() bool {
-	return s.EventSource == EventSourceHost
-}
-
-func (s *SyncContext) EventFromVirtual() bool {
-	return s.EventSource == EventSourceVirtual
-}
 
 func (c *ControllerContext) ToRegisterContext() *RegisterContext {
 	return &RegisterContext{

--- a/pkg/syncer/synccontext/events.go
+++ b/pkg/syncer/synccontext/events.go
@@ -1,0 +1,99 @@
+package synccontext
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+type SyncEventType string
+
+const (
+	SyncEventTypeUnknown SyncEventType = ""
+	SyncEventTypeDelete  SyncEventType = "Delete"
+)
+
+type SyncEventSource string
+
+const (
+	SyncEventSourceHost    SyncEventSource = "Host"
+	SyncEventSourceVirtual SyncEventSource = "Virtual"
+)
+
+func NewSyncToHostEvent[T client.Object](vObj T) *SyncToHostEvent[T] {
+	return &SyncToHostEvent[T]{
+		Source: SyncEventSourceVirtual,
+
+		Virtual: vObj,
+	}
+}
+
+func NewSyncToVirtualEvent[T client.Object](pObj T) *SyncToVirtualEvent[T] {
+	return &SyncToVirtualEvent[T]{
+		Source: SyncEventSourceVirtual,
+
+		Host: pObj,
+	}
+}
+
+func NewSyncEvent[T client.Object](pObj, vObj T) *SyncEvent[T] {
+	return &SyncEvent[T]{
+		Source: SyncEventSourceVirtual,
+
+		Host:    pObj,
+		Virtual: vObj,
+	}
+}
+
+func NewSyncEventWithSource[T client.Object](pObj, vObj T, source SyncEventSource) *SyncEvent[T] {
+	return &SyncEvent[T]{
+		Source: source,
+
+		Host:    pObj,
+		Virtual: vObj,
+	}
+}
+
+type SyncEvent[T client.Object] struct {
+	Type   SyncEventType
+	Source SyncEventSource
+
+	Host    T
+	Virtual T
+}
+
+func (s *SyncEvent[T]) SourceObject() T {
+	if s.Source == SyncEventSourceHost {
+		return s.Host
+	}
+	return s.Virtual
+}
+
+func (s *SyncEvent[T]) TargetObject() T {
+	if s.Source == SyncEventSourceHost {
+		return s.Virtual
+	}
+	return s.Host
+}
+
+func (s *SyncEvent[T]) IsDelete() bool {
+	return s.Type == SyncEventTypeDelete
+}
+
+type SyncToHostEvent[T client.Object] struct {
+	Type   SyncEventType
+	Source SyncEventSource
+
+	Virtual T
+}
+
+func (s *SyncToHostEvent[T]) IsDelete() bool {
+	return s.Type == SyncEventTypeDelete
+}
+
+type SyncToVirtualEvent[T client.Object] struct {
+	Type   SyncEventType
+	Source SyncEventSource
+
+	Host T
+}
+
+func (s *SyncToVirtualEvent[T]) IsDelete() bool {
+	return s.Type == SyncEventTypeDelete
+}

--- a/pkg/syncer/types/syncer.go
+++ b/pkg/syncer/types/syncer.go
@@ -26,15 +26,16 @@ type Syncer interface {
 	Object
 	synccontext.Mapper
 
-	// SyncToHost is called when a virtual object was created and needs to be synced down to the physical cluster
-	SyncToHost(ctx *synccontext.SyncContext, vObj client.Object) (ctrl.Result, error)
-	// Sync is called to sync a virtual object with a physical object
-	Sync(ctx *synccontext.SyncContext, pObj client.Object, vObj client.Object) (ctrl.Result, error)
+	Syncer() Sync[client.Object]
 }
 
-type ToVirtualSyncer interface {
+type Sync[T client.Object] interface {
+	// SyncToHost is called when a virtual object was created and needs to be synced down to the physical cluster
+	SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[T]) (ctrl.Result, error)
+	// Sync is called to sync a virtual object with a physical object
+	Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[T]) (ctrl.Result, error)
 	// SyncToVirtual is called when a host object exists but the virtual object does not exist
-	SyncToVirtual(ctx *synccontext.SyncContext, pObj client.Object) (ctrl.Result, error)
+	SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[T]) (ctrl.Result, error)
 }
 
 type FakeSyncer interface {

--- a/pkg/syncer/wrapper.go
+++ b/pkg/syncer/wrapper.go
@@ -1,0 +1,50 @@
+package syncer
+
+import (
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ToGenericSyncer[T client.Object](syncer syncertypes.Sync[T]) syncertypes.Sync[client.Object] {
+	return &toSyncer[T]{
+		syncer: syncer,
+	}
+}
+
+type toSyncer[T client.Object] struct {
+	syncer syncertypes.Sync[T]
+}
+
+func (t *toSyncer[T]) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[client.Object]) (ctrl.Result, error) {
+	hostConverted, _ := event.Host.(T)
+
+	return t.syncer.SyncToVirtual(ctx, &synccontext.SyncToVirtualEvent[T]{
+		Type:   event.Type,
+		Source: event.Source,
+		Host:   hostConverted,
+	})
+}
+
+func (t *toSyncer[T]) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[client.Object]) (ctrl.Result, error) {
+	hostConverted, _ := event.Host.(T)
+	virtualConverted, _ := event.Virtual.(T)
+
+	return t.syncer.Sync(ctx, &synccontext.SyncEvent[T]{
+		Type:    event.Type,
+		Source:  event.Source,
+		Host:    hostConverted,
+		Virtual: virtualConverted,
+	})
+}
+
+func (t *toSyncer[T]) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[client.Object]) (ctrl.Result, error) {
+	virtualConverted, _ := event.Virtual.(T)
+
+	return t.syncer.SyncToHost(ctx, &synccontext.SyncToHostEvent[T]{
+		Type:    event.Type,
+		Source:  event.Source,
+		Virtual: virtualConverted,
+	})
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Restructures the syncer and makes the parameters generic so we don't have to cast objects anymore