### PR TITLE
Make it possible to create virtual clusters with numbers only name

### DIFF
--- a/chart/templates/_helper.tpl
+++ b/chart/templates/_helper.tpl
@@ -15,3 +15,11 @@
 {{ .repository }}:{{ .tag }}
 {{- end -}}
 {{- end -}}
+
+{{- define "vcluster.name" -}}
+{{- if regexMatch "^[0-9]+$" .Release.Name -}}
+{{- printf "vc-%s" .Release.Name -}}
+{{- else -}}
+{{- printf "%s" .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/headless-service.yaml
+++ b/chart/templates/headless-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-headless
+  name: {{ template "vcluster.name" . }}-headless
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "vcluster.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
@@ -41,6 +41,6 @@ spec:
   {{- if and (not .Values.controlPlane.service.spec.selector) (not .Values.experimental.isolatedControlPlane.headless) }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
   {{- end }}
 {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: {{ include "vcluster.kind" . }}
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: vcluster
@@ -21,13 +21,13 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
   {{- if eq (include "vcluster.kind" .) "StatefulSet" }}
   {{- if ge (int .Capabilities.KubeVersion.Minor) 27 }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy }}
   {{- end }}
-  serviceName: {{ .Release.Name }}-headless
+  serviceName: {{ template "vcluster.name" . }}-headless
   podManagementPolicy: {{ .Values.controlPlane.statefulSet.scheduling.podManagementPolicy }}
 {{ include "vcluster.persistence" . | indent 2 }}
   {{- else }}
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
         {{- if .Values.controlPlane.statefulSet.pods.labels }}
 {{ toYaml .Values.controlPlane.statefulSet.pods.labels | indent 8 }}
         {{- end }}
@@ -87,7 +87,7 @@ spec:
       dnsPolicy: {{ .Values.controlPlane.statefulSet.dnsPolicy }}
       {{- end }}
       {{- if .Values.controlPlane.statefulSet.dnsConfig }}
-      dnsConfig: 
+      dnsConfig:
 {{ toYaml .Values.controlPlane.statefulSet.dnsConfig | indent 8 }}
       {{- end }}
       {{- if .Values.controlPlane.advanced.serviceAccount.name }}

--- a/chart/tests/headless-service_test.yaml
+++ b/chart/tests/headless-service_test.yaml
@@ -61,6 +61,16 @@ tests:
           path: metadata.namespace
           value: my-namespace
 
+  - it: should prepend vc to service name when only digits are given
+    release:
+      name: 1234
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: vc-1234-headless
+
   - it: embedded-etcd
     set:
       controlPlane:

--- a/chart/tests/service_test.yaml
+++ b/chart/tests/service_test.yaml
@@ -93,6 +93,16 @@ tests:
           path: spec.ports
           count: 2
 
+  - it: should prepend vc to service name when only digits are given
+    release:
+      name: 1234
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: vc-1234
+
   - it: isolated control plane
     release:
       name: my-release

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -9,6 +9,7 @@ vars:
   COMMON_VALUES: ./test/commonValues.yaml
   PRO_VALUES: ./test/proValues.yaml
   VALUES_FILE: ./test/e2e/values.yaml
+  RELEASE_NAME: "vcluster"
 
 # Images DevSpace will build for vcluster
 images:
@@ -23,7 +24,7 @@ images:
 deployments:
   vcluster-k8s:
     helm:
-      releaseName: vcluster
+      releaseName: ${RELEASE_NAME}
       chart:
         name: ./chart
       values:
@@ -51,7 +52,7 @@ deployments:
 
   vcluster-k3s:
     helm:
-      releaseName: vcluster
+      releaseName: ${RELEASE_NAME}
       chart:
         name: ./chart
       values:
@@ -79,7 +80,7 @@ deployments:
 
   vcluster-k0s:
     helm:
-      releaseName: vcluster
+      releaseName: ${RELEASE_NAME}
       chart:
         name: ./chart
       values:

--- a/pkg/certs/ensure.go
+++ b/pkg/certs/ensure.go
@@ -107,9 +107,7 @@ func EnsureCerts(
 
 	ownerRef := []metav1.OwnerReference{}
 	if options.Experimental.SyncSettings.SetOwner {
-		// options.ServiceName gets rewritten to the workload service name so we use options.Name as the helm chart
-		// directly uses the release name for the service name
-		controlPlaneService, err := currentNamespaceClient.CoreV1().Services(currentNamespace).Get(ctx, options.Name, metav1.GetOptions{})
+		controlPlaneService, err := currentNamespaceClient.CoreV1().Services(currentNamespace).Get(ctx, options.ControlPlaneService, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("get vcluster service: %w", err)
 		}

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -3,12 +3,15 @@ package config
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/strvals"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
+
+var digitsOnlyRegex = regexp.MustCompile("^[0-9]+$")
 
 func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, error) {
 	// check if name is empty
@@ -37,10 +40,18 @@ func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, 
 	}
 
 	// build config
+
+	var svcName string
+	if digitsOnlyRegex.MatchString(name) {
+		svcName = fmt.Sprintf("vc-%s", name)
+	} else {
+		svcName = name
+	}
+
 	retConfig := &VirtualClusterConfig{
 		Config:              *rawConfig,
 		Name:                name,
-		ControlPlaneService: name,
+		ControlPlaneService: svcName,
 	}
 
 	// validate config

--- a/pkg/controllers/resources/nodes/nodeservice/node_service.go
+++ b/pkg/controllers/resources/nodes/nodeservice/node_service.go
@@ -123,7 +123,7 @@ func (n *nodeServiceProvider) Unlock() {
 }
 
 func (n *nodeServiceProvider) GetNodeIP(ctx context.Context, name string) (string, error) {
-	serviceName := translate.SafeConcatName(translate.VClusterName, "node", strings.ReplaceAll(name, ".", "-"))
+	serviceName := translate.SafeConcatName(translate.VClusterServiceName, "node", strings.ReplaceAll(name, ".", "-"))
 
 	service := &corev1.Service{}
 	err := n.currentNamespaceClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: n.currentNamespace}, service)

--- a/pkg/setup/config.go
+++ b/pkg/setup/config.go
@@ -26,6 +26,7 @@ func InitAndValidateConfig(ctx context.Context, vConfig *config.VirtualClusterCo
 
 	// set global vCluster name
 	translate.VClusterName = vConfig.Name
+	translate.VClusterServiceName = vConfig.WorkloadService
 
 	// set workload namespace
 	err = os.Setenv("NAMESPACE", vConfig.WorkloadNamespace)

--- a/pkg/util/translate/types.go
+++ b/pkg/util/translate/types.go
@@ -25,7 +25,8 @@ var (
 	NamespaceLabelPrefix = "vcluster.loft.sh/ns-label"
 
 	// VClusterName is the vcluster name, usually set at start time
-	VClusterName = "suffix"
+	VClusterName        = "suffix"
+	VClusterServiceName = "vcluster"
 
 	ManagedAnnotationsAnnotation = "vcluster.loft.sh/managed-annotations"
 	ManagedLabelsAnnotation      = "vcluster.loft.sh/managed-labels"

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	PollTimeout              = time.Minute
-	DefaultVclusterName      = "vcluster"
-	DefaultVclusterNamespace = "vcluster"
-	DefaultClientTimeout     = 32 * time.Second // the default in client-go is 32
+	PollTimeout                = time.Minute
+	DefaultVclusterName        = "vcluster"
+	DefaultVclusterNamespace   = "vcluster"
+	DefaultVclusterServiceName = "vcluster"
+	DefaultClientTimeout       = 32 * time.Second // the default in client-go is 32
 )
 
 var DefaultFramework = &Framework{}
@@ -101,6 +102,10 @@ func CreateFramework(ctx context.Context, scheme *runtime.Scheme) error {
 	if ns == "" {
 		ns = DefaultVclusterNamespace
 	}
+	serviceName := os.Getenv("VCLUSTER_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = DefaultVclusterServiceName
+	}
 	timeoutEnvVar := os.Getenv("VCLUSTER_CLIENT_TIMEOUT")
 	var timeout time.Duration
 	timeoutInt, err := strconv.Atoi(timeoutEnvVar)
@@ -116,6 +121,7 @@ func CreateFramework(ctx context.Context, scheme *runtime.Scheme) error {
 		suffix = "vcluster"
 	}
 	translate.VClusterName = suffix
+	translate.VClusterServiceName = serviceName
 
 	var multiNamespaceMode bool
 	if os.Getenv("MULTINAMESPACE_MODE") == "true" {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4551


**Please provide a short message that should be published in the vcluster release notes**
Make it possible to create virtual clusters with digits only name


**What else do we need to know?** 
In order to be able to create virtual clusters with a digits-only name we have to change the way how we create services based on the name. Previously we just used the name verbatim which in case of pure digits violates the DNS-1035 naming convention for service names used by Kubernetes. 
It turned out this change cannot only be made to our helm templates as there have been several places in the code base that implicitly rely on services being named like the virtual cluster itself. I hope I found all the places and adjusted them to rely on the service name directly.
The change should be backwards compatible as the `vc-` prefix is only prepended to the name when the vcluster name consists of digits only (thx @ThomasK33). So if users already have virtual clusters running with a regular name (e.g. "foo") the service's name will remain "foo" as well.

**TODO after merge**
- [ ] Bump vcluster dep in vcluster-pro