### PR TITLE
Enforce reuse-namespace config for creating multiple vClusters in same ns

### DIFF
--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -103,13 +103,13 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	}
 	// add a deprecation warning for multiple vCluster creation scenario
 	if vClusterExists {
-		logger.Warnf("Please note that the scenario of creating multiple virtual clusters in the same namespace " +
-			"and the 'reuseNamespace' config both are deprecated and will be removed soon.")
+		logger.Warnf("Please note that creating multiple virtual clusters in the same namespace " +
+			"and the 'reuseNamespace' config are deprecated and will be removed soon.")
 
 		// throw an error if reuseNamespace config is not set
 		if !vConfig.Experimental.ReuseNamespace {
 			return fmt.Errorf("there is already a virtual cluster in namespace %s. To create multiple virtual clusters "+
-				"within the same namespace, it is mandatory to set 'reuse-namespace=true' in vCluster config", vConfig.ControlPlaneNamespace)
+				"within the same namespace, it is mandatory to set 'reuse-namespace' to true in vCluster config", vConfig.ControlPlaneNamespace)
 		}
 	}
 

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -101,11 +101,16 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 			break
 		}
 	}
-	// add a note for setting reuse-namespace config in v0.24 and a deprecation warning for multiple vCluster creation scenario
+	// add a deprecation warning for multiple vCluster creation scenario
 	if vClusterExists {
-		logger.Warnf("Please note that in next release i.e. v0.24, for creating multiple virtual clusters within the " +
-			"same namespace, it'll be mandatory to set 'reuse-namespace=true' in vcluster config. " +
-			"This config and the scenario of creating multiple virtual clusters in the same namespace is deprecated and will be removed soon.")
+		logger.Warnf("Please note that the scenario of creating multiple virtual clusters in the same namespace " +
+			"and the 'reuseNamespace' config both are deprecated and will be removed soon.")
+
+		// throw an error if reuseNamespace config is not set
+		if !vConfig.Experimental.ReuseNamespace {
+			return fmt.Errorf("there is already a virtual cluster in namespace %s. To create multiple virtual clusters "+
+				"within the same namespace, it is mandatory to set 'reuse-namespace=true' in vCluster config", vConfig.ControlPlaneNamespace)
+		}
 	}
 
 	err = setup.Initialize(ctx, vConfig)

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -68,7 +68,7 @@ vcluster create test --namespace test
 	cobraCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm or platform.")
 	cobraCmd.Flags().BoolVar(&cmd.reuseNamespace, "reuse-namespace", false, "Allows to create multiple virtual clusters in a single namespace")
 	cobraCmd.Flag("reuse-namespace").Hidden = true
-	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "creation of multiple virtual clusters within the same namespace will be deprecated soon.")
+	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "creation of multiple virtual clusters within the same namespace is deprecated.")
 
 	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
 	create.AddHelmFlags(cobraCmd, &cmd.CreateOptions)

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -292,7 +292,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	// multiple vCluster creation inside same ns should fail if `reuseNamespace` is not set as true in vCluster config
 	if reuseNamespace && !vClusterConfig.Experimental.ReuseNamespace {
 		return fmt.Errorf("there is already a virtual cluster in namespace %s; to create multiple virtual clusters "+
-			"within the same namespace, please set 'reuse-namespace=true' in vCluster config", cmd.Namespace)
+			"within the same namespace, please set 'reuse-namespace' to true in vCluster config", cmd.Namespace)
 	}
 
 	if vClusterConfig.Experimental.IsolatedControlPlane.Headless {

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -142,8 +142,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if !reuseNamespace {
 		for _, v := range vClusters {
 			if v.Namespace == cmd.Namespace && v.Name != vClusterName {
-				return fmt.Errorf("there is already a virtual cluster in namespace %s. To create multiple virtual clusters "+
-					"within the same namespace, it is mandatory to set the 'reuse-namespace' flag as true", cmd.Namespace)
+				return fmt.Errorf("there is already a virtual cluster in namespace %s", cmd.Namespace)
 			}
 		}
 	} else {
@@ -288,6 +287,12 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	vClusterConfig, err := cmd.parseVClusterYAML(chartValues)
 	if err != nil {
 		return err
+	}
+
+	// multiple vCluster creation inside same ns should fail if `reuseNamespace` is not set as true in vCluster config
+	if reuseNamespace && !vClusterConfig.Experimental.ReuseNamespace {
+		return fmt.Errorf("there is already a virtual cluster in namespace %s; to create multiple virtual clusters "+
+			"within the same namespace, please set 'reuse-namespace=true' in vCluster config", cmd.Namespace)
 	}
 
 	if vClusterConfig.Experimental.IsolatedControlPlane.Headless {

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -142,7 +142,8 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if !reuseNamespace {
 		for _, v := range vClusters {
 			if v.Namespace == cmd.Namespace && v.Name != vClusterName {
-				return fmt.Errorf("there is already a virtual cluster in namespace %s", cmd.Namespace)
+				return fmt.Errorf("there is already a virtual cluster in namespace %s. To create multiple virtual clusters "+
+					"within the same namespace, it is mandatory to set the 'reuse-namespace' flag as true", cmd.Namespace)
 			}
 		}
 	} else {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5919


**Please provide a short message that should be published in the vcluster release notes**
For v0.24, it will be mandatory set `reuse-namespace=true` in vcluster config to create multiple vclusters in same ns, failing to which the vcluster pod won't come up. This applies to both via CLI and helm.


**What else do we need to know?** 

**Testing scenarios:**

- Using helm, when the user creates another vcluster without giving setting `reuse-namespace` config to true:

![image](https://github.com/user-attachments/assets/2051d3c9-a477-4c92-b224-3d4352f79a43)
 
 - When user created it using CLI in v0.22 and upgrades to v0.24 then also the pod should fail with the same warning if the config is not set to true- it'll fail citing that `reuse-namespace` config is not set, same as above:
 ```there is already a virtual cluster in namespace vcluster-1. To create multiple virtual clusters within the same namespace, it is mandatory to set 'reuse-namespace=true' in vCluster config```

- Using CLI, the creation should fail if inside vcluster config `reuse-namespace=true` is not set even if `--reuse-namespace` flag used:

![image](https://github.com/user-attachments/assets/e89c9881-4ce3-42fb-9224-1bd3abfe4f56) 
