### PR TITLE
[0.20] fix(helm): Do not download helm if not needed

### DIFF
--- a/pkg/controllers/deploy/start.go
+++ b/pkg/controllers/deploy/start.go
@@ -23,9 +23,12 @@ func RegisterInitManifestsController(controllerCtx *config.ControllerContext) er
 		return err
 	}
 
-	helmBinaryPath, err := helmdownloader.GetHelmBinaryPath(controllerCtx.Context, log.GetInstance())
-	if err != nil {
-		return err
+	var helmBinaryPath string
+	if controllerCtx != nil && controllerCtx.Config != nil && len(controllerCtx.Config.Experimental.Deploy.VCluster.Helm) > 0 {
+		helmBinaryPath, err = helmdownloader.GetHelmBinaryPath(controllerCtx.Context, log.GetInstance())
+		if err != nil {
+			return err
+		}
 	}
 
 	controller := &Deployer{


### PR DESCRIPTION
Backports: https://github.com/loft-sh/vcluster/pull/2254
Conflict forced a manual backport