### PR TITLE
add --all flag to vcluster platform add vcluster

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/vcluster.go
@@ -29,7 +29,12 @@ Adds a vCluster to the vCluster platform.
 
 Example:
 vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --project my-project --import-name my-vcluster
+
+Add all vClusters in the host cluster:
+vcluster platform add vcluster ignored --project my-project --all
+
 ###############################################
+
 	`
 
 	addCmd := &cobra.Command{
@@ -51,6 +56,7 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 	addCmd.Flags().BytesBase64Var(&cmd.CertificateAuthorityData, "ca-data", []byte{}, "additional, base64 encoded certificate authority data that will be passed to the platform secret")
 	// This is hidden until the platform side will be ready to use it
 	_ = addCmd.Flags().MarkHidden("ca-data")
+	addCmd.Flags().BoolVar(&cmd.All, "all", false, "all will try to add all vCluster found in all namespaces in the host cluster. If this flag is set, vcluster name argument is ignored")
 
 	return addCmd
 }

--- a/cmd/vclusterctl/cmd/platform/add/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/vcluster.go
@@ -30,7 +30,7 @@ Adds a vCluster to the vCluster platform.
 Example:
 vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --project my-project --import-name my-vcluster
 
-Add all vClusters in the host cluster:
+Add all vCluster instances in the host cluster:
 vcluster platform add vcluster --project my-project --all
 
 ###############################################

--- a/cmd/vclusterctl/cmd/platform/add/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/vcluster.go
@@ -31,7 +31,7 @@ Example:
 vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --project my-project --import-name my-vcluster
 
 Add all vClusters in the host cluster:
-vcluster platform add vcluster ignored --project my-project --all
+vcluster platform add vcluster --project my-project --all
 
 ###############################################
 
@@ -41,7 +41,7 @@ vcluster platform add vcluster ignored --project my-project --all
 		Use:   "vcluster",
 		Short: "Adds an existing vCluster to the vCluster platform",
 		Long:  description,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},
@@ -56,12 +56,12 @@ vcluster platform add vcluster ignored --project my-project --all
 	addCmd.Flags().BytesBase64Var(&cmd.CertificateAuthorityData, "ca-data", []byte{}, "additional, base64 encoded certificate authority data that will be passed to the platform secret")
 	// This is hidden until the platform side will be ready to use it
 	_ = addCmd.Flags().MarkHidden("ca-data")
-	addCmd.Flags().BoolVar(&cmd.All, "all", false, "all will try to add all vCluster found in all namespaces in the host cluster. If this flag is set, vcluster name argument is ignored")
+	addCmd.Flags().BoolVar(&cmd.All, "all", false, "all will try to add Virtual Cluster found in all namespaces in the host cluster. If this flag is set, any provided vCluster name argument is ignored")
 
 	return addCmd
 }
 
 // Run executes the functionality
 func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
-	return cli.AddVClusterHelm(ctx, &cmd.AddVClusterOptions, cmd.GlobalFlags, args[0], cmd.Log)
+	return cli.AddVClusterHelm(ctx, &cmd.AddVClusterOptions, cmd.GlobalFlags, args, cmd.Log)
 }

--- a/pkg/cli/add_vcluster_helm.go
+++ b/pkg/cli/add_vcluster_helm.go
@@ -42,14 +42,13 @@ func AddVClusterHelm(
 		return errors.New("empty vCluster name but no --all flag set, please either set vCluster name to add one cluster or set --all flag to add all of them")
 	}
 	if options.All {
-		log.Debugf("add vcluster called with --all flag")
-		log.Info("looking for vClusters in all namespaces")
+		log.Info("looking for vCluster instances in all namespaces")
 		vClustersInNamespace, err := find.ListVClusters(ctx, globalFlags.Context, "", "", log)
 		if err != nil {
 			return err
 		}
 		if len(vClustersInNamespace) == 0 {
-			log.Infof("no vClusters found in context %s", globalFlags.Context)
+			log.Infof("no vCluster instances found in context %s", globalFlags.Context)
 		} else {
 			vClusters = append(vClusters, vClustersInNamespace...)
 		}
@@ -78,7 +77,7 @@ func AddVClusterHelm(
 		return err
 	}
 	var addErrors []error
-	log.Debugf("trying to add %d vClusters to platform", len(vClusters))
+	log.Debugf("trying to add %d vCluster instances to platform", len(vClusters))
 	for _, vCluster := range vClusters {
 		vCluster := vCluster
 		log.Infof("adding %s vCluster to platform", vCluster.Name)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4109


**Please provide a short message that should be published in the vcluster release notes**
Adds `--all` flag to `vcluster platform add vcluster`. This can be used to import all vClusters from host cluster to the platform.

**What else do we need to know?** 
