### PR TITLE
Exclude backingStore.etcd's image from getting populated when disabled

### DIFF
--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -173,18 +173,9 @@ func applyK8SExtraValues(vConfig *Config, options *ExtraValuesOptions) error {
 		return err
 	}
 
-	// get etcd image
-	etcdImage, err := getImageByVersion(options.KubernetesVersion, K8SEtcdVersionMap)
-	if err != nil {
-		return err
-	}
-
 	// build values
 	if apiImage != "" {
 		vConfig.ControlPlane.Distro.K8S.Version = parseImage(apiImage).Tag
-	}
-	if etcdImage != "" {
-		vConfig.ControlPlane.BackingStore.Etcd.Deploy.StatefulSet.Image = parseImage(etcdImage)
 	}
 
 	return nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5526 (#2398) 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue in vcluster v0.20 where the controlPlane.backingStore.etcd's image is getting populated with default values even when it has been disabled.

**What else do we need to know?** 
While reproducing the issue, I came to a conclusion that this issue happens in vcluster version 0.20 when k8s version < 1.30, a quick fix for the user would be to either upgrade vcluster to latest version OR upgrade k8s to a version >= 1.30

Now, for the users on vcluster 0.20 and having k8s version < 1.30, this PR would resolve the issue. Please refer to the artifact attached below. With this fix, controlPlane.backingStore.etcd's image will not get populated if disabled.

One thing to note here- similar to etcd image, there are distro images as well present in the output as mentioned in the issue. These can also be fixed in the similar fashion as this PR. Let me know if we want to resolve that along with this etcd image fix.

![Screenshot from 2025-01-17 21-22-43](https://github.com/user-attachments/assets/f73e8661-cbe3-4bc6-bac8-1afe24e4b86d)

