### PR TITLE
[BACKPORT v0.20] fix: wrong namespace for vcluster

### DIFF
--- a/cmd/vclusterctl/cmd/platform/reset.go
+++ b/cmd/vclusterctl/cmd/platform/reset.go
@@ -22,13 +22,13 @@ import (
 
 type PasswordCmd struct {
 	*flags.GlobalFlags
-
-	User     string
-	Password string
-	Create   bool
-	Force    bool
-
 	Log log.Logger
+
+	Namespace string
+	User      string
+	Password  string
+	Create    bool
+	Force     bool
 }
 
 func NewResetCmd(globalFlags *flags.GlobalFlags) *cobra.Command {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
