### PR TITLE
[v0.22] bugfix: set allocatable resources to 0 when free capacity goes negative

### DIFF
--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -203,15 +203,23 @@ func (s *nodeSyncer) translateUpdateStatus(ctx *synccontext.SyncContext, pNode *
 			pods -= nonVClusterPods
 			if pods > 0 {
 				translatedStatus.Allocatable[corev1.ResourcePods] = *resource.NewQuantity(pods, resource.DecimalSI)
+			} else {
+				translatedStatus.Allocatable[corev1.ResourcePods] = *resource.NewQuantity(0, resource.DecimalSI)
 			}
 			if cpu > 0 {
 				translatedStatus.Allocatable[corev1.ResourceCPU] = *resource.NewMilliQuantity(cpu, resource.DecimalSI)
+			} else {
+				translatedStatus.Allocatable[corev1.ResourceCPU] = *resource.NewMilliQuantity(0, resource.DecimalSI)
 			}
 			if memory > 0 {
 				translatedStatus.Allocatable[corev1.ResourceMemory] = *resource.NewQuantity(memory, resource.BinarySI)
+			} else {
+				translatedStatus.Allocatable[corev1.ResourceMemory] = *resource.NewQuantity(0, resource.BinarySI)
 			}
 			if storageEphemeral > 0 {
 				translatedStatus.Allocatable[corev1.ResourceEphemeralStorage] = *resource.NewQuantity(storageEphemeral, resource.BinarySI)
+			} else {
+				translatedStatus.Allocatable[corev1.ResourceEphemeralStorage] = *resource.NewQuantity(0, resource.BinarySI)
 			}
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5381


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would set Allocatable resource inside the virtual cluster to full capacity instead of 0 when free capacity goes negative


**What else do we need to know?** 
