### PR TITLE
ConfigMaps From Host Sync:

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -412,6 +412,10 @@ jobs:
             kubectl apply -f ${{ matrix.test-suite-path }}/role.yaml
           fi
 
+          if [ ${{ matrix.test-suite-path }} == "./test/e2e" ]; then
+            kubectl create namespace foobar
+          fi
+
           sudo apt-get install -y sed
 
           sed -i "s|REPLACE_REPOSITORY_NAME|${{ env.REPOSITORY_NAME }}|g" ${{ matrix.test-suite-path }}/../commonValues.yaml

--- a/Justfile
+++ b/Justfile
@@ -119,6 +119,7 @@ e2e distribution="k3s" path="./test/e2e" multinamespace="false": create-kind && 
   sed -i.bak "s|kind-control-plane|vcluster-control-plane|g" dist/commonValues.yaml
   rm dist/commonValues.yaml.bak
 
+  kubectl create namespace foobar
   ./dist/vcluster-cli_$(go env GOOS)_$(go env GOARCH | sed s/amd64/amd64_v1/g)/vcluster \
     create vcluster -n vcluster \
     --create-namespace \
@@ -137,6 +138,7 @@ e2e distribution="k3s" path="./test/e2e" multinamespace="false": create-kind && 
     MULTINAMESPACE_MODE={{ multinamespace }} \
     KIND_NAME=vcluster \
     go test -v -ginkgo.v -ginkgo.skip='.*NetworkPolicy.*' -ginkgo.fail-fast
+
 
 cli version="0.0.0" *ARGS="":
   RELEASE_VERSION={{ version }} go generate -tags embed_chart ./...

--- a/chart/templates/_helper.tpl
+++ b/chart/templates/_helper.tpl
@@ -15,3 +15,49 @@
 {{ .repository }}:{{ .tag }}
 {{- end -}}
 {{- end -}}
