### PR TITLE
feat(cli): implement platform destroy command

### DIFF
--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -1,0 +1,105 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/destroy"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/start"
+	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
+	"github.com/spf13/cobra"
+)
+
+type DestroyCmd struct {
+	destroy.DeleteOptions
+}
+
+func NewDestroyCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &DestroyCmd{
+		DeleteOptions: destroy.DeleteOptions{
+			Options: start.Options{
+				GlobalFlags: globalFlags,
+				Log:         log.GetInstance(),
+				CommandName: "destroy",
+			},
+		},
+	}
+
+	destroyCmd := &cobra.Command{
+		Use:   "destroy",
+		Short: "Destroy a vCluster platform instance",
+		Long: `########################################################
+############# vcluster platform destroy ##################
+########################################################
+
+Destroys a vCluster platform instance in your Kubernetes cluster.
+
+Please make sure you meet the following requirements
+before running this command:
+
+1. Current kube-context has admin access to the cluster
+2. Helm v3 must be installed
+
+
+VirtualClusterInstances managed with driver helm will be deleted, but the underlying virtual cluster will not be uninstalled
+
+########################################################
+	`,
+		Args: cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return cmd.Run(cobraCmd.Context())
+		},
+	}
+
+	destroyCmd.Flags().StringVar(&cmd.Context, "context", "", "The kube context to use for installation")
+	destroyCmd.Flags().StringVar(&cmd.Namespace, "namespace", "", "The namespace vCluster platform is installed in")
+	destroyCmd.Flags().BoolVar(&cmd.DeleteNamespace, "delete-namespace", true, "Whether to delete the namespace or not")
+	destroyCmd.Flags().BoolVar(&cmd.IgnoreNotFound, "ignore-not-found", false, "Exit successfully if platform installation is not found")
+	destroyCmd.Flags().BoolVar(&cmd.Force, "force", false, "Try uninstalling even if the platform is not installed. '--namespace' is required if true")
+	destroyCmd.Flags().IntVar(&cmd.TimeoutMinutes, "timeout-minutes", 5, "How long to try deleting the platform before giving up")
+
+	return destroyCmd
+}
+
+func (cmd *DestroyCmd) Run(ctx context.Context) error {
+	// initialise clients, verify binaries exist, sanity-check context
+	err := cmd.Options.Prepare()
+	if err != nil {
+		return fmt.Errorf("failed to prepare clients: %w", err)
+	}
+
+	if cmd.Namespace == "" {
+		namespace, err := clihelper.VClusterPlatformInstallationNamespace(ctx)
+		if err != nil {
+			if cmd.IgnoreNotFound && errors.Is(err, clihelper.ErrPlatformNamespaceNotFound) {
+				cmd.Log.Info("no platform installation found")
+				return nil
+			}
+			return fmt.Errorf("vCluster platform may not be installed: %w", err)
+		}
+		cmd.Log.Infof("found platform installation in namespace %q", namespace)
+		cmd.Namespace = namespace
+	}
+
+	found, err := clihelper.IsLoftAlreadyInstalled(ctx, cmd.KubeClient, cmd.Namespace)
+	if err != nil {
+		return fmt.Errorf("vCluster platform may not be installed: %w", err)
+	}
+	shouldForce := cmd.Force && cmd.Namespace != ""
+	if !found && !shouldForce {
+		if cmd.IgnoreNotFound {
+			cmd.Log.Info("no platform installation found")
+			return nil
+		}
+		return fmt.Errorf("platform not installed in namespace %q", cmd.Namespace)
+	}
+
+	err = destroy.Destroy(ctx, cmd.DeleteOptions)
+	if err != nil {
+		return fmt.Errorf("failed to destroy platform: %w", err)
+	}
+	return nil
+}

