### PR TITLE
refactor: cache authorizer & short local k8s timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -333,6 +334,10 @@ func ValidateStoreAndDistroChanges(currentStoreType, previousStoreType StoreType
 }
 
 func (c *Config) IsProFeatureEnabled() bool {
+	if os.Getenv("SKIP_VALIDATE_PRO_FEATURES") == "true" {
+		return false
+	}
+
 	if len(c.Networking.ResolveDNS) > 0 {
 		return true
 	}

--- a/pkg/authentication/delegatingauthenticator/delegatingauthenticator.go
+++ b/pkg/authentication/delegatingauthenticator/delegatingauthenticator.go
@@ -13,8 +13,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	cacheTime = 5 * time.Second
+)
+
 func New(client client.Client) authenticator.Request {
-	cache, _ := lru.New[string, cacheEntry](256)
+	cache, _ := lru.New[string, cacheEntry](512)
 	return bearertoken.New(&delegatingAuthenticator{
 		client: client,
 		cache:  cache,
@@ -63,7 +67,7 @@ func (d *delegatingAuthenticator) AuthenticateToken(ctx context.Context, token s
 	}
 	d.cache.Add(token, cacheEntry{
 		response: response,
-		exp:      now.Add(time.Second * 5),
+		exp:      now.Add(cacheTime),
 	})
 	return response, true, nil
 }

--- a/pkg/authorization/delegatingauthorizer/cache.go
+++ b/pkg/authorization/delegatingauthorizer/cache.go
@@ -1,0 +1,69 @@
+package delegatingauthorizer
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+var (
+	cacheTime = 5 * time.Second
+)
+
+type Cache struct {
+	cache *lru.Cache[string, cacheEntry]
+}
+
+func NewCache() *Cache {
+	cache, _ := lru.New[string, cacheEntry](256)
+	return &Cache{
+		cache: cache,
+	}
+}
+
+type cacheEntry struct {
+	authorized authorizer.Decision
+	reason     string
+
+	exp time.Time
+}
+
+func (c *Cache) Set(a authorizer.Attributes, authorized authorizer.Decision, reason string) {
+	c.cache.Add(getCacheKey(a), cacheEntry{
+		authorized: authorized,
+		reason:     reason,
+		exp:        time.Now().Add(cacheTime),
+	})
+}
+
+func (c *Cache) Get(a authorizer.Attributes) (authorized authorizer.Decision, reason string, exists bool) {
+	// check if in cache
+	now := time.Now()
+	entry, ok := c.cache.Get(getCacheKey(a))
+	if ok && entry.exp.After(now) {
+		return entry.authorized, entry.reason, true
+	}
+
+	return authorizer.DecisionNoOpinion, "", false
+}
+
+func getCacheKey(a authorizer.Attributes) string {
+	parts := []string{}
+	if a.GetUser() != nil {
+		parts = append(parts, a.GetUser().GetName(), a.GetUser().GetUID(), strings.Join(a.GetUser().GetGroups(), ","))
+	}
+	if a.IsResourceRequest() {
+		parts = append(parts, a.GetAPIGroup(), a.GetAPIVersion(), a.GetResource(), a.GetSubresource(), a.GetVerb(), a.GetNamespace(), a.GetName())
+	} else {
+		parts = append(parts, a.GetPath(), a.GetVerb())
+	}
+
+	// hash the string
+	h := sha256.New()
+	h.Write([]byte(strings.Join(parts, "#")))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/cli/localkubernetes/configure.go
+++ b/pkg/cli/localkubernetes/configure.go
@@ -30,7 +30,7 @@ func (c ClusterType) LocalKubernetes() bool {
 
 func ExposeLocal(ctx context.Context, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service) (string, error) {
 	// Timeout to wait for connection before falling back to port-forwarding
-	timeout := time.Second * 30
+	timeout := time.Second * 5
 	clusterType := DetectClusterType(rawConfig)
 	switch clusterType {
 	case ClusterTypeOrbstack:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

Changes:
* Caches the subjectaccessreview calls
* Reduces the timeout to wait for local k8s connection before falling back to background proxy