### PR TITLE
fix: fix host to virtual service selector syncing

### DIFF
--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -203,10 +203,9 @@ func (s *serviceSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.Sy
 	}
 
 	// translate selector
-	// TODO: ryan - convert to bidirectional
-	if !apiequality.Semantic.DeepEqual(event.VirtualOld.Spec.Selector, event.Virtual.Spec.Selector) || apiequality.Semantic.DeepEqual(event.HostOld.Spec.Selector, event.Host.Spec.Selector) {
+	if !apiequality.Semantic.DeepEqual(event.VirtualOld.Spec.Selector, event.Virtual.Spec.Selector) {
 		event.Host.Spec.Selector = translate.HostLabelsMap(event.Virtual.Spec.Selector, event.Host.Spec.Selector, event.Virtual.Namespace, false)
-	} else {
+	} else if !apiequality.Semantic.DeepEqual(event.HostOld.Spec.Selector, event.Host.Spec.Selector) {
 		event.Virtual.Spec.Selector = translate.VirtualLabelsMap(event.Host.Spec.Selector, event.Virtual.Spec.Selector)
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

This brings the selector syncing inline with the [CopyBidirectional](https://github.com/loft-sh/vcluster/blob/main/pkg/patcher/sync.go#L17-L21) logic.

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-5654


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the host service selector should have been synced to the virtual, but it was nullified to match the virtual instead.

**What else do we need to know?** 

Example of what occurred 

 - Selector was removed from host service
 - The change was synced down to the virtual cluster removing it
 - The selector was added back to the host service
 - The [check here](https://github.com/loft-sh/vcluster/blob/main/pkg/controllers/resources/services/syncer.go#L207) was true since the host hadn't changed, and HostLabelsMap [returned nil](https://github.com/loft-sh/vcluster/blob/main/pkg/util/translate/labels.go#L45) since the vCluster selector was nil.