### PR TITLE
Check if vcluster chart version supports k8s version

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -265,7 +265,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if err != nil {
 		return err
 	}
-	chartValues, err := config.GetExtraValues(chartOptions)
+	chartValues, err := config.GetExtraValues(chartOptions, options.ChartVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/create_platform.go
+++ b/pkg/cli/create_platform.go
@@ -612,7 +612,7 @@ func mergeValues(platformClient platform.Client, options *CreateOptions, log log
 	if err != nil {
 		return "", err
 	}
-	chartValues, err := vclusterconfig.GetExtraValues(chartOptions)
+	chartValues, err := vclusterconfig.GetExtraValues(chartOptions, options.ChartVersion)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-4480

Prior, an extra value, distro.k8s.version, could be set for a vcluster with a version that does not support the distro.k8s.version field. This would lead to a panic in vcluster. Now, the value is only set if the vcluster chart version is known to support it. Otherwise, it is left empty, leading to the omission of the field and no panic.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where older vcluster versions may panic due to being passed an unsupported value.

**What else do we need to know?** 
