### PR TITLE
add --ca-cert flag to the vcluster platform add vcluster, so it can b…

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/vcluster.go
@@ -48,9 +48,9 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 	addCmd.Flags().StringVar(&cmd.AccessKey, "access-key", "", "The access key for the vCluster to connect to the platform. If empty, the CLI will generate one")
 	addCmd.Flags().StringVar(&cmd.Host, "host", "", "The host where to reach the platform")
 	addCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "If the platform host is insecure")
-	addCmd.Flags().BytesBase64Var(&cmd.CaCert, "ca-cert", []byte{}, "additional, base64 encoded CA cert that will be passed to the platform secret")
+	addCmd.Flags().BytesBase64Var(&cmd.CertificateAuthorityData, "ca-data", []byte{}, "additional, base64 encoded certificate authority data that will be passed to the platform secret")
 	// This is hidden until the platform side will be ready to use it
-	_ = addCmd.Flags().MarkHidden("ca-cert")
+	_ = addCmd.Flags().MarkHidden("ca-data")
 
 	return addCmd
 }

--- a/cmd/vclusterctl/cmd/platform/add/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/vcluster.go
@@ -48,6 +48,9 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 	addCmd.Flags().StringVar(&cmd.AccessKey, "access-key", "", "The access key for the vCluster to connect to the platform. If empty, the CLI will generate one")
 	addCmd.Flags().StringVar(&cmd.Host, "host", "", "The host where to reach the platform")
 	addCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "If the platform host is insecure")
+	addCmd.Flags().BytesBase64Var(&cmd.CaCert, "ca-cert", []byte{}, "additional, base64 encoded CA cert that will be passed to the platform secret")
+	// This is hidden until the platform side will be ready to use it
+	_ = addCmd.Flags().MarkHidden("ca-cert")
 
 	return addCmd
 }

--- a/pkg/cli/add_vcluster_helm.go
+++ b/pkg/cli/add_vcluster_helm.go
@@ -23,6 +23,7 @@ type AddVClusterOptions struct {
 	Insecure   bool
 	AccessKey  string
 	Host       string
+	CaCert     []byte
 }
 
 func AddVClusterHelm(
@@ -98,6 +99,7 @@ func AddVClusterHelm(
 		options.AccessKey,
 		options.Host,
 		options.Insecure,
+		options.CaCert,
 	)
 	if err != nil {
 		return err

--- a/pkg/cli/add_vcluster_helm.go
+++ b/pkg/cli/add_vcluster_helm.go
@@ -17,13 +17,13 @@ import (
 )
 
 type AddVClusterOptions struct {
-	Project    string
-	ImportName string
-	Restart    bool
-	Insecure   bool
-	AccessKey  string
-	Host       string
-	CaCert     []byte
+	Project                  string
+	ImportName               string
+	Restart                  bool
+	Insecure                 bool
+	AccessKey                string
+	Host                     string
+	CertificateAuthorityData []byte
 }
 
 func AddVClusterHelm(
@@ -99,7 +99,7 @@ func AddVClusterHelm(
 		options.AccessKey,
 		options.Host,
 		options.Insecure,
-		options.CaCert,
+		options.CertificateAuthorityData,
 	)
 	if err != nil {
 		return err

--- a/pkg/cli/config/types.go
+++ b/pkg/cli/config/types.go
@@ -36,6 +36,8 @@ type Platform struct {
 	VirtualClusterAccessKey string `json:"virtualClusterAccessKey,omitempty"`
 	// Insecure specifies if the loft instance is insecure
 	Insecure bool `json:"insecure,omitempty"`
+	// CertificateAuthorityData is passed as certificate-authority-data to the platform config
+	CertificateAuthorityData []byte `json:"certificateAuthorityData,omitempty"`
 }
 
 type VirtualClusterCertificatesEntry struct {

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -380,7 +380,7 @@ func (cmd *createHelm) addVCluster(ctx context.Context, vClusterConfig *config.C
 		return nil
 	}
 
-	err = platform.ApplyPlatformSecret(ctx, cmd.LoadedConfig(cmd.log), cmd.kubeClient, "", cmd.Namespace, cmd.Project, "", "", false)
+	err = platform.ApplyPlatformSecret(ctx, cmd.LoadedConfig(cmd.log), cmd.kubeClient, "", cmd.Namespace, cmd.Project, "", "", false, []byte{})
 	if err != nil {
 		return fmt.Errorf("apply platform secret: %w", err)
 	}

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -380,7 +380,7 @@ func (cmd *createHelm) addVCluster(ctx context.Context, vClusterConfig *config.C
 		return nil
 	}
 
-	err = platform.ApplyPlatformSecret(ctx, cmd.LoadedConfig(cmd.log), cmd.kubeClient, "", cmd.Namespace, cmd.Project, "", "", false, []byte{})
+	err = platform.ApplyPlatformSecret(ctx, cmd.LoadedConfig(cmd.log), cmd.kubeClient, "", cmd.Namespace, cmd.Project, "", "", false, cmd.LoadedConfig(cmd.log).Platform.CertificateAuthorityData)
 	if err != nil {
 		return fmt.Errorf("apply platform secret: %w", err)
 	}

--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -31,6 +31,7 @@ func ApplyPlatformSecret(
 	accessKey,
 	host string,
 	insecure bool,
+	caCert []byte,
 ) error {
 	var err error
 	accessKey, host, insecure, err = getAccessKeyAndHost(ctx, config, accessKey, host, insecure)
@@ -43,6 +44,7 @@ func ApplyPlatformSecret(
 		"accessKey": []byte(accessKey),
 		"host":      []byte(strings.TrimPrefix(host, "https://")),
 		"insecure":  []byte(strconv.FormatBool(insecure)),
+		"caCert":    caCert,
 	}
 	if project != "" {
 		payload["project"] = []byte(project)

--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -31,7 +31,7 @@ func ApplyPlatformSecret(
 	accessKey,
 	host string,
 	insecure bool,
-	caCert []byte,
+	certificateAuthorityData []byte,
 ) error {
 	var err error
 	accessKey, host, insecure, err = getAccessKeyAndHost(ctx, config, accessKey, host, insecure)
@@ -41,10 +41,10 @@ func ApplyPlatformSecret(
 
 	// build secret payload
 	payload := map[string][]byte{
-		"accessKey": []byte(accessKey),
-		"host":      []byte(strings.TrimPrefix(host, "https://")),
-		"insecure":  []byte(strconv.FormatBool(insecure)),
-		"caCert":    caCert,
+		"accessKey":                []byte(accessKey),
+		"host":                     []byte(strings.TrimPrefix(host, "https://")),
+		"insecure":                 []byte(strconv.FormatBool(insecure)),
+		"certificateAuthorityData": certificateAuthorityData,
 	}
 	if project != "" {
 		payload["project"] = []byte(project)


### PR DESCRIPTION
…e used by passing .additionalCA from platform config

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of ENG-4224


**Please provide a short message that should be published in the vcluster release notes**
adds --ca-cert flag and adds `certificate-authority-data` to the platform secret to enable secure connection between platform and vcluster. Overall behavior is described [in this PR](https://github.com/loft-sh/vcluster-pro/pull/384)


**What else do we need to know?** 
