### PR TITLE
fix: Add missing ca data when using exportKubeConfig

### DIFF
--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -219,10 +219,10 @@ func WriteKubeConfigToSecret(ctx context.Context, virtualConfig *rest.Config, cu
 			}
 
 			syncerConfig.Clusters[key] = &clientcmdapi.Cluster{
-				Server:     options.ExportKubeConfig.Server,
-				Extensions: make(map[string]runtime.Object),
-
-				InsecureSkipTLSVerify: options.ExportKubeConfig.Insecure,
+				Server:                   options.ExportKubeConfig.Server,
+				Extensions:               make(map[string]runtime.Object),
+				CertificateAuthorityData: cluster.CertificateAuthorityData,
+				InsecureSkipTLSVerify:    options.ExportKubeConfig.Insecure,
 			}
 		}
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2226 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vCluster would omit adding the certificate authority data to the `vc-NAME` secret.


**What else do we need to know?** 
