### PR TITLE
Downgrade k0s version supported to 1.30 and update kindest node image in E2E tests to 1.32 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -159,8 +159,8 @@ jobs:
       - name: Set up kind k8s cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.20.0"
-          image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+          version: "v0.26.0"
+          image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
 
       - name: Testing kind cluster set-up
         run: |
@@ -237,8 +237,8 @@ jobs:
       - name: Set up kind k8s cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.20.0"
-          image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+          version: "v0.26.0"
+          image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
 
       - name: Testing kind cluster set-up
         run: |
@@ -360,8 +360,8 @@ jobs:
       - name: Set up kind k8s cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.20.0"
-          image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+          version: "v0.26.0"
+          image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
 
       - name: Testing kind cluster set-up
         run: |

--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -33,7 +33,7 @@ var K3SVersionMap = map[string]string{
 
 // K0SVersionMap holds the supported k0s versions
 var K0SVersionMap = map[string]string{
-	"1.32": "k0sproject/k0s:v1.32.1-k0s.0",
+	"1.32": "k0sproject/k0s:v1.30.2-k0s.0",
 	"1.31": "k0sproject/k0s:v1.30.2-k0s.0",
 	"1.30": "k0sproject/k0s:v1.30.2-k0s.0",
 	"1.29": "k0sproject/k0s:v1.29.6-k0s.0",

--- a/docs/pages/deploying-vclusters/compat-matrix.mdx
+++ b/docs/pages/deploying-vclusters/compat-matrix.mdx
@@ -51,7 +51,7 @@ Legend:
 
 Compatibility matrix showing which host k8s version (left column) is supported by which vCluster k0s distro versions.
 
-|      |   v1.32.1-k0s.0    |   v1.30.2-k0s.0    |   v1.30.2-k0s.0    |   v1.29.6-k0s.0    |   v1.28.11-k0s.0   |   v1.27.16-k0s.0   |
+|      |   v1.30.2-k0s.0    |   v1.30.2-k0s.0    |   v1.30.2-k0s.0    |   v1.29.6-k0s.0    |   v1.28.11-k0s.0   |   v1.27.16-k0s.0   |
 |------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
 | 1.32 | :white_check_mark: | :ok:               | :ok:               | :ok:               | :ok:               | :ok:               |
 | 1.31 | :ok:               | :white_check_mark: | :ok:               | :ok:               | :ok:               | :ok:               |

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -347,6 +347,16 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 		return ctrl.Result{}, err
 	}
 
+	// ignore the QOSClass field while updating pod status when there is a
+	// mismatch in this field value on vcluster and host. This field
+	// has become immutable from k8s 1.32 version and patch fails if
+	// syncer tries to update this field.
+	// This needs to be done before patch object is created when
+	// NewSyncerPatcher() is called so that there are no
+	// differences found in host QOSClass and virtual QOSClass and
+	// a patch event for this field is not created
+	event.Host.Status.QOSClass = event.VirtualOld.Status.QOSClass
+
 	// patch objects
 	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.ToHost.Pods.Patches, false))
 	if err != nil {

--- a/pkg/controllers/resources/pods/translate/diff.go
+++ b/pkg/controllers/resources/pods/translate/diff.go
@@ -13,12 +13,6 @@ import (
 )
 
 func (t *translator) Diff(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*corev1.Pod]) error {
-	// ignore the QOSClass field while updating pod status when there is a
-	// mismatch in this field value on vcluster and host. This field
-	// has become immutable from k8s 1.32 version and patch fails if
-	// syncer tries to update this field.
-	event.Host.Status.QOSClass = event.VirtualOld.Status.QOSClass
-
 	// sync conditions
 	event.Virtual.Status.Conditions, event.Host.Status.Conditions = patcher.CopyBidirectional(
 		event.VirtualOld.Status.Conditions,

--- a/test/e2e/syncer/pods/pods.go
+++ b/test/e2e/syncer/pods/pods.go
@@ -83,6 +83,12 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 
 		// ignore HostIP differences
 		resetHostIP(vpod, pod)
+
+		// Since k8s 1.32, status.QOSClass field has become immutable,
+		// hence we have stopeed syncing it. So ignore
+		// the differences in the status.QOSClass field
+		ignoreQOSClassDiff(vpod, pod)
+
 		framework.ExpectEqual(vpod.Status, pod.Status)
 
 		// check for ephemeralContainers subResource
@@ -144,6 +150,12 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 
 		// ignore HostIP differences
 		resetHostIP(vpod, pod)
+
+		// Since k8s 1.32, status.QOSClass field has become immutable,
+		// hence we have stopeed syncing it. So ignore
+		// the differences in the status.QOSClass field
+		ignoreQOSClassDiff(vpod, pod)
+
 		framework.ExpectEqual(vpod.Status, pod.Status)
 
 		// check for conditions
@@ -693,4 +705,8 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 func resetHostIP(vpod, pod *corev1.Pod) {
 	vpod.Status.HostIP, pod.Status.HostIP = "", ""
 	vpod.Status.HostIPs, pod.Status.HostIPs = nil, nil
+}
+
+func ignoreQOSClassDiff(vpod, pod *corev1.Pod) {
+	pod.Status.QOSClass = vpod.Status.QOSClass
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5390


**Please provide a short message that should be published in the vcluster release notes**
Update K8s dependencies to 1.32


**What else do we need to know?** 
    - vcluster is breaking on k0s 1.32 as seen in the CI failure in [this](https://github.com/loft-sh/vcluster/pull/2495) PR, hence  downgrading the support for k0s to 1.30.
    - This also fixes E2E tests for QOSClass field after upgrading kind image to 1.32. Earlier the tests were being run on k8s version 1.30
