### PR TITLE
fix fromHost sync namespace parsing & hostToVirtual/virtualToHost tra…

### DIFF
--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/loft-sh/vcluster/pkg/constants"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-
 	"github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/strvals"
+	"github.com/loft-sh/vcluster/pkg/util/stringutil"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/yaml"
 )
 
@@ -113,8 +113,15 @@ func parseHostNamespacesFromMappings(mappings map[string]string, vClusterNs stri
 		if len(parts) != 2 {
 			continue
 		}
+
+		if parts[0] == "" {
+			// this means that the mapping key is e.g. "/my-cm-1",
+			// then, we should append virtual cluster namespace
+			ret = append(ret, vClusterNs)
+			continue
+		}
 		hostNs := parts[0]
 		ret = append(ret, hostNs)
 	}
-	return ret
+	return stringutil.RemoveDuplicates(ret)
 }

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -28,13 +28,31 @@ func TestParseHostNamespacesFromMappings(t *testing.T) {
 			mappings:   map[string]string{},
 			expected:   []string{},
 		},
+		{
+			name:       "vcluster namespace different than vCluster",
+			vClusterNs: "ns1",
+			mappings: map[string]string{
+				"/my-cm-1": "default/my-virtual-1",
+				"/my-cm-2": "default/my-virtual-2",
+			},
+			expected: []string{"ns1"},
+		},
+		{
+			name:       "repeated host namespaces",
+			vClusterNs: "vcluster",
+			mappings: map[string]string{
+				"my-ns/my-cm":   "target2/my-cm",
+				"my-ns/my-cm-2": "target3/my-cm-2",
+			},
+			expected: []string{"my-ns"},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := parseHostNamespacesFromMappings(tc.mappings, tc.vClusterNs)
 			if len(got) != len(tc.expected) {
-				t.Logf("expectedVirtual %d namespaces, got %d", len(tc.expected), len(got))
+				t.Logf("expectedVirtual %d namespaces (%v), got %d (%v)", len(tc.expected), tc.expected, len(got), got)
 				t.Fail()
 			}
 			sort.Strings(got)

--- a/pkg/syncer/translator/from_config_translator_test.go
+++ b/pkg/syncer/translator/from_config_translator_test.go
@@ -1,0 +1,166 @@
+package translator
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestMatches(t *testing.T) {
+	defaultVclusterNs := "vcluster"
+	cases := []struct {
+		name                  string
+		mappings              map[string]string
+		hostName              string
+		hostNs                string
+		virtualName           string
+		virtualNs             string
+		vClusterHostNamespace string
+		noMatchExpected       bool
+		expectedVirtual       types.NamespacedName
+	}{
+		{
+			name: "mirror",
+			mappings: map[string]string{
+				"my-ns/my-cm":   "my-ns/my-cm",
+				"my-ns/my-cm-2": "my-ns/my-cm-3",
+				"my-ns-2/*":     "my-ns-2/*",
+			},
+			hostName:              "my-cm",
+			hostNs:                "my-ns",
+			virtualName:           "my-cm",
+			virtualNs:             "my-ns",
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "my-cm", Namespace: "my-ns"},
+		},
+		{
+			name: "match all in namespace",
+			mappings: map[string]string{
+				"my-ns/*":   "my-ns-2/*",
+				"my-ns-3/*": "my-ns-3/*",
+			},
+			hostName:              "my-cm",
+			hostNs:                "my-ns",
+			virtualName:           "my-cm",
+			virtualNs:             "my-ns-2",
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "my-cm", Namespace: "my-ns-2"},
+		},
+		{
+			name: "change name and namespace",
+			mappings: map[string]string{
+				"my-ns/my-cm": "my-ns-2/my-cm-2",
+				"my-ns-3/*":   "my-ns-3/*",
+			},
+			hostName:              "my-cm",
+			hostNs:                "my-ns",
+			virtualName:           "my-cm-2",
+			virtualNs:             "my-ns-2",
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "my-cm-2", Namespace: "my-ns-2"},
+		},
+		{
+			name: "all from vCluster host namespace to another namespace in virtual",
+			mappings: map[string]string{
+				"": "my-ns",
+			},
+			hostName:              "my-cm",
+			hostNs:                "vcluster",
+			virtualName:           "my-cm",
+			virtualNs:             "my-ns",
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "my-cm", Namespace: "my-ns"},
+		},
+		{
+			name: "no match",
+			mappings: map[string]string{
+				"":              "my-ns",
+				"my-ns/*":       "my-ns-2/*",
+				"my-ns-2/my-cm": "my-ns-2/my-cm",
+			},
+			hostName:              "my-cm-2",
+			hostNs:                "my-ns-2",
+			virtualName:           "",
+			virtualNs:             "",
+			noMatchExpected:       true,
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "", Namespace: ""}, // no match
+		},
+		{
+			name: "kube-root-ca.crt skipped",
+			mappings: map[string]string{
+				"":              "my-ns",
+				"my-ns/*":       "my-ns-2/*",
+				"my-ns-2/my-cm": "my-ns-2/my-cm",
+			},
+			hostName:              "kube-root-ca.crt",
+			hostNs:                "ingress-nginx",
+			virtualName:           "",
+			virtualNs:             "",
+			noMatchExpected:       true,
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "", Namespace: ""}, // no match
+		},
+		{
+			name: "a few objects from vcluster's namespace",
+			mappings: map[string]string{
+				"/my-cm":   "my-ns-2/my-cm-2",
+				"/my-cm-2": "my-ns-3/my-cm-3",
+			},
+			hostName:              "my-cm",
+			hostNs:                "vcluster",
+			virtualName:           "my-cm-2",
+			virtualNs:             "my-ns-2",
+			vClusterHostNamespace: defaultVclusterNs,
+			expectedVirtual:       types.NamespacedName{Name: "my-cm-2", Namespace: "my-ns-2"},
+		},
+		{
+			name: "a few objects from vcluster's namespace (not default)",
+			mappings: map[string]string{
+				"/my-cm":   "my-ns-2/my-cm-2",
+				"/my-cm-2": "my-ns-3/my-cm-3",
+			},
+			hostName:              "my-cm",
+			hostNs:                "ns1",
+			virtualName:           "my-cm-2",
+			virtualNs:             "my-ns-2",
+			vClusterHostNamespace: "ns1",
+			expectedVirtual:       types.NamespacedName{Name: "my-cm-2", Namespace: "my-ns-2"},
+		},
+	}
+
+	t.Run("match host", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, _ := matchesHostObject(tc.hostName, tc.hostNs, tc.mappings, tc.vClusterHostNamespace, func(hostName, _ string) bool {
+					return hostName == "kube-root-ca.crt"
+				})
+				if got.Name == tc.virtualName && got.Namespace == tc.virtualNs {
+					return
+				}
+				t.Logf("expectedVirtual %s/%s, got %s", tc.virtualNs, tc.virtualName, got.String())
+				t.Fail()
+			})
+		}
+	})
+
+	t.Run("match virtual", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				virtualToHost := make(map[string]string, len(tc.mappings))
+				for host, virtual := range tc.mappings {
+					virtualToHost[virtual] = host
+				}
+				got, match := matchesVirtualObject(tc.virtualNs, tc.virtualName, virtualToHost, tc.vClusterHostNamespace)
+				if tc.noMatchExpected && match != tc.noMatchExpected {
+					return
+				}
+				if got.Name == tc.hostName && got.Namespace == tc.hostNs {
+					return
+				}
+				t.Logf("expectedHost %s/%s, got %s", tc.hostNs, tc.hostName, got.String())
+				t.Fail()
+			})
+		}
+	})
+}

--- a/test/e2e/values.yaml
+++ b/test/e2e/values.yaml
@@ -47,3 +47,4 @@ sync:
         mappings:
           "from-host-sync-test-2/dummy": "barfoo2/dummy"
           "default/my-secret": "barfoo2/secret-my"
+          "/my-secret-in-default-ns": "barfoo2/secret-from-default-ns"


### PR DESCRIPTION
…nslation

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5736


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was not parsing fromHost sync config properly


**What else do we need to know?**
there were two issues:
1. We didn't parse namespaces correctly to set up physical watchers
2. We didn't translate host <-> virtual properly (the case with `/obj-name: virtual-ns/virtual-obj` was not supported)
