### PR TITLE
[v0.20] test: Add tests for volumes and volumeMounts translation with hostpathmapper enabled

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"fmt"
+	"path/filepath"
+
+	generictesting "github.com/loft-sh/vcluster/pkg/controllers/syncer/testing"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"gotest.tools/v3/assert"
@@ -172,6 +176,9 @@ type translatePodAffinityTermTestCase struct {
 }
 
 func TestVolumeTranslation(t *testing.T) {
+	virtualPath := fmt.Sprintf(VirtualPathTemplate, generictesting.DefaultTestCurrentNamespace, generictesting.DefaultTestVClusterName)
+	hostToContainer := corev1.MountPropagationHostToContainer
+
 	testCases := []translatePodVolumesTestCase{
 		{
 			name: "ephemeral volume",
@@ -205,29 +212,101 @@ func TestVolumeTranslation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                   "hostpath mapper",
+			mountPhysicalHostPaths: true,
+			vPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-name",
+					Namespace: "test-ns",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "varlog",
+									MountPath: "/var/log/pods/",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "varlog",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/log/pods/",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "varlog",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: virtualPath + "/log/pods",
+						},
+					},
+				},
+				{
+					Name: fmt.Sprintf("%s-%s", "varlog", PhysicalVolumeNameSuffix),
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: PodLoggingHostPath,
+						},
+					},
+				},
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:             "varlog",
+					ReadOnly:         true,
+					MountPath:        "/var/log/pods/",
+					MountPropagation: &hostToContainer,
+				},
+				{
+					Name:      fmt.Sprintf("%s-%s", "varlog", PhysicalVolumeNameSuffix),
+					ReadOnly:  true,
+					MountPath: PhysicalPodLogVolumeMountPath,
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			fakeRecorder := record.NewFakeRecorder(10)
 			tr := &translator{
-				eventRecorder: fakeRecorder,
-				log:           loghelper.New("pods-syncer-translator-test"),
-				pClient:       fake.NewClientBuilder().Build(),
+				eventRecorder:          fakeRecorder,
+				log:                    loghelper.New("pods-syncer-translator-test"),
+				pClient:                fake.NewClientBuilder().Build(),
+				mountPhysicalHostPaths: testCase.mountPhysicalHostPaths,
+				virtualPodLogsPath:     filepath.Join(virtualPath, "log", "pods"),
 			}
 
 			pPod := testCase.vPod.DeepCopy()
 			err := tr.translateVolumes(context.Background(), pPod, &testCase.vPod)
 			assert.NilError(t, err)
 			assert.Assert(t, cmp.DeepEqual(pPod.Spec.Volumes, testCase.expectedVolumes), "Unexpected translation of the Volumes in the '%s' test case", testCase.name)
+
+			if len(testCase.expectedVolumeMounts) > 0 {
+				assert.Assert(t, cmp.DeepEqual(pPod.Spec.Containers[0].VolumeMounts, testCase.expectedVolumeMounts), "Unexpected translation of the Volume Mounts in the '%s' test case", testCase.name)
+			}
 		})
 	}
 }
 
 type translatePodVolumesTestCase struct {
-	name            string
-	vPod            corev1.Pod
-	expectedVolumes []corev1.Volume
+	name                   string
+	vPod                   corev1.Pod
+	expectedVolumes        []corev1.Volume
+	expectedVolumeMounts   []corev1.VolumeMount
+	mountPhysicalHostPaths bool
 }
 
 func appendNamespacesToMatchExpressions(source *metav1.LabelSelector, namespaces ...string) *metav1.LabelSelector {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind test

**What else do we need to know?**
Tests added for https://github.com/loft-sh/vcluster/pull/2169 as requested by @hidalgopl 🙂