### PR TITLE
fix: update platform add command to reference the platform instead of loft

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/cluster.go
@@ -106,7 +106,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 
 	loftVersion, err := platformClient.Version()
 	if err != nil {
-		return fmt.Errorf("get loft version: %w", err)
+		return fmt.Errorf("get platform version: %w", err)
 	}
 
 	// TODO(ThomasK33): Eventually change this into an Apply instead of a Create call
@@ -254,7 +254,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	cmd.Log.Donef("Successfully added cluster %s to Loft", clusterName)
+	cmd.Log.Donef("Successfully added cluster %s to the platform", clusterName)
 
 	return nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of #eng-4516


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform add referenced `loft` instead of the new platform references. 


**What else do we need to know?** 
