### PR TITLE
feat: add dnsPolicy, dnsConfig config options for the controlPlane

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -83,6 +83,13 @@ spec:
       {{- if .Values.controlPlane.statefulSet.scheduling.priorityClassName }}
       priorityClassName: {{ .Values.controlPlane.statefulSet.scheduling.priorityClassName }}
       {{- end }}
+      {{- if .Values.controlPlane.statefulSet.dnsPolicy }}
+      dnsPolicy: {{ .Values.controlPlane.statefulSet.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.controlPlane.statefulSet.dnsConfig }}
+      dnsConfig: 
+{{ toYaml .Values.controlPlane.statefulSet.dnsConfig | indent 8 }}
+      {{- end }}
       {{- if .Values.controlPlane.advanced.serviceAccount.name }}
       serviceAccountName: {{ .Values.controlPlane.advanced.serviceAccount.name }}
       {{- else }}

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -751,3 +751,40 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[3].image
           value: registry.k8s.io/kube-apiserver:v99914
+  
+  - it: custom dnsPolicy
+    set:
+      controlPlane:
+        statefulSet:
+          dnsPolicy: "ClusterFirst"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: "ClusterFirst"
+
+  - it: custom dnsConfig
+    set:
+      controlPlane:
+        statefulSet:
+          dnsConfig:
+            nameservers:
+            - 192.0.2.1    
+            searches:
+              - ns1.svc.cluster-domain.example
+            options:
+              - name: ndots
+                value: "2"
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsConfig.nameservers[0]
+          value: "192.0.2.1"
+      - equal:
+          path: spec.template.spec.dnsConfig.searches[0]
+          value: "ns1.svc.cluster-domain.example"
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].name
+          value: "ndots"
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "2"
+

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -517,6 +517,14 @@
           },
           "type": "array",
           "description": "Env are additional environment variables for the statefulSet container."
+        },
+        "dnsPolicy": {
+          "type": "string",
+          "description": "Set DNS policy for the pod."
+        },
+        "dnsConfig": {
+          "$ref": "#/$defs/PodDNSConfig",
+          "description": "Specifies the DNS parameters of a pod."
         }
       },
       "additionalProperties": false,
