### PR TITLE
fix: update `login.go` to reflect `vcluster login` is deprecated

### DIFF
--- a/cmd/vclusterctl/cmd/login.go
+++ b/cmd/vclusterctl/cmd/login.go
@@ -28,7 +28,7 @@ func NewLoginCmd(globalFlags *flags.GlobalFlags) (*cobra.Command, error) {
 	description := `########################################################
 #################### vcluster login ####################
 ########################################################
-Login into vCluster platform
+This command is deprecated. Use "vcluster platform login" instead.
 
 Example:
 vcluster login https://my-vcluster-platform.com


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
* Updates command description to reflect depreciation. 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
This is a tidy up activity for something left over from `0.20` release.
