### PR TITLE
fix: prevent vcluster crash when network policy syncing is enabled

### DIFF
--- a/pkg/controllers/resources/networkpolicies/syncer.go
+++ b/pkg/controllers/resources/networkpolicies/syncer.go
@@ -3,7 +3,7 @@ package networkpolicies
 import (
 	"fmt"
 
-	"github.com/loft-sh/vcluster/pkg/mappings/generic"
+	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/patcher"
 	"github.com/loft-sh/vcluster/pkg/pro"
 	"github.com/loft-sh/vcluster/pkg/syncer"
@@ -18,7 +18,7 @@ import (
 )
 
 func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
-	mapper, err := generic.NewMapper(ctx, &networkingv1.NetworkPolicy{}, translate.Default.HostName)
+	mapper, err := ctx.Mappings.ByGVK(mappings.NetworkingPolicies())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/resources/networkpolicies/syncer_test.go
+++ b/pkg/controllers/resources/networkpolicies/syncer_test.go
@@ -3,8 +3,10 @@ package networkpolicies
 import (
 	"testing"
 
+	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	"gotest.tools/assert"
 	"k8s.io/utils/ptr"
 
@@ -217,7 +219,10 @@ func TestSync(t *testing.T) {
 		},
 	}
 
-	syncertesting.RunTests(t, []*syncertesting.SyncTest{
+	syncertesting.RunTestsWithContext(t, func(vConfig *config.VirtualClusterConfig, pClient *testingutil.FakeIndexClient, vClient *testingutil.FakeIndexClient) *synccontext.RegisterContext {
+		vConfig.Sync.ToHost.NetworkPolicies.Enabled = true
+		return syncertesting.NewFakeRegisterContext(vConfig, pClient, vClient)
+	}, []*syncertesting.SyncTest{
 		{
 			Name:                "Create forward",
 			InitialVirtualState: []runtime.Object{vBaseNetworkPolicy.DeepCopy()},

--- a/pkg/mappings/registry.go
+++ b/pkg/mappings/registry.go
@@ -129,6 +129,10 @@ func Namespaces() schema.GroupVersionKind {
 	return corev1.SchemeGroupVersion.WithKind("Namespace")
 }
 
+func NetworkingPolicies() schema.GroupVersionKind {
+	return networkingv1.SchemeGroupVersion.WithKind("NetworkPolicy")
+}
+
 func Ingresses() schema.GroupVersionKind {
 	return networkingv1.SchemeGroupVersion.WithKind("Ingress")
 }

--- a/pkg/mappings/resources/networkpolicies.go
+++ b/pkg/mappings/resources/networkpolicies.go
@@ -1,0 +1,12 @@
+package resources
+
+import (
+	"github.com/loft-sh/vcluster/pkg/mappings/generic"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+func CreateNetworkPoliciesMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper, error) {
+	return generic.NewMapper(ctx, &networkingv1.NetworkPolicy{}, translate.Default.HostName)
+}

--- a/pkg/mappings/resources/register.go
+++ b/pkg/mappings/resources/register.go
@@ -20,6 +20,7 @@ func getMappers(ctx *synccontext.RegisterContext) []BuildMapper {
 		CreateEventsMapper,
 		isEnabled(ctx.Config.Sync.ToHost.Ingresses.Enabled, CreateIngressesMapper),
 		CreateNamespacesMapper,
+		isEnabled(ctx.Config.Sync.ToHost.NetworkPolicies.Enabled, CreateNetworkPoliciesMapper),
 		CreateNodesMapper,
 		CreatePersistentVolumeClaimsMapper,
 		isEnabled(ctx.Config.Sync.ToHost.ServiceAccounts.Enabled, CreateServiceAccountsMapper),


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5193


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster restarts when enabling networkpolicy syncing

