### PR TITLE
[v0.19] feat: exclude Rancher managed annotations while syncing ingress (#2259)

### DIFF
--- a/pkg/controllers/resources/ingresses/syncer.go
+++ b/pkg/controllers/resources/ingresses/syncer.go
@@ -3,6 +3,7 @@ package ingresses
 import (
 	"strings"
 
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	syncertypes "github.com/loft-sh/vcluster/pkg/types"
@@ -14,8 +15,9 @@ import (
 )
 
 func NewSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
+	excludedAnnotations := []string{services.RancherPublicEndpointsAnnotation}
 	return &ingressSyncer{
-		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "ingress", &networkingv1.Ingress{}),
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "ingress", &networkingv1.Ingress{}, excludedAnnotations...),
 	}, nil
 }
 

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -19,14 +19,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ServiceBlockDeletion = "vcluster.loft.sh/block-deletion"
+var (
+	ServiceBlockDeletion             = "vcluster.loft.sh/block-deletion"
+	RancherPublicEndpointsAnnotation = "field.cattle.io/publicEndpoints"
+)
 
 func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	return &serviceSyncer{
 		// exclude "field.cattle.io/publicEndpoints" annotation used by Rancher,
 		// because if it is also installed in the host cluster, it will be
 		// overriding it, which would cause endless updates back and forth.
-		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "service", &corev1.Service{}, "field.cattle.io/publicEndpoints"),
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "service", &corev1.Service{}, RancherPublicEndpointsAnnotation),
 
 		serviceName: ctx.Options.ServiceName,
 	}, nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5035


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now ignore updates to Rancher managed annotations when syncing ingress to & from the virtual cluster.


**What else do we need to know?** 
