### PR TITLE
Validate comments in config/config.go before generating jsonschema

### DIFF
--- a/.github/workflows/sync-config-schema.yaml
+++ b/.github/workflows/sync-config-schema.yaml
@@ -135,8 +135,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
         run: |
+          rm -rf vcluster-config/ || true
           git clone --single-branch https://github.com/loft-sh/vcluster-config.git
-
           # copy generated schema from vcluster chart values to vcluster-config
           cp chart/values.schema.json vcluster-config/values.schema.json
           cp -R config/. vcluster-config/config/

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1041,7 +1041,7 @@
         },
         "version": {
           "type": "string",
-          "description": "Version specifies k8s components (scheduler, kube-controller-manager \u0026 apiserver) version.\nIt is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,\ncontrolPlane.distro.k8s.controllerManager.image.tag and\ncontrolPlane.distro.k8s.scheduler.image.tag\nIf e.g. controlPlane.distro.k8s.version is set to v1.30.1 and\ncontrolPlane.distro.k8s.scheduler.image.tag\n(or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)\nis set to v1.31.0,\nvalue from controlPlane.distro.k8s.\u003ccontrolPlane-component\u003e.image.tag will be used\n(where \u003ccontrolPlane-component is apiServer, controllerManager and scheduler)."
+          "description": "Version specifies k8s components (scheduler, kube-controller-manager \u0026 apiserver) version.\nIt is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,\ncontrolPlane.distro.k8s.controllerManager.image.tag and\ncontrolPlane.distro.k8s.scheduler.image.tag\nIf e.g. controlPlane.distro.k8s.version is set to v1.30.1 and\ncontrolPlane.distro.k8s.scheduler.image.tag\n(or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)\nis set to v1.31.0,\nvalue from controlPlane.distro.k8s.(controlPlane-component).image.tag will be used\n(where controlPlane-component is apiServer, controllerManager and scheduler)."
         },
         "apiServer": {
           "$ref": "#/$defs/DistroContainerEnabled",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -161,8 +161,8 @@ controlPlane:
       # controlPlane.distro.k8s.scheduler.image.tag
       # (or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)
       # is set to v1.31.0,
-      # value from controlPlane.distro.k8s.<controlPlane-component>.image.tag will be used
-      # (where <controlPlane-component is apiServer, controllerManager and scheduler).
+      # value from controlPlane.distro.k8s.(controlPlane-component).image.tag will be used
+      # (where controlPlane-component is apiServer, controllerManager and scheduler).
       version: ""
       # APIServer holds configuration specific to starting the api server.
       apiServer:

--- a/config/config.go
+++ b/config/config.go
@@ -1007,8 +1007,8 @@ type DistroK8s struct {
 	// controlPlane.distro.k8s.scheduler.image.tag
 	//(or controlPlane.distro.k8s.controllerManager.image.tag or controlPlane.distro.k8s.apiServer.image.tag)
 	// is set to v1.31.0,
-	// value from controlPlane.distro.k8s.<controlPlane-component>.image.tag will be used
-	// (where <controlPlane-component is apiServer, controllerManager and scheduler).
+	// value from controlPlane.distro.k8s.(controlPlane-component).image.tag will be used
+	// (where controlPlane-component is apiServer, controllerManager and scheduler).
 	Version string `json:"version,omitempty"`
 
 	// APIServer holds configuration specific to starting the api server.

--- a/hack/schema/main.go
+++ b/hack/schema/main.go
@@ -239,6 +239,12 @@ func getReflector() (*jsonschema.Reflector, error) {
 	}
 	r.CommentMap = commentMap
 
+	for k, comment := range commentMap {
+		if strings.Contains(comment, "<") || strings.Contains(comment, ">") {
+			return nil, fmt.Errorf("comment for %s (%s) contains '<' or '>', please remove it because it will break docs generation", k, comment)
+		}
+	}
+
 	return r, nil
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
- add checking for invalid characters that will break .mdx generation  in docs to hack/schema/main.go;
- fix sync-config-schema.yaml vcluster-config syncing


**Please provide a short message that should be published in the vcluster release notes**
Enhancement: do not allow invalid characters in config/config.go comments


**What else do we need to know?** 
