### PR TITLE
fix(cli): clean up clusteroles/bindings, config.json, add prompt

### DIFF
--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/loft-sh/log"
+	"github.com/loft-sh/log/survey"
 	"github.com/loft-sh/vcluster/pkg/cli/destroy"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/start"
@@ -37,6 +39,9 @@ func NewDestroyCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 Destroys a vCluster Platform instance in your Kubernetes cluster.
 
+Important: This action is done against the cluster the the kube-context is pointing to, and not the vCluster Platform instance that is logged in.
+It does not require logging in to vCluster Platform. 
+
 Please make sure you meet the following requirements
 before running this command:
 
@@ -59,6 +64,7 @@ VirtualClusterInstances managed with driver helm will be deleted, but the underl
 	destroyCmd.Flags().BoolVar(&cmd.DeleteNamespace, "delete-namespace", true, "Whether to delete the namespace or not")
 	destroyCmd.Flags().BoolVar(&cmd.IgnoreNotFound, "ignore-not-found", false, "Exit successfully if platform installation is not found")
 	destroyCmd.Flags().BoolVar(&cmd.Force, "force", false, "Try uninstalling even if the platform is not installed. '--namespace' is required if true")
+	destroyCmd.Flags().BoolVar(&cmd.NonInteractive, "non-interactive", false, "Will not prompt for confirmation")
 	destroyCmd.Flags().IntVar(&cmd.TimeoutMinutes, "timeout-minutes", 5, "How long to try deleting the platform before giving up")
 
 	return destroyCmd
@@ -66,7 +72,7 @@ VirtualClusterInstances managed with driver helm will be deleted, but the underl
 
 func (cmd *DestroyCmd) Run(ctx context.Context) error {
 	// initialise clients, verify binaries exist, sanity-check context
-	err := cmd.Options.Prepare()
+	err := cmd.Options.Prepare(cmd.NonInteractive)
 	if err != nil {
 		return fmt.Errorf("failed to prepare clients: %w", err)
 	}
@@ -95,6 +101,20 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 			return nil
 		}
 		return fmt.Errorf("platform not installed in namespace %q", cmd.Namespace)
+	}
+
+	if !cmd.NonInteractive {
+		deleteOpt := "delete"
+		out, err := cmd.Log.Question(&survey.QuestionOptions{
+			Question: fmt.Sprintf("IMPORTANT! You are destroy the vCluster Platform in the namespace %q.\nThis may result in data loss. Please ensure your kube-context is pointed at the right cluster.\n Please type %q to continue:", cmd.Namespace, deleteOpt),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to prompt for confirmation: %w", err)
+		}
+		if out != deleteOpt {
+			cmd.Log.Info("destroy cancelled")
+			return nil
+		}
 	}
 
 	err = destroy.Destroy(ctx, cmd.DeleteOptions)

--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -39,7 +39,7 @@ func NewDestroyCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 Destroys a vCluster Platform instance in your Kubernetes cluster.
 
-Important: This action is done against the cluster the the kube-context is pointing to, and not the vCluster Platform instance that is logged in.
+IMPORTANT: This action is done against the cluster the the kube-context is pointing to, and not the vCluster Platform instance that is logged in.
 It does not require logging in to vCluster Platform. 
 
 Please make sure you meet the following requirements
@@ -121,5 +121,17 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to destroy platform: %w", err)
 	}
+
+	cmd.Log.Infof("deleting platform config at %q", cmd.Config)
+	cliConfig := cmd.LoadedConfig(cmd.Log)
+	err = cliConfig.Delete()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && cmd.IgnoreNotFound {
+			cmd.Log.Info("no platform config detected")
+			return nil
+		}
+		return fmt.Errorf("failed to delete platform config: %w", err)
+	}
+
 	return nil
 }

--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -152,22 +152,6 @@ func Destroy(ctx context.Context, opts DeleteOptions) error {
 		return err
 	}
 
-	for _, name := range clihelper.DefaultClusterRoles {
-		name := name + "-binding"
-		opts.Log.Infof("deleting clusterrolebinding %q", name)
-		err := opts.KubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, name+"-binding", metav1.DeleteOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete clusterrole: %w", err)
-		}
-	}
-	for _, name := range clihelper.DefaultClusterRoles {
-		opts.Log.Infof("deleting clusterrole %q", name)
-		err := opts.KubeClient.RbacV1().ClusterRoles().Delete(ctx, name, metav1.DeleteOptions{})
-		if err != nil && !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete clusterrole: %w", err)
-		}
-	}
-
 	opts.Log.Info("deleting CRDS")
 	err = wait.ExponentialBackoffWithContext(ctx, wait.Backoff{Duration: time.Second, Factor: backoffFactor, Cap: time.Duration(opts.TimeoutMinutes) * time.Minute, Steps: math.MaxInt32}, func(ctx context.Context) (bool, error) {
 		list, err := apiextensionclientset.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
@@ -233,6 +217,22 @@ func Destroy(ctx context.Context, opts DeleteOptions) error {
 		})
 		if err != nil {
 			return err
+		}
+	}
+
+	for _, name := range clihelper.DefaultClusterRoles {
+		name := name + "-binding"
+		opts.Log.Infof("deleting clusterrolebinding %q", name)
+		err := opts.KubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete clusterrole: %w", err)
+		}
+	}
+	for _, name := range clihelper.DefaultClusterRoles {
+		opts.Log.Infof("deleting clusterrole %q", name)
+		err := opts.KubeClient.RbacV1().ClusterRoles().Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete clusterrole: %w", err)
 		}
 	}
 

--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -73,6 +73,7 @@ type DeleteOptions struct {
 	DeleteNamespace bool
 	IgnoreNotFound  bool
 	Force           bool
+	NonInteractive  bool
 	TimeoutMinutes  int
 }
 

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -157,6 +157,10 @@ func (c *client) Save() error {
 	return c.config.Save()
 }
 
+func (c *client) Delete() error {
+	return c.config.Delete()
+}
+
 func (c *client) ManagementConfig() (*rest.Config, error) {
 	return c.restConfig("/kubernetes/management")
 }

--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -67,8 +67,10 @@ var defaultDeploymentName = "loft"
 
 var DefaultClusterRoles = []string{
 	"loft-agent-cluster",
-	"loft-runnner-cluster",
+	"loft-runner-cluster",
 	"loft-vcluster-cluster",
+	"loft-cluster-authenticated",
+	"loft-management-authenticated",
 }
 
 func Timeout() time.Duration {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
ENG-5254

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5254
resolves ENG-5244





**What else do we need to know?** 
vcluster platform destroy will now prompt the user to type "delete" to confirm destruction, unless the --non-interactive flag is passed

vcluster platform destroy now properly cleans up config.json, and a few clusterroles/bindings it missed before


prompt example:
![image](https://github.com/user-attachments/assets/ca1deb18-ceda-4cdc-92dd-102de939bb0f)
