### PR TITLE
Connect to vCluster Platform earlier

### DIFF
--- a/pkg/pro/platform.go
+++ b/pkg/pro/platform.go
@@ -7,6 +7,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var ConnectToPlatform = func(context.Context, *config.VirtualClusterConfig, manager.Manager) error {
-	return nil
+var ConnectToPlatform = func(context.Context, *config.VirtualClusterConfig) (func(mgr manager.Manager) error, error) {
+	return func(_ manager.Manager) error { return nil }, nil
 }


### PR DESCRIPTION
vCluster is now able to request a data source from vCluster Platform. vCluster is only able to use the data source if it attempts to connect to the vCluster Platform prior to deploying its own control plane. vCluster Platform is now connected before control plane is deployed but the platform controllers and tailscale server are started after because they require the control plane to be running.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Part of ENG-4279
Part of enabling using the same database server credential for multiple vcluster datastores by creating new database and user, then returning credentials for the created database and user.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
