### PR TITLE
fix: add ingress host automatically to certificate

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -90,7 +90,7 @@ func NewServer(ctx *synccontext.ControllerContext, requestHeaderCaFile, clientCa
 	uncachedVirtualClient = pluginhookclient.WrapVirtualClient(uncachedVirtualClient)
 	uncachedLocalClient = pluginhookclient.WrapPhysicalClient(uncachedLocalClient)
 
-	certSyncer, err := cert.NewSyncer(ctx, ctx.Config.WorkloadNamespace, ctx.WorkloadNamespaceClient, ctx.Config)
+	certSyncer, err := cert.NewSyncer(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "create cert syncer")
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2086


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not add the ingress host automatically to the extra SANs of its self-signed certificate