### PR TITLE
Reject empty datasource if external database is enabled

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -62,6 +62,13 @@ func StartK8S(
 
 		etcdEndpoints = constants.K8sKineEndpoint
 	} else if vConfig.ControlPlane.BackingStore.Database.External.Enabled {
+		// we check for an empty datasource string here because the platform connect
+		// process may overwrite an empty datasource string with a platform supplied
+		// one. At this point the platform connect process is assumed to have happened.
+		if vConfig.ControlPlane.BackingStore.Database.External.DataSource == "" {
+			return fmt.Errorf("external datasource cannot be empty if external database is enabled")
+		}
+
 		// call out to the pro code
 		var err error
 		etcdEndpoints, etcdCertificates, err = pro.ConfigureExternalDatabase(ctx, vConfig)


### PR DESCRIPTION
Prior, an empty datasource was accepted when external database was enabled. An empty datasource causes kine to use sqlite which is embedded- not external. Now, passing an empty datasource while external database is enabled will result in an error.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-4330


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
