### PR TITLE
Delete previously replicated services after disabling from host syncing

### DIFF
--- a/pkg/setup/cleanup.go
+++ b/pkg/setup/cleanup.go
@@ -3,29 +3,28 @@ package setup
 import (
 	"fmt"
 
+	"github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // deletePreviouslySyncedResources deletes resources that were synced from host to virtual, but
 // should not be synced anymore, because from host syncing has been disabled.
 func deletePreviouslySyncedResources(ctx *synccontext.ControllerContext) error {
-	err := deletePreviouslySyncedServices(ctx)
+	err := deletePreviouslyReplicatedServices(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to delete previously synced services: %w", err)
 	}
 	return nil
 }
 
-// deletePreviouslySyncedServices deletes services that were synced from host to virtual, but
+// deletePreviouslyReplicatedServices deletes services that were synced from host to virtual, but
 // should not be synced anymore, because from host syncing for services has been disabled.
-func deletePreviouslySyncedServices(ctx *synccontext.ControllerContext) error {
-	if len(ctx.Config.Networking.ReplicateServices.FromHost) > 0 {
-		return nil
-	}
+func deletePreviouslyReplicatedServices(ctx *synccontext.ControllerContext) error {
 	virtualClient := ctx.VirtualManager.GetClient()
 	listOptions := client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
@@ -44,6 +43,10 @@ func deletePreviouslySyncedServices(ctx *synccontext.ControllerContext) error {
 	logger := ctx.VirtualManager.GetLogger()
 	logger.Info("deleting previously synced services")
 	for _, service := range previouslySyncedServices.Items {
+		if replicateServicesFromHostConfigContainsVirtualService(ctx.Config.Networking.ReplicateServices, service) {
+			logger.Info("service has replication config", "name", service.Name, "namespace", service.Namespace)
+			continue
+		}
 		logger.Info("deleting previously synced service", "name", service.Name, "namespace", service.Namespace)
 		err = virtualClient.Delete(ctx, &service)
 		if err != nil {
@@ -53,4 +56,17 @@ func deletePreviouslySyncedServices(ctx *synccontext.ControllerContext) error {
 	}
 	logger.Info("deleted all previously synced services")
 	return nil
+}
+
+func replicateServicesFromHostConfigContainsVirtualService(replicateServicesConfig config.ReplicateServices, service corev1.Service) bool {
+	serviceNamespacedName := types.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}.String()
+	for _, serviceMapping := range replicateServicesConfig.FromHost {
+		if serviceMapping.To == serviceNamespacedName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/setup/cleanup.go
+++ b/pkg/setup/cleanup.go
@@ -58,7 +58,7 @@ func deletePreviouslyReplicatedServices(ctx *synccontext.ControllerContext) erro
 		logger.Info("deleted previously synced service", "name", service.Name, "namespace", service.Namespace)
 	}
 	if len(deleteErrors) > 0 {
-		return fmt.Errorf("failed to delete one or more previously synced services: %v", errors.Join(deleteErrors...))
+		return fmt.Errorf("failed to delete one or more previously synced services: %w", errors.Join(deleteErrors...))
 	}
 	logger.Info("finished deleting previously synced services")
 	return nil

--- a/pkg/setup/cleanup.go
+++ b/pkg/setup/cleanup.go
@@ -1,0 +1,56 @@
+package setup
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// deletePreviouslySyncedResources deletes resources that were synced from host to virtual, but
+// should not be synced anymore, because from host syncing has been disabled.
+func deletePreviouslySyncedResources(ctx *synccontext.ControllerContext) error {
+	err := deletePreviouslySyncedServices(ctx)
+	if err != nil {
+		return fmt.Errorf("error ocurred when trying to delete previously synced services: %w", err)
+	}
+	return nil
+}
+
+// deletePreviouslySyncedServices deletes services that were synced from host to virtual, but
+// should not be synced anymore, because from host syncing for services has been disabled.
+func deletePreviouslySyncedServices(ctx *synccontext.ControllerContext) error {
+	if len(ctx.Config.Networking.ReplicateServices.FromHost) > 0 {
+		return nil
+	}
+	virtualClient := ctx.VirtualManager.GetClient()
+	listOptions := client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{
+			translate.ControllerLabel: "vcluster",
+		}),
+	}
+	previouslySyncedServices := &corev1.ServiceList{}
+	err := virtualClient.List(ctx, previouslySyncedServices, &listOptions)
+	if err != nil {
+		return fmt.Errorf("failed to list previously synced services: %w", err)
+	}
+	if len(previouslySyncedServices.Items) == 0 {
+		return nil
+	}
+
+	logger := ctx.VirtualManager.GetLogger()
+	logger.Info("deleting previously synced services")
+	for _, service := range previouslySyncedServices.Items {
+		logger.Info("deleting previously synced service", "name", service.Name, "namespace", service.Namespace)
+		err = virtualClient.Delete(ctx, &service)
+		if err != nil {
+			return fmt.Errorf("failed to delete previously synced service: %v", err)
+		}
+		logger.Info("deleted previously synced service", "name", service.Name, "namespace", service.Namespace)
+	}
+	logger.Info("deleted all previously synced services")
+	return nil
+}

--- a/pkg/setup/cleanup.go
+++ b/pkg/setup/cleanup.go
@@ -15,7 +15,7 @@ import (
 func deletePreviouslySyncedResources(ctx *synccontext.ControllerContext) error {
 	err := deletePreviouslySyncedServices(ctx)
 	if err != nil {
-		return fmt.Errorf("error ocurred when trying to delete previously synced services: %w", err)
+		return fmt.Errorf("failed to delete previously synced services: %w", err)
 	}
 	return nil
 }
@@ -47,7 +47,7 @@ func deletePreviouslySyncedServices(ctx *synccontext.ControllerContext) error {
 		logger.Info("deleting previously synced service", "name", service.Name, "namespace", service.Namespace)
 		err = virtualClient.Delete(ctx, &service)
 		if err != nil {
-			return fmt.Errorf("failed to delete previously synced service: %v", err)
+			return fmt.Errorf("failed to delete previously synced service: %w", err)
 		}
 		logger.Info("deleted previously synced service", "name", service.Name, "namespace", service.Namespace)
 	}

--- a/pkg/setup/cleanup_test.go
+++ b/pkg/setup/cleanup_test.go
@@ -1,0 +1,190 @@
+package setup
+
+import (
+	"context"
+	"testing"
+
+	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestDeletePreviouslyReplicatedServices(t *testing.T) {
+	hostService1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-service-1",
+			Namespace: "host-namespace-1",
+		},
+	}
+	virtualService1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "virtual-service-1",
+			Namespace: "virtual-namespace-1",
+			Labels: map[string]string{
+				translate.ControllerLabel: "vcluster",
+			},
+		},
+	}
+
+	const targetNamespace = "my-vcluster"
+	hostServiceDefaultTargetNamespace := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-service-2",
+			Namespace: targetNamespace,
+		},
+	}
+	virtualService2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "virtual-service-2",
+			Namespace: "virtual-namespace-2",
+			Labels: map[string]string{
+				translate.ControllerLabel: "vcluster",
+			},
+		},
+	}
+
+	hostService3 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "host-service-3",
+			Namespace: "host-namespace-3",
+		},
+	}
+	virtualService3 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "virtual-service-3",
+			Namespace: "virtual-namespace-3",
+			Labels: map[string]string{
+				translate.ControllerLabel: "vcluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                                string
+		workloadTargetNamespace             string
+		replicateServicesConfig             vclusterconfig.ReplicateServices
+		initialHostServicesBeforeCleanup    []runtime.Object
+		initialVirtualServicesBeforeCleanup []runtime.Object
+		expectedHostServicesAfterCleanup    []runtime.Object
+		expectedVirtualServicesAfterCleanup []runtime.Object
+	}{
+		{
+			name: "No services, no cleanup",
+		},
+		{
+			name: "Has replicated service config, no cleanup",
+			replicateServicesConfig: vclusterconfig.ReplicateServices{
+				FromHost: []vclusterconfig.ServiceMapping{
+					{
+						From: "host-namespace-1/host-service-1",
+						To:   "virtual-namespace-1/virtual-service-1",
+					},
+				},
+			},
+			initialHostServicesBeforeCleanup:    []runtime.Object{hostService1},
+			initialVirtualServicesBeforeCleanup: []runtime.Object{virtualService1},
+			expectedHostServicesAfterCleanup:    []runtime.Object{hostService1},
+			expectedVirtualServicesAfterCleanup: []runtime.Object{virtualService1},
+		},
+		{
+			name:                    "Has replicated service config that uses target namespace on host, no cleanup",
+			workloadTargetNamespace: "my-vcluster",
+			replicateServicesConfig: vclusterconfig.ReplicateServices{
+				FromHost: []vclusterconfig.ServiceMapping{
+					{
+						From: "host-service",
+						To:   "virtual-namespace-2/virtual-service-2",
+					},
+				},
+			},
+			initialHostServicesBeforeCleanup:    []runtime.Object{hostServiceDefaultTargetNamespace},
+			initialVirtualServicesBeforeCleanup: []runtime.Object{virtualService2},
+			expectedHostServicesAfterCleanup:    []runtime.Object{hostServiceDefaultTargetNamespace},
+			expectedVirtualServicesAfterCleanup: []runtime.Object{virtualService2},
+		},
+		{
+			name: "Replicated service removed from config",
+			replicateServicesConfig: vclusterconfig.ReplicateServices{
+				FromHost: []vclusterconfig.ServiceMapping{
+					{
+						From: "host-namespace/other-host-service",
+						To:   "virtual-namespace/other-virtual-service",
+					},
+				},
+			},
+			initialHostServicesBeforeCleanup:    []runtime.Object{hostService1},
+			initialVirtualServicesBeforeCleanup: []runtime.Object{virtualService1},
+			expectedHostServicesAfterCleanup:    []runtime.Object{hostService1},
+			expectedVirtualServicesAfterCleanup: []runtime.Object{},
+		},
+		{
+			name: "Multiple replicated services removed from config",
+			replicateServicesConfig: vclusterconfig.ReplicateServices{
+				FromHost: []vclusterconfig.ServiceMapping{
+					{
+						From: "host-namespace/other-host-service",
+						To:   "virtual-namespace/other-virtual-service",
+					},
+					{
+						From: "host-service",
+						To:   "virtual-namespace-2/virtual-service-2",
+					},
+				},
+			},
+			initialHostServicesBeforeCleanup:    []runtime.Object{hostService1, hostServiceDefaultTargetNamespace, hostService3},
+			initialVirtualServicesBeforeCleanup: []runtime.Object{virtualService1, virtualService2, virtualService3},
+			expectedHostServicesAfterCleanup:    []runtime.Object{hostService1, hostServiceDefaultTargetNamespace, hostService3},
+			expectedVirtualServicesAfterCleanup: []runtime.Object{virtualService2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup dependencies
+			ctx := context.Background()
+			fakeConfig := testingutil.NewFakeConfig()
+			fakeConfig.Networking.ReplicateServices = tc.replicateServicesConfig
+			if tc.workloadTargetNamespace != "" {
+				fakeConfig.WorkloadTargetNamespace = tc.workloadTargetNamespace
+			}
+			pClient := testingutil.NewFakeClient(scheme.Scheme, tc.initialHostServicesBeforeCleanup...)
+			vClient := testingutil.NewFakeClient(scheme.Scheme, tc.initialVirtualServicesBeforeCleanup...)
+			fakeControllerContext := NewFakeControllerContext(ctx, fakeConfig, pClient, vClient)
+
+			err := deletePreviouslyReplicatedServices(fakeControllerContext)
+			assert.NilError(t, err)
+
+			// check expected host resources
+			err = syncertesting.CompareObjs(ctx, t, tc.name+" physical state", pClient, mappings.Services(), scheme.Scheme, tc.expectedHostServicesAfterCleanup, nil)
+			if err != nil {
+				t.Fatalf("%s - Physical state mismatch: %v", tc.name, err)
+			}
+
+			// check expected virtual resources
+			err = syncertesting.CompareObjs(ctx, t, tc.name+" virtual state", vClient, mappings.Services(), scheme.Scheme, tc.expectedVirtualServicesAfterCleanup, nil)
+			if err != nil {
+				t.Fatalf("%s - Virtual state mismatch: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func NewFakeControllerContext(ctx context.Context, config *config.VirtualClusterConfig, hostClient, virtualClient *testingutil.FakeIndexClient) *synccontext.ControllerContext {
+	hostManager := testingutil.NewFakeManager(hostClient)
+	virtualManager := testingutil.NewFakeManager(virtualClient)
+	return &synccontext.ControllerContext{
+		Context:        ctx,
+		LocalManager:   hostManager,
+		VirtualManager: virtualManager,
+		Config:         config,
+	}
+}

--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -168,6 +168,15 @@ func StartControllers(controllerContext *synccontext.ControllerContext, syncers 
 	// start mappings store garbage collection
 	controllerContext.Mappings.Store().StartGarbageCollection(controllerContext.Context)
 
+	// When the user disables from host syncing for some kind, the previously synced resources will
+	// stay in the virtual cluster. Since the controllers for those resources do not exist anymore,
+	// here we delete those stale virtual resources that were synced from host but should not be
+	// synced anymore.
+	err = deletePreviouslySyncedResources(controllerContext)
+	if err != nil {
+		return fmt.Errorf("failed to delete previouly synced resources: %w", err)
+	}
+
 	// we are done here
 	klog.FromContext(controllerContext).Info("Successfully started vCluster controllers")
 	return nil

--- a/test/e2e/servicesync/removestale.go
+++ b/test/e2e/servicesync/removestale.go
@@ -1,0 +1,41 @@
+package servicesync
+
+import (
+	"time"
+
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("previously replicated services removed from replication config", func() {
+	var f *framework.Framework
+	var vClusterNamespace string
+
+	ginkgo.BeforeEach(func() {
+		f = framework.DefaultFramework
+		vClusterNamespace = f.VClusterNamespace
+		if f.MultiNamespaceMode {
+			vClusterNamespace = translate.NewMultiNamespaceTranslator(f.VClusterNamespace).HostNamespace(nil, "default")
+		}
+	})
+
+	ginkgo.It("doesn't find virtual service that is removed from replication config", func() {
+		// A test service 'test-replicated-service-cleanup' has been created in the vcluster that
+		// is used for e2e tests, you can find it in 'test/e2e/values.yaml' in this repo. This
+		// service mimics a previously replicated service, which is achieved by setting label
+		// 'vcluster.loft.sh/controlled-by: vcluster'.
+		// Since this service is not present in the .networking.replicateServices.fromHost config
+		// it should be deleted when vcluster starts.
+
+		gomega.Eventually(func() bool {
+			_, err := f.VClusterClient.CoreV1().Services(vClusterNamespace).Get(f.Context, "test-replicated-service-cleanup", metav1.GetOptions{})
+			return kerrors.IsNotFound(err)
+		}).WithPolling(5 * time.Second).
+			WithTimeout(framework.PollTimeout).
+			Should(gomega.BeTrue())
+	})
+})

--- a/test/e2e/values.yaml
+++ b/test/e2e/values.yaml
@@ -8,6 +8,21 @@ experimental:
           name: test-configmap
         data:
           foo: bar
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: test-replicated-service-cleanup
+          labels:
+            vcluster.loft.sh/controlled-by: vcluster
+        spec:
+          selector:
+            app: fake-app
+          ports:
+          - protocol: TCP
+            port: 8080
+            targetPort: 8080
+            name: tcp
       manifestsTemplate: |-
         apiVersion: v1
         kind: ConfigMap


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
towards #ENG-5567


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster does not delete services that were synced from host to virtual, but should not be synced anymore, because from host syncing for services has been disabled.


**What else do we need to know?** 

How it's tested:
- Added unit tests
- Added e2e test
- Tested manually with the following config that enables syncing services from host:
```
networking:
  replicateServices:
    fromHost:
    - from: host-hello/my-host-service
      to: virtual-hello/my-virtual-service
```

After removing this config the synced service has been deleted from the virtual cluster.