### PR TITLE
fix: remove kubernetes-version flag in vcluster create

### DIFF
--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -176,21 +176,3 @@ func addCommonReleaseValues(config *Config, options *ExtraValuesOptions) {
 		}
 	}
 }
-
-func ParseKubernetesVersionInfo(versionStr string) (*KubernetesVersion, error) {
-	if versionStr[0] == 'v' {
-		versionStr = versionStr[1:]
-	}
-
-	splittedVersion := strings.Split(versionStr, ".")
-	if len(splittedVersion) != 2 && len(splittedVersion) != 3 {
-		return nil, fmt.Errorf("unrecognized kubernetes version %s, please use format vX.X", versionStr)
-	}
-
-	major := splittedVersion[0]
-	minor := splittedVersion[1]
-	return &KubernetesVersion{
-		Major: major,
-		Minor: minor,
-	}, nil
-}

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -710,37 +710,9 @@ func (cmd *createHelm) createNamespace(ctx context.Context) error {
 }
 
 func (cmd *createHelm) getKubernetesVersion() (*version.Info, error) {
-	var (
-		kubernetesVersion *version.Info
-		err               error
-	)
-	if cmd.KubernetesVersion != "" {
-		if cmd.KubernetesVersion[0] != 'v' {
-			cmd.KubernetesVersion = "v" + cmd.KubernetesVersion
-		}
-
-		if !semver.IsValid(cmd.KubernetesVersion) {
-			return nil, fmt.Errorf("please use valid semantic versioning format, e.g. vX.X")
-		}
-
-		majorMinorVer := semver.MajorMinor(cmd.KubernetesVersion)
-
-		parsedVersion, err := config.ParseKubernetesVersionInfo(majorMinorVer)
-		if err != nil {
-			return nil, err
-		}
-
-		kubernetesVersion = &version.Info{
-			Major: parsedVersion.Major,
-			Minor: parsedVersion.Minor,
-		}
-	}
-
-	if kubernetesVersion == nil {
-		kubernetesVersion, err = cmd.kubeClient.ServerVersion()
-		if err != nil {
-			return nil, err
-		}
+	kubernetesVersion, err := cmd.kubeClient.ServerVersion()
+	if err != nil {
+		return nil, err
 	}
 
 	return kubernetesVersion, nil

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -263,6 +263,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if err != nil {
 		return err
 	}
+
 	chartValues, err := config.GetExtraValues(chartOptions)
 	if err != nil {
 		return err
@@ -723,10 +724,6 @@ func (cmd *createHelm) getKubernetesVersion() (*version.Info, error) {
 		}
 
 		majorMinorVer := semver.MajorMinor(cmd.KubernetesVersion)
-
-		if splittedVersion := strings.Split(cmd.KubernetesVersion, "."); len(splittedVersion) > 2 {
-			cmd.log.Warnf("currently we only support major.minor version (%s) and not the patch version (%s)", majorMinorVer, cmd.KubernetesVersion)
-		}
 
 		parsedVersion, err := config.ParseKubernetesVersionInfo(majorMinorVer)
 		if err != nil {

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -263,7 +263,6 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if err != nil {
 		return err
 	}
-
 	chartValues, err := config.GetExtraValues(chartOptions)
 	if err != nil {
 		return err

--- a/pkg/cli/create_platform.go
+++ b/pkg/cli/create_platform.go
@@ -164,7 +164,7 @@ func createWithoutTemplate(ctx context.Context, platformClient platform.Client, 
 	}
 
 	// merge values
-	helmValues, err := mergeValues(platformClient, options, log)
+	helmValues, err := mergeValues(platformClient, options)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func upgradeWithoutTemplate(ctx context.Context, platformClient platform.Client,
 	}
 
 	// merge values
-	helmValues, err := mergeValues(platformClient, options, log)
+	helmValues, err := mergeValues(platformClient, options)
 	if err != nil {
 		return nil, err
 	}
@@ -584,9 +584,9 @@ func validateTemplateOptions(options *CreateOptions) error {
 	return nil
 }
 
-func mergeValues(platformClient platform.Client, options *CreateOptions, log log.Logger) (string, error) {
+func mergeValues(platformClient platform.Client, options *CreateOptions) (string, error) {
 	// merge values
-	chartOptions, err := toChartOptions(platformClient, options, log)
+	chartOptions, err := toChartOptions(platformClient, options)
 	if err != nil {
 		return "", err
 	}
@@ -647,7 +647,7 @@ func parseString(str string) (map[string]interface{}, error) {
 	return out, nil
 }
 
-func toChartOptions(platformClient platform.Client, options *CreateOptions, log log.Logger) (*vclusterconfig.ExtraValuesOptions, error) {
+func toChartOptions(platformClient platform.Client, options *CreateOptions) (*vclusterconfig.ExtraValuesOptions, error) {
 	if !util.Contains(options.Distro, AllowedDistros) {
 		return nil, fmt.Errorf("unsupported distro %s, please select one of: %s", options.Distro, strings.Join(AllowedDistros, ", "))
 	}

--- a/pkg/cli/flags/create/create.go
+++ b/pkg/cli/flags/create/create.go
@@ -15,7 +15,6 @@ func AddCommonFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 	cmd.Flags().StringVar(&options.ChartVersion, "chart-version", upgrade.GetVersion(), "The virtual cluster chart version to use (e.g. v0.9.1)")
 	cmd.Flags().StringVar(&options.ChartName, "chart-name", "vcluster", "The virtual cluster chart name to use")
 	cmd.Flags().StringVar(&options.ChartRepo, "chart-repo", constants.LoftChartRepo, "The virtual cluster chart repo to use")
-	cmd.Flags().StringVar(&options.KubernetesVersion, "kubernetes-version", "", "The kubernetes version to use (e.g. v1.20). Patch versions are not supported")
 	cmd.Flags().StringArrayVarP(&options.Values, "values", "f", []string{}, "Path where to load extra helm values from")
 	cmd.Flags().StringArrayVar(&options.SetValues, "set", []string{}, "Set values for helm. E.g. --set 'persistence.enabled=true'")
 	cmd.Flags().BoolVar(&options.Print, "print", false, "If enabled, prints the context to the console")
@@ -29,8 +28,6 @@ func AddCommonFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 	_ = cmd.Flags().MarkDeprecated("distro", fmt.Sprintf("please specify the distro by setting %q accordingly via values.yaml file.", "controlPlane.distro"))
 	_ = cmd.Flags().MarkHidden("update-current")
 	_ = cmd.Flags().MarkDeprecated("update-current", fmt.Sprintf("please use %q.", "--connect"))
-	_ = cmd.Flags().MarkHidden("kubernetes-version")
-	_ = cmd.Flags().MarkDeprecated("kubernetes-version", fmt.Sprintf("please specify the kubernetes version by setting %q accordingly via values.yaml file.", "controlPlane.distro.k8s.version"))
 }
 
 func AddHelmFlags(cmd *cobra.Command, options *cli.CreateOptions) {

--- a/pkg/cli/flags/create/create.go
+++ b/pkg/cli/flags/create/create.go
@@ -29,6 +29,8 @@ func AddCommonFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 	_ = cmd.Flags().MarkDeprecated("distro", fmt.Sprintf("please specify the distro by setting %q accordingly via values.yaml file.", "controlPlane.distro"))
 	_ = cmd.Flags().MarkHidden("update-current")
 	_ = cmd.Flags().MarkDeprecated("update-current", fmt.Sprintf("please use %q.", "--connect"))
+	_ = cmd.Flags().MarkHidden("kubernetes-version")
+	_ = cmd.Flags().MarkDeprecated("kubernetes-version", fmt.Sprintf("please specify the kubernetes version by setting %q accordingly via values.yaml file.", "controlPlane.distro.k8s.version"))
 }
 
 func AddHelmFlags(cmd *cobra.Command, options *cli.CreateOptions) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2294
resolves ENG-5242


**Please provide a short message that should be published in the vcluster release notes**
Remove the `kubernetes-version` flag in `vcluster create`command, kubernetes version can now be configured from values.yaml.

**What else do we need to know?** 