### PR TITLE
feat: Try secure login first, and only overwrite platform config if --insecure is specified

### DIFF
--- a/cmd/vclusterctl/cmd/platform/login.go
+++ b/cmd/vclusterctl/cmd/platform/login.go
@@ -77,7 +77,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 
 	loginCmd.Flags().StringVar(&cmd.Driver, "use-driver", "", "Switch vCluster driver between platform and helm")
 	loginCmd.Flags().StringVar(&cmd.AccessKey, "access-key", "", "The access key to use")
-	loginCmd.Flags().BoolVar(&cmd.Insecure, "insecure", true, product.Replace("Allow login into an insecure Loft instance"))
+	loginCmd.Flags().BoolVar(&cmd.Insecure, "insecure", false, product.Replace("Allow login into an insecure Loft instance"))
 	loginCmd.Flags().BoolVar(&cmd.DockerLogin, "docker-login", true, "If true, will log into the docker image registries the user has image pull secrets for")
 
 	return loginCmd

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -329,10 +329,27 @@ func (c *client) LoginWithAccessKey(host, accessKey string, insecure bool) error
 		}
 	}
 
-	platformConfig.Host = host
-	platformConfig.Insecure = insecure
-	platformConfig.AccessKey = accessKey
-	c.Config().Platform = platformConfig
+	// Try a secure login first, even if they specify --insecure
+	if lgnErr := c.mgmtLogin(host, accessKey, false); lgnErr != nil {
+		if !insecure {
+			return lgnErr
+		}
+
+		// If specified, try an insecure login and save to the platform config if successful
+		if lgnErr = c.mgmtLogin(host, accessKey, true); lgnErr != nil {
+			return lgnErr
+		}
+	}
+
+	c.Config().Platform.Insecure = insecure
+	return c.Save()
+}
+
+func (c *client) mgmtLogin(host, accessKey string, insecure bool) error {
+	platformCfg := c.Config().Platform
+	platformCfg.Host = host
+	platformCfg.AccessKey = accessKey
+	platformCfg.Insecure = insecure
 
 	// verify the connection works
 	managementClient, err := c.Management()
@@ -354,7 +371,7 @@ func (c *client) LoginWithAccessKey(host, accessKey string, insecure bool) error
 		return perrors.Errorf("error logging in: %v", err)
 	}
 
-	return c.Save()
+	return nil
 }
 
 func (c *client) restConfig(hostSuffix string) (*rest.Config, error) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-6079

### The intended behavior:

  * If cert works, only write insecure if explicitly provided via --insecure flag
  * If cert does not work,
    * and platform config has insecure configured, write insecure in file
    * and platform config has nothing configured, fail and tell user that --insecure flag is required to be used

### The changes
 Write to the config whatever was specified on the command line, defaulting to false and always makes an attempt at a secure login, even if it ultimately falls back to insecure and/or writes `insecure: true` to the platform config allowing insecure logins to virtual clusters as intended by a user.

**What else do we need to know?** 
⚠️ Currently insecure defaults to true with platform login and a user must specify `--insecure=false` this flips that.