### PR TITLE
Support labelSelectors to filter out services before syncing to the host cluster

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1114,6 +1114,10 @@
           "type": "boolean",
           "description": "Enabled defines if this option should be enabled."
         },
+        "selector": {
+          "$ref": "#/$defs/SyncSelector",
+          "description": "Selector defines the labelSelector based filtering for syncing the resources to the host cluster."
+        },
         "patches": {
           "items": {
             "$ref": "#/$defs/TranslatePatch"
@@ -2030,6 +2034,24 @@
           },
           "type": "object",
           "description": "Labels defines what labels should be looked for"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "LabelSelectorRequirement": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -3283,6 +3305,24 @@
         "resources": {
           "$ref": "#/$defs/Resources",
           "description": "Resources are the resources that should be assigned to the init container for each stateful set init container."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncSelector": {
+      "properties": {
+        "matchLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "matchExpressions": {
+          "items": {
+            "$ref": "#/$defs/LabelSelectorRequirement"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,8 @@ sync:
     services:
       # Enabled defines if this option should be enabled.
       enabled: true
+      # Selector defines the labelSelector based filtering for syncing the resources to the host cluster.
+      selector: {}
     # Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
     endpoints:
       # Enabled defines if this option should be enabled.

--- a/config/config.go
+++ b/config/config.go
@@ -509,7 +509,10 @@ type EnableSwitchWithPatches struct {
 }
 
 type SyncSelector struct {
-	MatchLabels      map[string]string                 `json:"matchLabels,omitempty"`
+	// MatchLabels are the labels to select the object from.
+	MatchLabels map[string]string `json:"matchLabels,omitempty"`
+
+	// MatchExpressions is a list of label selector requirements which supports operators such as In, NotIn, Exists and DoesNotExist.
 	MatchExpressions []metav1.LabelSelectorRequirement `json:"matchExpressions,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/invopop/jsonschema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"regexp"
 	"strings"
@@ -500,8 +501,16 @@ type EnableSwitchWithPatches struct {
 	// Enabled defines if this option should be enabled.
 	Enabled bool `json:"enabled,omitempty"`
 
+	// Selector defines the labelSelector based filtering for syncing the resources to the host cluster.
+	Selector *SyncSelector `json:"selector,omitempty"`
+
 	// Patches patch the resource according to the provided specification.
 	Patches []TranslatePatch `json:"patches,omitempty"`
+}
+
+type SyncSelector struct {
+	MatchLabels      map[string]string                 `json:"matchLabels,omitempty"`
+	MatchExpressions []metav1.LabelSelectorRequirement `json:"matchExpressions,omitempty"`
 }
 
 type SyncFromHost struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -5,6 +5,8 @@ sync:
   toHost:
     services:
       enabled: true
+      # selector defines the label and expression based filtering before syncing the services to the host cluster.
+      selector: {}
     endpoints:
       enabled: true
     persistentVolumeClaims:

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -83,7 +83,7 @@ func (s *serviceSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccont
 	}
 	// cancel sync operation if the validation fails i.e. there is a mismatch in the labels.
 	if !validated {
-		ctx.Log.Infof("The labels of the service %s don't match against the selector provided in the config", event.Virtual.Name)
+		ctx.Log.Debugf("The labels of the service %s don't match against the selector provided in the config", event.Virtual.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/resources/services/validate.go
+++ b/pkg/controllers/resources/services/validate.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// ValidateServiceBeforeSync checks whether service labels match with the label selector provided in the vcluster config.
+// These matchers provided in the config decide whether the services will be synced to host or not.
+func ValidateServiceBeforeSync(ctx *synccontext.SyncContext, serviceLabels map[string]string) (bool, error) {
+	// fetch the selector provided in the config.
+	configLabelSelector := ctx.Config.Sync.ToHost.Services.Selector
+	var selector labels.Selector
+	var err error
+	if configLabelSelector != nil {
+		// form metav1.LabelSelector object from selector provided in the config.
+		labelSelector := &metav1.LabelSelector{
+			MatchLabels:      configLabelSelector.MatchLabels,
+			MatchExpressions: configLabelSelector.MatchExpressions,
+		}
+		selector, err = metav1.LabelSelectorAsSelector(labelSelector)
+		if err != nil {
+			return false, fmt.Errorf("invalid label selector: %v", err)
+		}
+	}
+
+	if selector != nil && !selector.Matches(labels.Set(serviceLabels)) {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1622 


**Please provide a short message that should be published in the vcluster release notes**
Added a feature enhancement to support filtering out services using label selectors, in particular MatchExpressions (for eg. label/export-service NotIn ["false"]

**What else do we need to know?** 
