### PR TITLE
fix: respect platform config insecure value on login

### DIFF
--- a/pkg/cli/start/login.go
+++ b/pkg/cli/start/login.go
@@ -95,9 +95,10 @@ func (l *LoftStarter) loginViaCLI(url string) error {
 	}
 
 	// log into loft
-	loginClient := platform.NewLoginClientFromConfig(l.LoadedConfig(l.Log))
+	config := l.LoadedConfig(l.Log)
+	loginClient := platform.NewLoginClientFromConfig(config)
 	url = strings.TrimSuffix(url, "/")
-	err = loginClient.LoginWithAccessKey(url, accessKey.AccessKey, true)
+	err = loginClient.LoginWithAccessKey(url, accessKey.AccessKey, config.Platform.Insecure)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-6079


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would always login with insecure when starting the platform rather than abiding by the platform config

**What else do we need to know?** 
