### PR TITLE
[v0.19] Set fake Node IP for the virtual pod status.HostIP field when fakeKubeletIPs is enabled

### DIFF
--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -425,6 +425,10 @@ func TestSync(t *testing.T) {
 
 	pPodFakeKubelet := pPodBase.DeepCopy()
 	pPodFakeKubelet.Spec.NodeName = testNodeName
+	pPodFakeKubelet.Status.HostIP = "3.3.3.3"
+	pPodFakeKubelet.Status.HostIPs = []corev1.HostIP{
+		{IP: "3.3.3.3"},
+	}
 
 	vPodWithHostIP := vPodWithNodeName.DeepCopy()
 	vPodWithHostIP.Status.HostIP = pVclusterService.Spec.ClusterIP
@@ -578,7 +582,7 @@ func TestSync(t *testing.T) {
 		},
 		{
 			Name:                 "Fake Kubelet enabled with Node sync",
-			InitialVirtualState:  []runtime.Object{testNode.DeepCopy(), vPodWithNodeName},
+			InitialVirtualState:  []runtime.Object{testNode.DeepCopy(), vPodWithNodeName, vNamespace.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{testNode.DeepCopy(), pVclusterNodeService.DeepCopy(), pPodFakeKubelet.DeepCopy()},
 			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
 				corev1.SchemeGroupVersion.WithKind("Pod"): {vPodWithHostIP},

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -43,6 +43,8 @@ const (
 	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
 	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
 	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
+	HostIPAnnotation                     = "vcluster.loft.sh/host-ip"
+	HostIPsAnnotation                    = "vcluster.loft.sh/host-ips"
 )
 
 var (
@@ -91,6 +93,7 @@ func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder record.EventR
 		serviceAccountsEnabled:       ctx.Controllers.Has("serviceaccounts"),
 		priorityClassesEnabled:       ctx.Controllers.Has("priorityclasses"),
 		enableScheduler:              ctx.Options.EnableScheduler,
+		fakeKubeletIPs:               ctx.Options.FakeKubeletIPs,
 		syncedLabels:                 ctx.Options.SyncLabels,
 
 		mountPhysicalHostPaths:   ctx.Options.MountPhysicalHostPaths,
@@ -119,6 +122,7 @@ type translator struct {
 	overrideHostsImage           string
 	priorityClassesEnabled       bool
 	enableScheduler              bool
+	fakeKubeletIPs               bool
 	syncedLabels                 []string
 
 	mountPhysicalHostPaths   bool
@@ -271,7 +275,7 @@ func (t *translator) Translate(ctx context.Context, vPod *corev1.Pod, services [
 
 	// translate containers
 	for i := range pPod.Spec.Containers {
-		envVar, envFrom := ContainerEnv(pPod.Spec.Containers[i].Env, pPod.Spec.Containers[i].EnvFrom, vPod, serviceEnv)
+		envVar, envFrom := ContainerEnv(pPod.Spec.Containers[i].Env, pPod.Spec.Containers[i].EnvFrom, vPod, serviceEnv, t.fakeKubeletIPs, t.enableScheduler)
 		pPod.Spec.Containers[i].Env = envVar
 		pPod.Spec.Containers[i].EnvFrom = envFrom
 		pPod.Spec.Containers[i].Image = t.imageTranslator.Translate(pPod.Spec.Containers[i].Image)
@@ -279,7 +283,7 @@ func (t *translator) Translate(ctx context.Context, vPod *corev1.Pod, services [
 
 	// translate init containers
 	for i := range pPod.Spec.InitContainers {
-		envVar, envFrom := ContainerEnv(pPod.Spec.InitContainers[i].Env, pPod.Spec.InitContainers[i].EnvFrom, vPod, serviceEnv)
+		envVar, envFrom := ContainerEnv(pPod.Spec.InitContainers[i].Env, pPod.Spec.InitContainers[i].EnvFrom, vPod, serviceEnv, t.fakeKubeletIPs, t.enableScheduler)
 		pPod.Spec.InitContainers[i].Env = envVar
 		pPod.Spec.InitContainers[i].EnvFrom = envFrom
 		pPod.Spec.InitContainers[i].Image = t.imageTranslator.Translate(pPod.Spec.InitContainers[i].Image)
@@ -287,7 +291,7 @@ func (t *translator) Translate(ctx context.Context, vPod *corev1.Pod, services [
 
 	// translate ephemeral containers
 	for i := range pPod.Spec.EphemeralContainers {
-		envVar, envFrom := ContainerEnv(pPod.Spec.EphemeralContainers[i].Env, pPod.Spec.EphemeralContainers[i].EnvFrom, vPod, serviceEnv)
+		envVar, envFrom := ContainerEnv(pPod.Spec.EphemeralContainers[i].Env, pPod.Spec.EphemeralContainers[i].EnvFrom, vPod, serviceEnv, t.fakeKubeletIPs, t.enableScheduler)
 		pPod.Spec.EphemeralContainers[i].Env = envVar
 		pPod.Spec.EphemeralContainers[i].EnvFrom = envFrom
 		pPod.Spec.EphemeralContainers[i].Image = t.imageTranslator.Translate(pPod.Spec.EphemeralContainers[i].Image)
@@ -577,12 +581,22 @@ func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector) {
 		fieldSelector.FieldPath = "metadata.annotations['" + UIDAnnotation + "']"
 	case "spec.serviceAccountName":
 		fieldSelector.FieldPath = "metadata.annotations['" + ServiceAccountNameAnnotation + "']"
+	case "status.hostIP":
+		fieldSelector.FieldPath = "metadata.annotations['" + HostIPAnnotation + "']"
+	case "status.hostIPs":
+		fieldSelector.FieldPath = "metadata.annotations['" + HostIPsAnnotation + "']"
 	}
 }
 
-func ContainerEnv(envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, vPod *corev1.Pod, serviceEnvMap map[string]string) ([]corev1.EnvVar, []corev1.EnvFromSource) {
+func ContainerEnv(envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, vPod *corev1.Pod, serviceEnvMap map[string]string, fakeKubeletIPs, enableScheduler bool) ([]corev1.EnvVar, []corev1.EnvFromSource) {
 	envNameMap := make(map[string]struct{})
 	for j, env := range envVar {
+		// translate downward API references for status.hostIP(s) only when both virtual scheduler & fakeKubeletIPs are enabled
+		if (env.ValueFrom != nil && env.ValueFrom.FieldRef != nil && (env.ValueFrom.FieldRef.FieldPath == "status.hostIP" || env.ValueFrom.FieldRef.FieldPath == "status.hostIPs")) &&
+			!(fakeKubeletIPs && enableScheduler) {
+			continue
+		}
+
 		translateDownwardAPI(&envVar[j])
 		if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Name != "" {
 			envVar[j].ValueFrom.ConfigMapKeyRef.Name = translate.Default.PhysicalName(envVar[j].ValueFrom.ConfigMapKeyRef.Name, vPod.Namespace)

--- a/test/e2e/syncer/pods/pods.go
+++ b/test/e2e/syncer/pods/pods.go
@@ -80,6 +80,8 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		pod, err := f.HostClient.CoreV1().Pods(translate.Default.PhysicalNamespace(ns)).Get(f.Context, translate.Default.PhysicalName(podName, ns), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
+		// ignore HostIP differences
+		resetHostIP(vpod, pod)
 		framework.ExpectEqual(vpod.Status, pod.Status)
 
 		// check for ephemeralContainers subResource
@@ -137,6 +139,9 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		framework.ExpectNoError(err)
 		pod, err := f.HostClient.CoreV1().Pods(translate.Default.PhysicalNamespace(ns)).Get(f.Context, translate.Default.PhysicalName(podName, ns), metav1.GetOptions{})
 		framework.ExpectNoError(err)
+
+		// ignore HostIP differences
+		resetHostIP(vpod, pod)
 		framework.ExpectEqual(vpod.Status, pod.Status)
 
 		// check for conditions
@@ -542,3 +547,8 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		}
 	})
 })
+
+func resetHostIP(vpod, pod *corev1.Pod) {
+	vpod.Status.HostIP, pod.Status.HostIP = "", ""
+	vpod.Status.HostIPs, pod.Status.HostIPs = nil, nil
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5474


**Please provide a short message that should be published in the vcluster release notes**
vcluster will now show fake Node IPs under pod status.HostIP field when fakeKubeletIPs is enabled


**What else do we need to know?** 
