### PR TITLE
fix: service label sync problems

### DIFF
--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -204,7 +204,7 @@ func (s *serviceSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.Sy
 
 	// translate selector
 	// TODO: ryan - convert to bidirectional
-	if !apiequality.Semantic.DeepEqual(event.VirtualOld.Spec.Selector, event.Virtual.Spec.Selector) {
+	if !apiequality.Semantic.DeepEqual(event.VirtualOld.Spec.Selector, event.Virtual.Spec.Selector) || apiequality.Semantic.DeepEqual(event.HostOld.Spec.Selector, event.Host.Spec.Selector) {
 		event.Host.Spec.Selector = translate.HostLabelsMap(event.Virtual.Spec.Selector, event.Host.Spec.Selector, event.Virtual.Namespace, false)
 	} else {
 		event.Virtual.Spec.Selector = translate.VirtualLabelsMap(event.Host.Spec.Selector, event.Virtual.Spec.Selector)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not sync service label selectors correctly on upgrade