+
+{{- define "extractNamespacesFromHostMappings" -}}
+{{- $root := index . 0 -}}
+{{- $mappings := index . 1 -}}
+{{- $namespaces := list -}}
+{{- range $key, $val := $mappings -}}
+  {{- $sourceNs := splitList "/" $key | first -}}
+  {{- if eq $sourceNs "*" -}}
+    {{- $namespaces = append $namespaces $root.Release.Namespace -}}
+  {{- else -}}
+    {{- $namespaces = append $namespaces $sourceNs -}}
+  {{- end -}}
+{{- end -}}
+{{- $nsList := $namespaces | uniq | sortAlpha -}}
+{{- range $namespace := $nsList }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vc-{{ $root.Release.Name }}-from-host
+  namespace: {{ $namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vc-{{ $root.Release.Name }}-from-host
+  namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vc-{{ $root.Release.Name }}-from-host
+subjects:
+  - kind: ServiceAccount
+    {{- if $root.Values.controlPlane.advanced.serviceAccount.name }}
+    name: {{ $root.Values.controlPlane.advanced.serviceAccount.name | quote }}
+    {{- else }}
+    name: vc-{{ $root.Release.Name }}
+    {{- end }}
+    namespace: {{ $root.Release.Namespace }}
+---
+{{- end }}
+{{- end }}
+

--- a/chart/templates/fromhost_role.yaml
+++ b/chart/templates/fromhost_role.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.sync.fromHost.configMaps.enabled -}}
+{{- with .Values.sync.fromHost.configMaps.selector -}}
+{{- if .mappings -}}
+{{- include "extractNamespacesFromHostMappings" (list $ .mappings)  -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1125,6 +1125,27 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "EnableSwitchWithResourcesMappings": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "selector": {
+          "$ref": "#/$defs/FromHostSelector",
+          "description": "Selector for Namespace and Object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Etcd": {
       "properties": {
         "embedded": {
@@ -1798,6 +1819,19 @@
         "clusterStores": {
           "$ref": "#/$defs/ClusterStoresSyncConfig",
           "description": "ClusterStores defines whether to sync cluster stores or not"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FromHostSelector": {
+      "properties": {
+        "mappings": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Mappings is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.\nThere are several wildcards supported:\n1. To match all objects in host namespace and sync them to different namespace in vCluster:\nmappings:\n  \"foo/*\": \"foo-in-virtual/*\"\n2. To match specific object in the host namespace and sync it to the same namespace with the same name:\nmappings:\n  \"foo/my-object\": \"foo/my-object\"\n3. To match specific object in the host namespace and sync it to the same namespace with different name:\nmappings:\n  \"foo/my-object\": \"foo/my-virtual-object\"\n4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:\nmappings:\n  \"*\": \"my-virtual-namespace/*\""
         }
       },
       "additionalProperties": false,
@@ -3145,6 +3179,10 @@
         "volumeSnapshotClasses": {
           "$ref": "#/$defs/EnableSwitchWithPatches",
           "description": "VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster."
+        },
+        "configMaps": {
+          "$ref": "#/$defs/EnableSwitchWithResourcesMappings",
+          "description": "ConfigMaps defines if config maps in the host should get synced to the virtual cluster."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,6 +101,27 @@ sync:
     events:
       # Enabled defines if this option should be enabled.
       enabled: true
+    # ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
+    configMaps:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+      # Selector for Namespace and Object
+      selector:
+        # Mappings is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
+        # There are several wildcards supported:
+        # 1. To match all objects in host namespace and sync them to different namespace in vCluster:
+        # mappings:
+        #   "foo/*": "foo-in-virtual/*"
+        # 2. To match specific object in the host namespace and sync it to the same namespace with the same name:
+        # mappings:
+        #   "foo/my-object": "foo/my-object"
+        # 3. To match specific object in the host namespace and sync it to the same namespace with different name:
+        # mappings:
+        #   "foo/my-object": "foo/my-virtual-object"
+        # 4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+        # mappings:
+        #   "*": "my-virtual-namespace/*"
+        mappings: {}
     # CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
     csiDrivers:
       # Enabled defines if this option should be enabled.

--- a/config/config.go
+++ b/config/config.go
@@ -504,6 +504,35 @@ type EnableSwitchWithPatches struct {
 	Patches []TranslatePatch `json:"patches,omitempty"`
 }
 
+type EnableSwitchWithResourcesMappings struct {
+	// Enabled defines if this option should be enabled.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// Patches patch the resource according to the provided specification.
+	Patches []TranslatePatch `json:"patches,omitempty"`
+
+	// Selector for Namespace and Object
+	Selector FromHostSelector `json:"selector,omitempty"`
+}
+
+type FromHostSelector struct {
+	// Mappings is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
+	// There are several wildcards supported:
+	// 1. To match all objects in host namespace and sync them to different namespace in vCluster:
+	// mappings:
+	//   "foo/*": "foo-in-virtual/*"
+	// 2. To match specific object in the host namespace and sync it to the same namespace with the same name:
+	// mappings:
+	//   "foo/my-object": "foo/my-object"
+	// 3. To match specific object in the host namespace and sync it to the same namespace with different name:
+	// mappings:
+	//   "foo/my-object": "foo/my-virtual-object"
+	// 4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+	// mappings:
+	//   "*": "my-virtual-namespace/*"
+	Mappings map[string]string `json:"mappings,omitempty"`
+}
+
 type SyncFromHost struct {
 	// Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 	Nodes SyncNodes `json:"nodes,omitempty"`
@@ -537,6 +566,9 @@ type SyncFromHost struct {
 
 	// VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 	VolumeSnapshotClasses EnableSwitchWithPatches `json:"volumeSnapshotClasses,omitempty"`
+
+	// ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
+	ConfigMaps EnableSwitchWithResourcesMappings `json:"configMaps,omitempty"`
 }
 
 type SyncToHostCustomResource struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -54,6 +54,10 @@ sync:
   fromHost:
     events:
       enabled: true
+    configMaps:
+      enabled: false
+      selector:
+        mappings: {}
     csiDrivers:
       enabled: auto
     csiNodes:

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/go-github/v30 v30.1.0 // indirect
+	github.com/google/go-github/v30 v30.1.0
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
@@ -175,7 +175,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v1.20.4 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/tcnksm/go-gitconfig v0.1.2 // indirect
+	github.com/tcnksm/go-gitconfig v0.1.2
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.16
@@ -195,7 +195,7 @@ require (
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6
 	golang.org/x/net v0.30.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
+	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/pkg/controllers/resources/configmaps/from_host_syncer.go
+++ b/pkg/controllers/resources/configmaps/from_host_syncer.go
@@ -1,0 +1,183 @@
+package configmaps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/loft-sh/vcluster/pkg/patcher"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/syncer"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func NewFromHost(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
+	configMapTranslator, err := NewConfigMapFromHostTranslate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &configMapFromHostSyncer{
+		GenericTranslator: configMapTranslator,
+		skipFuncs:         []skipHostObject{skipKubeRootCaConfigMap},
+	}, nil
+}
+
+type configMapFromHostSyncer struct {
+	syncertypes.GenericTranslator
+	skipFuncs []skipHostObject
+}
+
+func (s *configMapFromHostSyncer) Options() *syncertypes.Options {
+	return &syncertypes.Options{
+		UsesCustomPhysicalCache: true,
+	}
+}
+
+func (s *configMapFromHostSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*corev1.ConfigMap]) (ctrl.Result, error) {
+	klog.FromContext(ctx).Info("SyncToHost called")
+	return ctrl.Result{}, ctx.VirtualClient.Delete(ctx, event.Virtual)
+}
+
+func (s *configMapFromHostSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*corev1.ConfigMap]) (_ ctrl.Result, retErr error) {
+	klog.FromContext(ctx).Info("Sync called")
+
+	patchHelper, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.ToHost.ConfigMaps.Patches, false))
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
+	}
+
+	defer func() {
+		patchHelper.SkipHostPatch()
+		if err := patchHelper.Patch(ctx, event.Host, event.Virtual); err != nil {
+			retErr = utilerrors.NewAggregate([]error{retErr, err})
+		}
+		if retErr != nil {
+			s.EventRecorder().Eventf(event.Virtual, "Warning", "SyncError", "Error syncing: %v", retErr)
+		}
+	}()
+
+	hostCopy := event.Host.DeepCopy()
+	event.Virtual.Annotations = event.Host.Annotations
+	event.Virtual.Labels = event.Host.Labels
+	event.Virtual.Data = hostCopy.Data
+
+	return ctrl.Result{}, nil
+}
+
+func (s *configMapFromHostSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*corev1.ConfigMap]) (ctrl.Result, error) {
+	klog.FromContext(ctx).Info("SyncToVirtual called")
+	if event.VirtualOld != nil || event.Host.DeletionTimestamp != nil {
+		return patcher.DeleteHostObject(ctx, event.Host, event.VirtualOld, "virtual object was deleted")
+	}
+
+	vObj := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host))
+
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// make sure namespace exists
+	namespace := &corev1.Namespace{}
+	err = ctx.VirtualClient.Get(ctx, client.ObjectKey{Name: vObj.Namespace}, namespace)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return ctrl.Result{Requeue: true},
+				ctx.VirtualClient.Create(
+					ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{Name: vObj.Namespace},
+					},
+				)
+		}
+
+		return ctrl.Result{}, err
+	} else if namespace.DeletionTimestamp != nil {
+		// cannot create events in terminating namespaces, requeue to re-create namespaces later
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	return patcher.CreateVirtualObject(ctx, event.Host, vObj, s.EventRecorder(), false)
+}
+
+func (s *configMapFromHostSyncer) Syncer() syncertypes.Sync[client.Object] {
+	return syncer.ToGenericSyncer(s)
+}
+
+var _ syncertypes.Syncer = &configMapFromHostSyncer{}
+
+var _ syncertypes.OptionsProvider = &configMapFromHostSyncer{}
+
+func (s *configMapFromHostSyncer) ModifyController(ctx *synccontext.RegisterContext, b *builder.Builder) (*builder.Builder, error) {
+	// the default cache is configured to look at only the target namespaces, create an event source from
+	// a cache that watches all namespaces
+	hostNamespacesToWatch := getHostNamespacesAndConfig(ctx.Config.Sync.FromHost.ConfigMaps.Selector.Mappings, ctx.Config.ControlPlaneNamespace)
+
+	nsCache, err := cache.New(
+		ctx.PhysicalManager.GetConfig(),
+		cache.Options{
+			Mapper:            ctx.PhysicalManager.GetRESTMapper(),
+			DefaultNamespaces: hostNamespacesToWatch,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create nsCache: %w", err)
+	}
+
+	err = ctx.PhysicalManager.Add(nsCache)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add nsCache to physical manager: %w", err)
+	}
+	syncContext := ctx.ToSyncContext("configmap from host syncer")
+
+	return b.WatchesRawSource(source.Kind(nsCache, s.Resource(), &handler.Funcs{
+		CreateFunc: func(_ context.Context, ce event.TypedCreateEvent[client.Object], rli workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			obj := ce.Object
+			s.enqueuePhysical(syncContext, obj, rli)
+		},
+		UpdateFunc: func(_ context.Context, ue event.TypedUpdateEvent[client.Object], rli workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			obj := ue.ObjectNew
+			s.enqueuePhysical(syncContext, obj, rli)
+		},
+		DeleteFunc: func(_ context.Context, de event.TypedDeleteEvent[client.Object], rli workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			obj := de.Object
+			s.enqueuePhysical(syncContext, obj, rli)
+		},
+		GenericFunc: func(_ context.Context, ge event.TypedGenericEvent[client.Object], rli workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			obj := ge.Object
+			s.enqueuePhysical(syncContext, obj, rli)
+		},
+	})), nil
+}
+
+func (s *configMapFromHostSyncer) enqueuePhysical(ctx *synccontext.SyncContext, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+	if obj == nil {
+		return
+	}
+	if nn, ok := s.shouldSync(ctx, obj); ok {
+		q.Add(reconcile.Request{NamespacedName: nn})
+	}
+}
+
+func (s *configMapFromHostSyncer) shouldSync(ctx *synccontext.SyncContext, obj client.Object) (types.NamespacedName, bool) {
+	hostName, hostNs := obj.GetName(), obj.GetNamespace()
+	return matchesHostObject(hostName, hostNs, ctx.Config.Sync.FromHost.ConfigMaps.Selector.Mappings, ctx.Config.ControlPlaneNamespace, s.skipFuncs...)
+}

