### PR TITLE
refactor: only rewrite release label

### DIFF
--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -137,7 +137,7 @@ func (s *serviceSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.Sy
 	event.Host.Annotations = updatedAnnotations
 
 	// translate selector
-	event.Host.Spec.Selector = translate.HostLabelsMap(event.Virtual.Spec.Selector, event.Host.Spec.Selector, event.Virtual.Namespace)
+	event.Host.Spec.Selector = translate.HostLabelsMap(event.Virtual.Spec.Selector, event.Host.Spec.Selector, event.Virtual.Namespace, false)
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/resources/services/translate.go
+++ b/pkg/controllers/resources/services/translate.go
@@ -9,7 +9,7 @@ import (
 
 func (s *serviceSyncer) translate(ctx *synccontext.SyncContext, vObj *corev1.Service) *corev1.Service {
 	newService := translate.HostMetadata(vObj, s.VirtualToHost(ctx, types.NamespacedName{Name: vObj.GetName(), Namespace: vObj.GetNamespace()}, vObj), s.excludedAnnotations...)
-	newService.Spec.Selector = translate.HostLabelsMap(vObj.Spec.Selector, nil, vObj.Namespace)
+	newService.Spec.Selector = translate.HostLabelsMap(vObj.Spec.Selector, nil, vObj.Namespace, false)
 	if newService.Spec.ClusterIP != "None" {
 		newService.Spec.ClusterIP = ""
 	}

--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -155,7 +155,7 @@ func (e *ServiceSyncer) syncServiceWithSelector(ctx context.Context, fromService
 			e.Log.Infof("Add owner reference to host target service %s", to.Name)
 			toService.OwnerReferences = translate.GetOwnerReference(nil)
 		}
-		toService.Spec.Selector = translate.HostLabelsMap(fromService.Spec.Selector, toService.Spec.Selector, fromService.Namespace)
+		toService.Spec.Selector = translate.HostLabelsMap(fromService.Spec.Selector, toService.Spec.Selector, fromService.Namespace, false)
 		e.Log.Infof("Create target service %s/%s because it is missing", to.Namespace, to.Name)
 		return ctrl.Result{}, e.To.GetClient().Create(ctx, toService)
 	} else if toService.Labels == nil || toService.Labels[translate.ControllerLabel] != "vcluster" {
@@ -165,7 +165,7 @@ func (e *ServiceSyncer) syncServiceWithSelector(ctx context.Context, fromService
 
 	// rewrite selector
 	targetService := toService.DeepCopy()
-	targetService.Spec.Selector = translate.HostLabelsMap(fromService.Spec.Selector, toService.Spec.Selector, fromService.Namespace)
+	targetService.Spec.Selector = translate.HostLabelsMap(fromService.Spec.Selector, toService.Spec.Selector, fromService.Namespace, false)
 
 	// compare service ports
 	if !apiequality.Semantic.DeepEqual(toService.Spec.Ports, fromService.Spec.Ports) || !apiequality.Semantic.DeepEqual(toService.Spec.Selector, targetService.Spec.Selector) {

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -215,7 +215,7 @@ func createService(ctx *synccontext.SyncContext, req *http.Request, decoder enco
 		newService.Annotations = map[string]string{}
 	}
 	newService.Annotations[services.ServiceBlockDeletion] = "true"
-	newService.Spec.Selector = translate.HostLabelsMap(vService.Spec.Selector, nil, vService.Namespace)
+	newService.Spec.Selector = translate.HostLabelsMap(vService.Spec.Selector, nil, vService.Namespace, false)
 	err = ctx.PhysicalClient.Create(req.Context(), newService)
 	if err != nil {
 		klog.Infof("Error creating service in physical cluster: %v", err)

--- a/pkg/util/translate/types.go
+++ b/pkg/util/translate/types.go
@@ -13,7 +13,6 @@ var (
 )
 
 var (
-	VClusterAppLabel     = "app"
 	VClusterReleaseLabel = "release"
 	NamespaceLabel       = "vcluster.loft.sh/namespace"
 	MarkerLabel          = "vcluster.loft.sh/managed-by"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Improves the way vCluster rewrites labels as we only rewrite the release label, because `app` label is quite commonly used. This still avoids conflicts with the vCluster resources themselves. We also avoid adding the namespace label and marker label if the host labels exist and didn't include that yet.
