### PR TITLE
feature: add controlPlane.distro.k8s.version chart value for CAPI

### DIFF
--- a/chart/templates/_init-containers.tpl
+++ b/chart/templates/_init-containers.tpl
@@ -8,6 +8,37 @@
 {{- end -}}
 {{- end -}}
 
+{{/* Bump $defaultTag value whenever k8s version is bumped */}}
+{{- define "vcluster.k8s.controllerManager.image.tag" -}}
+{{- $defaultTag := "v1.30.2" -}}
+{{- if and (not (empty .Values.controlPlane.distro.k8s.version)) (eq .Values.controlPlane.distro.k8s.controllerManager.image.tag $defaultTag) -}}
+{{ .Values.controlPlane.distro.k8s.version}}
+{{- else -}}
+{{ .Values.controlPlane.distro.k8s.controllerManager.image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Bump $defaultTag value whenever k8s version is bumped */}}
+{{- define "vcluster.k8s.apiServer.image.tag" -}}
+{{- $defaultTag := "v1.30.2" -}}
+{{- if and (not (empty .Values.controlPlane.distro.k8s.version)) (eq .Values.controlPlane.distro.k8s.apiServer.image.tag $defaultTag) -}}
+{{ .Values.controlPlane.distro.k8s.version}}
+{{- else -}}
+{{ .Values.controlPlane.distro.k8s.apiServer.image.tag }}
+{{- end -}}
+{{- end -}}
+
+
+{{/* Bump $defaultTag value whenever k8s version is bumped */}}
+{{- define "vcluster.k8s.scheduler.image.tag" -}}
+{{- $defaultTag := "v1.30.2" -}}
+{{- if and (not (empty .Values.controlPlane.distro.k8s.version)) (eq .Values.controlPlane.distro.k8s.scheduler.image.tag $defaultTag) -}}
+{{ .Values.controlPlane.distro.k8s.version}}
+{{- else -}}
+{{ .Values.controlPlane.distro.k8s.scheduler.image.tag }}
+{{- end -}}
+{{- end -}}
+
 {{- define "vcluster.k8s.initContainers" -}}
 {{- include "vcluster.oldPlugins.initContainers" . }}
 {{- include "vcluster.plugins.initContainers" . }}
@@ -32,7 +63,7 @@
 {{ toYaml .Values.controlPlane.distro.k8s.resources | indent 4 }}
 {{- if .Values.controlPlane.distro.k8s.controllerManager.enabled }}
 - name: kube-controller-manager
-  image: "{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" .Values.controlPlane.distro.k8s.controllerManager.image.registry "repository" .Values.controlPlane.distro.k8s.controllerManager.image.repository "tag" .Values.controlPlane.distro.k8s.controllerManager.image.tag) }}"
+  image: "{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" .Values.controlPlane.distro.k8s.controllerManager.image.registry "repository" .Values.controlPlane.distro.k8s.controllerManager.image.repository "tag" (include "vcluster.k8s.controllerManager.image.tag" .)) }}"
   volumeMounts:
     - mountPath: /binaries
       name: binaries
@@ -52,7 +83,7 @@
 {{- end }}
 {{- if .Values.controlPlane.advanced.virtualScheduler.enabled }}
 - name: kube-scheduler-manager
-  image: "{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" .Values.controlPlane.distro.k8s.scheduler.image.registry "repository" .Values.controlPlane.distro.k8s.scheduler.image.repository "tag" .Values.controlPlane.distro.k8s.scheduler.image.tag) }}"
+  image: "{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" .Values.controlPlane.distro.k8s.scheduler.image.registry "repository" .Values.controlPlane.distro.k8s.scheduler.image.repository "tag" (include "vcluster.k8s.scheduler.image.tag" .)) }}"
   volumeMounts:
     - mountPath: /binaries
       name: binaries
@@ -72,7 +103,7 @@
 {{- end }}
 {{- if .Values.controlPlane.distro.k8s.apiServer.enabled }}
 - name: kube-apiserver
-  image: "{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" .Values.controlPlane.distro.k8s.apiServer.image.registry "repository" .Values.controlPlane.distro.k8s.apiServer.image.repository "tag" .Values.controlPlane.distro.k8s.apiServer.image.tag) }}"
+  image: "{{ include "vcluster.image" (dict "defaultImageRegistry" .Values.controlPlane.advanced.defaultImageRegistry "registry" .Values.controlPlane.distro.k8s.apiServer.image.registry "repository" .Values.controlPlane.distro.k8s.apiServer.image.repository "tag" (include "vcluster.k8s.apiServer.image.tag" .)) }}"
   volumeMounts:
     - mountPath: /binaries
       name: binaries

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -576,3 +576,178 @@ tests:
             name: data
             persistentVolumeClaim:
               claimName: my-custom-pvc
