### PR TITLE
Fix warning message for platform destroy

### DIFF
--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -332,7 +332,7 @@ func deleteAllResourcesAndWait(ctxWithoutDeadline, ctxWithDeadLine context.Conte
 							}
 						}
 					} else {
-						log.Warnf("removing an externally deployed virtual cluster %q from the platform. It will not be destroyed as the deployment is managed externally, but its connection to its database will be removed.", namespacedName)
+						log.Warnf("removing an externally deployed virtual cluster %q from the platform. It will not be destroyed as the deployment is managed externally.", namespacedName)
 					}
 				}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5881


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster where platform destroy command was giving incorrect warning.


**What else do we need to know?** 