--- a/pkg/controllers/resources/configmaps/from_host_translate.go
+++ b/pkg/controllers/resources/configmaps/from_host_translate.go
@@ -1,0 +1,81 @@
+package configmaps
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncer "github.com/loft-sh/vcluster/pkg/syncer/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type fromHostTranslate struct {
+	gvk           schema.GroupVersionKind
+	eventRecorder record.EventRecorder
+	virtualToHost map[string]string
+	skipFuncs     []skipHostObject
+}
+
+func NewConfigMapFromHostTranslate(ctx *synccontext.RegisterContext) (syncer.GenericTranslator, error) {
+	gvk, err := apiutil.GVKForObject(&corev1.ConfigMap{}, scheme.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve GVK for object failed: %w", err)
+	}
+	hostToVirtual := ctx.Config.Sync.FromHost.ConfigMaps.Selector.Mappings
+	virtualToHost := make(map[string]string, len(ctx.Config.Sync.FromHost.ConfigMaps.Selector.Mappings))
+	for host, virtual := range hostToVirtual {
+		virtualToHost[virtual] = host
+	}
+
+	return &fromHostTranslate{
+		gvk:           gvk,
+		eventRecorder: ctx.VirtualManager.GetEventRecorderFor("from-host-configmaps-syncer"),
+		virtualToHost: virtualToHost,
+		skipFuncs:     []skipHostObject{skipKubeRootCaConfigMap},
+	}, nil
+}
+
+func (c *fromHostTranslate) Name() string {
+	return "configmap-from-host-translator"
+}
+
+func (c *fromHostTranslate) Resource() client.Object {
+	return &corev1.ConfigMap{}
+}
+
+func (c *fromHostTranslate) Migrate(_ *synccontext.RegisterContext, _ synccontext.Mapper) error {
+	return nil
+}
+
+func (c *fromHostTranslate) GroupVersionKind() schema.GroupVersionKind {
+	return c.gvk
+}
+
+func (c *fromHostTranslate) VirtualToHost(ctx *synccontext.SyncContext, req types.NamespacedName, _ client.Object) types.NamespacedName {
+	vName, vNs := req.Name, req.Namespace
+	nn, _ := matchesVirtualObject(vNs, vName, c.virtualToHost, ctx.Config.ControlPlaneNamespace)
+	return nn
+}
+
+func (c *fromHostTranslate) HostToVirtual(ctx *synccontext.SyncContext, req types.NamespacedName, _ client.Object) types.NamespacedName {
+	nn, ok := matchesHostObject(req.Name, req.Namespace, ctx.Config.Sync.FromHost.ConfigMaps.Selector.Mappings, ctx.Config.ControlPlaneNamespace, c.skipFuncs...)
+	if !ok {
+		return types.NamespacedName{}
+	}
+	return nn
+}
+
+func (c *fromHostTranslate) IsManaged(ctx *synccontext.SyncContext, pObj client.Object) (bool, error) {
+	hostName, hostNs := pObj.GetName(), pObj.GetNamespace()
+	_, managed := matchesHostObject(hostName, hostNs, ctx.Config.Sync.FromHost.ConfigMaps.Selector.Mappings, ctx.Config.ControlPlaneNamespace, c.skipFuncs...)
+	return managed, nil
+}
+
+func (c *fromHostTranslate) EventRecorder() record.EventRecorder {
+	return c.eventRecorder
+}

