### PR TITLE
[v0.20] revert adding --ca-data flag to vcluster platform add cluster

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/cluster.go
@@ -30,17 +30,16 @@ import (
 type ClusterCmd struct {
 	Log log.Logger
 	*flags.GlobalFlags
-	Namespace                string
-	ServiceAccount           string
-	DisplayName              string
-	Context                  string
-	Insecure                 bool
-	Wait                     bool
-	HelmChartPath            string
-	HelmChartVersion         string
-	HelmSet                  []string
-	HelmValues               []string
-	CertificateAuthorityData []byte
+	Namespace        string
+	ServiceAccount   string
+	DisplayName      string
+	Context          string
+	Insecure         bool
+	Wait             bool
+	HelmChartPath    string
+	HelmChartVersion string
+	HelmSet          []string
+	HelmValues       []string
 }
 
 // NewClusterCmd creates a new command
@@ -81,7 +80,6 @@ vcluster platform add cluster my-cluster
 	c.Flags().StringArrayVar(&cmd.HelmSet, "helm-set", []string{}, "Extra helm values for the agent chart")
 	c.Flags().StringArrayVar(&cmd.HelmValues, "helm-values", []string{}, "Extra helm values for the agent chart")
 	c.Flags().StringVar(&cmd.Context, "context", "", "The kube context to use for installation")
-	c.Flags().BytesBase64Var(&cmd.CertificateAuthorityData, "ca-data", []byte{}, "additional, base64 encoded certificate authority data that will be passed to the platform secret")
 
 	return c
 }
@@ -204,8 +202,8 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		helmArgs = append(helmArgs, "--set", "insecureSkipVerify=true")
 	}
 
-	if len(cmd.CertificateAuthorityData) > 0 {
-		helmArgs = append(helmArgs, "--set", "additionalCA="+string(cmd.CertificateAuthorityData))
+	if accessKey.CaCert != "" {
+		helmArgs = append(helmArgs, "--set", "additionalCA="+accessKey.CaCert)
 	}
 
 	if cmd.Wait {


### PR DESCRIPTION
after changes made in https://github.com/loft-sh/loft-enterprise/pull/3187 , `--ca-data` flag in `vcluster platform add cluster` is redundant; it's actually better if user can configure additionalCA once for platform, and then connected clusters will automatically use it, instead of forcing user to pass it to the `vcluster platform add cluster` command every single time.

It reverts #2159 but keeps `--ca-data` flag for `platform add vcluster` commands visible