### PR TITLE
[v0.20] feat: exclude Rancher managed annotations while syncing ingress (#2259)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - tagalign
     - asciicheck
     - bidichk
+    - copyloopvar
     - decorder
     - dupl
     - durationcheck
@@ -15,7 +16,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - ginkgolinter
     - gocheckcompilerdirectives
     - gofmt

--- a/pkg/controllers/resources/ingresses/syncer.go
+++ b/pkg/controllers/resources/ingresses/syncer.go
@@ -3,6 +3,7 @@ package ingresses
 import (
 	"strings"
 
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"github.com/loft-sh/vcluster/pkg/controllers/syncer/translator"
 	syncertypes "github.com/loft-sh/vcluster/pkg/types"
@@ -14,8 +15,9 @@ import (
 )
 
 func NewSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
+	excludedAnnotations := []string{services.RancherPublicEndpointsAnnotation}
 	return &ingressSyncer{
-		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "ingress", &networkingv1.Ingress{}),
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "ingress", &networkingv1.Ingress{}, excludedAnnotations...),
 	}, nil
 }
 

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -157,10 +157,10 @@ func (s *nodeSyncer) ModifyController(ctx *synccontext.RegisterContext, bld *bui
 }
 
 // only used when scheduler is enabled
-func enqueueNonVClusterPod(old, new client.Object, q workqueue.RateLimitingInterface) {
-	pod, ok := new.(*corev1.Pod)
+func enqueueNonVClusterPod(old, newObj client.Object, q workqueue.RateLimitingInterface) {
+	pod, ok := newObj.(*corev1.Pod)
 	if !ok {
-		klog.Errorf("invalid type passed to pod handler: %T", new)
+		klog.Errorf("invalid type passed to pod handler: %T", newObj)
 		return
 	}
 	// skip if node name missing

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -18,14 +18,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ServiceBlockDeletion = "vcluster.loft.sh/block-deletion"
+var (
+	ServiceBlockDeletion             = "vcluster.loft.sh/block-deletion"
+	RancherPublicEndpointsAnnotation = "field.cattle.io/publicEndpoints"
+)
 
 func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	return &serviceSyncer{
 		// exclude "field.cattle.io/publicEndpoints" annotation used by Rancher,
 		// because if it is also installed in the host cluster, it will be
 		// overriding it, which would cause endless updates back and forth.
-		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "service", &corev1.Service{}, "field.cattle.io/publicEndpoints"),
+		NamespacedTranslator: translator.NewNamespacedTranslator(ctx, "service", &corev1.Service{}, RancherPublicEndpointsAnnotation),
 
 		serviceName: ctx.Config.WorkloadService,
 	}, nil

--- a/pkg/helm/time.go
+++ b/pkg/helm/time.go
@@ -49,8 +49,8 @@ func ParseInLocation(layout, value string, loc *time.Location) (Time, error) {
 	return Time{Time: t}, err
 }
 
-func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
-	return Time{Time: time.Date(year, month, day, hour, min, sec, nsec, loc)}
+func Date(year int, month time.Month, day, hour, minute, sec, nsec int, loc *time.Location) Time {
+	return Time{Time: time.Date(year, month, day, hour, minute, sec, nsec, loc)}
 }
 
 func Unix(sec int64, nsec int64) Time { return Time{Time: time.Unix(sec, nsec)} }

--- a/pkg/util/encoding/helper.go
+++ b/pkg/util/encoding/helper.go
@@ -31,7 +31,7 @@ func Convert(from runtime.Object, to runtime.Object) error {
 }
 
 // ConvertList converts the objects from the from list and puts them into the to list
-func ConvertList(fromList runtime.Object, toList runtime.Object, new rest.Storage) error {
+func ConvertList(fromList runtime.Object, toList runtime.Object, storage rest.Storage) error {
 	list, err := meta.ExtractList(fromList)
 	if err != nil {
 		return err
@@ -39,7 +39,7 @@ func ConvertList(fromList runtime.Object, toList runtime.Object, new rest.Storag
 
 	newItems := []runtime.Object{}
 	for _, item := range list {
-		newItem := new.New()
+		newItem := storage.New()
 		err = Convert(item, newItem)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5034


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now ignore updates to Rancher managed annotations when syncing ingress to & from the virtual cluster.


**What else do we need to know?** 
