### PR TITLE
feat: warn of experimental feature changes

### DIFF
--- a/config/experimental_helper.go
+++ b/config/experimental_helper.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/upgrade"
+	"golang.org/x/mod/semver"
+)
+
+type (
+	ExperimentalConfig struct {
+		Experimental map[string]any
+	}
+)
+
+var advisors = map[string]func() (warning string){
+	"sleepMode": SleepModeWarning,
+}
+
+func ExperimentalWarning(logger log.Logger, currentValues []byte) string {
+	exp := &ExperimentalConfig{}
+	if err := yaml.Unmarshal(currentValues, exp); err != nil {
+		logger.Warn(err)
+		return ""
+	}
+
+	var advice []string
+	for k := range exp.Experimental {
+		if advisor, ok := advisors[k]; ok {
+			if warning := advisor(); warning != "" {
+				advice = append(advice, warning)
+			}
+		}
+	}
+
+	if len(advice) == 0 {
+		return ""
+	}
+
+	expWarning := "An experimental feature you were using has been promoted! 🎉 See below on tips to update."
+	return strings.Join(append([]string{expWarning}, advice...), "\n")
+}
+
+const v24 = "v0.24.0-alpha.0"
+
+func SleepModeWarning() string {
+	// if we're not upgrading to v0.24+ no warning
+	if semver.Compare("v"+upgrade.GetVersion(), v24) == -1 {
+		return ""
+	}
+
+	return `
+sleepMode configuration is no longer under experimental. Please update your values and specify them with --values.
+
+For example
+
+|experimental:                          |sleepMode:
+|  sleepMode:                           |  enabled: true
+|    enabled: true            ---->     |  autoSleep:
+|    autoSleep:                         |    afterInactivity: 24h
+|      afterInactivity: 24h             |
+
+`
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-6136

New Behavior:

 - If the current configuration as sleepMode under experimental and they're upgrading to 0.24+
   - Show advice on how to update their config
   - Prompt if they'd like to proceed, warning that the experimental feature will be lost
   - Fail if they choose no
   - Proceed if they agree
   
### Note, only prompts in interactive terminals.  
In non-interactive terminals it warns, but proceeds otherwise.  Without proceeding, if it just returned the error they would be incapable of upgrading since their already deployed values won't validate against a new schema.   

Example Usage:

![6136](https://github.com/user-attachments/assets/55ee3fc4-4122-4291-b451-ea523e371f30)