+
+  - it: k8s version not set, default tag images used for apiServer and controllerManager
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v1.30.2
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-apiserver:v1.30.2
+
+  - it: k8s version sets image tag for apiServer and controllerManager
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            version: v1.35.999
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v1.35.999
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-apiserver:v1.35.999
+
+  - it: k8s version set but overridden by image tag for apiServer and controllerManager
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            version: v1.30.999
+            apiServer:
+              image:
+                tag: v99912
+            controllerManager:
+              image:
+                tag: v23123
+
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v23123
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-apiserver:v99912
+
+  - it: k8s not version set but image tags for apiServer and controllerManager set
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            apiServer:
+              image:
+                tag: v99914
+            controllerManager:
+              image:
+                tag: v23127
+
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v23127
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-apiserver:v99914
+
+  - it: k8s version not set, default tag images used for apiServer and controllerManager (virtual scheduler enabled)
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+        advanced:
+          virtualScheduler:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v1.30.2
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-scheduler:v1.30.2
+      - equal:
+          path: spec.template.spec.initContainers[3].image
+          value: registry.k8s.io/kube-apiserver:v1.30.2
+
+  - it: k8s version sets image tag for apiServer and controllerManager (virtual scheduler enabled)
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            version: v1.35.999
+        advanced:
+          virtualScheduler:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v1.35.999
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-scheduler:v1.35.999
+      - equal:
+          path: spec.template.spec.initContainers[3].image
+          value: registry.k8s.io/kube-apiserver:v1.35.999
+
+  - it: k8s version set but overridden by image tag for apiServer and controllerManager (virtual scheduler enabled)
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            version: v1.30.999
+            apiServer:
+              image:
+                tag: v99912
+            controllerManager:
+              image:
+                tag: v23123
+            scheduler:
+              image:
+                tag: v123654
+        advanced:
+          virtualScheduler:
+            enabled: true
+
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v23123
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-scheduler:v123654
+      - equal:
+          path: spec.template.spec.initContainers[3].image
+          value: registry.k8s.io/kube-apiserver:v99912
+
+  - it: k8s not version set but image tags for apiServer and controllerManager set (virtual scheduler enabled)
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            apiServer:
+              image:
+                tag: v99914
+            controllerManager:
+              image:
+                tag: v23127
+            scheduler:
+              image:
+                tag: v123656
+
+        advanced:
+          virtualScheduler:
+            enabled: true
+
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.k8s.io/kube-controller-manager:v23127
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: registry.k8s.io/kube-scheduler:v123656
+      - equal:
+          path: spec.template.spec.initContainers[3].image
+          value: registry.k8s.io/kube-apiserver:v99914

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -921,6 +921,10 @@
           "type": "boolean",
           "description": "Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time."
         },
