### PR TITLE
build: bump kubernetes 1.27 from 1.27.15 to 1.27.16

### DIFF
--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -26,7 +26,7 @@ var K3SVersionMap = map[string]string{
 	"1.30": "rancher/k3s:v1.30.2-k3s1",
 	"1.29": "rancher/k3s:v1.29.6-k3s1",
 	"1.28": "rancher/k3s:v1.28.11-k3s1",
-	"1.27": "rancher/k3s:v1.27.15-k3s1",
+	"1.27": "rancher/k3s:v1.27.16-k3s1",
 }
 
 // K0SVersionMap holds the supported k0s versions
@@ -34,7 +34,7 @@ var K0SVersionMap = map[string]string{
 	"1.30": "k0sproject/k0s:v1.30.2-k0s.0",
 	"1.29": "k0sproject/k0s:v1.29.6-k0s.0",
 	"1.28": "k0sproject/k0s:v1.28.11-k0s.0",
-	"1.27": "k0sproject/k0s:v1.27.15-k0s.0",
+	"1.27": "k0sproject/k0s:v1.27.16-k0s.0",
 }
 
 // K8SAPIVersionMap holds the supported k8s api servers
@@ -42,7 +42,7 @@ var K8SAPIVersionMap = map[string]string{
 	"1.30": "registry.k8s.io/kube-apiserver:v1.30.2",
 	"1.29": "registry.k8s.io/kube-apiserver:v1.29.6",
 	"1.28": "registry.k8s.io/kube-apiserver:v1.28.11",
-	"1.27": "registry.k8s.io/kube-apiserver:v1.27.15",
+	"1.27": "registry.k8s.io/kube-apiserver:v1.27.16",
 }
 
 // K8SControllerVersionMap holds the supported k8s controller managers
@@ -50,7 +50,7 @@ var K8SControllerVersionMap = map[string]string{
 	"1.30": "registry.k8s.io/kube-controller-manager:v1.30.2",
 	"1.29": "registry.k8s.io/kube-controller-manager:v1.29.6",
 	"1.28": "registry.k8s.io/kube-controller-manager:v1.28.11",
-	"1.27": "registry.k8s.io/kube-controller-manager:v1.27.15",
+	"1.27": "registry.k8s.io/kube-controller-manager:v1.27.16",
 }
 
 // K8SSchedulerVersionMap holds the supported k8s schedulers
@@ -58,7 +58,7 @@ var K8SSchedulerVersionMap = map[string]string{
 	"1.30": "registry.k8s.io/kube-scheduler:v1.30.2",
 	"1.29": "registry.k8s.io/kube-scheduler:v1.29.6",
 	"1.28": "registry.k8s.io/kube-scheduler:v1.28.11",
-	"1.27": "registry.k8s.io/kube-scheduler:v1.27.15",
+	"1.27": "registry.k8s.io/kube-scheduler:v1.27.16",
 }
 
 // K8SEtcdVersionMap holds the supported etcd

--- a/docs/pages/deploying-vclusters/compat-matrix.mdx
+++ b/docs/pages/deploying-vclusters/compat-matrix.mdx
@@ -7,7 +7,7 @@ sidebar_label: Compatibility Matrix
 
 Compatibility matrix showing which host k8s version (left column) is supported by which vCluster k3s distro versions.
 
-|      |    v1.30.2-k3s1    |    v1.29.6-k3s1    |   v1.28.11-k3s1    |   v1.27.15-k3s1    |
+|      |    v1.30.2-k3s1    |    v1.29.6-k3s1    |   v1.28.11-k3s1    |   v1.27.16-k3s1    |
 |------|--------------------|--------------------|--------------------|--------------------|
 | 1.30 | :white_check_mark: | :ok:               | :ok:               | :ok:               |
 | 1.29 | :ok:               | :white_check_mark: | :ok:               | :ok:               |
@@ -27,7 +27,7 @@ Legend:
 
 Compatibility matrix showing which host k8s version (left column) is supported by which vCluster k8s distro versions.
 
-|      |      v1.30.2       |      v1.29.6       |      v1.28.11      |      v1.27.15      |
+|      |      v1.30.2       |      v1.29.6       |      v1.28.11      |      v1.27.16      |
 |------|--------------------|--------------------|--------------------|--------------------|
 | 1.30 | :white_check_mark: | :ok:               | :ok:               | :ok:               |
 | 1.29 | :ok:               | :white_check_mark: | :ok:               | :ok:               |
@@ -47,7 +47,7 @@ Legend:
 
 Compatibility matrix showing which host k8s version (left column) is supported by which vCluster k0s distro versions.
 
-|      |   v1.30.2-k0s.0    |   v1.29.6-k0s.0    |   v1.28.11-k0s.0   |   v1.27.15-k0s.0   |
+|      |   v1.30.2-k0s.0    |   v1.29.6-k0s.0    |   v1.28.11-k0s.0   |   v1.27.16-k0s.0   |
 |------|--------------------|--------------------|--------------------|--------------------|
 | 1.30 | :white_check_mark: | :ok:               | :ok:               | :ok:               |
 | 1.29 | :ok:               | :white_check_mark: | :ok:               | :ok:               |


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A


**Please provide a short message that should be published in the vcluster release notes**
Bump Kubernetes 1.27 from 1.27.15 to 1.27.16

**What else do we need to know?** 

Kubernetes 1.27 is EOL, meaning 1.27.16 is the last release and there will not be any other. Thus, I think it makes a lot of sense to upgrade to it.