### PR TITLE
fix: Check if vcluster is reachable with the additional flags provided as input in `vcluster connect` command

### DIFF
--- a/test/e2e_cli/connect/connect.go
+++ b/test/e2e_cli/connect/connect.go
@@ -67,4 +67,15 @@ var _ = ginkgo.Describe("Connect to vCluster", func() {
 		err := connectCmd.Execute()
 		framework.ExpectNoError(err)
 	})
+
+	ginkgo.It("should fail saying the client timeout exceeded", func() {
+		connectCmd := cmd.NewConnectCmd(&flags.GlobalFlags{})
+		connectCmd.SetArgs([]string{f.VclusterName})
+		err := connectCmd.Flags().Set("kube-config", f.VClusterKubeConfigFile.Name())
+		framework.ExpectNoError(err)
+		err = connectCmd.Flags().Set("server", "testdomain.org")
+		framework.ExpectNoError(err)
+		err = connectCmd.Execute()
+		framework.ExpectError(err)
+	})
 })


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5488


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster connect` command was giving positive result even when vcluster is not exposed on the endpoint provided in `server` flag


**What else do we need to know?** 
With this PR, the `vcluster connect` command will perform an additional check of verifying the vcluster is accessible with the additional flags that are provided in the command. This is done by checking if we are able to list the `default` service account is in the vcluster.
eg: `vcluster connect --server` will verify if vcluster is accessible from the endpoint specified in `--server` flag
