### PR TITLE
reduce concurrent reconciles of the same virtual resource

### DIFF
--- a/pkg/syncer/handler.go
+++ b/pkg/syncer/handler.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -10,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
-type enqueueFunc func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request], isDelete, isPendingDelete bool)
+type enqueueFunc func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request], eventType synccontext.SyncEventType)
 
 func newEventHandler(enqueue enqueueFunc) handler.EventHandler {
 	return &eventHandler{enqueue: enqueue}
@@ -22,21 +23,21 @@ type eventHandler struct {
 
 // Create is called in response to an create event - e.g. Pod Creation.
 func (r *eventHandler) Create(ctx context.Context, evt event.CreateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.Object, q, false, false)
+	r.enqueue(ctx, evt.Object, q, synccontext.SyncEventTypeCreate)
 }
 
 // Update is called in response to an update event -  e.g. Pod Updated.
 func (r *eventHandler) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.ObjectNew, q, false, !evt.ObjectNew.GetDeletionTimestamp().IsZero())
+	r.enqueue(ctx, evt.ObjectNew, q, synccontext.SyncEventTypeUpdate)
 }
 
 // Delete is called in response to a delete event - e.g. Pod Deleted.
 func (r *eventHandler) Delete(ctx context.Context, evt event.DeleteEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.Object, q, true, false)
+	r.enqueue(ctx, evt.Object, q, synccontext.SyncEventTypeDelete)
 }
 
 // Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
 // external trigger request - e.g. reconcile Autoscaling, or a Webhook.
 func (r *eventHandler) Generic(ctx context.Context, evt event.GenericEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	r.enqueue(ctx, evt.Object, q, false, !evt.Object.GetDeletionTimestamp().IsZero())
+	r.enqueue(ctx, evt.Object, q, synccontext.SyncEventTypeUnknown)
 }

--- a/pkg/syncer/synccontext/events.go
+++ b/pkg/syncer/synccontext/events.go
@@ -6,6 +6,8 @@ type SyncEventType string
 
 const (
 	SyncEventTypeUnknown       SyncEventType = ""
+	SyncEventTypeCreate        SyncEventType = "Create"
+	SyncEventTypeUpdate        SyncEventType = "Update"
 	SyncEventTypeDelete        SyncEventType = "Delete"
 	SyncEventTypePendingDelete SyncEventType = "PendingDelete"
 )

--- a/pkg/util/loghelper/loghelper.go
+++ b/pkg/util/loghelper/loghelper.go
@@ -1,9 +1,11 @@
 package loghelper
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -24,6 +26,19 @@ func New(name string) Logger {
 		ctrl.Log.WithName(name).WithCallDepth(1),
 	}
 }
+
+func NewFromContext(ctx context.Context) Logger {
+	if ctxLogger, err := logr.FromContext(ctx); err == nil {
+		return &logger{
+			ctxLogger,
+		}
+	}
+
+	return &logger{
+		klog.Background(),
+	}
+}
+
 func NewFromExisting(log logr.Logger, name string) Logger {
 	return &logger{
 		log.WithName(name).WithCallDepth(1),

--- a/test/conformanceValues.yaml
+++ b/test/conformanceValues.yaml
@@ -6,23 +6,11 @@ controlPlane:
     etcd:
       deploy:
         enabled: true
-        statefulSet:
-          image:
-            tag: 3.5.14-0
   distro:
     k8s:
       apiServer:
         extraArgs:
           - --service-account-jwks-uri=https://kubernetes.default.svc.cluster.local/openid/v1/jwks
-        image:
-          tag: v1.31.1
-      controllerManager:
-        image:
-          tag: v1.31.1
-      enabled: true
-      scheduler:
-        image:
-          tag: v1.31.1
   statefulSet:
     scheduling:
       podManagementPolicy: OrderedReady


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4924


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster incorrectly re-created pods during garbage collection


**What else do we need to know?** 
The previous method of passing through the `syncEventType` would potentially enqueue the same object 4 different ways:
- virtual object: `ns/obj`
- delete virtual object: `delete#ns/obj`
- physical object: `host#ns/obj`
- delete physical object: `delete#host#ns/obj`

Usually this would not be a concern, but the following scenario occurs frequently enough to cause a conformance test to fail:
1. virtual object is deleted
1. a update event for the virtual object is received that adds the `deletionTimestamp`
1. a delete event for the virtual object is received
1. these events would enqueue the object as objects with the same name in different namespaces from the controller runtime's perspective
1. the two objects are reconciled concurrently by the controller-runtime
1. while the `Reconcile` function is processing the virtual object update the virtual object is deleted, this leads to the `SyncToVirtual` implementation incorrectly re-creating the virtual object

This PR attempts to solve this by:
- Reducing the amount of concurrent reconciles for the same virtual object by dropping the `delete#` prefix
- Using a different method of passing the `syncEventType` through to `Reconcile` (and the various sync event types). Event types are recorded by virtual object UID, only the last event is saved, and a delete event for a UID cannot be overwritten.
