### PR TITLE
Change vcluster coredns app label

### DIFF
--- a/chart/templates/coredns-configmap.yaml
+++ b/chart/templates/coredns-configmap.yaml
@@ -35,7 +35,7 @@ data:
 {{ toYaml .Values.controlPlane.coredns.service.annotations | indent 8 }}
         {{- end }}
       labels:
-        k8s-app: kube-dns
+        k8s-app: vcluster-kube-dns
         kubernetes.io/cluster-service: "true"
         kubernetes.io/name: "CoreDNS"
         {{- if .Values.controlPlane.coredns.service.labels }}
@@ -126,7 +126,7 @@ data:
 {{ toYaml .Values.controlPlane.coredns.deployment.annotations | indent 8 }}
       {{- end }}
       labels:
-        k8s-app: kube-dns
+        k8s-app: vcluster-kube-dns
         kubernetes.io/name: "CoreDNS"
         {{- if .Values.controlPlane.coredns.deployment.labels }}
 {{ toYaml .Values.controlPlane.coredns.deployment.labels | indent 8 }}
@@ -139,7 +139,7 @@ data:
           maxUnavailable: 1
       selector:
         matchLabels:
-          k8s-app: kube-dns
+          k8s-app: vcluster-kube-dns
       template:
         metadata:
           {{- if .Values.controlPlane.coredns.deployment.pods.annotations }}
@@ -147,7 +147,7 @@ data:
 {{ toYaml .Values.controlPlane.coredns.deployment.pods.annotations | indent 12 }}
           {{- end }}
           labels:
-            k8s-app: kube-dns
+            k8s-app: vcluster-kube-dns
           {{- if .Values.controlPlane.coredns.deployment.pods.labels }}
 {{ toYaml .Values.controlPlane.coredns.deployment.pods.labels | indent 12 }}
           {{- end }}
@@ -258,7 +258,7 @@ data:
 {{ toYaml .Values.controlPlane.coredns.service.annotations | indent 8 }}
         {{- end }}
       labels:
-        k8s-app: kube-dns
+        k8s-app: vcluster-kube-dns
         kubernetes.io/cluster-service: "true"
         kubernetes.io/name: "CoreDNS"
         {{- if .Values.controlPlane.coredns.service.labels }}
@@ -268,7 +268,7 @@ data:
 {{ toYaml .Values.controlPlane.coredns.service.spec | indent 6 }}
       {{- if not .Values.controlPlane.coredns.service.spec.selector }}
       selector:
-        k8s-app: kube-dns
+        k8s-app: vcluster-kube-dns
       {{- end }}
       {{- if not .Values.controlPlane.coredns.service.spec.ports }}
       ports:

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -94,7 +94,7 @@ spec:
               kubernetes.io/metadata.name: 'kube-system'
           podSelector:
             matchLabels:
-              k8s-app: kube-dns
+              k8s-app: vcluster-kube-dns
         {{- if .Values.policies.networkPolicy.outgoingConnections.platform }}
         - podSelector:
             matchLabels:

--- a/chart/tests/coredns-configmap_test.yaml
+++ b/chart/tests/coredns-configmap_test.yaml
@@ -111,7 +111,7 @@ tests:
               name: coredns
               namespace: kube-system
               labels:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
                 kubernetes.io/name: "CoreDNS"
             spec:
               replicas: 1
@@ -121,11 +121,11 @@ tests:
                   maxUnavailable: 1
               selector:
                 matchLabels:
-                  k8s-app: kube-dns
+                  k8s-app: vcluster-kube-dns
               template:
                 metadata:
                   labels:
-                    k8s-app: kube-dns
+                    k8s-app: vcluster-kube-dns
                 spec:
                   priorityClassName: ""
                   serviceAccountName: coredns
@@ -134,7 +134,7 @@ tests:
                   topologySpreadConstraints:
                     - labelSelector:
                         matchLabels:
-                          k8s-app: kube-dns
+                          k8s-app: vcluster-kube-dns
                       maxSkew: 1
                       topologyKey: kubernetes.io/hostname
                       whenUnsatisfiable: DoNotSchedule
