### PR TITLE
[v0.19] feat: Ignore updates to Rancher managed annotations (#2075)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,9 +144,18 @@ jobs:
     name: Execute test suites
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure git
+        run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
       - name: download current cli
         run: |
-          curl -L -o vcluster-current "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64"
+          VERSION=$(git ls-remote --tags origin -l 'v0.19.*' | awk -F'/' '{print $3}' | sort -V | tail -n 1)
+          curl -L -o vcluster-current "https://github.com/loft-sh/vcluster/releases/download/${VERSION}/vcluster-linux-amd64"
       - name: Upload vcluster cli to artifact
         uses: actions/upload-artifact@v4
         with:

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -298,25 +298,25 @@ func (cmd *CreateCmd) Run(ctx context.Context, args []string) error {
 
 func (cmd *CreateCmd) validateOSSFlags() error {
 	if cmd.Project != "" {
-		return fmt.Errorf("cannot use --project as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --project as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 	if cmd.Cluster != "" {
-		return fmt.Errorf("cannot use --cluster as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --cluster as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 	if cmd.Template != "" {
-		return fmt.Errorf("cannot use --template as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --template as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 	if cmd.TemplateVersion != "" {
-		return fmt.Errorf("cannot use --template-version as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --template-version as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 	if len(cmd.Links) > 0 {
-		return fmt.Errorf("cannot use --link as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --link as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 	if cmd.Params != "" {
-		return fmt.Errorf("cannot use --params as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --params as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 	if len(cmd.SetParams) > 0 {
-		return fmt.Errorf("cannot use --set-params as you are not connected to a vCluster.Pro instance." + loginText)
+		return errors.New("cannot use --set-params as you are not connected to a vCluster.Pro instance." + loginText)
 	}
 
 	return nil

--- a/hack/load-testing/tests/throughput/throughput.go
+++ b/hack/load-testing/tests/throughput/throughput.go
@@ -31,7 +31,7 @@ func TestThroughput(ctx context.Context, kubeClient client.Client, namespace str
 
 		err = kubeClient.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: fmt.Sprintf("secret-test-" + random.String(10) + "-"),
+				GenerateName: fmt.Sprint("secret-test-" + random.String(10) + "-"),
 				Namespace:    namespace,
 			},
 			Data: map[string][]byte{

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -19,7 +19,9 @@ import (
 )
 
 var (
-	TaintsAnnotation = "vcluster.loft.sh/original-taints"
+	TaintsAnnotation                  = "vcluster.loft.sh/original-taints"
+	RancherAgentPodRequestsAnnotation = "management.cattle.io/pod-requests"
+	RancherAgentPodLimitsAnnotation   = "management.cattle.io/pod-limits"
 )
 
 func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.Node) *corev1.Node {
@@ -27,7 +29,8 @@ func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.
 
 	// merge labels & taints
 	translatedSpec := pNode.Spec.DeepCopy()
-	labels, annotations := translate.ApplyMetadata(pNode.Annotations, vNode.Annotations, pNode.Labels, vNode.Labels, TaintsAnnotation)
+	excludeAnnotations := []string{TaintsAnnotation, RancherAgentPodRequestsAnnotation, RancherAgentPodLimitsAnnotation}
+	labels, annotations := translate.ApplyMetadata(pNode.Annotations, vNode.Annotations, pNode.Labels, vNode.Labels, excludeAnnotations...)
 
 	// merge taints together
 	oldPhysical := []string{}

--- a/pkg/controllers/syncer/syncer.go
+++ b/pkg/controllers/syncer/syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -267,7 +268,7 @@ func (r *syncerController) excludePhysical(ctx context.Context, pObj, vObj clien
 		if vObj != nil {
 			msg := "conflict: cannot sync virtual object as unmanaged physical object exists with desired name"
 			r.vEventRecorder.Eventf(vObj, "Warning", "SyncError", msg)
-			return false, fmt.Errorf(msg)
+			return false, errors.New(msg)
 		}
 
 		return true, nil

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -335,7 +335,7 @@ func InitControllerContext(
 		return nil, errors.Wrap(err, "get virtual cluster version")
 	}
 	nodes.FakeNodesVersion = virtualClusterVersion.GitVersion
-	klog.Infof("Can connect to virtual cluster with version " + virtualClusterVersion.GitVersion)
+	klog.Info("Can connect to virtual cluster with version " + virtualClusterVersion.GitVersion)
 
 	// create a new current namespace client
 	currentNamespaceClient, err := NewCurrentNamespaceClient(ctx, currentNamespace, localManager, vClusterOptions)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4358


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now ignore updates to Rancher managed annotations inside the virtual cluster when node syncing is enabled.


**What else do we need to know?** 
