### PR TITLE
fix: removes object cache updates from syncers.

### DIFF
--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -270,7 +270,6 @@ func recreatePersistentVolumeClaim(ctx *synccontext.SyncContext, virtualClient c
 	}
 
 	// make sure we don't set the resource version during create
-	ctx.ObjectCache.Virtual().Delete(vPVC)
 	vPVC = vPVC.DeepCopy()
 	vPVC.ResourceVersion = ""
 	vPVC.UID = ""
@@ -285,6 +284,5 @@ func recreatePersistentVolumeClaim(ctx *synccontext.SyncContext, virtualClient c
 		return nil, errors.Wrap(err, "create pvc")
 	}
 
-	ctx.ObjectCache.Virtual().Put(vPVC)
 	return vPVC, nil
 }

--- a/pkg/controllers/resources/pods/ephemeral_containers.go
+++ b/pkg/controllers/resources/pods/ephemeral_containers.go
@@ -64,7 +64,7 @@ func (s *podSyncer) syncEphemeralContainers(ctx *synccontext.SyncContext, physic
 
 	// do the actual update
 	ctx.Log.Infof("Update ephemeral containers for pod %s/%s", physicalPod.Namespace, physicalPod.Name)
-	updatedPod, err := physicalClusterClient.CoreV1().Pods(physicalPod.Namespace).UpdateEphemeralContainers(ctx, physicalPod.Name, physicalPod, metav1.UpdateOptions{})
+	_, err = physicalClusterClient.CoreV1().Pods(physicalPod.Namespace).UpdateEphemeralContainers(ctx, physicalPod.Name, physicalPod, metav1.UpdateOptions{})
 	if err != nil {
 		// The api-server will return a 404 when the EphemeralContainers feature is disabled because the `/ephemeralcontainers` subresource
 		// is missing. Unlike the 404 returned by a missing physicalPod, the status details will be empty.
@@ -75,6 +75,5 @@ func (s *podSyncer) syncEphemeralContainers(ctx *synccontext.SyncContext, physic
 		return false, fmt.Errorf("update ephemeral containers: %w", err)
 	}
 
-	ctx.ObjectCache.Host().Put(updatedPod)
 	return true, nil
 }

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -442,6 +442,5 @@ func (s *podSyncer) assignNodeToPod(ctx *synccontext.SyncContext, pObj *corev1.P
 		return err
 	}
 
-	ctx.ObjectCache.Virtual().Put(vPod)
 	return nil
 }

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -243,7 +243,6 @@ func recreateService(ctx *synccontext.SyncContext, virtualClient client.Client, 
 	}
 
 	// make sure we don't set the resource version during create
-	ctx.ObjectCache.Virtual().Delete(vService)
 	vService = vService.DeepCopy()
 	vService.ResourceVersion = ""
 	vService.UID = ""
@@ -257,7 +256,6 @@ func recreateService(ctx *synccontext.SyncContext, virtualClient client.Client, 
 		return err
 	}
 
-	ctx.ObjectCache.Virtual().Put(vService)
 	return nil
 }
 

--- a/pkg/controllers/resources/volumesnapshotcontents/syncer.go
+++ b/pkg/controllers/resources/volumesnapshotcontents/syncer.go
@@ -126,7 +126,6 @@ func (s *volumeSnapshotContentSyncer) Sync(ctx *synccontext.SyncContext, event *
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			ctx.ObjectCache.Virtual().Put(updated)
 		}
 
 		if !equality.Semantic.DeepEqual(event.Virtual.Status, event.Host.Status) {
@@ -137,7 +136,6 @@ func (s *volumeSnapshotContentSyncer) Sync(ctx *synccontext.SyncContext, event *
 			if err != nil && !kerrors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
-			ctx.ObjectCache.Virtual().Put(updated)
 		}
 
 		return ctrl.Result{RequeueAfter: time.Second}, nil

--- a/pkg/controllers/resources/volumesnapshots/syncer.go
+++ b/pkg/controllers/resources/volumesnapshots/syncer.go
@@ -66,8 +66,6 @@ func (s *volumeSnapshotSyncer) SyncToHost(ctx *synccontext.SyncContext, event *s
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-
-			ctx.ObjectCache.Virtual().Put(event.Virtual)
 		}
 
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.HostOld, "host object was deleted")
@@ -115,8 +113,6 @@ func (s *volumeSnapshotSyncer) Sync(ctx *synccontext.SyncContext, event *synccon
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-
-			ctx.ObjectCache.Virtual().Put(updated)
 		}
 
 		if !equality.Semantic.DeepEqual(event.Virtual.Status, event.Host.Status) {
@@ -127,8 +123,6 @@ func (s *volumeSnapshotSyncer) Sync(ctx *synccontext.SyncContext, event *synccon
 			if err != nil && !kerrors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
-
-			ctx.ObjectCache.Virtual().Put(updated)
 		}
 
 		return ctrl.Result{}, nil


### PR DESCRIPTION
Each of these object cache update come after calls to the client that will go through the SyncController's reconciliation that handles updating the cache.  These changes still pass the certified-conformance tests.

