### PR TITLE
feat: add sync.toHost.pods.priorityClassName

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3295,6 +3295,10 @@
           "type": "string",
           "description": "RuntimeClassName is the runtime class to set for synced pods."
         },
+        "priorityClassName": {
+          "type": "string",
+          "description": "PriorityClassName is the priority class to set for synced pods."
+        },
         "rewriteHosts": {
           "$ref": "#/$defs/SyncRewriteHosts",
           "description": "RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add\na small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by\nthe virtual cluster."

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,6 +38,8 @@ sync:
       useSecretsForSATokens: false
       # RuntimeClassName is the runtime class to set for synced pods.
       runtimeClassName: ""
+      # PriorityClassName is the priority class to set for synced pods.
+      priorityClassName: ""
       # RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
       # a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
       # the virtual cluster.

--- a/config/config.go
+++ b/config/config.go
@@ -698,6 +698,9 @@ type SyncPods struct {
 	// RuntimeClassName is the runtime class to set for synced pods.
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
 
+	// PriorityClassName is the priority class to set for synced pods.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 	// a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
 	// the virtual cluster.

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -21,6 +21,7 @@ sync:
       enforceTolerations: []
       useSecretsForSATokens: false
       runtimeClassName: ""
+      priorityClassName: ""
       rewriteHosts:
         enabled: true
         initContainer:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5095



**What else do we need to know?** 
With this PR we are:
- Adding sync.toHost.pods.priorityClassName config field which will add the specified priorityClassName to all workloads pods being synced to the host
- Fixing a bug that prevented the priorityClassName to be applied correctly when sync.fromHost.priorityClasses.enabled is true.