### PR TITLE
set clusterdomain value in _coredns.tpl

### DIFF
--- a/chart/templates/_coredns.tpl
+++ b/chart/templates/_coredns.tpl
@@ -16,7 +16,7 @@ Corefile: |-
       {{- if .Values.networking.advanced.proxyKubelets.byHostname }}
       rewrite name regex .*\.nodes\.vcluster\.com kubernetes.default.svc.cluster.local
       {{- end }}
-      kubernetes cluster.local in-addr.arpa ip6.arpa {
+      kubernetes {{- if .Values.networking.advanced.clusterDomain }} {{ .Values.networking.advanced.clusterDomain }} {{- end }} cluster.local in-addr.arpa ip6.arpa {
           {{- if .Values.controlPlane.coredns.embedded }}
           kubeconfig /data/vcluster/admin.conf
           {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #
the value set of field `values.networking.advanced.clusterDomain ` was not getting set in the coredns Corefile.

**Please provide a short message that should be published in the vcluster release notes**
added `values.networking.advanced.clusterDomain ` the value in the coredns  Corefile template.

**What else do we need to know?** 
