### PR TITLE
Validate exportKubeConfig in Helm chart

### DIFF
--- a/chart/templates/_exportKubeConfig.tpl
+++ b/chart/templates/_exportKubeConfig.tpl
@@ -12,7 +12,7 @@
 {{- $additionalSecretsSet = gt (len .Values.exportKubeConfig.additionalSecrets) 0 }}
 {{- end }}
 {{- if and $secretSet $additionalSecretsSet }}
-{{- fail "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time" }}
+{{- fail "exportKubeConfig.secret and exportKubeConfig.additionalSecrets cannot be set at the same time" }}
 {{- end }}
 {{- /*
   Verify that additional secrets have name or namespace set.

--- a/chart/templates/_exportKubeConfig.tpl
+++ b/chart/templates/_exportKubeConfig.tpl
@@ -1,0 +1,37 @@
+{{- define "vcluster.exportKubeConfig.validate" }}
+{{- /*
+  Verify that exportKubeConfig.secret and exportKubeConfig.additionalSecrets are
+  not set at the same time.
+*/}}
+{{- $secretSet := false }}
+{{- if .Values.exportKubeConfig.secret }}
+{{- $secretSet = or (.Values.exportKubeConfig.secret.name | trim | ne "") (.Values.exportKubeConfig.secret.namespace | trim | ne "") }}
+{{- end }}
+{{- $additionalSecretsSet := false }}
+{{- if .Values.exportKubeConfig.additionalSecrets }}
+{{- $additionalSecretsSet = gt (len .Values.exportKubeConfig.additionalSecrets) 0 }}
+{{- end }}
+{{- if and $secretSet $additionalSecretsSet }}
+{{- fail "exportKubeConfig.Secret and exportKubeConfig.AdditionalSecrets cannot be set at the same time" }}
+{{- end }}
+{{- /*
+  Verify that additional secrets have name or namespace set.
+*/}}
+{{- range $_, $additionalSecret := .Values.exportKubeConfig.additionalSecrets }}
+{{- $nameSet := false }}
+{{- $namespaceSet := false }}
+{{- if $additionalSecret.name }}
+{{- if $additionalSecret.name | trim | ne "" }}
+{{- $nameSet = true }}
+{{- end }}
+{{- end }}
+{{- if $additionalSecret.namespace }}
+{{- if $additionalSecret.namespace | trim | ne "" }}
+{{- $namespaceSet = true }}
+{{- end }}
+{{- end }}
+{{- if not (or $nameSet $namespaceSet) }}
+{{- fail (cat "additional secret must have name and/or namespace set, found:" (toJson $additionalSecret)) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- include "vcluster.exportKubeConfig.validate" . }}
 {{- if not .Values.experimental.isolatedControlPlane.headless }}
 apiVersion: apps/v1
 kind: {{ include "vcluster.kind" . }}

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -914,3 +914,25 @@ tests:
       - equal:
           path: kind
           value: StatefulSet
+
+  - it: fails when you set both exportKubeConfig.secret and exportKubeConfig.additionalSecrets
+    set:
+      exportKubeConfig:
+        secret:
+          name: my-secret
+        additionalSecrets:
+          - name: another-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "exportKubeConfig.secret and exportKubeConfig.additionalSecrets cannot be set at the same time"
+
+  - it: fails when additional secret does not have at least name or namespace
+    set:
+      exportKubeConfig:
+        additionalSecrets:
+          - name: my-secret
+            context: my-context
+          - server: my-server
+    asserts:
+      - failedTemplate:
+          errorMessage: "additional secret must have name and/or namespace set, found: {\"server\":\"my-server\"}"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-6128


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster create` command does not fail when both `exportKubeConfig.secret` and `exportKubeConfig.additionalSecrets` are set.


**What else do we need to know?** 
vCluster creation was already failing. This is an improvement, so that the `vcluster create` command (and Helm chart deployment) fails before trying to create the vCluster.

**Examples**

When both secret and additional secrets are set like this:
```yaml
exportKubeConfig:
  secret:
    name: kubeconfig-deprecated
  additionalSecrets:
  - name: kubeconfig-1
```

This is the error message when running `vcluster create`:
```
$ vcluster create vcl -n vcl -f ./vcluster.test/vcl.yaml --local-chart-dir chart
23:28:52 info Create vcluster vcl...
23:28:52 info execute command: helm upgrade vcl chart --create-namespace --kubeconfig /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/1728262265 --namespace vcl --install --repository-config='' --values /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/1910741153 --values ./vcluster.test/vcl.yaml
23:28:53 fatal error executing helm upgrade vcl chart --create-namespace --kubeconfig /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/1728262265 --namespace vcl --install --repository-config='' --values /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/1910741153 --values ./vcluster.test/vcl.yaml: Release "vcl" does not exist. Installing it now.
Error: execution error at (vcluster/templates/statefulset.yaml:1:4): exportKubeConfig.secret and exportKubeConfig.additionalSecrets cannot be set at the same time
```

Additionally, when an invalid additional secret is specified (without name and without namespace) like this:
```yaml
exportKubeConfig:
  additionalSecrets:
  - name: kubeconfig-1
  - context: nikola-ctx-2
```

This is the error message when running `vcluster create`:
```$ vcluster create vcl -n vcl -f ./vcluster.test/vcl.yaml --local-chart-dir chart
23:23:17 info Create vcluster vcl...
23:23:17 info execute command: helm upgrade vcl chart --create-namespace --kubeconfig /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/166045793 --namespace vcl --install --repository-config='' --values /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/460174345 --values ./vcluster.test/vcl.yaml
23:23:18 fatal error executing helm upgrade vcl chart --create-namespace --kubeconfig /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/166045793 --namespace vcl --install --repository-config='' --values /var/folders/6t/p6942gpj4cjbm1gk71fbnw7m0000gn/T/460174345 --values ./vcluster.test/vcl.yaml: Release "vcl" does not exist. Installing it now.
Error: execution error at (vcluster/templates/statefulset.yaml:1:4): additional secret must have name and/or namespace set, found: {"context":"nikola-ctx-2"}

```