### PR TITLE
wip: conformance debugging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -118,7 +118,7 @@ signs:
     artifacts: checksum
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   use: github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG KINE_VERSION="v0.13.1"
-FROM rancher/kine:${KINE_VERSION} as kine
+FROM rancher/kine:${KINE_VERSION} AS kine
 
 # Build program
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 
 WORKDIR /vcluster-dev
 ARG TARGETOS

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 WORKDIR /vcluster-dev
 ARG TARGETOS

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,8 @@
 ARG KINE_VERSION="v0.13.1"
-FROM rancher/kine:${KINE_VERSION} as kine
+FROM rancher/kine:${KINE_VERSION} AS kine
 
 # Build the manager binary
-FROM alpine:3.20 as builder
+FROM alpine:3.20 AS builder
 
 WORKDIR /vcluster-dev
 

--- a/Justfile
+++ b/Justfile
@@ -161,3 +161,26 @@ gen-license-report:
   go-licenses save --save_path=./licenses --ignore github.com/loft-sh ./...
 
   cp -r ./licenses ./cmd/vclusterctl/cmd/credits
+
+build-dev-image tag="":
+  TELEMETRY_PRIVATE_KEY="" goreleaser build --snapshot --clean
+
+  cp dist/vcluster_linux_$(go env GOARCH | sed s/amd64/amd64_v1/g)/vcluster ./vcluster
+  docker build -t vcluster:dev-{{tag}} -f Dockerfile.release --build-arg TARGETARCH=$(uname -m) --build-arg TARGETOS=linux .
+  rm ./vcluster
+
+run-conformance k8s_version="1.31.1" tag="conf" name="conf":
+  minikube start --kubernetes-version {{ k8s_version }} --nodes=2 -p {{ name }}
+  minikube profile {{ name }}
+  minikube addons enable metrics-server
+  # minikube image load vcluster:dev-{{tag}} -p {{ name }}
+
+  # vcluster create vcluster -n vcluster -f conformance/local/values.yaml --local-chart-dir=./chart
+
+  # sonobuoy run --mode=conformance-lite --level=debug
+
+conformance-status:
+  sonobuoy status
+
+conformance-logs:
+  sonobuoy logs

--- a/conformance/local/README.md
+++ b/conformance/local/README.md
@@ -1,0 +1,102 @@
+### Run Conformance Tests
+
+You will need a cluster with at least 2 nodes.
+The steps below assume that you will use a local minikube cluster.
+We executed the test on a minikube instance with docker driver (default auto-detected by system).
+
+
+### 1. Create a multinode minikube cluster
+
+```
+minikube start --kubernetes-version 1.30.2 --nodes=2
+```
+
+### 2. Create the vcluster
+
+Create a file called `values.yaml` with the following content:
+```yaml
+controlPlane:
+  advanced:
+    virtualScheduler:
+      enabled: true
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+        statefulSet:
+          image:
+            tag: 3.5.13-0
+  distro:
+    k8s:
+      apiServer:
+        extraArgs:
+        - --service-account-jwks-uri=https://kubernetes.default.svc.cluster.local/openid/v1/jwks
+        image:
+          tag: v1.30.2
+      controllerManager:
+        image:
+          tag: v1.30.2
+      enabled: true
+      scheduler:
+        image:
+          tag: v1.30.2
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+networking:
+  advanced:
+    proxyKubelets:
+      byHostname: false
+      byIP: false
+sync:
+  fromHost:
+    csiDrivers:
+      enabled: false
+    csiStorageCapacities:
+      enabled: false
+    nodes:
+      enabled: true
+      selector:
+        all: true
+  toHost:
+    persistentVolumes:
+      enabled: true
+    priorityClasses:
+      enabled: true
+    storageClasses:
+      enabled: true
+```
+
+Create virtual cluster using `vcluster version 0.20.0-beta.15` (latest) using the following command:
+```
+# Create the vcluster
+vcluster create vcluster -n vcluster -f values.yaml --distro k8s
+```
+
+### 3. Run Tests
+
+Download a binary release of the CLI, or build it yourself by running:
+```
+go install github.com/vmware-tanzu/sonobuoy@latest
+```
+
+Deploy a Sonobuoy pod to your cluster with:
+```
+sonobuoy run --mode=certified-conformance
+```
+View actively running pods:
+```
+sonobuoy status
+```
+To inspect the logs:
+```
+sonobuoy logs
+```
+Once sonobuoy status shows the run as completed, copy the output directory from the main Sonobuoy pod to a local directory:
+```
+outfile=$(sonobuoy retrieve)
+```
+This copies a single .tar.gz snapshot from the Sonobuoy pod into your local . directory. Extract the contents into ./results with:
+```
+mkdir ./results; tar xzf $outfile -C ./results
+```

