### PR TITLE
bugfix: do not output logs in vcluster connect if --print is set

### DIFF
--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -4,6 +4,10 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
@@ -77,6 +81,7 @@ func (cmd *ConnectCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	cmd.overrideLogStdoutIfNeeded()
 
 	cfg := cmd.LoadedConfig(cmd.Log)
 
@@ -99,4 +104,13 @@ func (cmd *ConnectCmd) validateFlags() error {
 	}
 
 	return nil
+}
+
+// overrideLogStdoutIfNeeded
+// If user specifies --print flag, we have to discard all the logs, otherwise
+// we will get invalid kubeconfig.
+func (cmd *ConnectCmd) overrideLogStdoutIfNeeded() {
+	if cmd.Print {
+		cmd.Log = log.NewStdoutLogger(os.Stdin, io.Discard, os.Stderr, logrus.InfoLevel)
+	}
 }

--- a/test/e2e_cli/connect/connect.go
+++ b/test/e2e_cli/connect/connect.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd"
@@ -12,7 +13,6 @@ import (
 
 var _ = ginkgo.Describe("Connect to vCluster", func() {
 	f := framework.DefaultFramework
-
 	ginkgo.BeforeEach(func() {
 		disconnectCmd := cmd.NewDisconnectCmd(&flags.GlobalFlags{})
 		disconnectCmd.SetArgs([]string{})
@@ -36,6 +36,28 @@ var _ = ginkgo.Describe("Connect to vCluster", func() {
 
 		err = connectCmd.Execute()
 		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("should print connect config to a file and use it to connect to an OSS vcluster", func() {
+		kcfgFile, err := os.CreateTemp("", "kubeconfig")
+		framework.ExpectNoError(err)
+		// vcluster CLI has to be in $PATH
+		connectCmd := exec.Command("vcluster", "connect", "-n", f.VclusterNamespace, "--print", f.VclusterName)
+		kubeConfigBytes, err := connectCmd.Output()
+		framework.ExpectNoError(err)
+		_, err = kcfgFile.Write(kubeConfigBytes)
+		framework.ExpectNoError(err)
+		kubectlCmd := exec.Command("kubectl", "--kubeconfig", kcfgFile.Name(), "get", "pods", "-A")
+		err = kubectlCmd.Run()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("should fail to print vcluster connect config to a file", func() {
+		notExistingVClusterName := "INVALID"
+		// vcluster CLI has to be in $PATH
+		connectCmd := exec.Command("vcluster", "connect", "-n", notExistingVClusterName, "--print", notExistingVClusterName)
+		err := connectCmd.Run()
+		framework.ExpectError(err)
 	})
 
 	ginkgo.It("should connect to an OSS vcluster and execute a command", func() {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4270

Fix replaces the `Log` if `--print` flag is set. This new Log instance will log all non-error logs to `io.Discard`. Also, added two e2e tests:
1. First executes `vcluster connect -n vcluster --print vcluster` and writes it to temporary file, and then uses `kubectl --kubeconfig=<temporary-file> get pods -A` to check if outputed kubeconfig can be used to connect to virtual cluster.
2. Second tests checks if the `vcluster connect -n vcluster --print NOT_EXISTING_CLUSTER_NAME` still outputs error.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster connect --print` outputs invalid kubeconfig (it included log)


**What else do we need to know?** 
I initially tried to construct `cobra.Command` inside the e2e test (as it is done [here](https://github.com/loft-sh/vcluster/pull/2014/files#diff-e64a93b22baa2c465b8c347271dbde99882ebaf5ed3d8fb5d1f2d9d6d8850518L30), but I couldn't direct the output of the `cmd.Execute()` to the temporary kubeconfig file (even using `cmd.SetOut(kubeCfgFile)`). I believe reason for that is that we write to `os.Stdout` directly here: https://github.com/hidalgopl/vcluster/blob/fix-vcluster-connect-with-print/pkg/cli/connect_helm.go#L154 (so we don't take into account the `outWriter` from `cobra.Command`.