### PR TITLE
Add support for namespaceOverride, nameOverride, and conditional namespace creation in vcluster Helm chart

### DIFF
--- a/chart/templates/_helper.tpl
+++ b/chart/templates/_helper.tpl
@@ -15,3 +15,11 @@
 {{ .repository }}:{{ .tag }}
 {{- end -}}
 {{- end -}}
+
+{{- define "vcluster.namespace" -}}
+{{ .Values.namespaceOverride | default .Release.Namespace }}
+{{- end -}}
+
+{{- define "vcluster.name" -}}
+{{ .Values.nameOverride | default .Release.Name }}
+{{- end -}}

--- a/chart/templates/_rbac.tpl
+++ b/chart/templates/_rbac.tpl
@@ -1,9 +1,9 @@
 {{- define "vcluster.clusterRoleName" -}}
-{{- printf "vc-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-%s-v-%s" (include "vcluster.name" .) (include "vcluster.namespace" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "vcluster.clusterRoleNameMultinamespace" -}}
-{{- printf "vc-mn-%s-v-%s" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-mn-%s-v-%s" (include "vcluster.name" .) (include "vcluster.namespace" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -150,7 +150,7 @@
 */}}
 {{- define "vcluster.rbac.createPlatformSecretRole" -}}
 {{- $createRBAC := dig "platform" "apiKey" "createRBAC" true .Values.external -}}
-{{- if and $createRBAC (ne (include "vcluster.rbac.platformSecretNamespace" .) .Release.Namespace) }}
+{{- if and $createRBAC (ne (include "vcluster.rbac.platformSecretNamespace" .) (include "vcluster.namespace" .)) }}
 {{- true -}}
 {{- end }}
 {{- end -}}
@@ -159,7 +159,7 @@
   Namespace containing the vCluster platform secret
 */}}
 {{- define "vcluster.rbac.platformSecretNamespace" -}}