@@ -2321,6 +2329,49 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "PodDNSConfig": {
+      "properties": {
+        "nameservers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.\n+optional\n+listType=atomic"
+        },
+        "searches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.\n+optional\n+listType=atomic"
+        },
+        "options": {
+          "items": {
+            "$ref": "#/$defs/PodDNSConfigOption"
+          },
+          "type": "array",
+          "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.\n+optional\n+listType=atomic"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy."
+    },
+    "PodDNSConfigOption": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required."
+        },
+        "value": {
+          "type": "string",
+          "description": "+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PodDNSConfigOption defines DNS resolver options of a pod."
     },
     "Policies": {
       "properties": {

--- a/config/config.go
+++ b/config/config.go
@@ -827,6 +827,12 @@ type ControlPlaneStatefulSet struct {
 
 	// Env are additional environment variables for the statefulSet container.
 	Env []map[string]interface{} `json:"env,omitempty"`
+
+	// Set DNS policy for the pod.
+	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// Specifies the DNS parameters of a pod.
+	DNSConfig *PodDNSConfig `json:"dnsConfig,omitempty"`
 }
 
 type Distro struct {
@@ -2106,6 +2112,63 @@ type RuleWithVerbs struct {
 	// If '*' is present, the length of the slice must be one.
 	Verbs []string `json:"operations,omitempty"`
 }
+
+// PodDNSConfig defines the DNS parameters of a pod in addition to
+// those generated from DNSPolicy.
+type PodDNSConfig struct {
+	// A list of DNS name server IP addresses.
+	// This will be appended to the base nameservers generated from DNSPolicy.
+	// Duplicated nameservers will be removed.
+	// +optional
+	// +listType=atomic
+	Nameservers []string `protobuf:"bytes,1,rep,name=nameservers" json:"nameservers,omitempty"`
+	// A list of DNS search domains for host-name lookup.
+	// This will be appended to the base search paths generated from DNSPolicy.
+	// Duplicated search paths will be removed.
+	// +optional
+	// +listType=atomic
+	Searches []string `protobuf:"bytes,2,rep,name=searches" json:"searches,omitempty"`
+	// A list of DNS resolver options.
+	// This will be merged with the base options generated from DNSPolicy.
+	// Duplicated entries will be removed. Resolution options given in Options
+	// will override those that appear in the base DNSPolicy.
+	// +optional
+	// +listType=atomic
+	Options []PodDNSConfigOption `protobuf:"bytes,3,rep,name=options" json:"options,omitempty"`
+}
+
+// PodDNSConfigOption defines DNS resolver options of a pod.
+type PodDNSConfigOption struct {
+	// Required.
+	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	// +optional
+	Value *string `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+}
+
+// DNSPolicy defines how a pod's DNS will be configured.
+// +enum
+type DNSPolicy string
+
+const (
+	// DNSClusterFirstWithHostNet indicates that the pod should use cluster DNS
+	// first, if it is available, then fall back on the default
+	// (as determined by kubelet) DNS settings.
+	DNSClusterFirstWithHostNet DNSPolicy = "ClusterFirstWithHostNet"
+
+	// DNSClusterFirst indicates that the pod should use cluster DNS
+	// first unless hostNetwork is true, if it is available, then
+	// fall back on the default (as determined by kubelet) DNS settings.
+	DNSClusterFirst DNSPolicy = "ClusterFirst"
+
+	// DNSDefault indicates that the pod should use the default (as
+	// determined by kubelet) DNS settings.
+	DNSDefault DNSPolicy = "Default"
+
+	// DNSNone indicates that the pod should use empty DNS settings. DNS
+	// parameters such as nameservers and search paths should be defined via
+	// DNSConfig.
+	DNSNone DNSPolicy = "None"
+)
 
 // addProToJSONSchema looks for fields with the `product:"pro"` tag and adds the pro tag to the central field.
 // Requires `json:""` tag to be set as well.

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,61 @@
+syncer:
+  env:
+    - name: PROXY_WEBHOOK_CONFIG
+      value: |-
+        ---
+        version: v1alphav1
+        checks:
+        - name: "Deny \"Node\" access"
+          rules:
+          - operations:
+            - "*"
+            apiGroups:
+            - ''
+            apiVersions:
+            - "*"
+            resources:
+            - "nodes/*" # using wildcard in order to cover subresources
+            scope: Cluster
+
+
+# controlPlane:
+#   hostPathMapper:
+#     enabled: true
+
+# isolation:
+#   enabled: true
+#   networkPolicy:
+#     enabled: true
+#     outgoingConnections:
+#       ipBlock:
+#         cidr: 0.0.0.0/0
+#         except:
+#           - 172.16.0.0/12
+
+# sync:
+#   generic:
+#    config: |-
+#     version: v1beta1
+#     hooks:
+#       virtualToHost:
+#         - apiVersion: networking.k8s.io/v1
+#           kind: Ingress
+
+#           patches:
+#             - op: rewriteName
+#               path: .metadata.annotations['nginx.ingress.kubernetes.io/mirror-target']
+#               regex: >
+#                 ^(https?:\/\/)*$NAME((\.$NAMESPACE)?(\.svc(\.cluster\.local)?){1})?.*$
+#       hostToVirtual: []
+
+# syncer:
+#   storage:
+#     binariesVolume:
+#       - name: binaries
+#         ephemeral:
+#           volumeClaimTemplate:
+#             spec:
+#               accessModes: [ "ReadWriteOnce" ]
+#               resources:
+#                 requests:
+#                   storage: 1Gi


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Add dnsPolicy, dnsConfig config options for the controlPlane ti be able to set these fields in the pod spec of the vcluster pod.

**Please provide a short message that should be published in the vcluster release notes**
Added dnsPolicy and dnsConfig config options for the controlPlane field in vcluster.yaml


**What else do we need to know?** 
