### PR TITLE
bump default coredns image to v1.11.3 (because previous ones had CVEs)

### DIFF
--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	DefaultImage          = "coredns/coredns:1.11.1"
+	DefaultImage          = "coredns/coredns:1.11.3"
 	ManifestRelativePath  = "coredns/coredns.yaml"
 	ManifestsOutputFolder = "/tmp/manifests-to-apply"
 	VarImage              = "IMAGE"

--- a/test/e2e/coredns/coredns.go
+++ b/test/e2e/coredns/coredns.go
@@ -3,6 +3,7 @@ package coredns
 import (
 	"fmt"
 
+	"github.com/loft-sh/vcluster/pkg/coredns"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/test/framework"
@@ -73,5 +74,15 @@ var _ = ginkgo.Describe("CoreDNS resolves host names correctly", func() {
 			framework.ExpectEmpty(stderrBuffer)
 			framework.ExpectEqual(string(stdoutBuffer), "ok")
 		}
+	})
+	ginkgo.It("Test coredns uses pinned image version", func() {
+		coreDNSName, coreDNSNamespace := "coredns", "kube-system"
+		coreDNSDeployment, err := f.VClusterClient.AppsV1().Deployments(coreDNSNamespace).Get(f.Context, coreDNSName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(coreDNSDeployment.Spec.Template.Spec.Containers), 1)
+		framework.ExpectEqual(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image, coredns.DefaultImage)
+		// these are images with known security vulnerabilities.
+		framework.ExpectNotEqual(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image, "1.11.1")
+		framework.ExpectNotEqual(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image, "1.11.0")
 	})
 })


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
It updates default coredns image to `1.11.3`, which has no CVEs and adds e2e tests to verify if pinned version is used:
```bash
trivy image coredns/coredns:1.11.3 --severity HIGH,CRITICAL

2024-08-05T08:51:42.727+0200	INFO	Vulnerability scanning is enabled
2024-08-05T08:51:42.727+0200	INFO	Secret scanning is enabled
2024-08-05T08:51:42.727+0200	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2024-08-05T08:51:42.727+0200	INFO	Please see also https://aquasecurity.github.io/trivy/v0.35/docs/secret/scanning/#recommendation for faster secret detection
2024-08-05T08:51:44.885+0200	INFO	Detected OS: debian
2024-08-05T08:51:44.885+0200	INFO	Detecting Debian vulnerabilities...
2024-08-05T08:51:44.885+0200	INFO	Number of language-specific files: 1
2024-08-05T08:51:44.885+0200	INFO	Detecting gobinary vulnerabilities...

coredns/coredns:1.11.3 (debian 11.10)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
resolves ENG-3849


**Please provide a short message that should be published in the vcluster release notes**
Bumped CoreDNS image to v1.11.3


**What else do we need to know?** 
