### PR TITLE
Made changes in verifyHost() function & return statement by replacing loft with vCluster platform

### DIFF
--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -232,7 +232,7 @@ func (c *client) Config() *config.CLI {
 
 func verifyHost(host string) error {
 	if !strings.HasPrefix(host, "https") {
-		return fmt.Errorf("cannot log into a non https loft instance '%s', please make sure you have TLS enabled", host)
+		return fmt.Errorf("cannot log into a non https vCluster platform instance '%s', please make sure you have TLS enabled", host)
 	}
 
 	return nil
@@ -347,7 +347,7 @@ func (c *client) LoginWithAccessKey(host, accessKey string, insecure bool) error
 		if errors.As(err, &urlError) && urlError != nil {
 			var err x509.UnknownAuthorityError
 			if errors.As(urlError.Err, &err) {
-				return fmt.Errorf("unsafe login endpoint '%s', if you wish to login into an insecure loft endpoint run with the '--insecure' flag", c.config.Platform.Host)
+				return fmt.Errorf("unsafe login endpoint '%s', if you wish to login into an insecure vCluster platform endpoint run with the '--insecure' flag", c.config.Platform.Host)
 			}
 		}
 


### PR DESCRIPTION

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation


**Please provide a short message that should be published in the vCluster release notes**
I resolved an issue in `client.go` where the functions incorrectly referenced the Loft instead of the vCluster platform.

