### PR TITLE
dynamically add config.Config.PlatformConfig to the generated schema

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1527,8 +1527,15 @@
       "description": "Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig."
     },
     "ExternalConfig": {
+      "properties": {
+        "platform": {
+          "$ref": "#/$defs/PlatformConfig",
+          "type": "object",
+          "description": "platform holds platform configuration"
+        }
+      },
       "type": "object",
-      "description": "ExternalConfig holds external tool configuration"
+      "description": "ExternalConfig holds external configuration"
     },
     "ExternalEtcdHighAvailability": {
       "properties": {
@@ -2234,6 +2241,35 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "PlatformAPIKey": {
+      "properties": {
+        "secretName": {
+          "type": "string",
+          "description": "SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace\nwhere the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace."
+        },
+        "createRBAC": {
+          "type": "boolean",
+          "description": "CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified\nin the above namespace, if specified.\nThis defaults to true."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PlatformAPIKey defines where to find the platform access key."
+    },
+    "PlatformConfig": {
+      "properties": {
+        "apiKey": {
+          "$ref": "#/$defs/PlatformAPIKey",
+          "description": "APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:\n* environment variable called LICENSE\n* secret specified under external.platform.apiKey.secretName\n* secret called \"vcluster-platform-api-key\" in the vCluster namespace"
+        }
+      },
+      "type": "object",
+      "description": "PlatformConfig holds platform configuration"
     },
     "Plugin": {
       "properties": {
@@ -3503,10 +3539,7 @@
       "description": "Experimental features for vCluster. Configuration here might change, so be careful with this."
     },
     "external": {
-      "additionalProperties": {
-        "$ref": "#/$defs/ExternalConfig"
-      },
-      "type": "object",
+      "$ref": "#/$defs/ExternalConfig",
       "description": "External holds configuration for tools that are external to the vCluster."
     },
     "telemetry": {

--- a/hack/schema/main.go
+++ b/hack/schema/main.go
@@ -120,7 +120,6 @@ func addPlatformSchema(toSchema *jsonschema.Schema) error {
 			AdditionalProperties: nil,
 			Description:          externalConfigName + " holds external configuration",
 			Properties:           properties,
-			Ref:                  externalConfigRef,
 		}
 	} else {
 		externalConfigNode.Properties = properties

--- a/hack/schema/main.go
+++ b/hack/schema/main.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+
 	"github.com/invopop/jsonschema"
 	"github.com/loft-sh/vcluster/config"
 	"gopkg.in/yaml.v3"
@@ -15,6 +17,13 @@ import (
 
 const OutFile = "chart/values.schema.json"
 const ValuesOutFile = "chart/values.yaml"
+const (
+	defsPrefix         = "#/$defs/"
+	externalConfigName = "ExternalConfig"
+	platformConfigName = "PlatformConfig"
+	platformConfigRef  = defsPrefix + platformConfigName
+	externalConfigRef  = defsPrefix + externalConfigName
+)
 
 var SkipProperties = map[string]string{
 	"EnableSwitch":              "*",
@@ -41,6 +50,10 @@ func main() {
 	generatedSchema := reflector.Reflect(&config.Config{})
 	transformMapProperties(generatedSchema)
 	modifySchema(generatedSchema, cleanUp)
+	err = addPlatformSchema(generatedSchema)
+	if err != nil {
+		panic(err)
+	}
 	err = writeSchema(generatedSchema, OutFile)
 	if err != nil {
 		panic(err)
@@ -50,6 +63,83 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func addPlatformSchema(toSchema *jsonschema.Schema) error {
+	commentsMap := make(map[string]string)
+	r := new(jsonschema.Reflector)
+	r.RequiredFromJSONSchemaTags = true
+	r.BaseSchemaID = "https://vcluster.com/schemas"
+	r.ExpandedStruct = true
+
+	if err := jsonschema.ExtractGoComments("github.com/loft-sh/vcluster", "config", commentsMap); err != nil {
+		return err
+	}
+	r.CommentMap = commentsMap
+	platformConfigSchema := r.Reflect(&config.PlatformConfig{})
+
+	platformNode := &jsonschema.Schema{
+		AdditionalProperties: nil,
+		Description:          platformConfigName + " holds platform configuration",
+		Properties:           jsonschema.NewProperties(),
+		Type:                 "object",
+	}
+	for pair := platformConfigSchema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		platformNode.Properties.AddPairs(
+			orderedmap.Pair[string, *jsonschema.Schema]{
+				Key:   pair.Key,
+				Value: pair.Value,
+			})
+	}
+
+	for k, v := range platformConfigSchema.Definitions {
+		if k == "PlatformConfig" {
+			continue
+		}
+		toSchema.Definitions[k] = v
+	}
+
+	for pair := platformConfigSchema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		pair := pair
+		platformNode.Properties.AddPairs(*pair)
+	}
+
+	toSchema.Definitions[platformConfigName] = platformNode
+	properties := jsonschema.NewProperties()
+	properties.AddPairs(orderedmap.Pair[string, *jsonschema.Schema]{
+		Key: "platform",
+		Value: &jsonschema.Schema{
+			Ref:         platformConfigRef,
+			Description: "platform holds platform configuration",
+			Type:        "object",
+		},
+	})
+	externalConfigNode, ok := toSchema.Definitions[externalConfigName]
+	if !ok {
+		externalConfigNode = &jsonschema.Schema{
+			AdditionalProperties: nil,
+			Description:          externalConfigName + " holds external configuration",
+			Properties:           properties,
+			Ref:                  externalConfigRef,
+		}
+	} else {
+		externalConfigNode.Properties = properties
+		externalConfigNode.Description = externalConfigName + " holds external configuration"
+	}
+	toSchema.Definitions[externalConfigName] = externalConfigNode
+
+	for defName, node := range platformConfigSchema.Definitions {
+		toSchema.Definitions[defName] = node
+	}
+	externalProperty, ok := toSchema.Properties.Get("external")
+	if !ok {
+		return nil
+	}
+	externalProperty.Ref = externalConfigRef
+	externalProperty.AdditionalProperties = nil
+	externalProperty.Type = ""
+
+	return nil
 }
 
 func writeValues(schema *jsonschema.Schema) error {
@@ -95,7 +185,7 @@ func traverseNode(node *yaml.Node, schema *jsonschema.Schema, definitions jsonsc
 
 			// find properties
 			properties := schema.Properties
-			ref := strings.TrimPrefix(schema.Ref, "#/$defs/")
+			ref := strings.TrimPrefix(schema.Ref, defsPrefix)
 			if ref != "" {
 				refSchema, ok := definitions[ref]
 				if ok {


### PR DESCRIPTION
This dynamically adds `config/config.go#PlatformConfig` in the schema generation script to `values.schema.json`

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of ENG-4185


**Please provide a short message that should be published in the vcluster release notes**
add PlatformConfig under `external.platform` in generated `values.schema.json`


**What else do we need to know?** 
