### PR TITLE
Add exportKubeConfig.additionalSecrets config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,5 +109,10 @@ issues:
   exclude-dirs:
     - licenses
 
-  exclude:
-    - "SA1019: (.+)Secret is deprecated: Use AdditionalSecrets instead."
+  exclude-rules:
+    # We are still using the deprecated exportKubeConfig.Secret field in a couple of places in code (as the support for
+    # exportKubeConfig.secret config is still not entirely removed).
+    - path: config/config.go
+      text: "SA1019: (.+)Secret is deprecated: Use AdditionalSecrets instead."
+    - path: pkg/config/validation.go
+      text: "SA1019: (.+)Secret is deprecated: Use AdditionalSecrets instead."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,4 +110,4 @@ issues:
     - licenses
 
   exclude:
-    - "SA1019: (.+)ExportKubeConfig.Secret is deprecated: Use AdditionalSecrets instead."
+    - "SA1019: (.+)Secret is deprecated: Use AdditionalSecrets instead."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,3 +108,6 @@ issues:
 
   exclude-dirs:
     - licenses
+
+  exclude:
+    - "SA1019: (.+)ExportKubeConfig.Secret is deprecated: Use AdditionalSecrets instead."

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1636,12 +1636,50 @@
         },
         "secret": {
           "$ref": "#/$defs/ExportKubeConfigSecretReference",
-          "description": "Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.\nIf this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,\nvCluster creates the config in this other secret."
+          "description": "Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.\nIf this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,\nvCluster creates the config in this other secret.\n\nDeprecated: Use AdditionalSecrets instead."
+        },
+        "additionalSecrets": {
+          "items": {
+            "$ref": "#/$defs/ExportKubeConfigAdditionalSecretReference"
+          },
+          "type": "array",
+          "description": "AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the\ngenerated virtual cluster kubeconfigs."
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "ExportKubeConfig describes how vCluster should export the vCluster kubeconfig."
+    },
+    "ExportKubeConfigAdditionalSecretReference": {
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "Context is the name of the context within the generated kubeconfig to use."
+        },
+        "server": {
+          "type": "string",
+          "description": "Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "If tls should get skipped for the server"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/ExportKubeConfigServiceAccount",
+          "description": "ServiceAccount can be used to generate a service account token instead of the default certificates."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the secret where the kubeconfig is stored."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace\nwhere you deployed vCluster, you need to make sure vCluster has access to this other namespace."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExportKubeConfigAdditionalSecretReference defines the additional host cluster secret in which vCluster stores the generated virtual cluster kubeconfigs."
     },
     "ExportKubeConfigSecretReference": {
       "properties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -972,6 +972,8 @@ exportKubeConfig:
   # Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
   # If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
   # vCluster creates the config in this other secret.
+
+  # Deprecated: Use AdditionalSecrets instead.
   secret:
     # Name is the name of the secret where the kubeconfig should get stored.
     name: ""

--- a/config/config.go
+++ b/config/config.go
@@ -403,6 +403,41 @@ func UnmarshalYAMLStrict(data []byte, i any) error {
 
 // ExportKubeConfig describes how vCluster should export the vCluster kubeconfig.
 type ExportKubeConfig struct {
+	ExportKubeConfigProperties
+
+	// Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
+	// If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
+	// vCluster creates the config in this other secret.
+	//
+	// Deprecated: Use AdditionalSecrets instead.
+	Secret ExportKubeConfigSecretReference `json:"secret,omitempty"`
+
+	// AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
+	// generated virtual cluster kubeconfigs.
+	AdditionalSecrets []ExportKubeConfigAdditionalSecretReference `json:"additionalSecrets,omitempty"`
+}
+
+// GetAdditionalSecrets returns optional additional kubeconfig Secrets.
+//
+// If the deprecated Secret property is set, GetAdditionalSecrets only returns that secret, and
+// AdditionalSecrets is ignored. On the other hand, if the AdditionalSecrets property is set,
+// GetAdditionalSecrets returns the secrets config from the AdditionalSecrets, and Secret property
+// is ignored.
+func (e *ExportKubeConfig) GetAdditionalSecrets() []ExportKubeConfigAdditionalSecretReference {
+	if e.Secret != (ExportKubeConfigSecretReference{}) {
+		return []ExportKubeConfigAdditionalSecretReference{
+			{
+				ExportKubeConfigProperties: e.ExportKubeConfigProperties,
+				Namespace:                  e.Secret.Namespace,
+				Name:                       e.Secret.Name,
+			},
+		}
+	}
+
+	return e.AdditionalSecrets
+}
+
+type ExportKubeConfigProperties struct {
 	// Context is the name of the context within the generated kubeconfig to use.
 	Context string `json:"context,omitempty"`
 
@@ -414,11 +449,6 @@ type ExportKubeConfig struct {
 
 	// ServiceAccount can be used to generate a service account token instead of the default certificates.
 	ServiceAccount ExportKubeConfigServiceAccount `json:"serviceAccount,omitempty"`
-
-	// Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
-	// If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
-	// vCluster creates the config in this other secret.
-	Secret ExportKubeConfigSecretReference `json:"secret,omitempty"`
 }
 
 type ExportKubeConfigServiceAccount struct {
@@ -441,6 +471,19 @@ type ExportKubeConfigSecretReference struct {
 	Name string `json:"name,omitempty"`
 
 	// Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
+	// where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// ExportKubeConfigAdditionalSecretReference defines the additional host cluster secret in which
+// vCluster stores the generated virtual cluster kubeconfigs.
+type ExportKubeConfigAdditionalSecretReference struct {
+	ExportKubeConfigProperties
+
+	// Name is the name of the secret where the kubeconfig is stored.
+	Name string `json:"name,omitempty"`
+
+	// Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 	// where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -424,7 +424,7 @@ type ExportKubeConfig struct {
 // GetAdditionalSecrets returns the secrets config from the AdditionalSecrets, and Secret property
 // is ignored.
 func (e *ExportKubeConfig) GetAdditionalSecrets() []ExportKubeConfigAdditionalSecretReference {
-	if e.Secret != (ExportKubeConfigSecretReference{}) {
+	if e.Secret.IsSet() {
 		return []ExportKubeConfigAdditionalSecretReference{
 			{
 				ExportKubeConfigProperties: e.ExportKubeConfigProperties,
@@ -473,6 +473,11 @@ type ExportKubeConfigSecretReference struct {
 	// Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 	// where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
 	Namespace string `json:"namespace,omitempty"`
+}
+
+// IsSet checks if at least one ExportKubeConfigSecretReference property is set.
+func (s *ExportKubeConfigSecretReference) IsSet() bool {
+	return *s != (ExportKubeConfigSecretReference{})
 }
 
 // ExportKubeConfigAdditionalSecretReference defines the additional host cluster secret in which

--- a/config/config.go
+++ b/config/config.go
@@ -424,7 +424,7 @@ type ExportKubeConfig struct {
 // GetAdditionalSecrets returns the secrets config from the AdditionalSecrets, and Secret property
 // is ignored.
 func (e *ExportKubeConfig) GetAdditionalSecrets() []ExportKubeConfigAdditionalSecretReference {
-	if e.Secret != (ExportKubeConfigSecretReference{}) {
+	if e.Secret.Name != "" {
 		return []ExportKubeConfigAdditionalSecretReference{
 			{
 				ExportKubeConfigProperties: e.ExportKubeConfigProperties,

--- a/config/config.go
+++ b/config/config.go
@@ -424,7 +424,7 @@ type ExportKubeConfig struct {
 // GetAdditionalSecrets returns the secrets config from the AdditionalSecrets, and Secret property
 // is ignored.
 func (e *ExportKubeConfig) GetAdditionalSecrets() []ExportKubeConfigAdditionalSecretReference {
-	if e.Secret.Name != "" {
+	if e.Secret != (ExportKubeConfigSecretReference{}) {
 		return []ExportKubeConfigAdditionalSecretReference{
 			{
 				ExportKubeConfigProperties: e.ExportKubeConfigProperties,

--- a/config/legacyconfig/migrate_test.go
+++ b/config/legacyconfig/migrate_test.go
@@ -653,6 +653,80 @@ sync:
       enabled: true`,
 			ExpectedErr: "",
 		},
+		{
+			Name:   "export kubeconfig with custom context and server",
+			Distro: "k8s",
+			In: `syncer:
+  extraArgs:
+  - --kube-config-context-name=my-context
+  - --out-kube-config-server=https://my-vcluster.example.com`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+exportKubeConfig:
+  context: my-context
+  server: https://my-vcluster.example.com`,
+		},
+		{
+			Name:   "export additional kubeconfig secret",
+			Distro: "k8s",
+			In: `syncer:
+  extraArgs:
+  - --out-kube-config-secret=my-secret
+  - --out-kube-config-secret-namespace=my-namespace`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+exportKubeConfig:
+  additionalSecrets:
+  - name: my-secret
+    namespace: my-namespace`,
+		},
+		{
+			Name:   "export additional kubeconfig secret with custom context and server",
+			Distro: "k8s",
+			In: `syncer:
+  extraArgs:
+  - --kube-config-context-name=my-context
+  - --out-kube-config-server=https://my-vcluster.example.com
+  - --out-kube-config-secret=my-secret
+  - --out-kube-config-secret-namespace=my-namespace`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+exportKubeConfig:
+  additionalSecrets:
+  - context: my-context
+    name: my-secret
+    namespace: my-namespace
+    server: https://my-vcluster.example.com
+  context: my-context
+  server: https://my-vcluster.example.com`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -694,6 +694,7 @@ func validateFromHostSyncMappingObjectName(objRef []string, resourceNamePlural s
 
 const (
 	exportKubeConfigBothSecretAndAdditionalSecretsSetError = "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time"
+	exportKubeConfigAdditionalSecretWithoutNameAndNamespace = "additional secret must have name and/or namespace set"
 )
 
 func validateExportKubeConfig(exportKubeConfig config.ExportKubeConfig) error {
@@ -702,7 +703,7 @@ func validateExportKubeConfig(exportKubeConfig config.ExportKubeConfig) error {
 	}
 	for _, additionalSecret := range exportKubeConfig.AdditionalSecrets {
 		if additionalSecret.Name == "" && additionalSecret.Namespace == "" {
-			return fmt.Errorf("additional secret must have name and/or namespace set")
+			return fmt.Errorf(exportKubeConfigAdditionalSecretWithoutNameAndNamespace)
 		}
 	}
 	return nil

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -693,19 +693,19 @@ func validateFromHostSyncMappingObjectName(objRef []string, resourceNamePlural s
 }
 
 const (
-	exportKubeConfigBothSecretAndAdditionalSecretsSetError = "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time"
+	exportKubeConfigBothSecretAndAdditionalSecretsSetError  = "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time"
 	exportKubeConfigAdditionalSecretWithoutNameAndNamespace = "additional secret must have name and/or namespace set"
 )
 
 func validateExportKubeConfig(exportKubeConfig config.ExportKubeConfig) error {
 	// You cannot set both Secret and AdditionalSecrets at the same time.
 	if exportKubeConfig.Secret.IsSet() && len(exportKubeConfig.AdditionalSecrets) > 0 {
-		return fmt.Errorf(exportKubeConfigBothSecretAndAdditionalSecretsSetError)
+		return errors.New(exportKubeConfigBothSecretAndAdditionalSecretsSetError)
 	}
 	for _, additionalSecret := range exportKubeConfig.AdditionalSecrets {
 		// You must set at least Name or Namespace for every additional kubeconfig secret.
 		if additionalSecret.Name == "" && additionalSecret.Namespace == "" {
-			return fmt.Errorf(exportKubeConfigAdditionalSecretWithoutNameAndNamespace)
+			return errors.New(exportKubeConfigAdditionalSecretWithoutNameAndNamespace)
 		}
 	}
 	return nil

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -698,10 +698,12 @@ const (
 )
 
 func validateExportKubeConfig(exportKubeConfig config.ExportKubeConfig) error {
+	// You cannot set both Secret and AdditionalSecrets at the same time.
 	if exportKubeConfig.Secret.IsSet() && len(exportKubeConfig.AdditionalSecrets) > 0 {
 		return fmt.Errorf(exportKubeConfigBothSecretAndAdditionalSecretsSetError)
 	}
 	for _, additionalSecret := range exportKubeConfig.AdditionalSecrets {
+		// You must set at least Name or Namespace for every additional kubeconfig secret.
 		if additionalSecret.Name == "" && additionalSecret.Namespace == "" {
 			return fmt.Errorf(exportKubeConfigAdditionalSecretWithoutNameAndNamespace)
 		}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -692,20 +692,20 @@ func validateFromHostSyncMappingObjectName(objRef []string, resourceNamePlural s
 	return nil
 }
 
-const (
-	exportKubeConfigBothSecretAndAdditionalSecretsSetError  = "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time"
-	exportKubeConfigAdditionalSecretWithoutNameAndNamespace = "additional secret must have name and/or namespace set"
+var (
+	errExportKubeConfigBothSecretAndAdditionalSecretsSet       = errors.New("exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time")
+	errExportKubeConfigAdditionalSecretWithoutNameAndNamespace = errors.New("additional secret must have name and/or namespace set")
 )
 
 func validateExportKubeConfig(exportKubeConfig config.ExportKubeConfig) error {
 	// You cannot set both Secret and AdditionalSecrets at the same time.
 	if exportKubeConfig.Secret.IsSet() && len(exportKubeConfig.AdditionalSecrets) > 0 {
-		return errors.New(exportKubeConfigBothSecretAndAdditionalSecretsSetError)
+		return errExportKubeConfigBothSecretAndAdditionalSecretsSet
 	}
 	for _, additionalSecret := range exportKubeConfig.AdditionalSecrets {
 		// You must set at least Name or Namespace for every additional kubeconfig secret.
 		if additionalSecret.Name == "" && additionalSecret.Namespace == "" {
-			return errors.New(exportKubeConfigAdditionalSecretWithoutNameAndNamespace)
+			return errExportKubeConfigAdditionalSecretWithoutNameAndNamespace
 		}
 	}
 	return nil

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -8,13 +8,13 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/loft-sh/vcluster/pkg/constants"
-
 	"github.com/ghodss/yaml"
-	"github.com/loft-sh/vcluster/config"
-	"github.com/loft-sh/vcluster/pkg/util/toleration"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/validation"
+
+	"github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/util/toleration"
 )
 
 var allowedPodSecurityStandards = map[string]bool{
@@ -692,9 +692,13 @@ func validateFromHostSyncMappingObjectName(objRef []string, resourceNamePlural s
 	return nil
 }
 
+const (
+	exportKubeConfigBothSecretAndAdditionalSecretsSetError = "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time"
+)
+
 func validateExportKubeConfig(exportKubeConfig config.ExportKubeConfig) error {
 	if exportKubeConfig.Secret.IsSet() && len(exportKubeConfig.AdditionalSecrets) > 0 {
-		return fmt.Errorf("exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time")
+		return fmt.Errorf(exportKubeConfigBothSecretAndAdditionalSecretsSetError)
 	}
 	for _, additionalSecret := range exportKubeConfig.AdditionalSecrets {
 		if additionalSecret.Name == "" && additionalSecret.Namespace == "" {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -593,11 +593,21 @@ func TestValidateExportKubeConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "Setting only exportKubeConfig.additionalSecrets is valid",
+			name: "Setting only exportKubeConfig.additionalSecrets with name is valid",
 			exportKubeConfig: config.ExportKubeConfig{
 				AdditionalSecrets: []config.ExportKubeConfigAdditionalSecretReference{
 					{
 						Name: "my-secret",
+					},
+				},
+			},
+		},
+		{
+			name: "Setting only exportKubeConfig.additionalSecrets with namespace is valid",
+			exportKubeConfig: config.ExportKubeConfig{
+				AdditionalSecrets: []config.ExportKubeConfigAdditionalSecretReference{
+					{
+						Namespace: "my-namespace",
 					},
 				},
 			},
@@ -615,6 +625,29 @@ func TestValidateExportKubeConfig(t *testing.T) {
 				},
 			},
 			expectedError: exportKubeConfigBothSecretAndAdditionalSecretsSetError,
+		},
+		{
+			name: "Setting empty additional secret is not valid",
+			exportKubeConfig: config.ExportKubeConfig{
+				AdditionalSecrets: []config.ExportKubeConfigAdditionalSecretReference{
+					{},
+				},
+			},
+			expectedError: exportKubeConfigAdditionalSecretWithoutNameAndNamespace,
+		},
+		{
+			name: "Setting non-empty additional secret, but without Name and Namespace, is not valid",
+			exportKubeConfig: config.ExportKubeConfig{
+				AdditionalSecrets: []config.ExportKubeConfigAdditionalSecretReference{
+					{
+						ExportKubeConfigProperties: config.ExportKubeConfigProperties{
+							Context: "my-context",
+							Server: "my-server",
+						},
+					},
+				},
+			},
+			expectedError: exportKubeConfigAdditionalSecretWithoutNameAndNamespace,
 		},
 	}
 

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -580,10 +580,10 @@ func TestValidateFromHostSyncCustomResources(t *testing.T) {
 
 func TestValidateExportKubeConfig(t *testing.T) {
 	cases := []struct {
-		name     string
+		name             string
 		exportKubeConfig config.ExportKubeConfig
 		expectedError    string
-	} {
+	}{
 		{
 			name: "Setting only exportKubeConfig.secret is valid",
 			exportKubeConfig: config.ExportKubeConfig{
@@ -642,7 +642,7 @@ func TestValidateExportKubeConfig(t *testing.T) {
 					{
 						ExportKubeConfigProperties: config.ExportKubeConfigProperties{
 							Context: "my-context",
-							Server: "my-server",
+							Server:  "my-server",
 						},
 					},
 				},

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/nodes"
 	"github.com/loft-sh/vcluster/pkg/etcd"
@@ -128,7 +129,11 @@ func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 
 func startPlugins(ctx context.Context, virtualConfig *rest.Config, virtualRawConfig *clientcmdapi.Config, options *config.VirtualClusterConfig) error {
 	klog.Infof("Start Plugins Manager...")
-	syncerConfig, err := CreateVClusterKubeConfig(virtualRawConfig, options)
+	createKubeConfigOptions := CreateKubeConfigOptions{
+		ControlPlaneProxy: options.ControlPlane.Proxy,
+		ExportKubeConfig:  options.ExportKubeConfig.ExportKubeConfigProperties,
+	}
+	syncerConfig, err := CreateVClusterKubeConfig(virtualRawConfig, createKubeConfigOptions)
 	if err != nil {
 		return err
 	}
@@ -221,7 +226,16 @@ func waitForClientConfig(ctx context.Context, options *config.VirtualClusterConf
 	return clientConfig, nil
 }
 
-func CreateVClusterKubeConfig(config *clientcmdapi.Config, options *config.VirtualClusterConfig) (*clientcmdapi.Config, error) {
+// CreateKubeConfigOptions defines all config options that are available when creating a virtual cluster config.
+type CreateKubeConfigOptions struct {
+	// ControlPlaneProxy specifies the proxy settings for the virtual cluster control plane.
+	ControlPlaneProxy vclusterconfig.ControlPlaneProxy
+
+	// ExportKubeConfig specifies kubeconfig values that override the default kubeconfig.
+	ExportKubeConfig vclusterconfig.ExportKubeConfigProperties
+}
+
+func CreateVClusterKubeConfig(config *clientcmdapi.Config, options CreateKubeConfigOptions) (*clientcmdapi.Config, error) {
 	config = config.DeepCopy()
 
 	// exchange kube config server & resolve certificate
@@ -241,7 +255,7 @@ func CreateVClusterKubeConfig(config *clientcmdapi.Config, options *config.Virtu
 			cluster.CertificateAuthorityData = o
 		}
 
-		cluster.Server = fmt.Sprintf("https://localhost:%d", options.ControlPlane.Proxy.Port)
+		cluster.Server = fmt.Sprintf("https://localhost:%d", options.ControlPlaneProxy.Port)
 	}
 
 	// resolve auth info cert & key

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -116,8 +116,10 @@ func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	// do we need access to another namespace to export the kubeconfig ?
 	// we will need access to all the objects that the vcluster usually has access to
 	// otherwise the controller will not start
-	if options.ExportKubeConfig.Secret.Namespace != "" {
-		defaultNamespaces[options.ExportKubeConfig.Secret.Namespace] = cache.Config{}
+	for _, secret := range options.ExportKubeConfig.GetAdditionalSecrets() {
+		if secret.Namespace != "" {
+			defaultNamespaces[secret.Namespace] = cache.Config{}
+		}
 	}
 
 	if len(defaultNamespaces) == 0 {

--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -308,16 +308,21 @@ func WriteKubeConfigToSecret(ctx context.Context, virtualConfig *rest.Config, cu
 			return fmt.Errorf("failed to create kubeconfig that is exported to the additional kubeconfig secret: %w", err)
 		}
 
-		// which namespace should we create the additional secret in?
+		// if the additional secret name is not specified, fallback to the default secret name
+		secretName := additionalSecret.Name
+		if secretName == "" {
+			secretName = kubeconfig.GetDefaultSecretName(translate.VClusterName)
+		}
+		// if the additional secret namespace is not specified, fallback to the current namespace
 		secretNamespace := additionalSecret.Namespace
 		if secretNamespace == "" {
 			secretNamespace = currentNamespace
 		}
 
-		// write the extra secret
-		err = kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, additionalSecret.Name, secretNamespace, additionalKubeConfig, isIsolatedControlPlaneKubeConfigSet)
+		// write the additional kubeconfig secret
+		err = kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, secretName, secretNamespace, additionalKubeConfig, isIsolatedControlPlaneKubeConfigSet)
 		if err != nil {
-			return fmt.Errorf("creating additional secret %s in the %s ns failed: %w", additionalSecret.Name, secretNamespace, err)
+			return fmt.Errorf("creating additional secret %s in the %s ns failed: %w", secretName, secretNamespace, err)
 		}
 	}
 

--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -317,7 +317,7 @@ func WriteKubeConfigToSecret(ctx context.Context, virtualConfig *rest.Config, cu
 		// write the extra secret
 		err = kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, additionalSecret.Name, secretNamespace, additionalKubeConfig, isIsolatedControlPlaneKubeConfigSet)
 		if err != nil {
-			return fmt.Errorf("creating additional secret %s in the %s ns failed: %w", options.ExportKubeConfig.Secret.Name, secretNamespace, err)
+			return fmt.Errorf("creating additional secret %s in the %s ns failed: %w", additionalSecret.Name, secretNamespace, err)
 		}
 	}
 

--- a/pkg/setup/controllers_test.go
+++ b/pkg/setup/controllers_test.go
@@ -29,11 +29,11 @@ func TestExportKubeConfig(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		syncerConfig clientcmdapi.Config
-		options CreateKubeConfigOptions
+		name               string
+		syncerConfig       clientcmdapi.Config
+		options            CreateKubeConfigOptions
 		expectedKubeConfig clientcmdapi.Config
-	} {
+	}{
 		{
 			name: "Export default kubeconfig",
 			syncerConfig: clientcmdapi.Config{
@@ -146,7 +146,7 @@ func TestExportKubeConfig(t *testing.T) {
 				},
 				Clusters: map[string]*clientcmdapi.Cluster{
 					exportedTestContext: {
-						Server: exportedTestServer,
+						Server:     exportedTestServer,
 						Extensions: map[string]runtime.Object{},
 					},
 				},
@@ -165,7 +165,7 @@ func TestExportKubeConfig(t *testing.T) {
 			ctx := context.Background()
 			virtualConfig := &rest.Config{}
 
-			kubeConfigResult, err := CreateVClusterKubeConfigForExport(ctx,virtualConfig, &tc.syncerConfig, tc.options)
+			kubeConfigResult, err := CreateVClusterKubeConfigForExport(ctx, virtualConfig, &tc.syncerConfig, tc.options)
 			if err != nil {
 				t.Errorf("Unexpected error when creating kubeconfig for export: %v", err)
 			}

--- a/pkg/setup/controllers_test.go
+++ b/pkg/setup/controllers_test.go
@@ -1,0 +1,178 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/loft-sh/vcluster/config"
+)
+
+func TestExportKubeConfig(t *testing.T) {
+	const (
+		testCluster          = "test-cluster"
+		testControlPlanePort = 8443
+		testContext          = "test-context"
+		testUser             = "test-user"
+		exportedTestContext  = "exported-test-context"
+		exportedTestServer   = "exported-test-server"
+	)
+
+	testControlPlaneProxy := config.ControlPlaneProxy{
+		Port: testControlPlanePort,
+	}
+
+	cases := []struct {
+		name     string
+		syncerConfig clientcmdapi.Config
+		options CreateKubeConfigOptions
+		expectedKubeConfig clientcmdapi.Config
+	} {
+		{
+			name: "Export default kubeconfig",
+			syncerConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {},
+				},
+			},
+			options: CreateKubeConfigOptions{
+				ControlPlaneProxy: testControlPlaneProxy,
+			},
+			expectedKubeConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {
+						Server: fmt.Sprintf("https://localhost:%d", testControlPlanePort),
+					},
+				},
+			},
+		},
+		{
+			name: "Export default kubeconfig with custom server",
+			syncerConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {},
+				},
+			},
+			options: CreateKubeConfigOptions{
+				ControlPlaneProxy: testControlPlaneProxy,
+				ExportKubeConfig: config.ExportKubeConfigProperties{
+					Server: exportedTestServer,
+				},
+			},
+			expectedKubeConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {
+						Server:     exportedTestServer,
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+			},
+		},
+		{
+			name: "Export default kubeconfig with custom context",
+			syncerConfig: clientcmdapi.Config{
+				CurrentContext: testContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					testUser: {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					testContext: {
+						Cluster:  testCluster,
+						AuthInfo: testUser,
+					},
+				},
+			},
+			options: CreateKubeConfigOptions{
+				ControlPlaneProxy: testControlPlaneProxy,
+				ExportKubeConfig: config.ExportKubeConfigProperties{
+					Context: exportedTestContext,
+				},
+			},
+			expectedKubeConfig: clientcmdapi.Config{
+				CurrentContext: exportedTestContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					exportedTestContext: {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					exportedTestContext: {
+						Server: fmt.Sprintf("https://localhost:%d", testControlPlanePort),
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					exportedTestContext: {
+						Cluster:  exportedTestContext,
+						AuthInfo: exportedTestContext,
+					},
+				},
+			},
+		},
+		{
+			name: "Export default kubeconfig with custom context and server",
+			syncerConfig: clientcmdapi.Config{
+				CurrentContext: testContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					testUser: {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					testContext: {
+						Cluster:  testCluster,
+						AuthInfo: testUser,
+					},
+				},
+			},
+			options: CreateKubeConfigOptions{
+				ControlPlaneProxy: testControlPlaneProxy,
+				ExportKubeConfig: config.ExportKubeConfigProperties{
+					Context: exportedTestContext,
+					Server:  exportedTestServer,
+				},
+			},
+			expectedKubeConfig: clientcmdapi.Config{
+				CurrentContext: exportedTestContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					exportedTestContext: {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					exportedTestContext: {
+						Server: exportedTestServer,
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					exportedTestContext: {
+						Cluster:  exportedTestContext,
+						AuthInfo: exportedTestContext,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			virtualConfig := &rest.Config{}
+
+			kubeConfigResult, err := CreateVClusterKubeConfigForExport(ctx,virtualConfig, &tc.syncerConfig, tc.options)
+			if err != nil {
+				t.Errorf("Unexpected error when creating kubeconfig for export: %v", err)
+			}
+
+			if !reflect.DeepEqual(*kubeConfigResult, tc.expectedKubeConfig) {
+				t.Errorf("Unexpected kubeconfig, here is the diff: %s", cmp.Diff(tc.expectedKubeConfig, kubeConfigResult))
+			}
+		})
+	}
+}

--- a/test/e2e/coredns/coredns.go
+++ b/test/e2e/coredns/coredns.go
@@ -2,6 +2,7 @@ package coredns
 
 import (
 	"fmt"
+	
 	"github.com/loft-sh/vcluster/pkg/coredns"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
 	"github.com/loft-sh/vcluster/pkg/util/random"

--- a/test/e2e/coredns/coredns.go
+++ b/test/e2e/coredns/coredns.go
@@ -2,14 +2,11 @@ package coredns
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/loft-sh/vcluster/pkg/coredns"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/test/framework"
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,13 +37,10 @@ var _ = ginkgo.Describe("CoreDNS resolves host names correctly", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		// delete test namespace (retry few times, as the client may time out sometimes when deleting a namespace)
-		gomega.Eventually(func() error {
-			return f.DeleteTestNamespace(ns, false)
-		}).
-			WithPolling(time.Second).
-			WithTimeout(3 * framework.PollTimeout).
-			Should(gomega.Succeed())
+		// delete test namespace
+
+		err := f.DeleteTestNamespace(ns, false)
+		framework.ExpectNoError(err)
 	})
 
 	ginkgo.It("Test Service is reachable via it's hostname", func() {

--- a/test/e2e/coredns/coredns.go
+++ b/test/e2e/coredns/coredns.go
@@ -2,7 +2,7 @@ package coredns
 
 import (
 	"fmt"
-	
+
 	"github.com/loft-sh/vcluster/pkg/coredns"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
 	"github.com/loft-sh/vcluster/pkg/util/random"

--- a/test/e2e/coredns/coredns.go
+++ b/test/e2e/coredns/coredns.go
@@ -38,7 +38,6 @@ var _ = ginkgo.Describe("CoreDNS resolves host names correctly", func() {
 
 	ginkgo.AfterEach(func() {
 		// delete test namespace
-
 		err := f.DeleteTestNamespace(ns, false)
 		framework.ExpectNoError(err)
 	})

--- a/test/e2e/syncer/pvc/pvc.go
+++ b/test/e2e/syncer/pvc/pvc.go
@@ -69,6 +69,10 @@ var _ = ginkgo.Describe("Persistent volume synced from host cluster", func() {
 
 		framework.ExpectNoError(err)
 
+		// Wait for the default service account to be created so the pod can use it
+		err = f.WaitForServiceAccount("default", ns)
+		framework.ExpectNoError(err)
+
 		// add a pod bound to the volume as by default storage class on kind is configured with
 		// volume binding mode as WaitForFirstConsumer
 		_, err = f.VClusterClient.CoreV1().Pods(ns).Create(f.Context, &corev1.Pod{

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -137,7 +137,7 @@ func (f *Framework) WaitForInitManifestConfigMapCreation(configMapName, ns strin
 }
 
 func (f *Framework) WaitForServiceAccount(saName string, ns string) error {
-	return wait.PollUntilContextTimeout(f.Context, time.Second, PollTimeout, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(f.Context, 5*time.Second, 2*PollTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := f.VClusterClient.CoreV1().ServiceAccounts(ns).Get(ctx, saName, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -225,7 +225,16 @@ func (f *Framework) WaitForServiceInSyncerCache(serviceName string, ns string) e
 }
 
 func (f *Framework) DeleteTestNamespace(ns string, waitUntilDeleted bool) error {
-	err := f.VClusterClient.CoreV1().Namespaces().Delete(f.Context, ns, metav1.DeleteOptions{})
+	var propagationPolicy metav1.DeletionPropagation
+	if waitUntilDeleted {
+		propagationPolicy = metav1.DeletePropagationForeground
+	} else {
+		propagationPolicy = metav1.DeletePropagationBackground
+	}
+	deleteOptions := metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	}
+	err := f.VClusterClient.CoreV1().Namespaces().Delete(f.Context, ns, deleteOptions)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -225,12 +225,11 @@ func (f *Framework) WaitForServiceInSyncerCache(serviceName string, ns string) e
 }
 
 func (f *Framework) DeleteTestNamespace(ns string, waitUntilDeleted bool) error {
-	var propagationPolicy metav1.DeletionPropagation
-	if waitUntilDeleted {
-		propagationPolicy = metav1.DeletePropagationForeground
-	} else {
-		propagationPolicy = metav1.DeletePropagationBackground
-	}
+	// Always delete in the background. The vCluster client timeout is set to 32 seconds, so deleting
+	// in the foreground may cause timeouts in delete requests, which will cause e2e tests to fail.
+	// If you need a blocking/foreground deletion call, you can set waitUntilDeleted to true, which
+	// will result in polling below, where we check if the namespace is deleted.
+	propagationPolicy := metav1.DeletePropagationBackground
 	deleteOptions := metav1.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	}

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -137,7 +137,7 @@ func (f *Framework) WaitForInitManifestConfigMapCreation(configMapName, ns strin
 }
 
 func (f *Framework) WaitForServiceAccount(saName string, ns string) error {
-	return wait.PollUntilContextTimeout(f.Context, 5*time.Second, 2*PollTimeout, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(f.Context, time.Second, PollTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := f.VClusterClient.CoreV1().ServiceAccounts(ns).Get(ctx, saName, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5486


**Please provide a short message that should be published in the vcluster release notes**
Add `exportKubeConfig.additionalSecrets` config and deprecate `exportKubeConfig.secret`.


**What else do we need to know?** 
You can set either old `exportKubeConfig.secret` or the new `exportKubeConfig.additionalSecrets`.

All previous usages of `exportKubeConfig.Secret` have been removed and the only two places where the `exportKubeConfig.Secret` property is now used are:
- `GetAdditionalSecrets()` func in `config/config.go` which returns either old `exportKubeConfig.Secret` or the new `exportKubeConfig.AdditionalSecrets`
- `validateExportKubeConfig(...)` func in `pkg/config/validation.go` where we verify that both old `exportKubeConfig.Secret` and new ``exportKubeConfig.AdditionalSecrets` are not set at the same time

This makes it easy to later entirely remove `exportKubeConfig.Secret`.

**TODOs**

- [x] Add new `exportKubeConfig.additionalSecrets` config
- [x] Deprecate old `exportKubeConfig.secret` config in favor of new `exportKubeConfig.additionalSecrets`
- [x] Update the implementation for exporting kubeconfig.
  - [x] When `exportKubeConfig.secret` is set, `exportKubeConfig.additionalSecrets` is ignored. With this behavior the backward compatibility is preserved.
  - [x] When `exportKubeConfig.additionalSecrets` is set, `exportKubeConfig.secret` is ignored.
  - [x] Block setting both config properties at the same time
- [x] Testing
  - [x] Manually test the changes
  - [x] Ensure that existing tests are passing
  - [x] Add tests for the new config
    - [x] Add unit tests for `exportKubeConfig` config validation
    - [x] Add unit tests for creating exported kubeconfig
- [x] Update code in other places where `exportKubeConfig.secret` is used.
- [x] Other minor improvements to the PR