### PR TITLE
feat: Render control plane additional volumes as template in helm chart

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- if .Values.controlPlane.statefulSet.persistence.addVolumes }}
-{{ toYaml .Values.controlPlane.statefulSet.persistence.addVolumes | indent 8 }}
+{{ tpl (toYaml .Values.controlPlane.statefulSet.persistence.addVolumes) $ | indent 8 }}
         {{- end }}
       {{- if (not .Values.experimental.syncSettings.disableSync) }}
       initContainers:

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -364,6 +364,25 @@ tests:
           path: spec.template.spec.volumes
           count: 8
 
+  - it: add templated volumes
+    set:
+      controlPlane:
+        distro:
+          k3s:
+            enabled: true
+        statefulSet:
+          persistence:
+            addVolumes:
+              - name: '{{ .Release.Name }}-myVolume'
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-myVolume
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 8
+
   - it: enable k8s
     set:
       controlPlane:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Similarly to #2289, this allows templates to be used in the `.Values.controlPlane.statefulSet.persistence.addVolumes` list, this is useful where additional volumes are created as part of a helm chart deployment with a templated name


**Please provide a short message that should be published in the vcluster release notes**
Allows use of templates in chart `.Values.controlPlane.statefulSet.persisntence.addVolumes`

**What else do we need to know?** 