### PR TITLE
fix(cli): add --force-remove-finalizers to platform destroy

### DIFF
--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -107,7 +107,7 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 	if !cmd.NonInteractive {
 		deleteOpt := "delete"
 		out, err := cmd.Log.Question(&survey.QuestionOptions{
-			Question: fmt.Sprintf("IMPORTANT! You are destroying the vCluster Platform installation in the namespace %q.\nThis may result in data loss. Please ensure your kube-context is pointed at the right cluster.\n Please type %q to continue:", cmd.Namespace, deleteOpt),
+			Question: fmt.Sprintf("IMPORTANT! You are destroying the vCluster Platform installation in the namespace %q.\n  This may result in data loss.\n  Externally deployed virtual clusters depending on an external database connection will be irrecoverable after the platform is destroyed.\n  Please ensure your kube-context is pointed at the right cluster.\nPlease type %q to continue:", cmd.Namespace, deleteOpt),
 		})
 		if err != nil {
 			return fmt.Errorf("failed to prompt for confirmation: %w", err)

--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -49,7 +49,7 @@ before running this command:
 2. Helm v3 must be installed
 
 
-VirtualClusterInstances managed with driver helm will be deleted, but the underlying virtual cluster will not be uninstalled
+VirtualClusterInstances managed with driver helm will be deleted, but the underlying virtual cluster will not be uninstalled.
 
 ########################################################
 	`,
@@ -65,7 +65,8 @@ VirtualClusterInstances managed with driver helm will be deleted, but the underl
 	destroyCmd.Flags().BoolVar(&cmd.IgnoreNotFound, "ignore-not-found", false, "Exit successfully if platform installation is not found")
 	destroyCmd.Flags().BoolVar(&cmd.Force, "force", false, "Try uninstalling even if the platform is not installed. '--namespace' is required if true")
 	destroyCmd.Flags().BoolVar(&cmd.NonInteractive, "non-interactive", false, "Will not prompt for confirmation")
-	destroyCmd.Flags().IntVar(&cmd.TimeoutMinutes, "timeout-minutes", 5, "How long to try deleting the platform before giving up")
+	destroyCmd.Flags().IntVar(&cmd.TimeoutMinutes, "timeout-minutes", 5, "How long to try deleting the platform before giving up. May increase when removing finalizers if --remove-finalizers is used")
+	destroyCmd.Flags().BoolVar(&cmd.ForceRemoveFinalizers, "force-remove-finalizers", false, "IMPORTANT! Removing finalizers may cause unintended behaviours like leaving resources behind, but will ensure the platform is uninstalled.")
 
 	return destroyCmd
 }
@@ -106,7 +107,7 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 	if !cmd.NonInteractive {
 		deleteOpt := "delete"
 		out, err := cmd.Log.Question(&survey.QuestionOptions{
-			Question: fmt.Sprintf("IMPORTANT! You are destroy the vCluster Platform in the namespace %q.\nThis may result in data loss. Please ensure your kube-context is pointed at the right cluster.\n Please type %q to continue:", cmd.Namespace, deleteOpt),
+			Question: fmt.Sprintf("IMPORTANT! You are destroying the vCluster Platform installation in the namespace %q.\nThis may result in data loss. Please ensure your kube-context is pointed at the right cluster.\n Please type %q to continue:", cmd.Namespace, deleteOpt),
 		})
 		if err != nil {
 			return fmt.Errorf("failed to prompt for confirmation: %w", err)
@@ -114,6 +115,19 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 		if out != deleteOpt {
 			cmd.Log.Info("destroy cancelled")
 			return nil
+		}
+		if cmd.ForceRemoveFinalizers {
+			forceRemoveOpt := "force-remove"
+			out, err := cmd.Log.Question(&survey.QuestionOptions{
+				Question: fmt.Sprintf("IMPORTANT! You have selected the --force-remove-finalizers option. Please ensure you understand the consequences. Removing finalizers may cause unintended behaviours like leaving resources behind, but will ensure the platform is uninstalled. To confirm, please type %q", forceRemoveOpt),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to prompt for confirmation: %w", err)
+			}
+			if out != forceRemoveOpt {
+				cmd.Log.Info("destroy cancelled")
+				return nil
+			}
 		}
 	}
 

--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -315,13 +315,14 @@ func deleteAllResourcesAndWait(ctxWithoutDeadline, ctxWithDeadLine context.Conte
 					if err != nil {
 						return false, fmt.Errorf("failed to unmarshal virtual cluster config for %v %q: %w", resource, namespacedName, err)
 					}
-					if !nonInteractive {
-						if vConfig.ControlPlane.BackingStore.Database.External.Enabled && vConfig.ControlPlane.BackingStore.Database.External.Connector != "" {
+					if vConfig.ControlPlane.BackingStore.Database.External.Connector != "" {
+						log.Warnf("IMPORTANT! You are removing an externally deployed virtual cluster %q from the platform.\n It will not be destroyed as the deployment is managed externally, but its database will be removed rendering it inoperable.", namespacedName)
+						if !nonInteractive {
 							yesOpt := "yes"
 							noOpt := "no"
 							out, err := log.Question(&survey.QuestionOptions{
 								Options:  []string{yesOpt, noOpt},
-								Question: fmt.Sprintf("IMPORTANT! You are removing an externally deployed virtual cluster %q from the platform.\n It will not be destroyed as the deployment is managed externally, but its connection to its database will be removed.\nDo you want to continue?", namespacedName),
+								Question: "Do you want to continue?",
 							})
 							if err != nil {
 								return false, fmt.Errorf("failed to prompt for confirmation: %w", err)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5245
resolves ENG-5264


**Please provide a short message that should be published in the vcluster release notes**



**What else do we need to know?** 

Adds prompt for this flag, also changes logging to mention that externally deployed vclusters are not cleaned up.