### PR TITLE
Populate AGENT_IMAGE env var during development

### DIFF
--- a/cmd/vclusterctl/cmd/platform/add/cluster.go
+++ b/cmd/vclusterctl/cmd/platform/add/cluster.go
@@ -174,6 +174,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 			"--namespace", namespace,
 			"--set", "agentOnly=true",
 			"--set", "image=" + cmp.Or(os.Getenv("DEVELOPMENT_IMAGE"), "ghcr.io/loft-sh/enterprise:release-test"),
+			"--set", "env.AGENT_IMAGE=" + cmp.Or(os.Getenv("AGENT_IMAGE"), os.Getenv("DEVELOPMENT_IMAGE"), "ghcr.io/loft-sh/enterprise:release-test"),
 		}
 	} else {
 		if cmd.HelmChartPath != "" {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
This makes it possible that the agent picks up the current dev image when adding a cluster to the platform during development via `DEVELOPMENT=true vcluster platform add cluster <cluster_name>`