### PR TITLE
[BACKPORT V0.20] fix: add ingress host automatically to certificate

### DIFF
--- a/pkg/server/cert/cert.go
+++ b/pkg/server/cert/cert.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func GenServingCerts(caCertFile, caKeyFile string, currentCert, currentKey []byte, clusterDomain string, SANs []string) ([]byte, []byte, bool, error) {
+func GenServingCerts(caCertFile, caKeyFile string, currentCert, currentKey []byte, clusterDomain, ingressHost string, SANs []string) ([]byte, []byte, bool, error) {
 	regen := false
 	commonName := "kube-apiserver"
 	extKeyUsage := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
@@ -22,6 +22,9 @@ func GenServingCerts(caCertFile, caKeyFile string, currentCert, currentKey []byt
 		"kubernetes.default",
 		"kubernetes",
 		"localhost",
+	}
+	if ingressHost != "" {
+		dnsNames = append(dnsNames, ingressHost)
 	}
 
 	altNames := &certhelper.AltNames{

--- a/pkg/server/cert/syncer.go
+++ b/pkg/server/cert/syncer.go
@@ -37,6 +37,8 @@ func NewSyncer(_ context.Context, currentNamespace string, currentNamespaceClien
 	return &syncer{
 		clusterDomain: options.Networking.Advanced.ClusterDomain,
 
+		ingressHost: options.ControlPlane.Ingress.Host,
+
 		serverCaKey:  options.VirtualClusterKubeConfig().ServerCAKey,
 		serverCaCert: options.VirtualClusterKubeConfig().ServerCACert,
 
@@ -53,6 +55,8 @@ func NewSyncer(_ context.Context, currentNamespace string, currentNamespaceClien
 
 type syncer struct {
 	clusterDomain string
+
+	ingressHost string
 
 	serverCaCert string
 	serverCaKey  string
@@ -210,7 +214,7 @@ func (s *syncer) regen(extraSANs []string) error {
 	klog.Infof("Generating serving cert for service ips: %v", extraSANs)
 
 	// GenServingCerts will write generated or updated cert/key to s.currentCert, s.currentKey
-	cert, key, _, err := GenServingCerts(s.serverCaCert, s.serverCaKey, s.currentCert, s.currentKey, s.clusterDomain, extraSANs)
+	cert, key, _, err := GenServingCerts(s.serverCaCert, s.serverCaKey, s.currentCert, s.currentKey, s.clusterDomain, s.ingressHost, extraSANs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2086


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not add the ingress host automatically to the extra SANs of its self-signed certificate