--- a/conformance/local/replicationcontroller.yaml
+++ b/conformance/local/replicationcontroller.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: test-rc
+spec:
+  replicas: 10
+  selector:
+    app: test-pod
+  template:
+    metadata:
+      labels:
+        app: test-pod
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: nginx
+        image: nginx:latest

--- a/conformance/local/values.yaml
+++ b/conformance/local/values.yaml
@@ -1,0 +1,59 @@
+controlPlane:
+  advanced:
+    virtualScheduler:
+      enabled: true
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+        statefulSet:
+          image:
+            tag: 3.5.14-0
+  distro:
+    k8s:
+      apiServer:
+        extraArgs:
+          - --service-account-jwks-uri=https://kubernetes.default.svc.cluster.local/openid/v1/jwks
+        image:
+          tag: v1.31.1
+      controllerManager:
+        image:
+          tag: v1.31.1
+      enabled: true
+      scheduler:
+        image:
+          tag: v1.31.1
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+    image:
+      registry: ""
+      repository: "vcluster"
+      tag: "dev-conf"
+    env:
+      - name: DEBUG
+        value: "true"
+
+networking:
+  advanced:
+    proxyKubelets:
+      byHostname: false
+      byIP: false
+
+sync:
+  fromHost:
+    csiDrivers:
+      enabled: false
+    csiStorageCapacities:
+      enabled: false
+    nodes:
+      enabled: true
+      selector:
+        all: true
+  toHost:
+    persistentVolumes:
+      enabled: true
+    priorityClasses:
+      enabled: true
+    storageClasses:
+      enabled: true

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -18,7 +18,8 @@ images:
     image: ${SYNCER_IMAGE}
     rebuildStrategy: ignoreContextChanges
     target: builder
-    buildKit: {}
+    buildKit:
+      preferMinikube: false
 
 # Deployment used for vcluster
 deployments:
@@ -162,6 +163,10 @@ pipelines:
 
       # Build the vcluster image
       build_images --all
+
+      echo "copying image to minikube"
+      minikube image load $(get_image "vcluster") --overwrite=false
+      echo "done copying image to minikube"
 
       # Deploy the vcluster
       if is_equal $(get_flag distro) k8s; then


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
commands to run:
Set up a minikube cluster

```shell
> just run-conformance
```

Start devspace:
```shell
> devspace dev --var COMMON_VALUES="/dev/null" --var VALUES_FILE="conformance/local/values.yaml" --profile test-k8s
```

Once in devspace, start the vcluster:
```shell
> go run -mod vendor cmd/vcluster/main.go start
```

Once the vcluster is running, connect to it:
```shell
> vcluster connect -n vcluster vcluster --background-proxy=false
```

Once the vcluster port-forwarding is running, run sonobouy tests:
```shell
> sonobuoy run --mode=conformance-lite --level=debug
```

To deploy the replication controller:
```shell
> kubectl apply -f conformance/local/replicationcontroller.yaml
```

To foreground delete the replication controller:
```shell
> kubectl delete replicationcontrollers test-rc --cascade=foreground
```

You might have to issue the delete call multiple times, as it is flaky. At some point you should see some pods stuck in `ContainerCreating`.

To clean up the ones in `ContainerCreating` you can issue:
```shell
> kubectl delete po $(kubectl get po --no-headers | grep 'test-rc' | awk '{print $1}')
```