### PR TITLE
Changes fallback ns to vcluster-platform

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/cluster.go
@@ -70,7 +70,7 @@ vcluster platform add cluster my-cluster
 		},
 	}
 
-	c.Flags().StringVar(&cmd.Namespace, "namespace", "loft", "The namespace to generate the service account in. The namespace will be created if it does not exist")
+	c.Flags().StringVar(&cmd.Namespace, "namespace", clihelper.DefaultPlatformNamespace, "The namespace to generate the service account in. The namespace will be created if it does not exist")
 	c.Flags().StringVar(&cmd.ServiceAccount, "service-account", "loft-admin", "The service account name to create")
 	c.Flags().StringVar(&cmd.DisplayName, "display-name", "", "The display name to show in the UI for this cluster")
 	c.Flags().BoolVar(&cmd.Wait, "wait", false, "If true, will wait until the cluster is initialized")

--- a/cmd/vclusterctl/cmd/platform/backup/management.go
+++ b/cmd/vclusterctl/cmd/platform/backup/management.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -67,8 +68,10 @@ vcluster platform backup management
 		},
 	}
 
+	platformNamespace, _ := clihelper.VClusterPlatformInstallationNamespace(context.Background())
+
 	c.Flags().StringSliceVar(&cmd.Skip, "skip", []string{}, "What resources the backup should skip. Valid options are: users, teams, accesskeys, sharedsecrets, clusters and clusteraccounttemplates")
-	c.Flags().StringVar(&cmd.Namespace, "namespace", "vcluster-platform", product.Replace("The namespace vCluster platform was installed into"))
+	c.Flags().StringVar(&cmd.Namespace, "namespace", platformNamespace, product.Replace("The namespace vCluster platform was installed into"))
 	c.Flags().StringVar(&cmd.Filename, "filename", "backup.yaml", "The filename to write the backup to")
 	return c
 }

--- a/cmd/vclusterctl/cmd/platform/get/secret.go
+++ b/cmd/vclusterctl/cmd/platform/get/secret.go
@@ -14,6 +14,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
 	pdefaults "github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/loft-sh/vcluster/pkg/projectutil"
 	"github.com/pkg/errors"
@@ -111,7 +112,7 @@ func (cmd *SecretCmd) Run(ctx context.Context, args []string) error {
 	case set.ProjectSecret:
 		namespace = projectutil.ProjectNamespace(cmd.Project)
 	case set.SharedSecret:
-		namespace, err = set.GetSharedSecretNamespace(cmd.Namespace)
+		namespace, err = clihelper.VClusterPlatformInstallationNamespace(ctx)
 		if err != nil {
 			return errors.Wrap(err, "get shared secrets namespace")
 		}

--- a/cmd/vclusterctl/cmd/platform/set/secret.go
+++ b/cmd/vclusterctl/cmd/platform/set/secret.go
@@ -13,6 +13,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
 	pdefaults "github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/loft-sh/vcluster/pkg/platform/kube"
 	"github.com/loft-sh/vcluster/pkg/projectutil"
@@ -112,7 +113,7 @@ func (cmd *SecretCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		namespace := projectutil.ProjectNamespace(cmd.Project)
 		return cmd.setProjectSecret(ctx, managementClient, args, namespace, secretName, keyName)
 	case SharedSecret:
-		namespace, err := GetSharedSecretNamespace(cmd.Namespace)
+		namespace, err := clihelper.VClusterPlatformInstallationNamespace(ctx)
 		if err != nil {
 			return errors.Wrap(err, "get shared secrets namespace")
 		}
@@ -257,12 +258,4 @@ func (cmd *SecretCmd) setSharedSecret(ctx context.Context, managementClient kube
 
 	cmd.log.Donef("Successfully set secret key %s.%s", secretName, keyName)
 	return nil
-}
-
-func GetSharedSecretNamespace(namespace string) (string, error) {
-	if namespace == "" {
-		namespace = "loft"
-	}
-
-	return namespace, nil
 }

--- a/cmd/vclusterctl/cmd/platform/start.go
+++ b/cmd/vclusterctl/cmd/platform/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/start"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -55,7 +56,7 @@ before running this command:
 	}
 
 	startCmd.Flags().StringVar(&cmd.Context, "context", "", "The kube context to use for installation")
-	startCmd.Flags().StringVar(&cmd.Namespace, "namespace", "vcluster-platform", "The namespace to install vCluster platform into")
+	startCmd.Flags().StringVar(&cmd.Namespace, "namespace", clihelper.DefaultPlatformNamespace, "The namespace to install vCluster platform into")
 	startCmd.Flags().StringVar(&cmd.LocalPort, "local-port", "", "The local port to bind to if using port-forwarding")
 	startCmd.Flags().StringVar(&cmd.Host, "host", "", "Provide a hostname to enable ingress and configure its hostname")
 	startCmd.Flags().StringVar(&cmd.Password, "password", "", "The password to use for the admin account. (If empty this will be the namespace UID)")

--- a/pkg/cli/start/success.go
+++ b/pkg/cli/start/success.go
@@ -239,7 +239,7 @@ func (l *LoftStarter) waitForLoft(ctx context.Context) (*corev1.Pod, error) {
 	}
 
 	// ensure user admin secret is there
-	isNewPassword, err := clihelper.EnsureAdminPassword(ctx, l.KubeClient, l.RestConfig, l.Password, l.Log)
+	isNewPassword, err := clihelper.EnsureAdminPassword(ctx, l.KubeClient, l.RestConfig, l.Namespace, l.Password, l.Log)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds function to look up loft deployment's namespace

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-4560


**Please provide a short message that should be published in the vcluster release notes**
Tries to look up the platform install's deployment to get the namespace rather than assuming "loft" if the user doesn't specify and the flag default isn't vcluster-platform.