--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -30,12 +30,12 @@ func NewDestroyCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 	destroyCmd := &cobra.Command{
 		Use:   "destroy",
-		Short: "Destroy a vCluster platform instance",
+		Short: "Destroy a vCluster Platform instance",
 		Long: `########################################################
 ############# vcluster platform destroy ##################
 ########################################################
 
-Destroys a vCluster platform instance in your Kubernetes cluster.
+Destroys a vCluster Platform instance in your Kubernetes cluster.
 
 Please make sure you meet the following requirements
 before running this command:
@@ -55,7 +55,7 @@ VirtualClusterInstances managed with driver helm will be deleted, but the underl
 	}
 
 	destroyCmd.Flags().StringVar(&cmd.Context, "context", "", "The kube context to use for installation")
-	destroyCmd.Flags().StringVar(&cmd.Namespace, "namespace", "", "The namespace vCluster platform is installed in")
+	destroyCmd.Flags().StringVar(&cmd.Namespace, "namespace", "", "The namespace vCluster Platform is installed in")
 	destroyCmd.Flags().BoolVar(&cmd.DeleteNamespace, "delete-namespace", true, "Whether to delete the namespace or not")
 	destroyCmd.Flags().BoolVar(&cmd.IgnoreNotFound, "ignore-not-found", false, "Exit successfully if platform installation is not found")
 	destroyCmd.Flags().BoolVar(&cmd.Force, "force", false, "Try uninstalling even if the platform is not installed. '--namespace' is required if true")
@@ -78,7 +78,7 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 				cmd.Log.Info("no platform installation found")
 				return nil
 			}
-			return fmt.Errorf("vCluster platform may not be installed: %w", err)
+			return fmt.Errorf("vCluster Platform may not be installed: %w", err)
 		}
 		cmd.Log.Infof("found platform installation in namespace %q", namespace)
 		cmd.Namespace = namespace
@@ -86,7 +86,7 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 
 	found, err := clihelper.IsLoftAlreadyInstalled(ctx, cmd.KubeClient, cmd.Namespace)
 	if err != nil {
-		return fmt.Errorf("vCluster platform may not be installed: %w", err)
+		return fmt.Errorf("vCluster Platform may not be installed: %w", err)
 	}
 	shouldForce := cmd.Force && cmd.Namespace != ""
 	if !found && !shouldForce {

--- a/cmd/vclusterctl/cmd/platform/logout.go
+++ b/cmd/vclusterctl/cmd/platform/logout.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/loft-sh/api/v4/pkg/product"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/use"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
@@ -76,7 +75,7 @@ func (cmd *LogoutCmd) Run(ctx context.Context) error {
 			return fmt.Errorf("save config: %w", err)
 		}
 
-		cmd.Log.Donef(product.Replace("Successfully logged out of vcluster platform instance %s"), ansi.Color(configHost, "white+b"))
+		cmd.Log.Donef("Successfully logged out of vCluster Palatform instance %s", ansi.Color(configHost, "white+b"))
 	}
 
 	return use.SwitchDriver(ctx, cfg, string(config.HelmDriver), cmd.Log)

--- a/cmd/vclusterctl/cmd/platform/logout.go
+++ b/cmd/vclusterctl/cmd/platform/logout.go
@@ -76,7 +76,7 @@ func (cmd *LogoutCmd) Run(ctx context.Context) error {
 			return fmt.Errorf("save config: %w", err)
 		}
 
-		cmd.Log.Donef(product.Replace("Successfully logged out of loft instance %s"), ansi.Color(configHost, "white+b"))
+		cmd.Log.Donef(product.Replace("Successfully logged out of vcluster platform instance %s"), ansi.Color(configHost, "white+b"))
 	}
 
 	return use.SwitchDriver(ctx, cfg, string(config.HelmDriver), cmd.Log)

--- a/cmd/vclusterctl/cmd/platform/platform.go
+++ b/cmd/vclusterctl/cmd/platform/platform.go
@@ -57,10 +57,12 @@ func NewPlatformCmd(globalFlags *flags.GlobalFlags) (*cobra.Command, error) {
 	}
 
 	startCmd := NewStartCmd(globalFlags)
+	destroyCmd := NewDestroyCmd(globalFlags)
 	loginCmd := NewCobraLoginCmd(globalFlags)
 	logoutCmd := NewLogoutCobraCmd(globalFlags)
 
 	platformCmd.AddCommand(startCmd)
+	platformCmd.AddCommand(destroyCmd)
 	platformCmd.AddCommand(NewResetCmd(globalFlags))
 	platformCmd.AddCommand(add.NewAddCmd(globalFlags))
 	platformCmd.AddCommand(NewAccessKeyCmd(globalFlags))

--- a/cmd/vclusterctl/cmd/platform/start.go
+++ b/cmd/vclusterctl/cmd/platform/start.go
@@ -21,19 +21,23 @@ import (
 )
 
 type StartCmd struct {
-	start.Options
+	start.StartOptions
 }
 
 func NewStartCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	name := "start"
 	cmd := &StartCmd{
-		Options: start.Options{
-			GlobalFlags: globalFlags,
-			Log:         log.GetInstance(),
+		StartOptions: start.StartOptions{
+			Options: start.Options{
+				CommandName: name,
+				GlobalFlags: globalFlags,
+				Log:         log.GetInstance(),
+			},
 		},
 	}
 
 	startCmd := &cobra.Command{
-		Use:   "start",
+		Use:   name,
 		Short: "Start a vCluster platform instance and connect via port-forwarding",
 		Long: `########################################################
 ############# vcluster platform start ##################
@@ -146,7 +150,7 @@ func (cmd *StartCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	return start.NewLoftStarter(cmd.Options).Start(ctx)
+	return start.NewLoftStarter(cmd.StartOptions).Start(ctx)
 }
 
 func (cmd *StartCmd) ensureEmailWithDisclaimer() error {

--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -1,0 +1,276 @@
+package destroy
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/start"
+	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+)
+
+// define the order of resource deletion
+var resourceOrder = []string{
+	// instances
+	"virtualclusterinstances",
+	"virtualclusters",
+	"devpodworkspaceinstances",
+	"spaceinstances",
+
+	// templates
+	"virtualclustertemplates",
+	"devpodenvironmenttemplates",
+	"devpodworkspacetemplates",
+	"clusterroletemplates",
+	"spacetemplates",
+	"apps",
+	"spaceconstraints",
+
+	// infra
+	"tasks",
+	"clusterquotas",
+	"projects",
+	"runners",
+	"clusters",
+	"clusteraccesses",
+	"networkpeers",
+
+	// access
+	"teams",
+	"users",
+	"sharedsecrets",
+	"accesskeys",
+	"localclusteraccesses",
+	"localteams",
+	"localusers",
+}
+
+// things listed here should also be included in resourceOrder
+var legacyResources = []string{
+	"virtualclusters",
+	"spaceconstraints",
+	"localclusteraccesses",
+	"localteams",
+	"localusers",
+}
+
+// DeleteOptions holds cli options for the delete command
+type DeleteOptions struct {
+	start.Options
+	// cli options
+	DeleteNamespace bool
+	IgnoreNotFound  bool
+	Force           bool
+	TimeoutMinutes  int
+}
+
+var backoffFactor = 1.2
+
+func Destroy(ctx context.Context, opts DeleteOptions) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(opts.TimeoutMinutes)*time.Minute)
+	defer cancel()
+
+	// create time.Duration(opts.TimeoutMinutes) * time.Minutea dynamic client
+	dynamicClient, err := dynamic.NewForConfig(opts.RestConfig)
+	if err != nil {
+		return err
+	}
+
+	// create a discovery client
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(opts.RestConfig)
+	if err != nil {
+		return err
+	}
+
+	apiextensionclientset, err := apiextensionsv1clientset.NewForConfig(opts.RestConfig)
+	if err != nil {
+		return err
+	}
+
+	// to compare resources advertised by server vs ones explicitly handled by us
+	clusterResourceSet := sets.New[string]()
+	handledResourceSet := sets.New(resourceOrder...)
+	legacyHandledResourceSet := sets.New(legacyResources...)
+
+	// get all custom resource definitions in storage.loft.sh
+	resourceList, err := discoveryClient.ServerResourcesForGroupVersion("storage.loft.sh/v1")
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to discover resources in storage.loft.sh/v1 group: %w", err)
+	}
+
+	// resource list may be nil if all resources in the group are already deleted
+	if resourceList == nil {
+		resourceList = &metav1.APIResourceList{APIResources: []metav1.APIResource{}}
+	}
+	// populate the set
+	for _, resource := range resourceList.APIResources {
+		// don't insert subresources
+		if strings.Contains(resource.Name, "/") {
+			continue
+		}
+		clusterResourceSet.Insert(resource.Name)
+	}
+
+	unhandledResourceSet := clusterResourceSet.Difference(handledResourceSet)
+	if unhandledResourceSet.Len() != 0 {
+		opts.Log.Errorf("some storage.loft.sh resources are unhandled: %v. Try a newer cli version", unhandledResourceSet.UnsortedList())
+		return err
+	}
+
+	for _, resourceName := range resourceOrder {
+		if !clusterResourceSet.Has(resourceName) {
+			// only debug output if legacy resource
+			if legacyHandledResourceSet.Has(resourceName) {
+				opts.Log.Debugf("legacy resource %q not found in discovery, skipping", resourceName)
+			} else {
+				opts.Log.Infof("resource %q not found in discovery, skipping", resourceName)
+			}
+			continue
+		}
+		// list and delete all resources
+		err = deleteAllResourcesAndWait(ctx, dynamicClient, opts.Log, opts.TimeoutMinutes, "storage.loft.sh", "v1", resourceName)
+		if err != nil {
+			return fmt.Errorf("failed to delete resource %q: %w", resourceName, err)
+		}
+	}
+
+	// helm uninstall and others
+	err = clihelper.UninstallLoft(ctx, opts.KubeClient, opts.RestConfig, opts.Context, opts.Namespace, opts.Log)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range clihelper.DefaultClusterRoles {
+		name := name + "-binding"
+		opts.Log.Infof("deleting clusterrolebinding %q", name)
+		err := opts.KubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, name+"-binding", metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete clusterrole: %w", err)
+		}
+	}
+	for _, name := range clihelper.DefaultClusterRoles {
+		opts.Log.Infof("deleting clusterrole %q", name)
+		err := opts.KubeClient.RbacV1().ClusterRoles().Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete clusterrole: %w", err)
+		}
+	}
+
+	opts.Log.Info("deleting CRDS")
+	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: backoffFactor, Cap: time.Duration(opts.TimeoutMinutes) * time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
+		list, err := apiextensionclientset.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		crdList := []apiextensionsv1.CustomResourceDefinition{}
+
+		for _, object := range list.Items {
+			if strings.HasSuffix(object.Name, ".storage.loft.sh") {
+				crdList = append(crdList, object)
+			}
+		}
+		if len(crdList) == 0 {
+			return true, nil
+		}
+		for _, object := range crdList {
+			crdSuffix := ".storage.loft.sh"
+			if !strings.HasSuffix(object.Name, crdSuffix) {
+				continue
+			}
+			opts.Log.Debugf("checking CRD %q", object.Name)
+			expectedResourceName := strings.TrimSuffix(object.Name, crdSuffix)
+			if !handledResourceSet.Has(expectedResourceName) {
+				opts.Log.Errorf("unhandled CRD: %q", object.Name)
+				continue
+			}
+			// retry later if object already deleted
+			if !object.GetDeletionTimestamp().IsZero() {
+				opts.Log.Infof("deleted CRD still found: %q", object.GetName())
+				continue
+			}
+			opts.Log.Infof("deleting customresourcedefinition %v", object.GetName())
+			err := apiextensionclientset.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, object.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return false, err
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete CRDs: %w", err)
+	}
+
+	if opts.DeleteNamespace {
+		opts.Log.Infof("deleting namespace %q", opts.Namespace)
+		err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: backoffFactor, Cap: time.Duration(opts.TimeoutMinutes) * time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
+			ns, err := opts.KubeClient.CoreV1().Namespaces().Get(ctx, opts.Namespace, metav1.GetOptions{})
+			if kerrors.IsNotFound(err) {
+				return true, nil
+			} else if err != nil {
+				return false, err
+			}
+
+			if ns.GetDeletionTimestamp().IsZero() {
+				err = opts.KubeClient.CoreV1().Namespaces().Delete(ctx, opts.Namespace, metav1.DeleteOptions{})
+				if err != nil {
+					return false, err
+				}
+			}
+			return false, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteAllResourcesAndWait(ctx context.Context, dynamicClient dynamic.Interface, log log.Logger, timeoutMinutes int, group, version, resource string) error {
+	gvr := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: backoffFactor, Cap: time.Duration(timeoutMinutes) * time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
+		log.Debugf("checking all %q", resource)
+
+		resourceClient := dynamicClient.Resource(gvr)
+		list, err := resourceClient.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(list.Items) == 0 {
+			return true, nil
+		}
+		for _, object := range list.Items {
+			if !object.GetDeletionTimestamp().IsZero() {
+				return false, nil
+			}
+			if object.GetNamespace() == "" {
+				log.Infof("deleting %v: %v", resource, object.GetName())
+			} else {
+				log.Infof("deleting %v: %v/%v", resource, object.GetNamespace(), object.GetName())
+			}
+			err := resourceClient.Namespace(object.GetNamespace()).Delete(ctx, object.GetName(), metav1.DeleteOptions{})
+			if err != nil && !kerrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cli/start/docker.go
+++ b/pkg/cli/start/docker.go
@@ -215,7 +215,7 @@ func (l *LoftStarter) prepareDocker() error {
 	// test for helm and kubectl
 	_, err := exec.LookPath("docker")
 	if err != nil {
-		return fmt.Errorf("seems like docker is not installed. Docker is required for the installation of loft. Please visit https://docs.docker.com/engine/install/ for install instructions")
+		return fmt.Errorf("seems like docker is not installed. Docker is required for the installation of vCluster Platform. Please visit https://docs.docker.com/engine/install/ for install instructions")
 	}
 
 	output, err := exec.Command("docker", "ps").CombinedOutput()

--- a/pkg/cli/start/start.go
+++ b/pkg/cli/start/start.go
@@ -161,7 +161,7 @@ func (l *Options) Prepare() error {
 		contextToLoad = l.Context
 	} else if platformConfig.LastInstallContext != "" && platformConfig.LastInstallContext != contextToLoad {
 		contextToLoad, err = l.Log.Question(&survey.QuestionOptions{
-			Question:     product.Replace(fmt.Sprintf("Seems like you try to use 'loft %s' with a different kubernetes context than before. Please choose which kubernetes context you want to use", l.CommandName)),
+			Question:     product.Replace(fmt.Sprintf("Seems like you try to use 'vcluster %s' with a different kubernetes context than before. Please choose which kubernetes context you want to use", l.CommandName)),
 			DefaultValue: contextToLoad,
 			Options:      []string{contextToLoad, platformConfig.LastInstallContext},
 		})
@@ -182,7 +182,7 @@ func (l *Options) Prepare() error {
 	// test for helm and kubectl
 	_, err = exec.LookPath("helm")
 	if err != nil {
-		return fmt.Errorf("seems like helm is not installed. Helm is required for the installation of loft. Please visit https://helm.sh/docs/intro/install/ for install instructions")
+		return fmt.Errorf("seems like helm is not installed. Helm is required for the installation of vCluster Platform. Please visit https://helm.sh/docs/intro/install/ for install instructions")
 	}
 
 	output, err := exec.Command("helm", "version").CombinedOutput()
@@ -192,7 +192,7 @@ func (l *Options) Prepare() error {
 
 	_, err = exec.LookPath("kubectl")
 	if err != nil {
-		return fmt.Errorf("seems like kubectl is not installed. Kubectl is required for the installation of loft. Please visit https://kubernetes.io/docs/tasks/tools/install-kubectl/ for install instructions")
+		return fmt.Errorf("seems like kubectl is not installed. Kubectl is required for the installation of vCluster Platform. Please visit https://kubernetes.io/docs/tasks/tools/install-kubectl/ for install instructions")
 	}
 
 	output, err = exec.Command("kubectl", "version", "--context", contextToLoad).CombinedOutput()

--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -65,6 +65,12 @@ const timeoutEnvVariable = "LOFT_TIMEOUT"
 
 var defaultDeploymentName = "loft"
 
+var DefaultClusterRoles = []string{
+	"loft-agent-cluster",
+	"loft-runnner-cluster",
+	"loft-vcluster-cluster",
+}
+
 func Timeout() time.Duration {
 	if timeout := os.Getenv(timeoutEnvVariable); timeout != "" {
 		if parsedTimeout, err := time.ParseDuration(timeout); err == nil {
@@ -444,7 +450,14 @@ func IsLoftAlreadyInstalled(ctx context.Context, kubeClient kubernetes.Interface
 		}
 	}
 
-	_, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, defaultDeploymentName, metav1.GetOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to get namespace %q", namespace)
+	}
+
+	_, err = kubeClient.AppsV1().Deployments(namespace).Get(ctx, defaultDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return false, nil
@@ -455,6 +468,8 @@ func IsLoftAlreadyInstalled(ctx context.Context, kubeClient kubernetes.Interface
 
 	return true, nil
 }
+
+var ErrPlatformNamespaceNotFound = errors.New("loft installation namespace not found")
 
 func VClusterPlatformInstallationNamespace(ctx context.Context) (string, error) {
 	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
@@ -486,7 +501,7 @@ func VClusterPlatformInstallationNamespace(ctx context.Context) (string, error) 
 		}
 	}
 
-	return "", fmt.Errorf("failed to find the namespace loft is installed in")
+	return "", ErrPlatformNamespaceNotFound
 }
 
 func UninstallLoft(ctx context.Context, kubeClient kubernetes.Interface, restConfig *rest.Config, kubeContext, namespace string, log log.Logger) error {

--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -469,7 +469,7 @@ func IsLoftAlreadyInstalled(ctx context.Context, kubeClient kubernetes.Interface
 	return true, nil
 }
 
-var ErrPlatformNamespaceNotFound = errors.New("loft installation namespace not found")
+var ErrPlatformNamespaceNotFound = errors.New("vCluster Platform installation namespace not found")
 
 func VClusterPlatformInstallationNamespace(ctx context.Context) (string, error) {
 	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-3980


**Please provide a short message that should be published in the vcluster release notes**
Add a new cli command: vcluster platform destroy


**What else do we need to know?** 

The command will wait for each resource type to finish cleaning up before proceeding to the next, so that resource types that depend on each other will not prevent cleanup. (Remove a cluster object before a virtualclusterinstance running on it, etc)


`vcluster platform destroy` (no args) on v4.0.0:

```
16:28:54 info found platform installation in namespace "vcluster-platform"
16:28:54 debug checking all "virtualclusterinstances"
16:28:54 info deleting virtualclusterinstances p-default/v1
16:28:56 debug checking all "virtualclusterinstances"
16:28:58 debug checking all "virtualclusterinstances"
16:29:00 debug checking all "virtualclusterinstances"
16:29:02 debug checking all "virtualclusterinstances"
16:29:04 debug checking all "virtualclusterinstances"
16:29:06 debug checking all "virtualclusterinstances"
16:29:08 debug checking all "virtualclusterinstances"
16:29:10 debug checking all "virtualclusterinstances"
16:29:12 debug checking all "virtualclusterinstances"
16:29:14 debug checking all "virtualclusterinstances"
16:29:14 debug legacy resource "virtualclusters" not found in discovery, skipping
16:29:14 debug checking all "devpodworkspaceinstances"
16:29:14 debug checking all "spaceinstances"
16:29:14 debug checking all "virtualclustertemplates"
16:29:14 info deleting virtualclustertemplates vcluster-pro-isolated-template
16:29:14 info deleting virtualclustertemplates vcluster-pro-template
16:29:16 debug checking all "virtualclustertemplates"
16:29:16 debug checking all "devpodenvironmenttemplates"
16:29:16 debug checking all "devpodworkspacetemplates"
16:29:16 info deleting devpodworkspacetemplates aws
16:29:16 info deleting devpodworkspacetemplates azure
16:29:16 info deleting devpodworkspacetemplates digitalocean
16:29:17 info deleting devpodworkspacetemplates ecs
16:29:17 info deleting devpodworkspacetemplates gcloud
16:29:17 info deleting devpodworkspacetemplates kubernetes
16:29:18 debug checking all "devpodworkspacetemplates"
16:29:18 debug checking all "clusterroletemplates"
16:29:18 info deleting clusterroletemplates loft-apps-admin
16:29:18 info deleting clusterroletemplates loft-apps-creator
16:29:19 info deleting clusterroletemplates loft-apps-viewer
16:29:19 info deleting clusterroletemplates loft-cluster-admin
16:29:19 info deleting clusterroletemplates loft-cluster-authenticated
16:29:19 info deleting clusterroletemplates loft-cluster-extra-space-admin-rules
16:29:19 info deleting clusterroletemplates loft-cluster-extra-space-viewer-rules
16:29:19 info deleting clusterroletemplates loft-cluster-space-admin
16:29:19 info deleting clusterroletemplates loft-cluster-space-viewer
16:29:19 info deleting clusterroletemplates loft-clusters-admin
16:29:19 info deleting clusterroletemplates loft-clusters-creator
16:29:19 info deleting clusterroletemplates loft-impersonator
16:29:19 info deleting clusterroletemplates loft-management-activity-viewer
16:29:19 info deleting clusterroletemplates loft-management-admin
16:29:20 info deleting clusterroletemplates loft-management-authenticated
16:29:20 info deleting clusterroletemplates loft-management-project-admin
16:29:20 info deleting clusterroletemplates loft-management-project-user
16:29:20 info deleting clusterroletemplates loft-management-project-viewer
16:29:20 info deleting clusterroletemplates loft-secrets-admin
16:29:21 info deleting clusterroletemplates loft-secrets-creator
16:29:21 info deleting clusterroletemplates loft-secrets-viewer
16:29:21 info deleting clusterroletemplates loft-teams-admin
16:29:21 info deleting clusterroletemplates loft-teams-creator
16:29:21 info deleting clusterroletemplates loft-teams-viewer
16:29:22 info deleting clusterroletemplates loft-templates-admin
16:29:22 info deleting clusterroletemplates loft-templates-creator
16:29:22 info deleting clusterroletemplates loft-templates-viewer
16:29:22 info deleting clusterroletemplates loft-users-admin
16:29:22 info deleting clusterroletemplates loft-users-creator
16:29:23 info deleting clusterroletemplates loft-users-viewer
16:29:23 debug checking all "clusterroletemplates"
16:29:23 debug checking all "spacetemplates"
16:29:23 info deleting spacetemplates isolated-space
16:29:25 debug checking all "spacetemplates"
16:29:25 debug checking all "apps"
16:29:25 info deleting apps argocd
16:29:25 info deleting apps central-hostpath-mapper
16:29:25 info deleting apps cert-manager
16:29:25 info deleting apps example-bash
16:29:25 info deleting apps example-helm
16:29:25 info deleting apps example-manifests
16:29:25 info deleting apps ingress-nginx
16:29:25 info deleting apps jspolicy
16:29:25 info deleting apps kube-prometheus-stack
16:29:26 info deleting apps opentelemetry-collector
16:29:27 debug checking all "apps"
16:29:27 debug legacy resource "spaceconstraints" not found in discovery, skipping
16:29:27 debug checking all "tasks"
16:29:27 debug checking all "clusterquotas"
16:29:27 debug checking all "projects"
16:29:27 info deleting projects default
16:29:29 debug checking all "projects"
16:29:31 debug checking all "projects"
16:29:33 debug checking all "projects"
16:29:33 debug checking all "runners"
16:29:33 info deleting runners local
16:29:35 debug checking all "runners"
16:29:35 debug checking all "clusters"
16:29:35 info deleting clusters loft-cluster
16:29:37 debug checking all "clusters"
16:29:37 debug checking all "clusteraccesses"
16:29:37 info deleting clusteraccesses loft-admins
16:29:39 debug checking all "clusteraccesses"
16:29:39 debug checking all "networkpeers"
16:29:39 info deleting networkpeers loft-7c7685654c-9sg5x.control-plane
16:29:41 debug checking all "networkpeers"
16:29:41 info deleting networkpeers loft-7c7685654c-9sg5x.local.runner
16:29:43 debug checking all "networkpeers"
16:29:43 debug checking all "teams"
16:29:43 info deleting teams loft-admins
16:29:45 debug checking all "teams"
16:29:47 debug checking all "teams"
16:29:49 debug checking all "teams"
16:29:51 debug checking all "teams"
16:29:53 debug checking all "teams"
16:29:55 debug checking all "teams"
16:29:57 debug checking all "teams"
16:29:59 debug checking all "teams"
16:29:59 debug checking all "users"
16:29:59 info deleting users admin
16:30:01 debug checking all "users"
16:30:01 debug checking all "sharedsecrets"
16:30:01 debug checking all "accesskeys"
16:30:01 info deleting accesskeys loft-control-plane
16:30:01 info deleting accesskeys loft-runner-local-bzbjm
16:30:03 debug checking all "accesskeys"
16:30:03 debug legacy resource "localclusteraccesses" not found in discovery, skipping
16:30:03 debug legacy resource "localteams" not found in discovery, skipping
16:30:03 debug legacy resource "localusers" not found in discovery, skipping
16:30:03 info Uninstalling vCluster Platform...
16:30:03 info Executing command: helm uninstall loft --kube-context kind-v1 --namespace vcluster-platform

16:30:03 done Successfully uninstalled vCluster Platform

16:30:03 info deleting clusterrole "loft-agent-cluster"
16:30:03 info deleting clusterrole "loft-runnner-cluster"
16:30:03 info deleting clusterrole "loft-vcluster-cluster"
16:30:03 info deleting clusterrolebinding "loft-agent-cluster-binding"
16:30:03 info deleting clusterrolebinding "loft-runnner-cluster-binding"
16:30:03 info deleting clusterrolebinding "loft-vcluster-cluster-binding"
16:30:03 info deleting customresourcedefinition accesskeys.storage.loft.sh
16:30:03 info deleting customresourcedefinition apps.storage.loft.sh
16:30:03 info deleting customresourcedefinition clusteraccesses.storage.loft.sh
16:30:03 info deleting customresourcedefinition clusterquotas.storage.loft.sh
16:30:04 info deleting customresourcedefinition clusterroletemplates.storage.loft.sh
16:30:04 info deleting customresourcedefinition clusters.storage.loft.sh
16:30:04 info deleting customresourcedefinition devpodenvironmenttemplates.storage.loft.sh
16:30:04 info deleting customresourcedefinition devpodworkspaceinstances.storage.loft.sh
16:30:04 info deleting customresourcedefinition devpodworkspacetemplates.storage.loft.sh
16:30:04 info deleting customresourcedefinition networkpeers.storage.loft.sh
16:30:04 info deleting customresourcedefinition projects.storage.loft.sh
16:30:04 info deleting customresourcedefinition runners.storage.loft.sh
16:30:04 info deleting customresourcedefinition sharedsecrets.storage.loft.sh
16:30:04 info deleting customresourcedefinition spaceinstances.storage.loft.sh
16:30:04 info deleting customresourcedefinition spacetemplates.storage.loft.sh
16:30:05 info deleting customresourcedefinition tasks.storage.loft.sh
16:30:05 info deleting customresourcedefinition teams.storage.loft.sh
16:30:05 info deleting customresourcedefinition users.storage.loft.sh
16:30:05 info deleting customresourcedefinition virtualclusterinstances.storage.loft.sh
16:30:05 info deleting customresourcedefinition virtualclustertemplates.storage.loft.sh
16:30:06 info deleting namespace "vcluster-platform"

```
`vcluster platform destroy` (no args) on v3.4.9:
```16:27:18 info found platform installation in namespace "vcluster-platform"
16:27:18 debug checking all "virtualclusterinstances"
16:27:18 debug checking all "virtualclusters"
16:27:18 debug checking all "devpodworkspaceinstances"
16:27:18 debug checking all "spaceinstances"
16:27:18 debug checking all "virtualclustertemplates"
16:27:18 info deleting virtualclustertemplates vcluster-pro-isolated-template
16:27:18 info deleting virtualclustertemplates vcluster-pro-template
16:27:20 debug checking all "virtualclustertemplates"
16:27:20 info resource "devpodenvironmenttemplates" not found in discovery, skipping
16:27:20 debug checking all "devpodworkspacetemplates"
16:27:20 info deleting devpodworkspacetemplates aws
16:27:20 info deleting devpodworkspacetemplates azure
16:27:20 info deleting devpodworkspacetemplates digitalocean
16:27:20 info deleting devpodworkspacetemplates ecs
16:27:20 info deleting devpodworkspacetemplates gcloud
16:27:20 info deleting devpodworkspacetemplates kubernetes
16:27:22 debug checking all "devpodworkspacetemplates"
16:27:22 debug checking all "clusterroletemplates"
16:27:22 info deleting clusterroletemplates loft-apps-admin
16:27:22 info deleting clusterroletemplates loft-apps-creator
16:27:22 info deleting clusterroletemplates loft-apps-viewer
16:27:22 info deleting clusterroletemplates loft-cluster-admin
16:27:22 info deleting clusterroletemplates loft-cluster-authenticated
16:27:22 info deleting clusterroletemplates loft-cluster-extra-space-admin-rules
16:27:22 info deleting clusterroletemplates loft-cluster-extra-space-viewer-rules
16:27:22 info deleting clusterroletemplates loft-cluster-space-admin
16:27:22 info deleting clusterroletemplates loft-cluster-space-viewer
16:27:23 info deleting clusterroletemplates loft-clusters-admin
16:27:23 info deleting clusterroletemplates loft-clusters-creator
16:27:23 info deleting clusterroletemplates loft-impersonator
16:27:23 info deleting clusterroletemplates loft-management-activity-viewer
16:27:23 info deleting clusterroletemplates loft-management-admin
16:27:24 info deleting clusterroletemplates loft-management-authenticated
16:27:24 info deleting clusterroletemplates loft-management-project-admin
16:27:24 info deleting clusterroletemplates loft-management-project-user
16:27:24 info deleting clusterroletemplates loft-management-project-viewer
16:27:24 info deleting clusterroletemplates loft-secrets-admin
16:27:25 info deleting clusterroletemplates loft-secrets-creator
16:27:25 info deleting clusterroletemplates loft-secrets-viewer
16:27:25 info deleting clusterroletemplates loft-teams-admin
16:27:25 info deleting clusterroletemplates loft-teams-creator
16:27:25 info deleting clusterroletemplates loft-teams-viewer
16:27:26 info deleting clusterroletemplates loft-templates-admin
16:27:26 info deleting clusterroletemplates loft-templates-creator
16:27:26 info deleting clusterroletemplates loft-templates-viewer
16:27:26 info deleting clusterroletemplates loft-users-admin
16:27:26 info deleting clusterroletemplates loft-users-creator
16:27:27 info deleting clusterroletemplates loft-users-viewer
16:27:27 debug checking all "clusterroletemplates"
16:27:27 debug checking all "spacetemplates"
16:27:27 info deleting spacetemplates isolated-space
16:27:29 debug checking all "spacetemplates"
16:27:29 debug checking all "apps"
16:27:29 info deleting apps argocd
16:27:29 info deleting apps central-hostpath-mapper
16:27:29 info deleting apps cert-manager
16:27:29 info deleting apps example-bash
16:27:29 info deleting apps example-helm
16:27:29 info deleting apps example-manifests
16:27:29 info deleting apps ingress-nginx
16:27:29 info deleting apps jspolicy
16:27:29 info deleting apps kube-prometheus-stack
16:27:30 info deleting apps opentelemetry-collector
16:27:31 debug checking all "apps"
16:27:31 debug checking all "spaceconstraints"
16:27:31 debug checking all "tasks"
16:27:31 debug checking all "clusterquotas"
16:27:31 debug checking all "projects"
16:27:31 info deleting projects default
16:27:33 debug checking all "projects"
16:27:35 debug checking all "projects"
16:27:37 debug checking all "projects"
16:27:37 debug checking all "runners"
16:27:37 info deleting runners local
16:27:39 debug checking all "runners"
16:27:39 debug checking all "clusters"
16:27:39 info deleting clusters loft-cluster
16:27:41 debug checking all "clusters"
16:27:41 debug checking all "clusteraccesses"
16:27:41 info deleting clusteraccesses loft-admins
16:27:43 debug checking all "clusteraccesses"
16:27:43 debug checking all "networkpeers"
16:27:43 info deleting networkpeers loft-b67bf7475-r7knc.control-plane
16:27:45 debug checking all "networkpeers"
16:27:45 debug checking all "teams"
16:27:45 info deleting teams loft-admins
16:27:47 debug checking all "teams"
16:27:49 debug checking all "teams"
16:27:51 debug checking all "teams"
16:27:53 debug checking all "teams"
16:27:55 debug checking all "teams"
16:27:57 debug checking all "teams"
16:27:59 debug checking all "teams"
16:27:59 debug checking all "users"
16:27:59 info deleting users admin
16:28:01 debug checking all "users"
16:28:01 debug checking all "sharedsecrets"
16:28:01 debug checking all "accesskeys"
16:28:01 info deleting accesskeys loft-agent-loft-cluster-47287
16:28:01 info deleting accesskeys loft-control-plane
16:28:01 info deleting accesskeys loft-runner-local-xsblh
16:28:03 debug checking all "accesskeys"
16:28:03 debug checking all "localclusteraccesses"
16:28:03 debug checking all "localteams"
16:28:03 debug checking all "localusers"
16:28:03 info Uninstalling vCluster Platform...
16:28:03 info Executing command: helm uninstall loft --kube-context kind-v3 --namespace vcluster-platform

16:28:03 done Successfully uninstalled vCluster Platform

16:28:03 info deleting clusterrole "loft-agent-cluster"
16:28:03 info deleting clusterrole "loft-runnner-cluster"
16:28:03 info deleting clusterrole "loft-vcluster-cluster"
16:28:03 info deleting clusterrolebinding "loft-agent-cluster-binding"
16:28:03 info deleting clusterrolebinding "loft-runnner-cluster-binding"
16:28:03 info deleting clusterrolebinding "loft-vcluster-cluster-binding"
16:28:03 info deleting customresourcedefinition accesskeys.storage.loft.sh
16:28:03 info deleting customresourcedefinition apps.storage.loft.sh
16:28:03 info deleting customresourcedefinition clusteraccesses.storage.loft.sh
16:28:03 info deleting customresourcedefinition clusterquotas.storage.loft.sh
16:28:03 info deleting customresourcedefinition clusterroletemplates.storage.loft.sh
16:28:03 info deleting customresourcedefinition clusters.storage.loft.sh
16:28:03 info deleting customresourcedefinition devpodworkspaceinstances.storage.loft.sh
16:28:03 info deleting customresourcedefinition devpodworkspacetemplates.storage.loft.sh
16:28:04 info deleting customresourcedefinition localclusteraccesses.storage.loft.sh
16:28:04 info deleting customresourcedefinition localteams.storage.loft.sh
16:28:04 info deleting customresourcedefinition localusers.storage.loft.sh
16:28:04 info deleting customresourcedefinition networkpeers.storage.loft.sh
16:28:04 info deleting customresourcedefinition projects.storage.loft.sh
16:28:04 info deleting customresourcedefinition runners.storage.loft.sh
16:28:04 info deleting customresourcedefinition sharedsecrets.storage.loft.sh
16:28:05 info deleting customresourcedefinition spaceconstraints.storage.loft.sh
16:28:05 info deleting customresourcedefinition spaceinstances.storage.loft.sh
16:28:05 info deleting customresourcedefinition spacetemplates.storage.loft.sh
16:28:05 info deleting customresourcedefinition tasks.storage.loft.sh
16:28:05 info deleting customresourcedefinition teams.storage.loft.sh
16:28:06 info deleting customresourcedefinition users.storage.loft.sh
16:28:06 info deleting customresourcedefinition virtualclusterinstances.storage.loft.sh
16:28:06 info deleting customresourcedefinition virtualclusters.storage.loft.sh
16:28:06 info deleting customresourcedefinition virtualclustertemplates.storage.loft.sh
16:28:07 info deleting namespace "vcluster-platform"
```