### PR TITLE
bugfix: sync config on release published, not only released

### DIFF
--- a/.github/workflows/sync-config-schema.yaml
+++ b/.github/workflows/sync-config-schema.yaml
@@ -2,7 +2,7 @@ name: Sync Config Schema
 on:
   release:
     types:
-      - released
+      - published
   workflow_dispatch:
     inputs:
       releaseTag:


### PR DESCRIPTION
so we can sync on betas and RCs. It was causing CI not to run on "pre-release" type of releases.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