@@ -212,13 +212,13 @@ tests:
                 prometheus.io/port: "9153"
                 prometheus.io/scrape: "true"
               labels:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
                 kubernetes.io/cluster-service: "true"
                 kubernetes.io/name: "CoreDNS"
             spec:
               type: ClusterIP
               selector:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
               ports:
                 - name: dns
                   port: 53
@@ -316,7 +316,7 @@ tests:
                 prometheus.io/port: "9153"
                 prometheus.io/scrape: "true"
               labels:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
                 kubernetes.io/cluster-service: "true"
                 kubernetes.io/name: "CoreDNS"
             spec:
@@ -441,7 +441,7 @@ tests:
               name: coredns
               namespace: kube-system
               labels:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
                 kubernetes.io/name: "CoreDNS"
             spec:
               replicas: 1
@@ -451,11 +451,11 @@ tests:
                   maxUnavailable: 1
               selector:
                 matchLabels:
-                  k8s-app: kube-dns
+                  k8s-app: vcluster-kube-dns
               template:
                 metadata:
                   labels:
-                    k8s-app: kube-dns
+                    k8s-app: vcluster-kube-dns
                 spec:
                   priorityClassName: ""
                   serviceAccountName: coredns
@@ -478,7 +478,7 @@ tests:
                   topologySpreadConstraints:
                     - labelSelector:
                         matchLabels:
-                          k8s-app: kube-dns
+                          k8s-app: vcluster-kube-dns
                       maxSkew: 1
                       topologyKey: kubernetes.io/hostname
                       whenUnsatisfiable: DoNotSchedule
@@ -556,13 +556,13 @@ tests:
                 prometheus.io/port: "9153"
                 prometheus.io/scrape: "true"
               labels:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
                 kubernetes.io/cluster-service: "true"
                 kubernetes.io/name: "CoreDNS"
             spec:
               type: ClusterIP
               selector:
-                k8s-app: kube-dns
+                k8s-app: vcluster-kube-dns
               ports:
                 - name: dns
                   port: 53

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -92,7 +92,7 @@ sync:
     persistentVolumes:
       # Enabled defines if this option should be enabled.
       enabled: false
-
+  
   # Configure what resources vCluster should sync from the host cluster to the virtual cluster.
   fromHost:
     # Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
@@ -289,7 +289,7 @@ controlPlane:
         requests:
           cpu: 40m
           memory: 64Mi
-
+  
   # BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
   backingStore:
     # Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
@@ -414,7 +414,7 @@ controlPlane:
         # HeadlessService holds options for the external etcd headless service.
         headlessService:
           annotations: {}
-
+  
   # Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
   proxy:
     # BindAddress under which vCluster will expose the proxy.
@@ -423,7 +423,7 @@ controlPlane:
     port: 8443
     # ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
     extraSANs: []
-
+  
   # CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
   coredns:
     # Enabled defines if coredns is enabled
@@ -479,7 +479,7 @@ controlPlane:
           labelSelector:
             matchLabels:
               k8s-app: vcluster-kube-dns
-
+  
   # Service defines options for vCluster service deployed by Helm.
   service:
     # Enabled defines if the control plane service should be enabled
@@ -493,7 +493,7 @@ controlPlane:
     # Spec allows you to configure extra service options.
     spec:
       type: ClusterIP
-
+  
   # Ingress defines options for vCluster ingress deployed by Helm.
   ingress:
     # Enabled defines if the control plane ingress should be enabled
@@ -510,7 +510,7 @@ controlPlane:
     # Spec allows you to configure extra ingress options.
     spec:
       tls: []
-
+  
   # StatefulSet defines options for vCluster statefulSet deployed by Helm.
   statefulSet:
     labels: {}
@@ -626,14 +626,14 @@ controlPlane:
       # StartupProbe specifies if the startup probe for the container should be enabled
       startupProbe:
         enabled: true
-
+  
   # ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
   serviceMonitor:
     # Enabled configures if Helm should create the service monitor.
     enabled: false
     labels: {}
     annotations: {}
-
+  
   # Advanced holds additional configuration for the vCluster control plane.
   advanced:
     # DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
@@ -680,7 +680,7 @@ integrations:
     nodes: true
     # Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
     pods: true
-
+  
   # ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster
   externalSecrets:
     # Enabled defines whether the external secret integration is enabled or not
@@ -703,7 +703,7 @@ integrations:
         # Selector defines what cluster stores should be synced
         selector:
           labels: {}
