### PR TITLE
[v0.20] feat: Ignore updates to Rancher managed annotations (#2075)

### DIFF
--- a/hack/load-testing/tests/throughput/throughput.go
+++ b/hack/load-testing/tests/throughput/throughput.go
@@ -31,7 +31,7 @@ func TestThroughput(ctx context.Context, kubeClient client.Client, namespace str
 
 		err = kubeClient.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: fmt.Sprintf("secret-test-" + random.String(10) + "-"),
+				GenerateName: fmt.Sprint("secret-test-" + random.String(10) + "-"),
 				Namespace:    namespace,
 			},
 			Data: map[string][]byte{

--- a/pkg/controllers/resources/nodes/syncer_test.go
+++ b/pkg/controllers/resources/nodes/syncer_test.go
@@ -617,4 +617,75 @@ func TestSync(t *testing.T) {
 			},
 		},
 	})
+
+	basePod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mypod",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: baseName.Name,
+		},
+	}
+	baseNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: baseName.Name,
+			Annotations: map[string]string{
+				RancherAgentPodRequestsAnnotation: "{\"pods\":\"3\"}",
+				RancherAgentPodLimitsAnnotation:   "{\"pods\":\"10\"}",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Address: GetNodeHost(baseName.Name),
+					Type:    corev1.NodeHostName,
+				},
+			},
+			DaemonEndpoints: corev1.NodeDaemonEndpoints{
+				KubeletEndpoint: corev1.DaemonEndpoint{
+					Port: constants.KubeletPort,
+				},
+			},
+		},
+	}
+
+	baseVNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: baseName.Name,
+			Annotations: map[string]string{
+				RancherAgentPodRequestsAnnotation: "{\"pods\":\"1\"}",
+				RancherAgentPodLimitsAnnotation:   "{\"pods\":\"5\"}",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Address: GetNodeHost(baseName.Name),
+					Type:    corev1.NodeHostName,
+				},
+			},
+			DaemonEndpoints: corev1.NodeDaemonEndpoints{
+				KubeletEndpoint: corev1.DaemonEndpoint{
+					Port: constants.KubeletPort,
+				},
+			},
+		},
+	}
+
+	generictesting.RunTests(t, []*generictesting.SyncTest{
+		{
+			Name:                 "Nodes syncing enabled -- Ignore updates to Rancher managed annotations",
+			InitialPhysicalState: []runtime.Object{basePod, baseNode},
+			InitialVirtualState:  []runtime.Object{basePod, baseVNode},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Node"): {baseVNode},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				ctx.Config.Networking.Advanced.ProxyKubelets.ByIP = false
+				syncCtx, syncer := newFakeSyncer(t, ctx)
+				_, err := syncer.Sync(syncCtx, baseNode, baseVNode)
+				assert.NilError(t, err)
+			},
+		},
+	})
 }

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -19,7 +19,9 @@ import (
 )
 
 var (
-	TaintsAnnotation = "vcluster.loft.sh/original-taints"
+	TaintsAnnotation                  = "vcluster.loft.sh/original-taints"
+	RancherAgentPodRequestsAnnotation = "management.cattle.io/pod-requests"
+	RancherAgentPodLimitsAnnotation   = "management.cattle.io/pod-limits"
 )
 
 func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.Node) *corev1.Node {
@@ -27,7 +29,8 @@ func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.
 
 	// merge labels & taints
 	translatedSpec := pNode.Spec.DeepCopy()
-	labels, annotations := translate.ApplyMetadata(pNode.Annotations, vNode.Annotations, pNode.Labels, vNode.Labels, TaintsAnnotation)
+	excludeAnnotations := []string{TaintsAnnotation, RancherAgentPodRequestsAnnotation, RancherAgentPodLimitsAnnotation}
+	labels, annotations := translate.ApplyMetadata(pNode.Annotations, vNode.Annotations, pNode.Labels, vNode.Labels, excludeAnnotations...)
 
 	// merge taints together
 	oldPhysical := []string{}

--- a/pkg/controllers/syncer/syncer.go
+++ b/pkg/controllers/syncer/syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -270,7 +271,7 @@ func (r *SyncController) excludePhysical(ctx context.Context, pObj, vObj client.
 		if !excluderOk && vObj != nil {
 			msg := fmt.Sprintf("conflict: cannot sync virtual object %s/%s as unmanaged physical object %s/%s exists with desired name", vObj.GetNamespace(), vObj.GetName(), pObj.GetNamespace(), pObj.GetName())
 			r.vEventRecorder.Eventf(vObj, "Warning", "SyncError", msg)
-			return false, fmt.Errorf(msg)
+			return false, errors.New(msg)
 		}
 
 		return true, nil

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -280,7 +280,7 @@ func initControllerContext(
 		return nil, errors.Wrap(err, "get virtual cluster version")
 	}
 	nodes.FakeNodesVersion = virtualClusterVersion.GitVersion
-	klog.Infof("Can connect to virtual cluster with version " + virtualClusterVersion.GitVersion)
+	klog.Info("Can connect to virtual cluster with version " + virtualClusterVersion.GitVersion)
 
 	// create a new current namespace client
 	currentNamespaceClient, err := newCurrentNamespaceClient(ctx, localManager, vClusterOptions)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4356


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now ignore updates to Rancher managed annotations inside the virtual cluster when node syncing is enabled.


**What else do we need to know?** 
