### PR TITLE
Allow vcluster pod (etcd and syncer) to query root cluster dns

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -94,6 +94,12 @@ spec:
               kubernetes.io/metadata.name: 'kube-system'
           podSelector:
             matchLabels:
+              k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: 'kube-system'
+          podSelector:
+            matchLabels:
               k8s-app: vcluster-kube-dns
         {{- if .Values.policies.networkPolicy.outgoingConnections.platform }}
         - podSelector:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

This issue resolve (https://loft-sh.slack.com/archives/C01N273CF4P/p1736419468114199) the Network policy was changed during the re-labeled of core-dns and make root dns unreacheable by etcd and syncer so the vcluster will not start

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster doesn't bootstrap well when network policies is enabled 
