### PR TITLE
Deprecate creation of multiple vclusters in same namespace

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3838,6 +3838,10 @@
         "$ref": "#/$defs/Plugin"
       },
       "description": "Plugin specifies which vCluster plugins to enable. Use \"plugins\" instead. Do not use this option anymore."
+    },
+    "reuseNamespace": {
+      "type": "boolean",
+      "description": "ReuseNamespace is a flag to control the decision of reusing the same namespace while creating vclusters using methods\nother than cli such as helm. This flag will immediately have a deprecation warning since this feature is going to be deprecated soon."
     }
   },
   "additionalProperties": false,

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3841,7 +3841,7 @@
     },
     "reuseNamespace": {
       "type": "boolean",
-      "description": "ReuseNamespace is a flag to control the decision of reusing the same namespace while creating vclusters using methods\nother than cli such as helm. This flag will immediately have a deprecation warning since this feature is going to be deprecated soon."
+      "description": "ReuseNamespace allows reusing the same namespace to create multiple vClusters.\nThis flag is deprecated, as this scenario will be removed entirely in upcoming releases."
     }
   },
   "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1036,3 +1036,7 @@ experimental:
 telemetry:
   # Enabled specifies that the telemetry for the vCluster control plane should be enabled.
   enabled: true
+
+# ReuseNamespace is a flag to control the decision of reusing the same namespace while creating vclusters using methods
+# other than cli such as helm. This flag will immediately have a deprecation warning since this feature is going to be deprecated soon.
+reuseNamespace: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1037,6 +1037,6 @@ telemetry:
   # Enabled specifies that the telemetry for the vCluster control plane should be enabled.
   enabled: true
 
-# ReuseNamespace is a flag to control the decision of reusing the same namespace while creating vclusters using methods
-# other than cli such as helm. This flag will immediately have a deprecation warning since this feature is going to be deprecated soon.
+# ReuseNamespace allows reusing the same namespace to create multiple vClusters.
+# This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
 reuseNamespace: false

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -97,13 +97,11 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 		return err
 	}
 
-	// add a deprecation warning if reuseNamespace flag is being set to true
-	if !vConfig.ReuseNamespace {
-		if len(vclusterServices) > 0 {
-			return fmt.Errorf("there is already a virtual cluster in the current namespace %s", vConfig.ControlPlaneNamespace)
-		}
-	} else {
-		logrus.Warnf("Creation of multiple vclusters within the same namespace will be deprecated soon.")
+	// add a note for setting reuse-namespace config in v0.24 and a deprecation warning for multiple vcluster creation scenario
+	if len(vclusterServices) > 0 {
+		logrus.Warnf("Please note that in next release i.e. v0.24, for creating multiple vclusters within the " +
+			"same namespace, it'll be mandatory to set 'reuse-namespace=true' in vcluster config. " +
+			"This config and the scenario of creating multiple vclusters in the same namespace will be deprecated soon.")
 	}
 
 	err = setup.Initialize(ctx, vConfig)

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -6,8 +6,7 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/integrations"
@@ -97,11 +96,12 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 		return err
 	}
 
+	logger := log.GetInstance()
 	// add a note for setting reuse-namespace config in v0.24 and a deprecation warning for multiple vcluster creation scenario
 	if len(vclusterServices) > 0 {
-		logrus.Warnf("Please note that in next release i.e. v0.24, for creating multiple vclusters within the " +
+		logger.Warnf("Please note that in next release i.e. v0.24, for creating multiple vclusters within the " +
 			"same namespace, it'll be mandatory to set 'reuse-namespace=true' in vcluster config. " +
-			"This config and the scenario of creating multiple vclusters in the same namespace will be deprecated soon.")
+			"This config and the scenario of creating multiple vclusters in the same namespace is deprecated and will be removed soon.")
 	}
 
 	err = setup.Initialize(ctx, vConfig)

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -68,7 +68,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm or platform.")
 	cobraCmd.Flags().BoolVar(&cmd.reuseNamespace, "reuse-namespace", false, "Allows to create multiple virtual clusters in a single namespace")
 	cobraCmd.Flag("reuse-namespace").Hidden = true
