### PR TITLE
[Backport-to-v0.20 set additional ca in platform add cluster

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/cluster.go
@@ -30,16 +30,17 @@ import (
 type ClusterCmd struct {
 	Log log.Logger
 	*flags.GlobalFlags
-	Namespace        string
-	ServiceAccount   string
-	DisplayName      string
-	Context          string
-	Insecure         bool
-	Wait             bool
-	HelmChartPath    string
-	HelmChartVersion string
-	HelmSet          []string
-	HelmValues       []string
+	Namespace                string
+	ServiceAccount           string
+	DisplayName              string
+	Context                  string
+	Insecure                 bool
+	Wait                     bool
+	HelmChartPath            string
+	HelmChartVersion         string
+	HelmSet                  []string
+	HelmValues               []string
+	CertificateAuthorityData []byte
 }
 
 // NewClusterCmd creates a new command
@@ -80,6 +81,7 @@ vcluster platform add cluster my-cluster
 	c.Flags().StringArrayVar(&cmd.HelmSet, "helm-set", []string{}, "Extra helm values for the agent chart")
 	c.Flags().StringArrayVar(&cmd.HelmValues, "helm-values", []string{}, "Extra helm values for the agent chart")
 	c.Flags().StringVar(&cmd.Context, "context", "", "The kube context to use for installation")
+	c.Flags().BytesBase64Var(&cmd.CertificateAuthorityData, "ca-data", []byte{}, "additional, base64 encoded certificate authority data that will be passed to the platform secret")
 
 	return c
 }
@@ -87,7 +89,6 @@ vcluster platform add cluster my-cluster
 func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	// Get clusterName from command argument
 	clusterName := args[0]
-
 	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.Log))
 	if err != nil {
 		return fmt.Errorf("new client from path: %w", err)
@@ -187,8 +188,8 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		helmArgs = append(helmArgs, "--set", "insecureSkipVerify=true")
 	}
 
-	if accessKey.CaCert != "" {
-		helmArgs = append(helmArgs, "--set", "additionalCA="+accessKey.CaCert)
+	if len(cmd.CertificateAuthorityData) > 0 {
+		helmArgs = append(helmArgs, "--set", "additionalCA="+string(cmd.CertificateAuthorityData))
 	}
 
 	if cmd.Wait {

--- a/cmd/vclusterctl/cmd/platform/add/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/vcluster.go
@@ -49,9 +49,6 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 	addCmd.Flags().StringVar(&cmd.Host, "host", "", "The host where to reach the platform")
 	addCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, "If the platform host is insecure")
 	addCmd.Flags().BytesBase64Var(&cmd.CertificateAuthorityData, "ca-data", []byte{}, "additional, base64 encoded certificate authority data that will be passed to the platform secret")
-	// This is hidden until the platform side will be ready to use it
-	_ = addCmd.Flags().MarkHidden("ca-data")
-
 	return addCmd
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4638
backport of #2153 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform add cluster was setting additionalCA for loft-agent when it was set in cluster access. Instead, now user can pass additionalCA for given loft agent as a command flag


**What else do we need to know?** 
