### PR TITLE
Prevent unsupported HA setup

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,26 @@
+name: Automatic backport action
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.5.1
+        with:
+          github_token: ${{ secrets.GH_ACCESS_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log
+

--- a/config/config.go
+++ b/config/config.go
@@ -209,6 +209,10 @@ func (c *Config) BackingStoreType() StoreType {
 	}
 }
 
+func (c *Config) EmbeddedDatabase() bool {
+	return !c.ControlPlane.BackingStore.Database.External.Enabled && !c.ControlPlane.BackingStore.Etcd.Embedded.Enabled && !c.ControlPlane.BackingStore.Etcd.Deploy.Enabled
+}
+
 func (c *Config) Distro() string {
 	if c.ControlPlane.Distro.K3S.Enabled {
 		return K3SDistro

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -276,6 +276,11 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 		}
 	}
 
+	err = validateHABackingStoreCompatibility(vClusterConfig)
+	if err != nil {
+		return err
+	}
+
 	if isVClusterDeployed(release) {
 		// While certain backing store changes are allowed we prohibit changes to another distro.
 		if err := config.ValidateChanges(currentVClusterConfig, vClusterConfig); err != nil {
@@ -410,6 +415,16 @@ func isLegacyVCluster(version string) bool {
 		return false
 	}
 	return semver.Compare("v"+version, "v0.20.0-alpha.0") == -1
+}
+
+func validateHABackingStoreCompatibility(config *config.Config) error {
+	if !config.EmbeddedDatabase() {
+		return nil
+	}
+	if !(config.ControlPlane.StatefulSet.HighAvailability.Replicas > 1) {
+		return nil
+	}
+	return fmt.Errorf("cannot use default embedded database (sqlite) in high availability mode. Try embedded etcd backing store instead")
 }
 
 func isLegacyConfig(values []byte) bool {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,10 +53,6 @@ type VirtualClusterConfig struct {
 	ControlPlaneNamespace string `json:"controlPlaneNamespace,omitempty"`
 }
 
-func (v VirtualClusterConfig) EmbeddedDatabase() bool {
-	return !v.ControlPlane.BackingStore.Database.External.Enabled && !v.ControlPlane.BackingStore.Etcd.Embedded.Enabled && !v.ControlPlane.BackingStore.Etcd.Deploy.Enabled
-}
-
 func (v VirtualClusterConfig) VirtualClusterKubeConfig() config.VirtualClusterKubeConfig {
 	distroConfig := config.VirtualClusterKubeConfig{}
 	switch v.Distro() {


### PR DESCRIPTION
High availability setups do not work with embedded sqlite. We are now validating that that high availability and embedded sqlite are not both enabled.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1910


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...
High availability setups do not work with embedded sqlite. We are now validating that that high availability and embedded sqlite are not both enabled.

**What else do we need to know?** 
Embedded etcd _is_ supported and can be used if embedded is desired.