### PR TITLE
fix: avoid unnecessary proxy container creation for already connected vCluster

### DIFF
--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -93,7 +93,8 @@ func (cmd *connectHelm) connect(ctx context.Context, vCluster *find.VCluster, co
 		return err
 	}
 	if currentContext == find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context) {
-		return fmt.Errorf("already connected to vcluster %q", vCluster.Name)
+		cmd.Log.Infof("already connected to vcluster %q", vCluster.Name)
+		return nil
 	}
 
 	// prepare clients and find vcluster

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -88,17 +88,13 @@ func ConnectHelm(ctx context.Context, options *ConnectOptions, globalFlags *flag
 }
 
 func (cmd *connectHelm) connect(ctx context.Context, vCluster *find.VCluster, command []string) error {
-	currentContext, _, err := find.CurrentContext()
-	if err != nil {
-		return err
-	}
-	if currentContext == find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context) {
+	if connected, _ := checkIfAlreadyConnected(ctx, vCluster); connected {
 		cmd.Log.Infof("already connected to vcluster %q", vCluster.Name)
 		return nil
 	}
 
 	// prepare clients and find vcluster
-	err = cmd.prepare(ctx, vCluster)
+	err := cmd.prepare(ctx, vCluster)
 	if err != nil {
 		return err
 	}
@@ -701,4 +697,29 @@ func (cmd *connectHelm) waitForVCluster(ctx context.Context, vKubeConfig clientc
 	}
 
 	return nil
+}
+
+func checkIfAlreadyConnected(ctx context.Context, vCluster *find.VCluster) (bool, error) {
+	currentContext, _, err := find.CurrentContext()
+	if err != nil {
+		return false, err
+	}
+	if currentContext == find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context) {
+		kubeConfig, err := vCluster.ClientFactory.ClientConfig()
+		if err != nil {
+			return false, err
+		}
+
+		vKubeClient, err := kubernetes.NewForConfig(kubeConfig)
+		if err != nil {
+			return false, err
+		}
+
+		_, err = vKubeClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -715,7 +715,11 @@ func checkIfAlreadyConnected(ctx context.Context, vCluster *find.VCluster) (bool
 			return false, err
 		}
 
-		_, err = vKubeClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		// Use the timeout context in the Get call
+		_, err = vKubeClient.CoreV1().ServiceAccounts("default").Get(timeoutCtx, "default", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -88,8 +88,16 @@ func ConnectHelm(ctx context.Context, options *ConnectOptions, globalFlags *flag
 }
 
 func (cmd *connectHelm) connect(ctx context.Context, vCluster *find.VCluster, command []string) error {
+	currentContext, _, err := find.CurrentContext()
+	if err != nil {
+		return err
+	}
+	if currentContext == find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context) {
+		return fmt.Errorf("already connected to vcluster %q", vCluster.Name)
+	}
+
 	// prepare clients and find vcluster
-	err := cmd.prepare(ctx, vCluster)
+	err = cmd.prepare(ctx, vCluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?**
This PR adds a check to prevent the creation of a background proxy container when already connected to the specified vCluster. For example, if the command `vcluster connect vcluster-test` is run while already connected to `vcluster-test`, the unnecessary proxy container will no longer be created. 
