### PR TITLE
fallback to checking if config is in correct format 

### DIFF
--- a/config/legacyconfig/migrate.go
+++ b/config/legacyconfig/migrate.go
@@ -43,6 +43,9 @@ func migrateK8sAndEKS(oldValues string, newConfig *config.Config) error {
 	oldConfig := &LegacyK8s{}
 	err := oldConfig.UnmarshalYAMLStrict([]byte(oldValues))
 	if err != nil {
+		if err := errIfConfigIsAlreadyConverted(oldValues); err != nil {
+			return err
+		}
 		return fmt.Errorf("unmarshal legacy config: %w", err)
 	}
 
@@ -91,6 +94,9 @@ func migrateK3sAndK0s(distro, oldValues string, newConfig *config.Config) error 
 	oldConfig := &LegacyK0sAndK3s{}
 	err := oldConfig.UnmarshalYAMLStrict([]byte(oldValues))
 	if err != nil {
+		if err := errIfConfigIsAlreadyConverted(oldValues); err != nil {
+			return err
+		}
 		return fmt.Errorf("unmarshal legacy config: %w", err)
 	}
 
@@ -134,6 +140,14 @@ func migrateK3sAndK0s(distro, oldValues string, newConfig *config.Config) error 
 
 	// convert the rest
 	return convertBaseValues(oldConfig.BaseHelm, newConfig)
+}
+
+func errIfConfigIsAlreadyConverted(oldValues string) error {
+	currentConfig := &config.Config{}
+	if err := currentConfig.UnmarshalYAMLStrict([]byte(oldValues)); err == nil {
+		return fmt.Errorf("config is already in correct format")
+	}
+	return nil
 }
 
 func convertEtcd(oldConfig EtcdValues, newConfig *config.Config) error {

--- a/config/legacyconfig/migrate_test.go
+++ b/config/legacyconfig/migrate_test.go
@@ -445,6 +445,50 @@ policies:
       podManagementPolicy: OrderedReady`,
 			ExpectedErr: "",
 		},
+		{
+			Name:   "k3s already migrated to correct format",
+			Distro: "k3s",
+			In: `sync:
+  fromHost:
+    nodes:
+      enabled: false
+  toHost:
+    serviceAccounts:
+      enabled: false
+controlPlane:
+  distro:
+    k3s:
+      enabled: true
+      image:
+        tag: v1.30.2-k3s2
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+
+`,
+			ExpectedErr: "migrate legacy k3s values: config is already in correct format",
+		},
+		{
+			Name:   "k8s already migrated to correct format",
+			Distro: "k8s",
+			In: `sync:
+  fromHost:
+    nodes:
+      enabled: false
+  toHost:
+    serviceAccounts:
+      enabled: false
+controlPlane:
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+
+`,
+			ExpectedErr: "migrate legacy k8s values: config is already in correct format",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
if we cannot unmarshal it into legacy config in vcluster config convert

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4307


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster config convert fails even if valid config is provided

**What else do we need to know?** 
I initially thought that we can return no error here, but I guess it may be confusing, as it will output an empty diff `{}`.
