### PR TITLE
Prevent recreating virtual cluster resource during delete

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -169,9 +169,7 @@ build-dev-image tag="":
   docker build -t vcluster:dev-{{tag}} -f Dockerfile.release --build-arg TARGETARCH=$(uname -m) --build-arg TARGETOS=linux .
   rm ./vcluster
 
-run-conformance k8s_version="1.31.1" mode="conformance-lite" tag="conf": (build-dev-image tag)
-  minikube start --kubernetes-version {{k8s_version}} --nodes=2
-  minikube addons enable metrics-server
+run-conformance k8s_version="1.31.1" mode="conformance-lite" tag="conf": (create-conformance k8s_version) (build-dev-image tag)
   minikube image load vcluster:dev-{{tag}}
 
   vcluster create vcluster -n vcluster -f ./conformance/v1.31/vcluster.yaml
@@ -183,3 +181,15 @@ conformance-status:
 
 conformance-logs:
   sonobuoy logs
+
+dev-conformance *ARGS:
+  devspace dev --profile test-conformance --namespace vcluster {{ARGS}}
+
+create-conformance k8s_version="1.31.1":
+  minikube start --kubernetes-version {{k8s_version}} --nodes=2
+  minikube addons enable metrics-server
+
+delete-conformance:
+  -minikube delete
+
+recreate-conformance: delete-conformance create-conformance

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -7,6 +7,7 @@ vars:
   DEVSPACE_FLAGS: "-n vcluster"
   SYNCER_IMAGE: ghcr.io/loft-sh/loft-enterprise/dev-vcluster
   COMMON_VALUES: ./test/commonValues.yaml
+  CONFORMANCE_VALUES: ./test/conformanceValues.yaml
   PRO_VALUES: ./test/proValues.yaml
   VALUES_FILE: ./test/e2e/values.yaml
   RELEASE_NAME: "vcluster"
@@ -163,6 +164,10 @@ pipelines:
       # Build the vcluster image
       build_images --all
 
+      if $(is_in "test-conformance" "${DEVSPACE_PROFILES}"); then
+        minikube image load $(get_image "vcluster") --overwrite=false || true
+      fi
+
       # Deploy the vcluster
       if is_equal $(get_flag distro) k8s; then
         create_deployments vcluster-k8s
@@ -216,6 +221,17 @@ profiles:
             - ${COMMON_VALUES}
             - ${VALUES_FILE}
             - ${PRO_VALUES}
+  - name: test-conformance
+    patches:
+      - op: replace
+        path: images.vcluster.buildKit
+        value:
+          preferMinikube: false
+      - op: add
+        path: deployments.vcluster-k8s.helm
+        value:
+          valuesFiles:
+            - ${CONFORMANCE_VALUES}
 
 commands:
   # e.g. devspace run test k3s

--- a/pkg/syncer/handler.go
+++ b/pkg/syncer/handler.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
-type enqueueFunc func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request], isDelete bool)
+type enqueueFunc func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request], isDelete, isPendingDelete bool)
 
 func newEventHandler(enqueue enqueueFunc) handler.EventHandler {
 	return &eventHandler{enqueue: enqueue}
@@ -22,21 +22,21 @@ type eventHandler struct {
 
 // Create is called in response to an create event - e.g. Pod Creation.
 func (r *eventHandler) Create(ctx context.Context, evt event.CreateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.Object, q, false)
+	r.enqueue(ctx, evt.Object, q, false, false)
 }
 
 // Update is called in response to an update event -  e.g. Pod Updated.
 func (r *eventHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.ObjectNew, q, false)
+	r.enqueue(ctx, evt.ObjectNew, q, false, !evt.ObjectNew.GetDeletionTimestamp().IsZero())
 }
 
 // Delete is called in response to a delete event - e.g. Pod Deleted.
 func (r *eventHandler) Delete(ctx context.Context, evt event.DeleteEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.Object, q, true)
+	r.enqueue(ctx, evt.Object, q, true, false)
 }
 
 // Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
 // external trigger request - e.g. reconcile Autoscaling, or a Webhook.
 func (r *eventHandler) Generic(ctx context.Context, evt event.GenericEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.Object, q, false)
+	r.enqueue(ctx, evt.Object, q, false, !evt.Object.GetDeletionTimestamp().IsZero())
 }

--- a/pkg/syncer/synccontext/events.go
+++ b/pkg/syncer/synccontext/events.go
@@ -5,8 +5,9 @@ import "sigs.k8s.io/controller-runtime/pkg/client"
 type SyncEventType string
 
 const (
-	SyncEventTypeUnknown SyncEventType = ""
-	SyncEventTypeDelete  SyncEventType = "Delete"
+	SyncEventTypeUnknown       SyncEventType = ""
+	SyncEventTypeDelete        SyncEventType = "Delete"
+	SyncEventTypePendingDelete SyncEventType = "PendingDelete"
 )
 
 type SyncEventSource string

--- a/test/conformanceValues.yaml
+++ b/test/conformanceValues.yaml
@@ -1,0 +1,59 @@
+controlPlane:
+  advanced:
+    virtualScheduler:
+      enabled: true
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+        statefulSet:
+          image:
+            tag: 3.5.14-0
+  distro:
+    k8s:
+      apiServer:
+        extraArgs:
+          - --service-account-jwks-uri=https://kubernetes.default.svc.cluster.local/openid/v1/jwks
+        image:
+          tag: v1.31.1
+      controllerManager:
+        image:
+          tag: v1.31.1
+      enabled: true
+      scheduler:
+        image:
+          tag: v1.31.1
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+    image:
+      registry: ""
+      repository: ghcr.io/loft-sh/loft-enterprise/vcluster
+      tag: ""
+    env:
+      - name: DEBUG
+        value: "true"
+
+networking:
+  advanced:
+    proxyKubelets:
+      byHostname: false
+      byIP: false
+
+sync:
+  fromHost:
+    csiDrivers:
+      enabled: false
+    csiStorageCapacities:
+      enabled: false
+    nodes:
+      enabled: true
+      selector:
+        all: true
+  toHost:
+    persistentVolumes:
+      enabled: true
+    priorityClasses:
+      enabled: true
+    storageClasses:
+      enabled: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4924


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the vcluster syncer would mistakenly re-create a resource when reconciling the update event that adds the `deletionTimestamp`


**What else do we need to know?** 

## Scenario
The syncer incorrectly re-creates a resource while it's being deleted. The sequence of events observed:
- A replicationcontroller with a `terminationGracePeriod` == 0 is deleted and its pods are garbage collected
- An update event that sets the deletionTimestamp is queued
- An delete event for the same resource is queued
- Syncer reconciles the update event but is unable to load the resource because it's already deleted. This triggers a call to `SyncToVirtual()`, which mistakenly re-creates the resource.

This scenario occurs more frequently with pods, but the solution has been made generic in case it occurs with different resource kinds.

## Solution
Add a `PendingDelete` event type to communicate that an update event occurred to a virtual resource being deleted. If the `SyncToVirtual` flow is reached by an event where the source == `Virtual` and the type == `PendingDelete`, then skip calling SyncToVirtual.