-	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "Creation of multiple vclusters within the same namespace will be deprecated soon.")
+	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "creation of multiple vclusters within the same namespace will be deprecated soon.")
 
 	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
 	create.AddHelmFlags(cobraCmd, &cmd.CreateOptions)

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -68,6 +68,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm or platform.")
 	cobraCmd.Flags().BoolVar(&cmd.reuseNamespace, "reuse-namespace", false, "Allows to create multiple virtual clusters in a single namespace")
 	cobraCmd.Flag("reuse-namespace").Hidden = true
+	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "Creation of multiple vclusters within the same namespace will be deprecated soon.")
 
 	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
 	create.AddHelmFlags(cobraCmd, &cmd.CreateOptions)

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,10 @@ type Config struct {
 
 	// Plugin specifies which vCluster plugins to enable. Use "plugins" instead. Do not use this option anymore.
 	Plugin map[string]Plugin `json:"plugin,omitempty"`
+
+	// ReuseNamespace is a flag to control the decision of reusing the same namespace while creating vclusters using methods
+	// other than cli such as helm. This flag will immediately have a deprecation warning since this feature is going to be deprecated soon.
+	ReuseNamespace bool `json:"reuseNamespace,omitempty"`
 }
 
 // Integrations holds config for vCluster integrations with other operators or tools running on the host cluster

--- a/config/config.go
+++ b/config/config.go
@@ -77,8 +77,8 @@ type Config struct {
 	// Plugin specifies which vCluster plugins to enable. Use "plugins" instead. Do not use this option anymore.
 	Plugin map[string]Plugin `json:"plugin,omitempty"`
 
-	// ReuseNamespace is a flag to control the decision of reusing the same namespace while creating vclusters using methods
-	// other than cli such as helm. This flag will immediately have a deprecation warning since this feature is going to be deprecated soon.
+	// ReuseNamespace allows reusing the same namespace to create multiple vClusters.
+	// This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
 	ReuseNamespace bool `json:"reuseNamespace,omitempty"`
 }
 

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -574,3 +574,5 @@ experimental:
 
 telemetry:
   enabled: true
+
+reuseNamespace: false

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -128,19 +128,19 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if err != nil {
 		return err
 	}
-	vclusters, err := find.ListVClusters(ctx, cmd.Context, "", cmd.Namespace, log)
+	vClusters, err := find.ListVClusters(ctx, cmd.Context, "", cmd.Namespace, log)
 	if err != nil {
 		return err
 	}
 
 	if !reuseNamespace {
-		for _, v := range vclusters {
+		for _, v := range vClusters {
 			if v.Namespace == cmd.Namespace && v.Name != vClusterName {
 				return fmt.Errorf("there is already a virtual cluster in namespace %s", cmd.Namespace)
 			}
 		}
 	} else {
-		cmd.log.Warn("Creation of multiple vclusters within the same namespace will be deprecated soon.")
+		cmd.log.Warn("Creation of multiple vClusters within the same namespace is deprecated and will be removed soon.")
 	}
 
 	err = cmd.prepare(ctx, vClusterName)

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -139,6 +139,8 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 				return fmt.Errorf("there is already a virtual cluster in namespace %s", cmd.Namespace)
 			}
 		}
+	} else {
+		cmd.log.Warn("Creation of multiple vclusters within the same namespace will be deprecated soon.")
 	}
 
 	err = cmd.prepare(ctx, vClusterName)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5363


**Please provide a short message that should be published in the vcluster release notes**
- Deprecate the `reuse-namespace` flag.
- Add a flag `reuse-namespace` in vcluster config with immediate deprecation warning.

**What else do we need to know?** 

**Testing**:

- CLI: here's the deprecation warning coming up if someone uses flag `reuse-namespace`:

![Screenshot from 2025-02-14 19-35-25](https://github.com/user-attachments/assets/fbb3ef53-8918-417f-a247-8cc86cafe99f)

- Using helm, multiple vcluster creation is allowed but with a note about `reuse-namespace` config and a deprecation warning like this:

![image](https://github.com/user-attachments/assets/7f34a9ec-ccbb-430d-94eb-9d76476a4799)
