### PR TITLE
feat: add mechanism for checking for license features on startup that might normally wait for first use

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -133,6 +133,11 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 		return fmt.Errorf("start license loader: %w", err)
 	}
 
+	err = pro.CheckFeatures(controllerCtx)
+	if err != nil {
+		return fmt.Errorf("pro features check: %w", err)
+	}
+
 	// start integrations
 	err = integrations.StartIntegrations(controllerCtx)
 	if err != nil {

--- a/pkg/pro/checks.go
+++ b/pkg/pro/checks.go
@@ -1,0 +1,17 @@
+package pro
+
+import "github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+
+type FeatureCheck func(ctx *synccontext.ControllerContext) error
+
+var FeatureChecks []FeatureCheck
+
+func CheckFeatures(ctx *synccontext.ControllerContext) error {
+	for _, check := range FeatureChecks {
+		if err := check(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
### 💡 To facilitate [checking on startup](https://github.com/loft-sh/vcluster-pro/pull/686)

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-5705

### 📝 Note
This is functionally equivalent to the `integration.Integrations` registration.  It's only semantically different, in that its not doing any starting or registering and they're not integrations, just checks on features. If someone has a strong opinion about renaming and combining them, I'm open to any suggestions.
