### PR TITLE
PR for Adding tests for installing and deleting virtual cluster from kubectl

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -139,6 +139,67 @@ jobs:
           name: e2e-binaries
           path: ./test/*/*.test
           retention-days: 7
+  
+  vcluster-install-delete:
+    name: Install and delete virtual cluster
+    needs:
+      - build-and-push-syncer-image
+      - build-vcluster-cli
+      
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        name: Setup Helm
+        with:
+          version: "v3.11.0"
+
+      - name: Set up kind k8s cluster
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.20.0"
+          image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+
+      - name: Testing kind cluster set-up
+        run: |
+          set -x
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "kubectl config current-context:" $(kubectl config current-context)
+          echo "KUBECONFIG env var:" ${KUBECONFIG}
+
+      - name: Download vcluster cli
+        uses: actions/download-artifact@v4
+        with:
+          name: vcluster
+
+      - name: Download syncer image
+        uses: actions/download-artifact@v4
+        with:
+          name: vcluster_syncer
+      
+      - name: Setup environment
+        run: |
+          
+          kind load image-archive vcluster_syncer
+          
+          chmod +x vcluster && sudo mv vcluster /usr/bin
+          
+          sudo apt-get install -y sed
+
+      - name: Run tests - install and delete virtual cluster using kubectl
+        run: |
+          set -x
+
+          ./hack/vcluster-install-scripts/test-kubectl-install.sh
+      
+      - name: Run tests - install and delete virtual cluster using helm
+        run: |
+          set -x
+          
+          ./hack/vcluster-install-scripts/test-helm-install.sh
 
   download-latest-cli:
     name: Execute test suites
@@ -153,7 +214,7 @@ jobs:
           name: vcluster-current
           path: ./vcluster-current
           retention-days: 7
-
+  
   upgrade-test:
     name: test if we can upgrade from older version
     needs:
@@ -423,3 +484,4 @@ jobs:
           echo "======================================================================================================================"
           kubectl describe pods -n ${{ env.VCLUSTER_NAMESPACE }}
           exit 1
+

--- a/hack/vcluster-install-scripts/test-helm-install.sh
+++ b/hack/vcluster-install-scripts/test-helm-install.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+
+VCLUSTER_NAME="${VCLUSTER_NAME}"      
+VCLUSTER_NAMESPACE="${VCLUSTER_NAMESPACE}"
+POLL_INTERVAL=10  
+MAX_WAIT_TIME=180
+PATH_TO_VALUES_FILE="./test/commonValues.yaml"
+HELM_CHART_DIR="./chart"
+
+if [ -z "$VCLUSTER_NAME" ]; then
+    echo "VCLUSTER_NAME environment variable is not set."
+    exit 1
+fi
+
+if [ -z "$VCLUSTER_NAMESPACE" ]; then
+    echo "VCLUSTER_NAMESPACE environment variable is not set."
+    exit 1
+fi
+
+if [ ! -f "$PATH_TO_VALUES_FILE" ]; then
+    echo "Values file $PATH_TO_VALUES_FILE does not exist."
+    exit 1
+fi
+
+sed -i "s|REPLACE_REPOSITORY_NAME|${REPOSITORY_NAME}|g" $PATH_TO_VALUES_FILE
+sed -i "s|REPLACE_TAG_NAME|${TAG_NAME}|g" $PATH_TO_VALUES_FILE
+
+echo "Creating namespace"
+kubectl create namespace $VCLUSTER_NAMESPACE
+
+echo "Installing or upgrading vCluster $VCLUSTER_NAME in namespace $VCLUSTER_NAMESPACE..."
+helm upgrade --install $VCLUSTER_NAME $HELM_CHART_DIR \
+  --values $PATH_TO_VALUES_FILE \
+  --namespace $VCLUSTER_NAMESPACE \
+  --repository-config=''
+
+if [ $? -ne 0 ]; then
+    echo "Failed to install or upgrade vCluster."
+    exit 1
+fi
+
+echo "Polling for vCluster $VCLUSTER_NAME to be in Running state..."
+check_vcluster_running() {
+    vcluster list -n $VCLUSTER_NAMESPACE | grep -q "Running"
+}
+
+elapsed_time=0
+while [ $elapsed_time -le $MAX_WAIT_TIME ]; do
+    if check_vcluster_running; then
+        echo "vCluster $VCLUSTER_NAME is in Running state."
+        break
+    fi
+    
+    echo "vCluster $VCLUSTER_NAME is not in Running state yet. Waiting..."
+    sleep $POLL_INTERVAL
+    elapsed_time=$((elapsed_time + POLL_INTERVAL))
+done
+
+if ! check_vcluster_running; then
+    echo "vCluster $VCLUSTER_NAME did not reach Running state within $MAX_WAIT_TIME seconds."
+    exit 1
+fi
+
+echo "Deleting vCluster $VCLUSTER_NAME..."
+helm uninstall $VCLUSTER_NAME -n $VCLUSTER_NAMESPACE
+
+if [ $? -ne 0 ]; then
+    echo "Failed to delete vCluster."
+    exit 1
+fi
+
+echo "vCluster $VCLUSTER_NAME has been deleted."
+kubectl delete namespace $VCLUSTER_NAMESPACE

--- a/hack/vcluster-install-scripts/test-kubectl-install.sh
+++ b/hack/vcluster-install-scripts/test-kubectl-install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+
+VCLUSTER_NAME="${VCLUSTER_NAME}"      
+VCLUSTER_NAMESPACE="${VCLUSTER_NAMESPACE}" 
+POLL_INTERVAL=10  
+MAX_WAIT_TIME=180 
+MANIFEST_FILE="vcluster-manifest.yaml"
+PATH_TO_VALUES_FILE="./test/commonValues.yaml"
+HELM_CHART_DIR="./chart"
+
+if [ -z "$VCLUSTER_NAME" ]; then
+    echo "VCLUSTER_NAME environment variable is not set."
+    exit 1
+fi
+
+if [ -z "$VCLUSTER_NAMESPACE" ]; then
+    echo "VCLUSTER_NAMESPACE environment variable is not set."
+    exit 1
+fi
+
+sed -i "s|REPLACE_REPOSITORY_NAME|${REPOSITORY_NAME}|g" $PATH_TO_VALUES_FILE
+sed -i "s|REPLACE_TAG_NAME|${TAG_NAME}|g" $PATH_TO_VALUES_FILE
+
+echo "Creating namespace"
+kubectl create namespace $VCLUSTER_NAMESPACE
+
+echo "Generating vCluster manifest for $VCLUSTER_NAME in namespace $VCLUSTER_NAMESPACE..."
+helm template $VCLUSTER_NAME $HELM_CHART_DIR -n $VCLUSTER_NAMESPACE -f $PATH_TO_VALUES_FILE > $MANIFEST_FILE
+
+echo "$PATH_TO_VALUES_FILE"
+
+if [ $? -ne 0 ]; then
+    echo "Failed to generate vCluster manifest."
+    exit 1
+fi
+
+echo "Applying vCluster manifest..."
+kubectl apply -f $MANIFEST_FILE
+
+if [ $? -ne 0 ]; then
+    echo "Failed to create vCluster."
+    exit 1
+fi
+
+echo "Polling for vCluster $VCLUSTER_NAME to be in Running state..."
+check_vcluster_running() {
+    vcluster list -n $VCLUSTER_NAMESPACE | grep -q "Running"
+}
+
+elapsed_time=0
+while [ $elapsed_time -le $MAX_WAIT_TIME ]; do
+    if check_vcluster_running; then
+        echo "vCluster $VCLUSTER_NAME is in Running state."
+        break
+    fi
+    
+    echo "vCluster $VCLUSTER_NAME is not in Running state yet. Waiting..."
+    sleep $POLL_INTERVAL
+    elapsed_time=$((elapsed_time + POLL_INTERVAL))
+done
+
+if ! check_vcluster_running; then
+    echo "vCluster $VCLUSTER_NAME did not reach Running state within $MAX_WAIT_TIME seconds."
+    exit 1
+fi
+
+echo "Deleting vCluster $VCLUSTER_NAME using manifest..."
+kubectl delete -f $MANIFEST_FILE
+
+if [ $? -ne 0 ]; then
+    echo "Failed to delete vCluster."
+    exit 1
+fi
+
+echo "vCluster $VCLUSTER_NAME has been deleted."
+
+echo "Delete namespace $VCLUSTER_NAMESPACE"
+kubectl delete namespace $VCLUSTER_NAMESPACE


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

- But this is for testing the GHA with some minor changes.
- Original PR: https://github.com/loft-sh/vcluster/pull/2011
- If this works, depending on how we want to proceed, I might close of these PRs
- fixed comments from here - https://github.com/loft-sh/vcluster/pull/2011#pullrequestreview-2213293663

**Details:**
- Implemented a module for running the install and delete commands for virtual cluster through helm and kubectl in the `e2e.yaml` GHA workflow file. 
- Added bash scripts for the actions - helm and kubectl

**To-do in next PR** 
- once this PR is merged - install and delete using argoCD and terraform

**What does this pull request do?**
Adds a test - install and delete vcluster using kubectl and helm


**Please provide a short message that should be published in the vcluster release notes**
N/A


**What else do we need to know?** 
