### PR TITLE
ENG-4867: Fixes platform create output so it prints internal vcluster create command instead of external

### DIFF
--- a/pkg/cli/start/success.go
+++ b/pkg/cli/start/success.go
@@ -221,7 +221,7 @@ func (l *LoftStarter) printVClusterProGettingStarted(url string) {
 
 	if l.isLoggedIn(url) {
 		l.Log.Donef("You are successfully logged into vCluster Platform!")
-		l.Log.WriteString(logrus.InfoLevel, "- Use `vcluster create` to create a new virtual cluster\n")
+		l.Log.WriteString(logrus.InfoLevel, "- Use `vcluster platform create vcluster` to create a new virtual cluster\n")
 		l.Log.WriteString(logrus.InfoLevel, "- Use `vcluster platform add vcluster` to add an existing virtual cluster to a vCluster platform instance\n")
 	} else {
 		l.Log.Warnf("You are not logged into vCluster Platform yet, please run the below command to log into the vCluster Platform instance")


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves ENG-4867


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster platform start` command printed the wrong type of vcluster create command