--- a/pkg/controllers/resources/configmaps/parse_util.go
+++ b/pkg/controllers/resources/configmaps/parse_util.go
@@ -1,0 +1,109 @@
+package configmaps
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func parseHostNamespacesFromMappings(mappings map[string]string, vClusterNs string) []string {
+	ret := make([]string, 0)
+	for host := range mappings {
+		if host == "*" {
+			ret = append(ret, vClusterNs)
+		}
+		parts := strings.Split(host, "/")
+		if len(parts) != 2 {
+			continue
+		}
+		hostNs := parts[0]
+		ret = append(ret, hostNs)
+	}
+	return ret
+}
+
+func getHostNamespacesAndConfig(mappings map[string]string, vClusterNs string) map[string]cache.Config {
+	namespaces := parseHostNamespacesFromMappings(mappings, vClusterNs)
+	ret := make(map[string]cache.Config, len(namespaces))
+	for _, ns := range namespaces {
+		ret[ns] = cache.Config{}
+	}
+	return ret
+}
+
+type skipHostObject func(hostName, hostNamespace string) bool
+
+func skipKubeRootCaConfigMap(hostName, _ string) bool {
+	return hostName == "kube-root-ca.crt"
+}
+
+func matchesHostObject(hostName, hostNamespace string, resourceMappings map[string]string, vClusterHostNamespace string, skippers ...skipHostObject) (types.NamespacedName, bool) {
+	for _, skipFunc := range skippers {
+		if skipFunc(hostName, hostNamespace) {
+			return types.NamespacedName{}, false
+		}
+	}
+
+	key := hostNamespace + "/" + hostName
+	matchesAllKeyInNamespaceKey := hostNamespace + "/*"
+	matchesAllKey := "*"
+
+	// first, let's try matching by namespace/name
+	if virtual, ok := resourceMappings[key]; ok {
+		virtualParts := strings.Split(virtual, "/")
+		if len(virtualParts) == 2 {
+			ns := virtualParts[0]
+			name := virtualParts[1]
+			if name == "*" {
+				name = hostName
+			}
+			return types.NamespacedName{Namespace: ns, Name: name}, true
+		}
+	}
+
+	// second, by namespace/*
+	if virtual, ok := resourceMappings[matchesAllKeyInNamespaceKey]; ok {
+		virtualParts := strings.Split(virtual, "/")
+		if len(virtualParts) == 2 {
+			ns := virtualParts[0]
+			return types.NamespacedName{Namespace: ns, Name: hostName}, true
+		}
+	}
+
+	// last chance, if user specified "*": <namespace>/*
+	if virtual, ok := resourceMappings[matchesAllKey]; ok {
+		if vClusterHostNamespace == hostNamespace {
+			virtualParts := strings.Split(virtual, "/")
+			if len(virtualParts) == 2 {
+				return types.NamespacedName{Namespace: virtualParts[0], Name: hostName}, true
+			}
+		}
+	}
+	return types.NamespacedName{}, false
+}
+
+func matchesVirtualObject(virtualNs, virtualName string, virtualToHost map[string]string, vClusterHostNamespace string) (types.NamespacedName, bool) {
+	virtualKey := virtualNs + "/" + virtualName
+	virtualAllInNamespaceKey := virtualNs + "/*"
+
+	// let's check if object is listed explicitly
+	if host, ok := virtualToHost[virtualKey]; ok {
+		if host == "*" {
+			return types.NamespacedName{Namespace: vClusterHostNamespace, Name: virtualName}, false
+		}
+		hostParts := strings.Split(host, "/")
+		if len(hostParts) == 2 {
+			return types.NamespacedName{Namespace: hostParts[0], Name: hostParts[1]}, true
+		}
+	}
+
+	// check if object's namespace is listed
+	if host, ok := virtualToHost[virtualAllInNamespaceKey]; ok {
+		hostParts := strings.Split(host, "/")
+		if len(hostParts) == 2 {
+			return types.NamespacedName{Namespace: hostParts[0], Name: virtualName}, true
+		}
+	}
+	return types.NamespacedName{}, false
+}

