### PR TITLE
fix: do not explicitly set zero values if key is not present

### DIFF
--- a/config/diff.go
+++ b/config/diff.go
@@ -56,19 +56,7 @@ func diff(from, to any) any {
 		// from -> to
 		for k, fromValue := range fromType {
 			toValue, ok := toMap[k]
-			if !ok {
-				switch fromValue.(type) {
-				// if its a boolean, its true -> false
-				case bool:
-					retMap[k] = false
-				// if its a string, its "something" -> ""
-				case string:
-					retMap[k] = ""
-				// if its an int, its 3 -> 0
-				case int:
-					retMap[k] = 0
-				}
-			} else if !reflect.DeepEqual(fromValue, toValue) {
+			if ok && !reflect.DeepEqual(fromValue, toValue) {
 				switch fromValue.(type) {
 				case map[string]interface{}:
 					retMap[k] = diff(fromValue, toValue)

--- a/config/legacyconfig/migrate_test.go
+++ b/config/legacyconfig/migrate_test.go
@@ -361,7 +361,6 @@ syncer:
         tag: v0.0.1
   statefulSet:
     image:
-      registry: ""
       repository: loft-sh/test
       tag: abc
     scheduling:
@@ -389,6 +388,37 @@ syncer:
     scheduling:
       podManagementPolicy: OrderedReady`,
 			ExpectedErr: "",
+		},
+		{
+			Name:   "quotas",
+			Distro: "k8s",
+			In: `isolation:
+  enabled: true
+  resourceQuota:
+    enabled: true
+    quota:
+      limits.cpu: 16`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+policies:
+  limitRange:
+    enabled: true
+  networkPolicy:
+    enabled: true
+  podSecurityStandard: baseline
+  resourceQuota:
+    enabled: true
+    quota:
+      limits.cpu: 16`,
 		},
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4125


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would overwrite explicit default values with the type's zero value.


**What else do we need to know?** 
There is an alternative PR here, which takes over the default values: https://github.com/loft-sh/vcluster/pull/1986
Not entirely sure which path we should follow?!