### PR TITLE
fix: external delete should check status field for service uid

### DIFF
--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"time"
 
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
@@ -24,8 +25,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
-
-const VirtualClusterServiceUIDLabel = "vcluster.loft.sh/service-uid"
 
 type DeleteOptions struct {
 	Driver string
@@ -121,10 +120,13 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 
 	// try to delete the vCluster in the platform
 	if vClusterService != nil {
+		cmd.log.Debugf("deleting vcluster in platform")
 		err = cmd.deleteVClusterInPlatform(ctx, vClusterService)
 		if err != nil {
 			return err
 		}
+	} else {
+		cmd.log.Warn("vcluster service not found, could not delete in platform")
 	}
 
 	// try to delete the pvc
@@ -241,15 +243,21 @@ func (cmd *deleteHelm) deleteVClusterInPlatform(ctx context.Context, vClusterSer
 		return nil
 	}
 
-	virtualClusterInstances, err := managementClient.Loft().ManagementV1().VirtualClusterInstances(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: VirtualClusterServiceUIDLabel + "=" + string(vClusterService.UID),
-	})
+	virtualClusterInstances, err := managementClient.Loft().ManagementV1().VirtualClusterInstances(corev1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		cmd.log.Debugf("Error retrieving vcluster instances: %v", err)
 		return nil
 	}
 
+	toDelete := []managementv1.VirtualClusterInstance{}
 	for _, virtualClusterInstance := range virtualClusterInstances.Items {
+		if virtualClusterInstance.Status.ServiceUID != "" && virtualClusterInstance.Status.ServiceUID == string(vClusterService.UID) {
+			toDelete = append(toDelete, virtualClusterInstance)
+		}
+	}
+	cmd.log.Debugf("found %d matching virtualclusterinstances", len(toDelete))
+
+	for _, virtualClusterInstance := range toDelete {
 		cmd.log.Infof("Delete virtual cluster instance %s/%s in platform", virtualClusterInstance.Namespace, virtualClusterInstance.Name)
 		err = managementClient.Loft().ManagementV1().VirtualClusterInstances(virtualClusterInstance.Namespace).Delete(ctx, virtualClusterInstance.Name, metav1.DeleteOptions{})
 		if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
fixes ENG-4405

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster looked for the matching virtualcluster instance using a non existent label. Now, it will check the virtualclusterinstance.status.serviceUID field to find the matching vcluster to delete.


**What else do we need to know?** 