--- a/pkg/controllers/resources/configmaps/parse_util_test.go
+++ b/pkg/controllers/resources/configmaps/parse_util_test.go
@@ -1,0 +1,161 @@
+package configmaps
+
+import (
+	"sort"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestParseHostNamespacesFromMappings(t *testing.T) {
+	cases := []struct {
+		name       string
+		vClusterNs string
+		mappings   map[string]string
+		expected   []string
+	}{
+		{
+			name:       "one namespace and wildcards",
+			vClusterNs: "vcluster",
+			mappings: map[string]string{
+				"*":           "target/",
+				"my-ns/my-cm": "target2/my-cm",
+				"my-ns-2/*":   "target3/*",
+			},
+			expected: []string{"vcluster", "my-ns", "my-ns-2"},
+		},
+		{
+			name:       "no namespaces",
+			vClusterNs: "vcluster",
+			mappings:   map[string]string{},
+			expected:   []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseHostNamespacesFromMappings(tc.mappings, tc.vClusterNs)
+			if len(got) != len(tc.expected) {
+				t.Logf("expectedVirtual %d namespaces, got %d", len(tc.expected), len(got))
+				t.Fail()
+			}
+			sort.Strings(got)
+			sort.Strings(tc.expected)
+			for i := range got {
+				if tc.expected[i] != got[i] {
+					t.Logf("expectedVirtual %s, got %s", tc.expected[i], got[i])
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestMatches(t *testing.T) {
+	cases := []struct {
+		name            string
+		mappings        map[string]string
+		hostName        string
+		hostNs          string
+		virtualName     string
+		virtualNs       string
+		noMatchExpected bool
+		expectedVirtual types.NamespacedName
+	}{
+		{
+			name: "mirror",
+			mappings: map[string]string{
+				"my-ns/my-cm":   "my-ns/my-cm",
+				"my-ns/my-cm-2": "my-ns/my-cm-3",
+				"my-ns-2/*":     "my-ns-2/*",
+			},
+			hostName:        "my-cm",
+			hostNs:          "my-ns",
+			virtualName:     "my-cm",
+			virtualNs:       "my-ns",
+			expectedVirtual: types.NamespacedName{Name: "my-cm", Namespace: "my-ns"},
+		},
+		{
+			name: "match all in namespace",
+			mappings: map[string]string{
+				"my-ns/*":   "my-ns-2/*",
+				"my-ns-3/*": "my-ns-3/*",
+			},
+			hostName:        "my-cm",
+			hostNs:          "my-ns",
+			virtualName:     "my-cm",
+			virtualNs:       "my-ns-2",
+			expectedVirtual: types.NamespacedName{Name: "my-cm", Namespace: "my-ns-2"},
+		},
+		{
+			name: "change name and namespace",
+			mappings: map[string]string{
+				"my-ns/my-cm": "my-ns-2/my-cm-2",
+				"my-ns-3/*":   "my-ns-3/*",
+			},
+			hostName:        "my-cm",
+			hostNs:          "my-ns",
+			virtualName:     "my-cm-2",
+			virtualNs:       "my-ns-2",
+			expectedVirtual: types.NamespacedName{Name: "my-cm-2", Namespace: "my-ns-2"},
+		},
+		{
+			name: "all from vCluster host namespace to another namespace in virtual",
+			mappings: map[string]string{
+				"*": "my-ns/my-cm",
+			},
+			hostName:        "my-cm",
+			hostNs:          "vcluster",
+			virtualName:     "my-cm",
+			virtualNs:       "my-ns",
+			expectedVirtual: types.NamespacedName{Name: "my-cm", Namespace: "my-ns"},
+		},
+		{
+			name: "no match",
+			mappings: map[string]string{
+				"*":             "my-ns/my-cm",
+				"my-ns/*":       "my-ns-2/*",
+				"my-ns-2/my-cm": "my-ns-2/my-cm",
+			},
+			hostName:        "my-cm-2",
+			hostNs:          "my-ns-2",
+			virtualName:     "",
+			virtualNs:       "",
+			noMatchExpected: true,
+			expectedVirtual: types.NamespacedName{Name: "", Namespace: ""}, // no match
+		},
+	}
+
+	t.Run("match host", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, _ := matchesHostObject(tc.hostName, tc.hostNs, tc.mappings, "vcluster")
+				if got.Name == tc.virtualName && got.Namespace == tc.virtualNs {
+					return
+				}
+				t.Logf("expectedVirtual %s/%s, got %s", tc.virtualNs, tc.virtualName, got.String())
+				t.Fail()
+			})
+		}
+	})
+
+	t.Run("match virtual", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				virtualToHost := make(map[string]string, len(tc.mappings))
+				for host, virtual := range tc.mappings {
+					virtualToHost[virtual] = host
+				}
+				got, match := matchesVirtualObject(tc.virtualNs, tc.virtualName, virtualToHost, "vcluster")
+				if tc.noMatchExpected && match != tc.noMatchExpected {
+					return
+				}
+				if got.Name == tc.hostName && got.Namespace == tc.hostNs {
+					return
+				}
+				t.Logf("expectedHost %s/%s, got %s", tc.hostNs, tc.hostName, got.String())
+				t.Fail()
+			})
+		}
+	})
+}

