### PR TITLE
fix: revert networkpolicy label selector

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -94,7 +94,7 @@ spec:
               kubernetes.io/metadata.name: 'kube-system'
           podSelector:
             matchLabels:
-              k8s-app: vcluster-kube-dns
+              k8s-app: kube-dns
         {{- if .Values.policies.networkPolicy.outgoingConnections.platform }}
         - podSelector:
             matchLabels:


### PR DESCRIPTION
Prior, the label selector "k8s-app=kube-dns" in the NetworkPolicy template was changed to target the updated vcluster coredns pod name, vcluster-kube-dns. Enabling NetworkPolicy creates a NetworkPolicy in the host cluster. The NetworkPolicy intends to target the host's coredns pod which is still named kube-dns. The NetworkPolicy is additionally targeting the kube-system namespace. There is no pod that matches the "k8s-app=kube-dns" selector in the host's kube-system namespace. Now, the change to the NetworkPolicy's label selector has been reverted so that it properly selects for the host's kube-dns pod.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-5522


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster with etcd backing store did not have access to host's coredns pod.


**What else do we need to know?** 