-{{- dig "platform" "apiKey" "namespace" .Release.Namespace .Values.external | default .Release.Namespace -}}
+{{- dig "platform" "apiKey" "namespace" (include "vcluster.namespace" .) .Values.external | default (include "vcluster.namespace" .) -}}
 {{- end -}}
 
 {{/*
@@ -170,10 +170,10 @@
 {{- end -}}
 
 {{- define "vcluster.rbac.platformRoleName" -}}
-{{- printf "vc-%s-v-%s-platform-role" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-%s-v-%s-platform-role" (include "vcluster.name" .) (include "vcluster.namespace" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 
 {{- define "vcluster.rbac.platformRoleBindingName" -}}
-{{- printf "vc-%s-v-%s-platform-role-binding" .Release.Name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- printf "vc-%s-v-%s-platform-role-binding" (include "vcluster.name" .) (include "vcluster.namespace" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.globalMetadata.annotations }}
   annotations:

--- a/chart/templates/clusterrolebinding.yaml
+++ b/chart/templates/clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.globalMetadata.annotations }}
   annotations:
@@ -17,9 +17,9 @@ subjects:
     {{- if .Values.controlPlane.advanced.serviceAccount.name }}
     name: {{ .Values.controlPlane.advanced.serviceAccount.name }}
     {{- else }}
-    name: vc-{{ .Release.Name }}
+    name: vc-{{ (include "vcluster.name" .) }}
     {{- end }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ (include "vcluster.namespace" .) }}
 roleRef:
   kind: ClusterRole
   name: {{ template "vcluster.clusterRoleName" . }}

--- a/chart/templates/config-secret.yaml
+++ b/chart/templates/config-secret.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "vc-config-{{ .Release.Name }}"
-  namespace: {{ .Release.Namespace }}
+  name: "vc-config-{{ (include "vcluster.name" .) }}"
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.globalMetadata.annotations }}
   annotations:

--- a/chart/templates/coredns-configmap.yaml
+++ b/chart/templates/coredns-configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vc-coredns-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: vc-coredns-{{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   {{- if .Values.controlPlane.advanced.globalMetadata.annotations }}
   annotations:
 {{ toYaml .Values.controlPlane.advanced.globalMetadata.annotations | indent 4 }}

--- a/chart/templates/etcd-headless-service.yaml
+++ b/chart/templates/etcd-headless-service.yaml
@@ -4,12 +4,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-etcd-headless
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}-etcd-headless
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge dict .Values.controlPlane.advanced.globalMetadata.annotations .Values.controlPlane.backingStore.etcd.deploy.headlessService.annotations }}
   {{- if $annotations }}
@@ -30,7 +30,7 @@ spec:
   clusterIP: None
   selector:
     app: vcluster-etcd
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/etcd-service.yaml
+++ b/chart/templates/etcd-service.yaml
@@ -4,12 +4,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-etcd
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}-etcd
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- $annotations := merge dict .Values.controlPlane.advanced.globalMetadata.annotations .Values.controlPlane.backingStore.etcd.deploy.service.annotations }}
   {{- if $annotations }}
@@ -29,7 +29,7 @@ spec:
       protocol: TCP
   selector:
     app: vcluster-etcd
-    release: {{ .Release.Name }}
+    release: {{ (include "vcluster.name" .) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -5,12 +5,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-etcd
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}-etcd
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster-etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
 {{- if $externalEtcd.labels }}
 {{ toYaml $externalEtcd.labels | indent 4 }}
@@ -23,7 +23,7 @@ metadata:
 spec:
   replicas: {{ $externalEtcd.highAvailability.replicas }}
   podManagementPolicy: {{ $externalEtcd.scheduling.podManagementPolicy }}
-  serviceName: {{ .Release.Name }}-etcd-headless
+  serviceName: {{ (include "vcluster.name" .) }}-etcd-headless
   {{- if eq $externalEtcd.persistence.volumeClaim.retentionPolicy "Delete" }}
   {{- if ge (int .Capabilities.KubeVersion.Minor) 27 }}
   persistentVolumeClaimRetentionPolicy:
@@ -33,7 +33,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-etcd
-      release: {{ .Release.Name }}
+      release: {{ (include "vcluster.name" .) }}
   {{- if $externalEtcd.persistence.volumeClaimTemplates }}
   volumeClaimTemplates:
 {{ toYaml $externalEtcd.persistence.volumeClaimTemplates | indent 4 }}
@@ -58,7 +58,7 @@ spec:
       {{- end }}
       labels:
         app: vcluster-etcd
-        release: {{ .Release.Name }}
+        release: {{ (include "vcluster.name" .) }}
         {{- range $k, $v := $externalEtcd.pods.labels }}
         {{ $k }}: {{ $v | quote }}
         {{- end }}
@@ -83,7 +83,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ (include "vcluster.name" .) }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -97,7 +97,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ (include "vcluster.name" .) }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if $externalEtcd.scheduling.topologySpreadConstraints }}
@@ -112,12 +112,12 @@ spec:
       {{- if .Values.controlPlane.advanced.serviceAccount.name }}
       serviceAccountName: {{ .Values.controlPlane.advanced.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ (include "vcluster.name" .) }}
       {{- end }}
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Release.Name }}-certs
+            secretName: {{ (include "vcluster.name" .) }}-certs
       {{- if $externalEtcd.persistence.addVolumes }}
 {{ toYaml $externalEtcd.persistence.addVolumes | indent 8 }}
       {{- end }}
@@ -141,12 +141,12 @@ spec:
           - '--cert-file=/run/config/pki/etcd-server.crt'
           - '--client-cert-auth=true'
           - '--data-dir=/var/lib/etcd'
-          - '--advertise-client-urls=https://$(NAME).{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}:2379'
-          - '--initial-advertise-peer-urls=https://$(NAME).{{ .Release.Name }}-etcd-headless.{{ .Release.Namespace }}:2380'
-          {{- $releaseName := .Release.Name -}}
-          {{- $releaseNamespace := .Release.Namespace }}
+          - '--advertise-client-urls=https://$(NAME).{{ (include "vcluster.name" .) }}-etcd-headless.{{ (include "vcluster.namespace" .) }}:2379'
+          - '--initial-advertise-peer-urls=https://$(NAME).{{ (include "vcluster.name" .) }}-etcd-headless.{{ (include "vcluster.namespace" .) }}:2380'
+          {{- $releaseName := (include "vcluster.name" .) -}}
+          {{- $releaseNamespace := (include "vcluster.namespace" .) }}
           - '--initial-cluster={{ range $index := untilStep 0 (int $externalEtcd.highAvailability.replicas) 1 }}{{ if (ne (int $index) 0) }},{{ end }}{{ $releaseName }}-etcd-{{ $index }}=https://{{ $releaseName }}-etcd-{{ $index }}.{{ $releaseName }}-etcd-headless.{{ $releaseNamespace }}:2380{{ end }}'
-          - '--initial-cluster-token={{ .Release.Name }}'
+          - '--initial-cluster-token={{ (include "vcluster.name" .) }}'
           - '--initial-cluster-state=new'
           - '--listen-client-urls=https://0.0.0.0:2379'
           - '--listen-metrics-urls=http://0.0.0.0:2381'

--- a/chart/templates/headless-service.yaml
+++ b/chart/templates/headless-service.yaml
@@ -3,12 +3,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-headless
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}-headless
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.headlessService.labels }}
 {{ toYaml .Values.controlPlane.advanced.headlessService.labels | indent 4 }}
@@ -38,6 +38,6 @@ spec:
   clusterIP: None
   selector:
     app: vcluster
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
 {{- end }}
 {{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -7,12 +7,12 @@ metadata:
   annotations:
   {{- toYaml $annotations | nindent 4 }}
   {{- end }}
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.ingress.labels }}
 {{ toYaml .Values.controlPlane.ingress.labels | indent 4 }}
@@ -28,7 +28,7 @@ spec:
        paths:
         - backend:
             service:
-              name: {{ .Release.Name }}
+              name: {{ (include "vcluster.name" .) }}
               port:
                 name: https
           path: /

--- a/chart/templates/limitrange.yaml
+++ b/chart/templates/limitrange.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ (include "vcluster.name" .) }}
   {{- if .Values.experimental.syncSettings.targetNamespace }}
   namespace: {{ .Values.experimental.syncSettings.targetNamespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   {{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.policies.limitRange.labels }}
 {{ toYaml .Values.policies.limitRange.labels | indent 4 }}

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.namespace.create -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "vcluster.namespace" . }}
+  labels:
+    app: vcluster
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ (include "vcluster.name" .) }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+{{- end -}}

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -2,16 +2,16 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: vc-work-{{ .Release.Name }}
+  name: vc-work-{{ (include "vcluster.name" .) }}
   {{- if .Values.experimental.syncSettings.targetNamespace }}
   namespace: {{ .Values.experimental.syncSettings.targetNamespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   {{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.policies.networkPolicy.labels }}
 {{ toYaml .Values.policies.networkPolicy.labels | indent 4 }}
@@ -24,7 +24,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ (include "vcluster.name" .) }}
   egress:
     # Allows outgoing connections to the vcluster control plane
     - ports:
@@ -33,7 +33,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ (include "vcluster.name" .) }}
     # Allows outgoing connections to DNS server
     - ports:
         - port: 53
@@ -45,7 +45,7 @@ spec:
     - to:
       - podSelector:
           matchLabels:
-            vcluster.loft.sh/managed-by: {{ .Release.Name }}
+            vcluster.loft.sh/managed-by: {{ (include "vcluster.name" .) }}
       - ipBlock:
           cidr: {{ .Values.policies.networkPolicy.outgoingConnections.ipBlock.cidr }}
           except:
@@ -58,12 +58,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: vc-cp-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: vc-cp-{{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.policies.networkPolicy.labels }}
 {{ toYaml .Values.policies.networkPolicy.labels | indent 4 }}
@@ -76,7 +76,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ (include "vcluster.name" .) }}
   egress:
     # Allows outgoing connections to all pods with
     # port 443, 8443 or 6443. This is needed for host Kubernetes

--- a/chart/templates/platform-rbac.yaml
+++ b/chart/templates/platform-rbac.yaml
@@ -21,7 +21,7 @@ subjects:
     {{- if .Values.controlPlane.advanced.serviceAccount.name }}
     name: {{ .Values.controlPlane.advanced.serviceAccount.name }}
     {{- else }}
-    name: vc-{{ .Release.Name }}
+    name: vc-{{ (include "vcluster.name" .) }}
     {{- end }}
     namespace: {{ include "vcluster.rbac.platformSecretNamespace" .}}
 roleRef:

--- a/chart/templates/resourcequota.yaml
+++ b/chart/templates/resourcequota.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ (include "vcluster.name" .) }}
   {{- if .Values.experimental.syncSettings.targetNamespace }}
   namespace: {{ .Values.experimental.syncSettings.targetNamespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   {{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.policies.resourceQuota.labels }}
 {{ toYaml .Values.policies.resourceQuota.labels | indent 4 }}

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -9,13 +9,13 @@ metadata:
 {{- if .Values.experimental.multiNamespaceMode.enabled }}
   name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
-  name: vc-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: vc-{{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
 {{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.globalMetadata.annotations }}
   annotations:

--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -9,13 +9,13 @@ metadata:
 {{- if .Values.experimental.multiNamespaceMode.enabled }}
   name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
-  name: vc-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: vc-{{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
 {{- end }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.globalMetadata.annotations }}
   annotations:
@@ -26,16 +26,16 @@ subjects:
     {{- if .Values.controlPlane.advanced.serviceAccount.name }}
     name: {{ .Values.controlPlane.advanced.serviceAccount.name }}
     {{- else }}
-    name: vc-{{ .Release.Name }}
+    name: vc-{{ (include "vcluster.name" .) }}
     {{- end }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ (include "vcluster.namespace" .) }}
 roleRef:
 {{- if .Values.experimental.multiNamespaceMode.enabled }}
   kind: ClusterRole
   name: {{ template "vcluster.clusterRoleNameMultinamespace" . }}
 {{- else }}
   kind: Role
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ (include "vcluster.name" .) }}
 {{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: vc-{{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: vc-{{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.serviceMonitor.labels }}
 {{ toYaml .Values.controlPlane.serviceMonitor.labels | indent 4 }}
@@ -21,7 +21,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: "{{ .Release.Name }}"
+      release: "{{ (include "vcluster.name" .) }}"
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       heritage: "{{ .Release.Service }}"
   endpoints:
@@ -32,13 +32,13 @@ spec:
     tlsConfig:
       ca:
         secret:
-          name: vc-{{ .Release.Name }}
+          name: vc-{{ (include "vcluster.name" .) }}
           key: certificate-authority
       cert:
         secret:
-          name: vc-{{ .Release.Name }}
+          name: vc-{{ (include "vcluster.name" .) }}
           key: client-certificate
       keySecret:
-        name: vc-{{ .Release.Name }}
+        name: vc-{{ (include "vcluster.name" .) }}
         key: client-key
 {{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
     {{- if .Values.controlPlane.service.labels }}
 {{ toYaml .Values.controlPlane.service.labels | indent 4 }}
@@ -41,6 +41,6 @@ spec:
   {{- if and (not .Values.controlPlane.service.spec.selector) (not .Values.experimental.isolatedControlPlane.headless) }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ (include "vcluster.name" .) }}
   {{- end }}
 {{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -5,13 +5,13 @@ metadata:
   {{- if .Values.controlPlane.advanced.serviceAccount.name }}
   name: {{ .Values.controlPlane.advanced.serviceAccount.name | quote }}
   {{- else }}
-  name: vc-{{ .Release.Name }}
+  name: vc-{{ (include "vcluster.name" .) }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.serviceAccount.labels }}
 {{ toYaml .Values.controlPlane.advanced.serviceAccount.labels | indent 4 }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: {{ include "vcluster.kind" . }}
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ (include "vcluster.name" .) }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.statefulSet.labels }}
 {{ toYaml .Values.controlPlane.statefulSet.labels | indent 4 }}
@@ -21,13 +21,13 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ (include "vcluster.name" .) }}
   {{- if eq (include "vcluster.kind" .) "StatefulSet" }}
   {{- if ge (int .Capabilities.KubeVersion.Minor) 27 }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy }}
   {{- end }}
-  serviceName: {{ .Release.Name }}-headless
+  serviceName: {{ (include "vcluster.name" .) }}-headless
   podManagementPolicy: {{ .Values.controlPlane.statefulSet.scheduling.podManagementPolicy }}
 {{ include "vcluster.persistence" . | indent 2 }}
   {{- else }}
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ (include "vcluster.name" .) }}
         {{- if .Values.controlPlane.statefulSet.pods.labels }}
 {{ toYaml .Values.controlPlane.statefulSet.pods.labels | indent 8 }}
         {{- end }}
@@ -86,7 +86,7 @@ spec:
       {{- if .Values.controlPlane.advanced.serviceAccount.name }}
       serviceAccountName: {{ .Values.controlPlane.advanced.serviceAccount.name }}
       {{- else }}
-      serviceAccountName: vc-{{ .Release.Name }}
+      serviceAccountName: vc-{{ (include "vcluster.name" .) }}
       {{- end }}
       volumes:
 {{- include "vcluster.plugins.volumes" . | indent 8 }}
@@ -107,11 +107,11 @@ spec:
         {{- end }}
         - name: vcluster-config
           secret:
-            secretName: vc-config-{{ .Release.Name }}
+            secretName: vc-config-{{ (include "vcluster.name" .) }}
         {{- if .Values.controlPlane.coredns.enabled }}
         - name: coredns
           configMap:
-            name: vc-coredns-{{ .Release.Name }}
+            name: vc-coredns-{{ (include "vcluster.name" .) }}
         # - name: custom-config-volume
         #   configMap:
         #     name: coredns-custom
@@ -182,7 +182,7 @@ spec:
 {{ toYaml .Values.controlPlane.statefulSet.resources | indent 12 }}
           env:
             - name: VCLUSTER_NAME
-              value: "{{ .Release.Name }}"
+              value: "{{ (include "vcluster.name" .) }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/templates/workload-serviceaccount.yaml
+++ b/chart/templates/workload-serviceaccount.yaml
@@ -5,13 +5,13 @@ metadata:
   {{- if .Values.controlPlane.advanced.workloadServiceAccount.name }}
   name: {{ .Values.controlPlane.advanced.workloadServiceAccount.name | quote }}
   {{- else }}
-  name: vc-workload-{{ .Release.Name }}
+  name: vc-workload-{{ (include "vcluster.name" .) }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ (include "vcluster.namespace" .) }}
   labels:
     app: vcluster
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
+    release: "{{ (include "vcluster.name" .) }}"
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.advanced.workloadServiceAccount.labels }}
 {{ toYaml .Values.controlPlane.advanced.workloadServiceAccount.labels | indent 4 }}

--- a/chart/tests/manifests_test.yaml
+++ b/chart/tests/manifests_test.yaml
@@ -73,7 +73,7 @@ tests:
               kind: Pod
               metadata:
                 name: nginx
-                namespace: {{ .Release.Namespace }}
+                namespace: {{ (include "vcluster.namespace" .) }}
                 labels:
                   app: nginx
               spec:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3127,6 +3127,23 @@
     }
   },
   "properties": {
+    "namespaceOverride": {
+      "type": "string",
+      "description": "Override the namespace for vcluster resources"
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the release name"
+    },
+    "namespace": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specify whether to create a namespace"
+        }
+      }
+    },
     "global": {
       "description": "Global values shared across all (sub)charts"
     },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,14 @@
+
+## Override the deployment name
+##wsl
+nameOverride: ""
+
+## Override the deployment namespace
+##
+namespaceOverride: ""
+
+namespace:
+  create: false
 # Sync describes how to sync resources from the virtual cluster to host cluster and back.
 sync:
   # Configure resources to sync from the virtual cluster to the host cluster.


### PR DESCRIPTION
This PR introduces three new features to the vcluster Helm chart:

1. namespaceOverride: Allows users to specify a custom namespace for the vcluster resources, different from the parent chart's namespace.
2. nameOverride: Allows users to override the release name used for vcluster resources.
3. Conditional Namespace Creation: Adds an option to conditionally create a namespace if it doesn't already exist.``