-
+  
   # KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
   kubeVirt:
     # Enabled signals if the integration should be enabled
@@ -766,7 +766,7 @@ rbac:
     overwriteRules: []
     # ExtraRules will add rules to the role.
     extraRules: []
-
+  
   # ClusterRole holds virtual cluster cluster role configuration
   clusterRole:
     # Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
@@ -786,10 +786,10 @@ networking:
     toHost: []
     # FromHost defines the services that should get synced from the host to the virtual cluster.
     fromHost: []
-
+  
   # ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
   resolveDNS: []
-
+  
   # Advanced holds advanced network options.
   advanced:
     # ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
@@ -838,7 +838,7 @@ policies:
       matchExpressions: []
     # Scopes are the resource quota scopes
     scopes: []
-
+  
   # LimitRange specifies limit range options.
   limitRange:
     # Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
@@ -860,7 +860,7 @@ policies:
     min: {}
     # Max are the max limits for the limit range
     max: {}
-
+  
   # NetworkPolicy specifies network policy options.
   networkPolicy:
     # Enabled defines if the network policy should be deployed by vCluster.
@@ -888,7 +888,7 @@ policies:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-
+  
   # CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
   centralAdmission:
     # ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
@@ -900,13 +900,13 @@ policies:
 exportKubeConfig:
   # Context is the name of the context within the generated kubeconfig to use.
   context: ""
-
+  
   # Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
   server: ""
-
+  
   # If tls should get skipped for the server
   insecure: false
-
+  
   # ServiceAccount can be used to generate a service account token instead of the default certificates.
   serviceAccount:
     # Name of the service account to be used to generate a service account token instead of the default certificates.
@@ -916,7 +916,7 @@ exportKubeConfig:
     namespace: ""
     # ClusterRole to assign to the service account.
     clusterRole: ""
-
+  
   # Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
   # If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
   # vCluster creates the config in this other secret.
@@ -939,7 +939,7 @@ experimental:
   multiNamespaceMode:
     # Enabled specifies if multi namespace mode should get enabled
     enabled: false
-
+  
   # SyncSettings are advanced settings for the syncer controller.
   syncSettings:
     # DisableSync will not sync any resources and disable most control plane functionality.
@@ -950,7 +950,7 @@ experimental:
     targetNamespace: ""
     # SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
     setOwner: true
-
+  
   # IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
   isolatedControlPlane:
     # Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
@@ -972,7 +972,7 @@ experimental:
       manifestsTemplate: ""
       # Helm are Helm charts that should get deployed into the virtual cluster
       helm: []
-
+  
   # GenericSync holds options to generically sync resources from virtual cluster to host.
   genericSync:
     clusterRole:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -92,7 +92,7 @@ sync:
     persistentVolumes:
       # Enabled defines if this option should be enabled.
       enabled: false
-  
+
   # Configure what resources vCluster should sync from the host cluster to the virtual cluster.
   fromHost:
     # Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
@@ -289,7 +289,7 @@ controlPlane:
         requests:
           cpu: 40m
           memory: 64Mi
-  
+
   # BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
   backingStore:
     # Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
@@ -414,7 +414,7 @@ controlPlane:
         # HeadlessService holds options for the external etcd headless service.
         headlessService:
           annotations: {}
-  
+
   # Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
   proxy:
     # BindAddress under which vCluster will expose the proxy.
@@ -423,7 +423,7 @@ controlPlane:
     port: 8443
     # ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
     extraSANs: []
-  
+
   # CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
   coredns:
     # Enabled defines if coredns is enabled
@@ -478,8 +478,8 @@ controlPlane:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              k8s-app: kube-dns
-  
+              k8s-app: vcluster-kube-dns
+
   # Service defines options for vCluster service deployed by Helm.
   service:
     # Enabled defines if the control plane service should be enabled
@@ -493,7 +493,7 @@ controlPlane:
     # Spec allows you to configure extra service options.
     spec:
       type: ClusterIP
-  
+
   # Ingress defines options for vCluster ingress deployed by Helm.
   ingress:
     # Enabled defines if the control plane ingress should be enabled
@@ -510,7 +510,7 @@ controlPlane:
     # Spec allows you to configure extra ingress options.
     spec:
       tls: []
