### PR TITLE
Only uninstall if reset flag is true

### DIFF
--- a/cmd/vclusterctl/cmd/platform/start.go
+++ b/cmd/vclusterctl/cmd/platform/start.go
@@ -64,7 +64,7 @@ before running this command:
 	startCmd.Flags().BoolVar(&cmd.ReuseValues, "reuse-values", true, "Reuse previous vCluster platform helm values on upgrade")
 	startCmd.Flags().BoolVar(&cmd.Upgrade, "upgrade", false, "If true, vCluster platform will try to upgrade the release")
 	startCmd.Flags().StringVar(&cmd.Email, "email", "", "The email to use for the installation")
-	startCmd.Flags().BoolVar(&cmd.Reset, "reset", false, "If true, an existing vCluster platform instance will be deleted before installing vCluster platform")
+	startCmd.Flags().BoolVar(&cmd.Reset, "reset", false, "If true, existing vCluster Platform resources, including the deployment, will be deleted before installing vCluster platform")
 	startCmd.Flags().BoolVar(&cmd.NoWait, "no-wait", false, "If true, vCluster platform will not wait after installing it")
 	startCmd.Flags().BoolVar(&cmd.NoPortForwarding, "no-port-forwarding", false, "If true, vCluster platform will not do port forwarding after installing it")
 	startCmd.Flags().BoolVar(&cmd.NoTunnel, "no-tunnel", false, "If true, vCluster platform will not create a loft.host tunnel for this installation")

--- a/pkg/cli/start/start.go
+++ b/pkg/cli/start/start.go
@@ -113,23 +113,12 @@ func (l *LoftStarter) Start(ctx context.Context) error {
 	l.Log.Info(product.Replace("Welcome to Loft!"))
 	l.Log.Info(product.Replace("This installer will help you configure and deploy Loft."))
 
-	// make sure we are ready for installing
-	err = l.prepareInstall(ctx)
-	if err != nil {
-		return err
-	}
-
 	err = l.upgradeLoft()
 	if err != nil {
 		return err
 	}
 
 	return l.success(ctx)
-}
-
-func (l *LoftStarter) prepareInstall(ctx context.Context) error {
-	// delete admin user & secret
-	return clihelper.UninstallLoft(ctx, l.KubeClient, l.RestConfig, l.Context, l.Namespace, log.Discard)
 }
 
 func (l *LoftStarter) prepare() error {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-4635.
Part of ENG-4400

Prior, the reset flag indicated that resources should be uninstalled. However, if an existing deployment was not detected, all other resources were removed regardless of the reset flag's value. Now, reset must be set to true to uninstall any existing vCluster Platform resources. This is more in line with how a reinstall performed with helm behaves and is more predictable for the user. The usage description has been updated to reflect the change.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vCluster uninstall would remove vCluster Platform resources from a previous install even if the "--reset" flag was set to false.


**What else do we need to know?** 
