### PR TITLE
[ENG-6046] feat(chart): turn etcd's `--snapshot-count` interpolable

### DIFF
--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -157,7 +157,7 @@ spec:
           - '--peer-client-cert-auth=true'
           - '--peer-key-file=/run/config/pki/etcd-peer.key'
           - '--peer-trusted-ca-file=/run/config/pki/etcd-ca.crt'
-          - '--snapshot-count=10000'
+          - '--snapshot-count={{ .Values.controlPlane.backingStore.etcd.deploy.statefulSet.snapshotCount }}'
           - '--trusted-ca-file=/run/config/pki/etcd-ca.crt'
           {{- range $f := $externalEtcd.extraArgs }}
           - {{ $f | quote }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1238,6 +1238,10 @@
           "type": "array",
           "description": "Env are extra environment variables"
         },
+        "snapshotCount": {
+          "type": "integer",
+          "description": "Snapshot count passed to the etcd's `snapshot-count` command."
+        },
         "extraArgs": {
           "items": {
             "type": "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -401,6 +401,8 @@ controlPlane:
             tag: "3.5.17-0"
           # ImagePullPolicy is the pull policy for the external etcd image
           imagePullPolicy: ""
+          # Snapshot count passed to the etcd's `snapshot-count` command
+          snapshotCount: 10000
           # ExtraArgs are appended to the etcd command.
           extraArgs: []
           # Env are extra environment variables


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6046


**Please provide a short message that should be published in the vcluster release notes**
It turns etcd's `--snapshot-count` into an interpolable value.
The default value is 10000 but can be changed with `--set`.