### PR TITLE
[0.23] Update deprecation warning message and move reuse-namespace to controlPlane/advanced section #2507

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -237,6 +237,10 @@
         "globalMetadata": {
           "$ref": "#/$defs/ControlPlaneGlobalMetadata",
           "description": "GlobalMetadata is metadata that will be added to all resources deployed by Helm."
+        },
+        "reuseNamespace": {
+          "type": "boolean",
+          "description": "ReuseNamespace allows reusing the same namespace to create multiple vClusters.\nThis flag is deprecated, as this scenario will be removed entirely in upcoming releases."
         }
       },
       "additionalProperties": false,
@@ -3838,10 +3842,6 @@
         "$ref": "#/$defs/Plugin"
       },
       "description": "Plugin specifies which vCluster plugins to enable. Use \"plugins\" instead. Do not use this option anymore."
-    },
-    "reuseNamespace": {
-      "type": "boolean",
-      "description": "ReuseNamespace allows reusing the same namespace to create multiple vClusters.\nThis flag is deprecated, as this scenario will be removed entirely in upcoming releases."
     }
   },
   "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -721,6 +721,9 @@ controlPlane:
     # GlobalMetadata is metadata that will be added to all resources deployed by Helm.
     globalMetadata:
       annotations: {}
+    # ReuseNamespace allows reusing the same namespace to create multiple vClusters.
+    # This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
+    reuseNamespace: false
 
 # Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 integrations:
@@ -1036,7 +1039,3 @@ experimental:
 telemetry:
   # Enabled specifies that the telemetry for the vCluster control plane should be enabled.
   enabled: true
-
-# ReuseNamespace allows reusing the same namespace to create multiple vClusters.
-# This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
-reuseNamespace: false

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -99,9 +99,9 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	logger := log.GetInstance()
 	// add a note for setting reuse-namespace config in v0.24 and a deprecation warning for multiple vcluster creation scenario
 	if len(vclusterServices) > 0 {
-		logger.Warnf("Please note that in next release i.e. v0.24, for creating multiple vclusters within the " +
+		logger.Warnf("Please note that in next release i.e. v0.24, for creating multiple virtual clusters within the " +
 			"same namespace, it'll be mandatory to set 'reuse-namespace=true' in vcluster config. " +
-			"This config and the scenario of creating multiple vclusters in the same namespace is deprecated and will be removed soon.")
+			"This config and the scenario of creating multiple virtual clusters in the same namespace is deprecated and will be removed soon.")
 	}
 
 	err = setup.Initialize(ctx, vConfig)

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -68,7 +68,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm or platform.")
 	cobraCmd.Flags().BoolVar(&cmd.reuseNamespace, "reuse-namespace", false, "Allows to create multiple virtual clusters in a single namespace")
 	cobraCmd.Flag("reuse-namespace").Hidden = true
-	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "creation of multiple vclusters within the same namespace will be deprecated soon.")
+	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "creation of multiple virtual clusters within the same namespace will be deprecated soon.")
 
 	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
 	create.AddHelmFlags(cobraCmd, &cmd.CreateOptions)

--- a/config/config.go
+++ b/config/config.go
@@ -76,10 +76,6 @@ type Config struct {
 
 	// Plugin specifies which vCluster plugins to enable. Use "plugins" instead. Do not use this option anymore.
 	Plugin map[string]Plugin `json:"plugin,omitempty"`
-
-	// ReuseNamespace allows reusing the same namespace to create multiple vClusters.
-	// This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
-	ReuseNamespace bool `json:"reuseNamespace,omitempty"`
 }
 
 // Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
@@ -1468,6 +1464,10 @@ type ControlPlaneAdvanced struct {
 
 	// GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 	GlobalMetadata ControlPlaneGlobalMetadata `json:"globalMetadata,omitempty"`
+
+	// ReuseNamespace allows reusing the same namespace to create multiple vClusters.
+	// This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
+	ReuseNamespace bool `json:"reuseNamespace,omitempty"`
 }
 
 type ControlPlaneHeadlessService struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -397,6 +397,8 @@ controlPlane:
     globalMetadata:
       annotations: {}
 
+    reuseNamespace: false
+
 integrations:
   metricsServer:
     enabled: false
@@ -574,5 +576,3 @@ experimental:
 
 telemetry:
   enabled: true
-
-reuseNamespace: false

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -140,7 +140,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 			}
 		}
 	} else {
-		cmd.log.Warn("Creation of multiple vClusters within the same namespace is deprecated and will be removed soon.")
+		cmd.log.Warn("Creation of multiple virtual clusters within the same namespace is deprecated and will be removed soon.")
 	}
 
 	err = cmd.prepare(ctx, vClusterName)


### PR DESCRIPTION
backport: https://github.com/loft-sh/vcluster/pull/2507
