### PR TITLE
fix: don't try to strictly marshal old values into the current config…

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -228,10 +228,6 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 			if err := currentVClusterConfig.UnmarshalYAMLStrict([]byte(migratedValues)); err != nil {
 				return err
 			}
-		} else {
-			if err := currentVClusterConfig.UnmarshalYAMLStrict([]byte(currentValues)); err != nil {
-				return err
-			}
 		}
 		// TODO end
 	}


### PR DESCRIPTION
… spec.  Let the chart version handle that.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #6136

**What else do we need to know?** 
This extra call to marshal strict on previous values against any new config.  This would break if any fields were removed or renamed between the current chart and the one they're trying to upgrade to.