### PR TITLE
From host sync additional config validation

### DIFF
--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -1,4 +1,4 @@
-package setup
+package config
 
 import (
 	"sort"

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -614,24 +614,61 @@ func validateFromHostSyncMappings(s config.EnableSwitchWithResourcesMappings, re
 				resourceNamePlural, key, value,
 			)
 		}
-		hostRef := strings.Split(key, "/")
-		virtualRef := strings.Split(value, "/")
-		if key != "" && len(hostRef) > 0 {
-			errs := validation.ValidateNamespaceName(hostRef[0], false)
-			if len(errs) > 0 && hostRef[0] != "" {
-				return fmt.Errorf("config.sync.fromHost.%s.selector.mappings parsed host namespace is not valid namespace name %s", resourceNamePlural, errs)
-			}
-			if err := validateFromHostSyncMappingObjectName(hostRef, resourceNamePlural); err != nil {
-				return err
-			}
+		if err := validateFromHostMappingEntry(key, value, resourceNamePlural); err != nil {
+			return err
 		}
-		if len(virtualRef) > 0 {
-			errs := validation.ValidateNamespaceName(virtualRef[0], false)
-			if len(errs) > 0 {
-				return fmt.Errorf("config.sync.fromHost.%s.selector.mappings parsed virtual namespace is not valid namespace name %s", resourceNamePlural, errs)
-			}
-			if err := validateFromHostSyncMappingObjectName(virtualRef, resourceNamePlural); err != nil {
-				return err
+	}
+	return nil
+}
+
+func validateFromHostMappingEntry(key, value, resourceNamePlural string) error {
+	if strings.Count(key, "/") > 1 || strings.Count(value, "/") > 1 {
+		return fmt.Errorf("config.sync.fromHost.%s.selector.mappings has key:value pair in invalid format: %s:%s (expected NAMESPACE_NAME/NAME, NAMESPACE_NAME/*, /NAME or \"\")", resourceNamePlural, key, value)
+	}
+	hostRef := strings.Split(key, "/")
+	virtualRef := strings.Split(value, "/")
+	if key != "" && len(hostRef) > 0 {
+		errs := validation.ValidateNamespaceName(hostRef[0], false)
+		if len(errs) > 0 && hostRef[0] != "" {
+			return fmt.Errorf("config.sync.fromHost.%s.selector.mappings parsed host namespace is not valid namespace name %s", resourceNamePlural, errs)
+		}
+		if err := validateFromHostSyncMappingObjectName(hostRef, resourceNamePlural); err != nil {
+			return err
+		}
+	}
+	if len(virtualRef) > 0 {
+		errs := validation.ValidateNamespaceName(virtualRef[0], false)
+		if len(errs) > 0 {
+			return fmt.Errorf("config.sync.fromHost.%s.selector.mappings parsed virtual namespace is not valid namespace name %s", resourceNamePlural, errs)
+		}
+		if err := validateFromHostSyncMappingObjectName(virtualRef, resourceNamePlural); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFromHostSyncCustomResources(customResources map[string]config.SyncFromHostCustomResource) error {
+	for key, customResource := range customResources {
+		if customResource.Scope != "" && customResource.Scope != config.ScopeCluster && customResource.Scope != config.ScopeNamespaced {
+			return fmt.Errorf("unsupported scope %s for sync.fromHost.customResources['%s'].scope. Only 'Cluster' and 'Namespaced' are allowed", customResource.Scope, key)
+		}
+		if len(customResource.Selector.Mappings) > 0 && customResource.Scope != config.ScopeNamespaced {
+			return fmt.Errorf(".selector.mappings are only supported for sync.fromHost.customResources['%s'] with scope 'Namespaced'", key)
+		}
+		if customResource.Scope == config.ScopeNamespaced && len(customResource.Selector.Mappings) == 0 {
+			return fmt.Errorf(".selector.mappings is required for Namespaced scope sync.fromHost.customResources['%s']", key)
+		}
+		err := validatePatches(patchesValidation{basePath: "sync.fromHost.customResources." + key, patches: customResource.Patches})
+		if err != nil {
+			return err
+		}
+
+		if customResource.Scope == config.ScopeNamespaced {
+			for host, virtual := range customResource.Selector.Mappings {
+				if err := validateFromHostMappingEntry(host, virtual, key); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -686,25 +686,6 @@ func validateFromHostSyncMappingObjectName(objRef []string, resourceNamePlural s
 	return nil
 }
 
-func validateFromHostSyncCustomResources(customResources map[string]config.SyncFromHostCustomResource) error {
-	for key, customResource := range customResources {
-		if customResource.Scope != "" && customResource.Scope != config.ScopeCluster && customResource.Scope != config.ScopeNamespaced {
-			return fmt.Errorf("unsupported scope %s for sync.fromHost.customResources['%s'].scope. Only 'Cluster' and 'Namespaced' are allowed", customResource.Scope, key)
-		}
-		if len(customResource.Selector.Mappings) > 0 && customResource.Scope != config.ScopeNamespaced {
-			return fmt.Errorf(".selector.mappings are only supported for sync.fromHost.customResources['%s'] with scope 'Namespaced'", key)
-		}
-		if customResource.Scope == config.ScopeNamespaced && len(customResource.Selector.Mappings) == 0 {
-			return fmt.Errorf(".selector.mappings is required for Namespaced scope sync.fromHost.customResources['%s']", key)
-		}
-		err := validatePatches(patchesValidation{basePath: "sync.fromHost.customResources." + key, patches: customResource.Patches})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 var ProValidateConfig = func(_ *VirtualClusterConfig) error {
 	return nil
 }

--- a/pkg/setup/config.go
+++ b/pkg/setup/config.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
+
+	"k8s.io/client-go/util/retry"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/config"
-	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/k3s"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -227,20 +226,4 @@ func SetGlobalOwner(ctx context.Context, vConfig *config.VirtualClusterConfig) e
 	translate.Owner = service
 
 	return nil
-}
-
-func parseHostNamespacesFromMappings(mappings map[string]string, vClusterNs string) []string {
-	ret := make([]string, 0)
-	for host := range mappings {
-		if host == constants.VClusterNamespaceInHostMappingSpecialCharacter {
-			ret = append(ret, vClusterNs)
-		}
-		parts := strings.Split(host, "/")
-		if len(parts) != 2 {
-			continue
-		}
-		hostNs := parts[0]
-		ret = append(ret, hostNs)
-	}
-	return ret
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5739


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was allowing invalid values in from host sync mapping entries


**What else do we need to know?** 
this contains config validation that got lost in the revert + better organization of functions in `pkg/syncer/from_host_syncer.go`, so we can use them in other repo.
