### PR TITLE
fix: Only error when we verify they're using a disposable domain.

### DIFF
--- a/pkg/cli/email/validate.go
+++ b/pkg/cli/email/validate.go
@@ -68,25 +68,25 @@ func Validate(emailAddress string, options ...Option) error {
 func checkDisposableDomains(domain string) error {
 	fb, err := domainsZip.ReadFile("disposable_domains.zip")
 	if err != nil {
-		return err
+		return nil
 	}
 
 	zipReader, err := zip.NewReader(bytes.NewReader(fb), int64(len(fb)))
 	if err != nil {
-		return fmt.Errorf("failed to read disposable domains list for verification: %w", err)
+		return nil
 	}
 
 	for _, file := range zipReader.File {
 		if file.Name == "disposable_domains.json" {
 			f, err := file.Open()
 			if err != nil {
-				return err
+				return nil
 			}
 			defer f.Close()
 
 			var domains []string
 			if err := json.NewDecoder(f).Decode(&domains); err != nil {
-				return fmt.Errorf("disposable domains list improperly formatted: %w", err)
+				return nil
 			}
 
 			if slices.Contains(domains, domain) {


### PR DESCRIPTION
This change ignores any errors in trying to get the disposable domains list and only returns an error if the domain being used is found in the list.

I tested this by providing a disposable domain to get the error and by using a list in an invalid json format to get the logging, and see it ignore the error.

/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-5542

