### PR TITLE
pass syncer to the object cache contructor

### DIFF
--- a/pkg/syncer/synccontext/cache.go
+++ b/pkg/syncer/synccontext/cache.go
@@ -15,18 +15,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-func NewBidirectionalObjectCache(obj client.Object) *BidirectionalObjectCache {
+func NewBidirectionalObjectCache(obj client.Object, mapper Mapper) *BidirectionalObjectCache {
 	return &BidirectionalObjectCache{
 		vCache: newObjectCache(),
 		pCache: newObjectCache(),
 
 		obj: obj,
+
+		mapper: mapper,
 	}
+
 }
 
 type BidirectionalObjectCache struct {
 	vCache *ObjectCache
 	pCache *ObjectCache
+
+	mapper Mapper
 
 	obj client.Object
 }
@@ -45,15 +50,9 @@ func (o *BidirectionalObjectCache) Start(ctx *RegisterContext) error {
 		return fmt.Errorf("gvk for object: %w", err)
 	}
 
-	mapper, err := ctx.Mappings.ByGVK(gvk)
-	if err != nil {
-		return fmt.Errorf("mapper for gvk %s couldn't be found", gvk.String())
-	}
-
 	go func() {
 		wait.Until(func() {
 			syncContext := ctx.ToSyncContext("bidirectional-object-cache")
-
 			// clear up host cache
 			o.pCache.cache.Range(func(key, _ any) bool {
 				// check physical object
@@ -63,7 +62,7 @@ func (o *BidirectionalObjectCache) Start(ctx *RegisterContext) error {
 				}
 
 				// check virtual object
-				vName := mapper.HostToVirtual(syncContext, pName, nil)
+				vName := o.mapper.HostToVirtual(syncContext, pName, nil)
 				if vName.Name == "" {
 					o.pCache.cache.Delete(key)
 					klog.FromContext(syncContext).V(1).Info("Delete from host cache", "gvk", gvk.String(), "key", pName.String())
@@ -88,7 +87,7 @@ func (o *BidirectionalObjectCache) Start(ctx *RegisterContext) error {
 				}
 
 				// check host object
-				pName := mapper.VirtualToHost(syncContext, vName, nil)
+				pName := o.mapper.VirtualToHost(syncContext, vName, nil)
 				if pName.Name == "" {
 					o.vCache.cache.Delete(key)
 					klog.FromContext(syncContext).V(1).Info("Delete from virtual cache", "gvk", gvk.String(), "key", vName.String())

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -37,7 +37,7 @@ func NewSyncController(ctx *synccontext.RegisterContext, syncer syncertypes.Sync
 
 	var objectCache *synccontext.BidirectionalObjectCache
 	if options.ObjectCaching {
-		objectCache = synccontext.NewBidirectionalObjectCache(syncer.Resource().DeepCopyObject().(client.Object))
+		objectCache = synccontext.NewBidirectionalObjectCache(syncer.Resource().DeepCopyObject().(client.Object), syncer)
 	}
 
 	return &SyncController{

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -584,7 +584,7 @@ func TestReconcile(t *testing.T) {
 			virtualClient: vClient,
 			options:       options,
 
-			objectCache: synccontext.NewBidirectionalObjectCache(syncer.Resource()),
+			objectCache: synccontext.NewBidirectionalObjectCache(syncer.Resource(), syncer),
 		}
 
 		// create objects

--- a/pkg/syncer/testing/context.go
+++ b/pkg/syncer/testing/context.go
@@ -49,7 +49,7 @@ func FakeStartSyncer(t *testing.T, ctx *synccontext.RegisterContext, create func
 	// check if object cache is needed
 	optionsProvider, ok := object.(syncer.OptionsProvider)
 	if ok && optionsProvider.Options().ObjectCaching {
-		syncCtx.ObjectCache = synccontext.NewBidirectionalObjectCache(object.Resource())
+		syncCtx.ObjectCache = synccontext.NewBidirectionalObjectCache(object.Resource(), mapper)
 	}
 
 	syncCtx.Log = loghelper.NewFromExisting(log.NewLog(0), object.Name())


### PR DESCRIPTION
…ache instead

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where names were wrongly translated between host and virtual in the object cache, because it was fetching Mapper by GVK (so for the from-host syncer wrong translator was used).


**What else do we need to know?** 