--- a/pkg/controllers/resources/register.go
+++ b/pkg/controllers/resources/register.go
@@ -44,6 +44,7 @@ func getSyncers(ctx *synccontext.RegisterContext) []BuildController {
 	return append([]BuildController{
 		isEnabled(ctx.Config.Sync.ToHost.Services.Enabled, services.New),
 		isEnabled(ctx.Config.Sync.ToHost.ConfigMaps.Enabled, configmaps.New),
+		isEnabled(ctx.Config.Sync.FromHost.ConfigMaps.Enabled, configmaps.NewFromHost),
 		isEnabled(ctx.Config.Sync.ToHost.Secrets.Enabled, secrets.New),
 		isEnabled(ctx.Config.Sync.ToHost.Endpoints.Enabled, endpoints.New),
 		isEnabled(ctx.Config.Sync.ToHost.Pods.Enabled, pods.New),

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -32,6 +32,10 @@ type hostStorageClassSyncer struct {
 	synccontext.Mapper
 }
 
+func (s *hostStorageClassSyncer) UseUncachedPhysicalClient() bool {
+	return false
+}
+
 func (s *hostStorageClassSyncer) Name() string {
 	return "host-storageclass"
 }

--- a/pkg/patcher/patcher.go
+++ b/pkg/patcher/patcher.go
@@ -55,8 +55,9 @@ func NewSyncerPatcher(ctx *synccontext.SyncContext, pObj, vObj client.Object, op
 }
 
 type SyncerPatcher struct {
-	vPatcher *Patcher
-	pPatcher *Patcher
+	vPatcher      *Patcher
+	pPatcher      *Patcher
+	skipHostPatch bool
 }
 
 // Patch will attempt to patch the given object, including its status.
@@ -71,13 +72,19 @@ func (h *SyncerPatcher) Patch(ctx *synccontext.SyncContext, pObj, vObj client.Ob
 	if err != nil {
 		return fmt.Errorf("patch virtual object: %w", err)
 	}
-
+	if h.skipHostPatch {
+		return nil
+	}
 	err = h.pPatcher.Patch(ctx, pObj)
 	if err != nil {
 		return fmt.Errorf("patch host object: %w", err)
 	}
 
 	return nil
+}
+
+func (h *SyncerPatcher) SkipHostPatch() {
+	h.skipHostPatch = true
 }
 
 // Patcher is a utility for ensuring the proper patching of objects.

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -122,6 +122,7 @@ func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	if len(defaultNamespaces) == 0 {
 		return cache.Options{DefaultNamespaces: nil}
 	}
+
 	return cache.Options{DefaultNamespaces: defaultNamespaces}
 }
 

--- a/pkg/syncer/types/syncer.go
+++ b/pkg/syncer/types/syncer.go
@@ -80,6 +80,11 @@ type Options struct {
 
 	// ObjectCaching enables an object cache that allows to view the old object states
 	ObjectCaching bool
+
+	// UsesCustomPhysicalCache - false by default.
+	// If set, syncer won't watch for resources in the vCluster namespace in the host cluster.
+	// Use it to override host cluster watches in the syncer ModifyController() function.
+	UsesCustomPhysicalCache bool
 }
 
 type OptionsProvider interface {

--- a/test/commonValues.yaml
+++ b/test/commonValues.yaml
@@ -43,7 +43,7 @@ networking:
       to: default/test
     - from: test/nginx
       to: default/nginx
-      
+
 experimental:
   syncSettings:
     setOwner: true

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/loft-sh/vcluster/test/e2e/manifests"
 	_ "github.com/loft-sh/vcluster/test/e2e/node"
 	_ "github.com/loft-sh/vcluster/test/e2e/servicesync"
+	_ "github.com/loft-sh/vcluster/test/e2e/syncer/fromhost"
 	_ "github.com/loft-sh/vcluster/test/e2e/syncer/networkpolicies"
 	_ "github.com/loft-sh/vcluster/test/e2e/syncer/pods"
 	_ "github.com/loft-sh/vcluster/test/e2e/syncer/pvc"

--- a/test/e2e/syncer/fromhost/from_host.go
+++ b/test/e2e/syncer/fromhost/from_host.go
@@ -1,0 +1,159 @@
+package fromhost
+
+import (
+	"strings"
+	"time"
+
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("ConfigMaps are synced to host and can be used in Pods", ginkgo.Ordered, func() {
+	var (
+		f                   *framework.Framework
+		configMap1          *corev1.ConfigMap
+		configMap2          *corev1.ConfigMap
+		cm1Name             = "dummy"
+		cm1HostNamespace    = "foobar"
+		cmsVirtualNamespace = "barfoo"
+		cm2HostNamespace    = "default"
+		cm2HostName         = "my-cm"
+		cm2VirtualName      = "cm-my"
+		podName             = "my-pod"
+	)
+
+	ginkgo.BeforeAll(func() {
+		f = framework.DefaultFramework
+		configMap1 = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cm1Name,
+				Namespace: cm1HostNamespace,
+			},
+			Data: map[string]string{
+				"BOO_BAR":     "hello-world",
+				"ANOTHER_ENV": "another-hello-world",
+			},
+		}
+		configMap2 = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cm2HostName,
+				Namespace: cm2HostNamespace,
+			},
+			Data: map[string]string{
+				"ENV_FROM_DEFAULT_NS":         "one",
+				"ANOTHER_ENV_FROM_DEFAULT_NS": "two",
+			},
+		}
+
+	})
+
+	ginkgo.AfterAll(func() {
+		framework.ExpectNoError(f.HostClient.CoreV1().ConfigMaps(configMap1.GetNamespace()).Delete(f.Context, configMap1.GetName(), metav1.DeleteOptions{}))
+		framework.ExpectNoError(f.HostClient.CoreV1().ConfigMaps(configMap2.GetNamespace()).Delete(f.Context, configMap2.GetName(), metav1.DeleteOptions{}))
+
+		framework.ExpectNoError(f.VClusterClient.CoreV1().Pods(cmsVirtualNamespace).Delete(f.Context, podName, metav1.DeleteOptions{}))
+		// verify whether config maps got deleted from virtual too
+		_, err := f.VClusterClient.CoreV1().ConfigMaps(cmsVirtualNamespace).Get(f.Context, cm1Name, metav1.GetOptions{})
+		framework.ExpectError(err, "expected config map to be deleted")
+		_, err = f.VClusterClient.CoreV1().ConfigMaps(cmsVirtualNamespace).Get(f.Context, cm2VirtualName, metav1.GetOptions{})
+		framework.ExpectError(err, "expected config map to be deleted")
+
+		framework.ExpectNoError(f.HostClient.CoreV1().Namespaces().Delete(f.Context, cm1HostNamespace, metav1.DeleteOptions{}))
+	})
+
+	ginkgo.It("create config maps in host", func() {
+		_, err := f.HostClient.CoreV1().ConfigMaps(configMap1.GetNamespace()).Create(f.Context, configMap1, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		_, err = f.HostClient.CoreV1().ConfigMaps(configMap2.GetNamespace()).Create(f.Context, configMap2, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("update in host config map should get synced to virtual", func() {
+		freshHostConfigMap, err := f.HostClient.CoreV1().ConfigMaps(configMap1.GetNamespace()).Get(f.Context, configMap1.GetName(), metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		freshHostConfigMap.Data["UPDATED_ENV"] = "one"
+		if freshHostConfigMap.Labels == nil {
+			freshHostConfigMap.Labels = make(map[string]string, 1)
+		}
+		freshHostConfigMap.Labels["updated-label"] = "updated-value"
+		if freshHostConfigMap.Annotations == nil {
+			freshHostConfigMap.Annotations = make(map[string]string, 1)
+		}
+		freshHostConfigMap.Annotations["updated-annotation"] = "updated-value"
+		_, err = f.HostClient.CoreV1().ConfigMaps(freshHostConfigMap.GetNamespace()).Update(f.Context, freshHostConfigMap, metav1.UpdateOptions{})
+		framework.ExpectNoError(err)
+		gomega.Eventually(func() bool {
+			updatedCm1, err := f.VClusterClient.CoreV1().ConfigMaps(cmsVirtualNamespace).Get(f.Context, cm1Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			return updatedCm1.Data["UPDATED_ENV"] == "one" && updatedCm1.Labels["updated-label"] == "updated-value" && updatedCm1.Annotations["updated-annotation"] == "updated-value"
+
+		}).
+			WithPolling(time.Second).
+			WithTimeout(framework.PollTimeout).
+			Should(gomega.BeTrue())
+	})
+
+	ginkgo.It("synced config maps can be used as env source for pod", func() {
+		optional := false
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: cmsVirtualNamespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "default",
+						Image:           "nginxinc/nginx-unprivileged",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						SecurityContext: f.GetDefaultSecurityContext(),
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: cm1Name,
+									},
+									Optional: &optional,
+								},
+							},
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: cm2VirtualName,
+									},
+									Optional: &optional,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		createdPod, err := f.VClusterClient.CoreV1().Pods(pod.GetNamespace()).Create(f.Context, pod, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		framework.ExpectNoError(f.WaitForPodRunning(createdPod.GetName(), createdPod.GetNamespace()))
+
+		output, err := f.ExecCommandInThePod(createdPod.GetName(), createdPod.GetNamespace(), []string{"sh", "-c", "printenv"})
+		framework.ExpectNoError(err, output)
+
+		envVars := strings.Split(strings.TrimSpace(output), "\n")
+		envs := make(map[string]string, len(envVars))
+		for _, envVar := range envVars {
+			parts := strings.Split(envVar, "=")
+			envs[parts[0]] = strings.ReplaceAll(parts[1], "\r", "")
+		}
+
+		gomega.Expect(envs["ANOTHER_ENV_FROM_DEFAULT_NS"]).To(gomega.Equal("two"))
+		gomega.Expect(envs["UPDATED_ENV"]).To(gomega.Equal("one"))
+		gomega.Expect(envs["ANOTHER_ENV"]).To(gomega.Equal("another-hello-world"))
+		gomega.Expect(envs["BOO_BAR"]).To(gomega.Equal("hello-world"))
+		gomega.Expect(envs["ENV_FROM_DEFAULT_NS"]).To(gomega.Equal("one"))
+	})
+
+})

--- a/test/e2e/values.yaml
+++ b/test/e2e/values.yaml
@@ -32,3 +32,11 @@ experimental:
             name: fluent-bit
             namespace: fluent-bit
           timeout: "50s"
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          "foobar/*": "barfoo/*"
+          "default/my-cm": "barfoo/cm-my"


### PR DESCRIPTION
- adds sync.fromHost.configMaps config options
- parses namespaces in sync.fromHost.configMaps.selector.mappings and creates Roles and RoleBindings accordingly
- implements translator based on the sync.fromHost.configMaps.selector.mappings
- adds from host syncer for ConfigMap, it watches for ConfigMaps in additional namespaces in the host, so it uses also uncachedPhysicalClient
- adds E2E test for syncing config maps from two different namespaces in the host to another one in vCluster, then creates a Pod that uses these ConfigMaps as EnvVar source

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5653


**Please provide a short message that should be published in the vcluster release notes**
ConfigMaps From Host Sync


**What else do we need to know?** 
Roles and RoleBindings created by helm assume that all Namespaces listed in the `sync.fromHost.configMaps.selector.mappings` already exist in the host. I added creating `foobar` namespace (which is used in e2e test) to Justfile & e2e CI (it has to happen before creating vCluster).
