### PR TITLE
Change deletion order for network peer to fix time-out issue

### DIFF
--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -52,7 +52,6 @@ var resourceOrder = []string{
 	"runners",
 	"clusters",
 	"clusteraccesses",
-	"networkpeers",
 
 	// access
 	"teams",
@@ -62,6 +61,10 @@ var resourceOrder = []string{
 	"localclusteraccesses",
 	"localteams",
 	"localusers",
+
+	// since accessKeys is the owner of networkpeer so ideally networkpeer would be deleted right after it
+	// via cascade deletion, still keeping it here as a fail-safe
+	"networkpeers",
 }
 
 // things listed here should also be included in resourceOrder


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5882


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform destroy gets stuck due to networkpeer deletion times-out.


**What else do we need to know?** 