+        "version": {
+          "type": "string",
+          "description": "Version specifies k8s components (scheduler, kube-controller-manager \u0026 apiserver) version.\nIt is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,\ncontrolPlane.distro.k8s.controllerManager.image.tag and\ncontrolPlane.distro.k8s.scheduler.image.tag\nIf e.g. controlPlane.distro.k8s.version is set to v1.30.1 and\ncontrolPlane.distro.k8s.scheduler.image.tag\n(or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)\nis set to v1.31.0,\nvalue from controlPlane.distro.k8s.\u003ccontrolPlane-component\u003e.image.tag will be used\n(where \u003ccontrolPlane-component is apiServer, controllerManager and scheduler)."
+        },
         "apiServer": {
           "$ref": "#/$defs/DistroContainerEnabled",
           "description": "APIServer holds configuration specific to starting the api server."

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,6 +124,17 @@ controlPlane:
     k8s:
       # Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
       enabled: false
+      # Version specifies k8s components (scheduler, kube-controller-manager & apiserver) version.
+      # It is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,
+      # controlPlane.distro.k8s.controllerManager.image.tag and
+      # controlPlane.distro.k8s.scheduler.image.tag
+      # If e.g. controlPlane.distro.k8s.version is set to v1.30.1 and
+      # controlPlane.distro.k8s.scheduler.image.tag
+      # (or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)
+      # is set to v1.31.0,
+      # value from controlPlane.distro.k8s.<controlPlane-component>.image.tag will be used
+      # (where <controlPlane-component is apiServer, controllerManager and scheduler).
+      version: ""
       # APIServer holds configuration specific to starting the api server.
       apiServer:
         enabled: true

--- a/config/config.go
+++ b/config/config.go
@@ -781,6 +781,18 @@ type DistroK8s struct {
 	// Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 	Enabled bool `json:"enabled,omitempty"`
 
+	// Version specifies k8s components (scheduler, kube-controller-manager & apiserver) version.
+	// It is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,
+	// controlPlane.distro.k8s.controllerManager.image.tag and
+	// controlPlane.distro.k8s.scheduler.image.tag
+	// If e.g. controlPlane.distro.k8s.version is set to v1.30.1 and
+	// controlPlane.distro.k8s.scheduler.image.tag
+	//(or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)
+	// is set to v1.31.0,
+	// value from controlPlane.distro.k8s.<controlPlane-component>.image.tag will be used
+	// (where <controlPlane-component is apiServer, controllerManager and scheduler).
+	Version string `json:"version,omitempty"`
+
 	// APIServer holds configuration specific to starting the api server.
 	APIServer DistroContainerEnabled `json:"apiServer,omitempty"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	_ "embed"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -377,4 +379,25 @@ func TestConfig_IsProFeatureEnabled(t *testing.T) {
 			assert.Equal(t, tt.config.IsProFeatureEnabled(), tt.expected)
 		})
 	}
+}
+
+func TestIfDefaultImagesVersionsAreInSync(t *testing.T) {
+	defaultConfig, err := NewDefaultConfig()
+	assert.NilError(t, err)
+	// this will fail when this test is moved or _init-containers.tpl is moved
+	initContainersTplFilePath := "../chart/templates/_init-containers.tpl"
+	tplBytes, err := os.ReadFile(initContainersTplFilePath)
+
+	assert.NilError(t, err)
+	assert.Equal(t, defaultConfig.ControlPlane.Distro.K8S.ControllerManager.Image.Tag, defaultConfig.ControlPlane.Distro.K8S.APIServer.Image.Tag)
+	assert.Equal(t, defaultConfig.ControlPlane.Distro.K8S.ControllerManager.Image.Tag, defaultConfig.ControlPlane.Distro.K8S.Scheduler.Image.Tag)
+	assert.Equal(t, defaultConfig.ControlPlane.Distro.K8S.APIServer.Image.Tag, defaultConfig.ControlPlane.Distro.K8S.Scheduler.Image.Tag)
+	expectedDefaultTag := fmt.Sprintf("{{- $defaultTag := %q -}}", defaultConfig.ControlPlane.Distro.K8S.ControllerManager.Image.Tag)
+	got := strings.Count(string(tplBytes), expectedDefaultTag)
+	assert.Equal(
+		t, got, 3,
+		fmt.Sprintf("please update $defaultTag in %s so it's equal to the "+
+			".Values.controlPlane.distro.k8s.controllerManager.image.tag",
+			initContainersTplFilePath),
+	)
 }

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -73,6 +73,7 @@ controlPlane:
   distro:
     k8s:
       enabled: false
+      version: ""
       apiServer:
         enabled: true
         command: []

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -7,10 +7,9 @@ export GOFLAGS=-mod=vendor
 # Test if we can build the program
 echo "Building virtual cluster..."
 go generate ./... && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build cmd/vcluster/main.go || exit 1
- 
+
 # List packages
 PKGS=$(go list ./... | grep -v -e /vendor/ -e /test)
-
 echo "Start testing..."
 fail=false
 for pkg in $PKGS; do


### PR DESCRIPTION
… intergration

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-2725
`controlPlane.distro.k8s.version` is a shortcut to set image tags for.

- controlPlane.distro.k8s.apiServer.image.tag
- controlPlane.distro.k8s.controllerManager.image.tag
- controlPlane.distro.k8s.schedule.image.tag

New behavior: `controlPlane.distro.k8s.version` will override image tags only if they're not specified by user (so they're different than current default tag, `v1.30.3`. This only affects `k8s` distro.


**Please provide a short message that should be published in the vcluster release notes**
Add `controlPlane.distro.k8s.version` to ease setting up the cluster control plane components version.


**What else do we need to know?** 
It's a bit unfortunate that I had to add the logic to the helm chart, but I don't see other way around it (open to suggestions!). Added a bunch of unit tests.
