### PR TITLE
fix(cli): Adopt new UX in the messaging on 'platform start'

### DIFF
--- a/vendor/github.com/loft-sh/api/v4/pkg/product/strings.go
+++ b/vendor/github.com/loft-sh/api/v4/pkg/product/strings.go
@@ -12,7 +12,7 @@ func LoginCmd() string {
 	case licenseapi.DevPodPro:
 		return "devpod login"
 	case licenseapi.VClusterPro:
-		return "vcluster login"
+		return "vcluster platform login"
 	case licenseapi.Loft:
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-5956


**Please provide a short message that should be published in the vcluster release notes**
Fixed the UX for adoption of `vcluster platform login` instead of `vcluster login` when starting a platform