### PR TITLE
Exclude rancher managed annotation from ingress sync

### DIFF
--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -23,7 +23,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ServiceBlockDeletion = "vcluster.loft.sh/block-deletion"
+var (
+	ServiceBlockDeletion             = "vcluster.loft.sh/block-deletion"
+	RancherPublicEndpointsAnnotation = "field.cattle.io/publicEndpoints"
+)
 
 func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	mapper, err := ctx.Mappings.ByGVK(mappings.Services())
@@ -39,7 +42,7 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		Importer:          pro.NewImporter(mapper),
 
 		excludedAnnotations: []string{
-			"field.cattle.io/publicEndpoints",
+			RancherPublicEndpointsAnnotation,
 		},
 
 		serviceName: ctx.Config.WorkloadService,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4976


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now ignore updates to Rancher managed annotations when syncing ingress to & from the virtual cluster.


**What else do we need to know?** 