-  
+
   # StatefulSet defines options for vCluster statefulSet deployed by Helm.
   statefulSet:
     labels: {}
@@ -626,14 +626,14 @@ controlPlane:
       # StartupProbe specifies if the startup probe for the container should be enabled
       startupProbe:
         enabled: true
-  
+
   # ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
   serviceMonitor:
     # Enabled configures if Helm should create the service monitor.
     enabled: false
     labels: {}
     annotations: {}
-  
+
   # Advanced holds additional configuration for the vCluster control plane.
   advanced:
     # DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
@@ -680,7 +680,7 @@ integrations:
     nodes: true
     # Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
     pods: true
-  
+
   # ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster
   externalSecrets:
     # Enabled defines whether the external secret integration is enabled or not
@@ -703,7 +703,7 @@ integrations:
         # Selector defines what cluster stores should be synced
         selector:
           labels: {}
-  
+
   # KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
   kubeVirt:
     # Enabled signals if the integration should be enabled
@@ -766,7 +766,7 @@ rbac:
     overwriteRules: []
     # ExtraRules will add rules to the role.
     extraRules: []
-  
+
   # ClusterRole holds virtual cluster cluster role configuration
   clusterRole:
     # Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
@@ -786,10 +786,10 @@ networking:
     toHost: []
     # FromHost defines the services that should get synced from the host to the virtual cluster.
     fromHost: []
-  
+
   # ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
   resolveDNS: []
-  
+
   # Advanced holds advanced network options.
   advanced:
     # ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
@@ -838,7 +838,7 @@ policies:
       matchExpressions: []
     # Scopes are the resource quota scopes
     scopes: []
-  
+
   # LimitRange specifies limit range options.
   limitRange:
     # Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
@@ -860,7 +860,7 @@ policies:
     min: {}
     # Max are the max limits for the limit range
     max: {}
-  
+
   # NetworkPolicy specifies network policy options.
   networkPolicy:
     # Enabled defines if the network policy should be deployed by vCluster.
@@ -888,7 +888,7 @@ policies:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-  
+
   # CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
   centralAdmission:
     # ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
@@ -900,13 +900,13 @@ policies:
 exportKubeConfig:
   # Context is the name of the context within the generated kubeconfig to use.
   context: ""
-  
+
   # Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
   server: ""
-  
+
   # If tls should get skipped for the server
   insecure: false
-  
+
   # ServiceAccount can be used to generate a service account token instead of the default certificates.
   serviceAccount:
     # Name of the service account to be used to generate a service account token instead of the default certificates.
@@ -916,7 +916,7 @@ exportKubeConfig:
     namespace: ""
     # ClusterRole to assign to the service account.
     clusterRole: ""
-  
+
   # Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
   # If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
   # vCluster creates the config in this other secret.
@@ -939,7 +939,7 @@ experimental:
   multiNamespaceMode:
     # Enabled specifies if multi namespace mode should get enabled
     enabled: false
-  
+
   # SyncSettings are advanced settings for the syncer controller.
   syncSettings:
     # DisableSync will not sync any resources and disable most control plane functionality.
@@ -950,7 +950,7 @@ experimental:
     targetNamespace: ""
     # SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
     setOwner: true
-  
+
   # IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
   isolatedControlPlane:
     # Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
@@ -972,7 +972,7 @@ experimental:
       manifestsTemplate: ""
       # Helm are Helm charts that should get deployed into the virtual cluster
       helm: []
-  
+
   # GenericSync holds options to generically sync resources from virtual cluster to host.
   genericSync:
     clusterRole:

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -259,7 +259,7 @@ controlPlane:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              k8s-app: kube-dns
+              k8s-app: vcluster-kube-dns
 
   service:
     enabled: true

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -354,7 +354,7 @@ func (f *Framework) CreateEgressNetworkPolicyForDNS(ctx context.Context, ns stri
 					},
 					To: []networkingv1.NetworkPolicyPeer{
 						{
-							PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}},
+							PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "vcluster-kube-dns"}},
 							NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"}},
 						},
 					},


### PR DESCRIPTION
Changed vcluster coredns app label. The previous app label would trigger cilium to restart the coredns pod.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-5194


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster coredns pods were repeatedly restarted if cilium was installed in the host cluster.


**What else do we need to know?** 
I am concerned that this would interfere with a cilium install in the vcluster.