### PR TITLE
[v0.19] fix: handle trailing slash in mount paths for hostpath mapper

### DIFF
--- a/pkg/controllers/resources/pods/translate/hostpath.go
+++ b/pkg/controllers/resources/pods/translate/hostpath.go
@@ -25,6 +25,9 @@ const (
 func (t *translator) ensureMountPropagation(pPod *corev1.Pod) {
 	for i, container := range pPod.Spec.Containers {
 		for j, volumeMount := range container.VolumeMounts {
+			// handle scenarios where path ends with a /
+			volumeMount.MountPath = strings.TrimSuffix(volumeMount.MountPath, "/")
+
 			if volumeMount.MountPath == PodLoggingHostPath ||
 				volumeMount.MountPath == KubeletPodPath ||
 				volumeMount.MountPath == LogHostPath {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4672


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where bind mounts for hostpath mapping would not forward changes correctly when mountpath contained a trailing forward-slash