### PR TITLE
Align host to virtual metadata sync across all resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ profile.out
 /vcluster
 /zzz
 /cmd/vclusterctl/__debug_bin
+/main
 /release
 /cmd/vclusterctl/cmd/charts/
 /pkg/embed/chart/vcluster-*

--- a/pkg/controllers/resources/configmaps/to_host_syncer_test.go
+++ b/pkg/controllers/resources/configmaps/to_host_syncer_test.go
@@ -39,6 +39,7 @@ func TestSync(t *testing.T) {
 				translate.HostNameAnnotation:      translate.Default.HostName(nil, baseConfigMap.Name, baseConfigMap.Namespace).Name,
 			},
 			Labels: map[string]string{
+				translate.MarkerLabel:    translate.VClusterName,
 				translate.NamespaceLabel: baseConfigMap.Namespace,
 			},
 		},

--- a/pkg/controllers/resources/csidrivers/syncer.go
+++ b/pkg/controllers/resources/csidrivers/syncer.go
@@ -48,6 +48,7 @@ func (s *csidriverSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 func (s *csidriverSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*storagev1.CSIDriver]) (ctrl.Result, error) {
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
+	translate.SyncHostMetadataToVirtual(event.Host, vObj, translate.ApplyMetadataOptions{})
 
 	// Apply pro patches
 	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSIDrivers.Patches, true)
@@ -71,8 +72,7 @@ func (s *csidriverSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.
 	}()
 
 	// check if there is a change
-	event.Virtual.Annotations = event.Host.Annotations
-	event.Virtual.Labels = event.Host.Labels
+	translate.SyncHostMetadataToVirtual(event.Host, event.Virtual, translate.ApplyMetadataOptions{})
 	event.Host.Spec.DeepCopyInto(&event.Virtual.Spec)
 	return ctrl.Result{}, nil
 }

--- a/pkg/controllers/resources/csidrivers/syncer_test.go
+++ b/pkg/controllers/resources/csidrivers/syncer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
 	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"gotest.tools/assert"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,10 +24,29 @@ var (
 func TestSync(t *testing.T) {
 	pObjectMeta := metav1.ObjectMeta{
 		Name: "test-csidriver",
+		Annotations: map[string]string{
+			"test-annotation-1": "hello-1",
+			"test-annotation-2": "hello-2",
+		},
+		Labels: map[string]string{
+			"test-label-1": "hello-1",
+			"test-label-2": "hello-2",
+		},
 	}
 	vObjectMeta := metav1.ObjectMeta{
 		Name:            "test-csidriver",
 		ResourceVersion: "999",
+		Annotations: map[string]string{
+			"test-annotation-1":                    "hello-1",
+			"test-annotation-2":                    "hello-2",
+			translate.ManagedAnnotationsAnnotation: translate.ManagedKeysValue(pObjectMeta.Annotations),
+			translate.ManagedLabelsAnnotation:      translate.ManagedKeysValue(pObjectMeta.Labels),
+		},
+		Labels: map[string]string{
+			"test-label-1":        "hello-1",
+			"test-label-2":        "hello-2",
+			translate.MarkerLabel: translate.VClusterName,
+		},
 	}
 
 	pObj := &storagev1.CSIDriver{
@@ -78,7 +98,7 @@ func TestSync(t *testing.T) {
 	}
 
 	vObjUpdated := &storagev1.CSIDriver{
-		ObjectMeta: pObjectMeta,
+		ObjectMeta: vObjectMeta,
 		Spec: storagev1.CSIDriverSpec{
 			AttachRequired:       boolRef(false),
 			PodInfoOnMount:       boolRef(true),

--- a/pkg/controllers/resources/csinodes/syncer_test.go
+++ b/pkg/controllers/resources/csinodes/syncer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
 	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -76,8 +77,14 @@ func TestSync(t *testing.T) {
 		},
 	}
 
+	var vObjUpdatedMeta metav1.ObjectMeta
+	vObjectMeta.DeepCopyInto(&vObjUpdatedMeta)
+	if vObjUpdatedMeta.Labels == nil {
+		vObjUpdatedMeta.Labels = map[string]string{}
+	}
+	vObjUpdatedMeta.Labels[translate.MarkerLabel] = translate.VClusterName
 	vObjUpdated := &storagev1.CSINode{
-		ObjectMeta: vObjectMeta,
+		ObjectMeta: vObjUpdatedMeta,
 		Spec: storagev1.CSINodeSpec{
 			Drivers: []storagev1.CSINodeDriver{
 				{

--- a/pkg/controllers/resources/csinodes/syncer_test.go
+++ b/pkg/controllers/resources/csinodes/syncer_test.go
@@ -19,18 +19,20 @@ import (
 const kind = "CSINode"
 
 func TestSync(t *testing.T) {
-	pObjectMeta := metav1.ObjectMeta{
-		Name: "test-node",
-	}
-	vObjectMeta := metav1.ObjectMeta{
-		Name:            "test-node",
-		ResourceVersion: "999",
-	}
-
 	vNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
 
 	pObj := &storagev1.CSINode{
-		ObjectMeta: pObjectMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			Annotations: map[string]string{
+				"test-annotation-1": "hello-1",
+				"test-annotation-2": "hello-2",
+			},
+			Labels: map[string]string{
+				"test-label-1": "hello-1",
+				"test-label-2": "hello-2",
+			},
+		},
 		Spec: storagev1.CSINodeSpec{
 			Drivers: []storagev1.CSINodeDriver{
 				{
@@ -44,7 +46,21 @@ func TestSync(t *testing.T) {
 	}
 
 	vObj := &storagev1.CSINode{
-		ObjectMeta: vObjectMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-node",
+			ResourceVersion: "999",
+			Annotations: map[string]string{
+				"test-annotation-1":                    "hello-1",
+				"test-annotation-2":                    "hello-2",
+				translate.ManagedAnnotationsAnnotation: translate.ManagedKeysValue(pObj.Annotations),
+				translate.ManagedLabelsAnnotation:      translate.ManagedKeysValue(pObj.Labels),
+			},
+			Labels: map[string]string{
+				"test-label-1":        "hello-1",
+				"test-label-2":        "hello-2",
+				translate.MarkerLabel: translate.VClusterName,
+			},
+		},
 		Spec: storagev1.CSINodeSpec{
 			Drivers: []storagev1.CSINodeDriver{
 				{
@@ -58,7 +74,7 @@ func TestSync(t *testing.T) {
 	}
 
 	pObjUpdated := &storagev1.CSINode{
-		ObjectMeta: pObjectMeta,
+		ObjectMeta: pObj.ObjectMeta,
 		Spec: storagev1.CSINodeSpec{
 			Drivers: []storagev1.CSINodeDriver{
 				{
@@ -77,14 +93,8 @@ func TestSync(t *testing.T) {
 		},
 	}
 
-	var vObjUpdatedMeta metav1.ObjectMeta
-	vObjectMeta.DeepCopyInto(&vObjUpdatedMeta)
-	if vObjUpdatedMeta.Labels == nil {
-		vObjUpdatedMeta.Labels = map[string]string{}
-	}
-	vObjUpdatedMeta.Labels[translate.MarkerLabel] = translate.VClusterName
 	vObjUpdated := &storagev1.CSINode{
-		ObjectMeta: vObjUpdatedMeta,
+		ObjectMeta: vObj.ObjectMeta,
 		Spec: storagev1.CSINodeSpec{
 			Drivers: []storagev1.CSINodeDriver{
 				{

--- a/pkg/controllers/resources/csistoragecapacities/syncer_test.go
+++ b/pkg/controllers/resources/csistoragecapacities/syncer_test.go
@@ -27,19 +27,32 @@ func TestSyncHostStorageClass(t *testing.T) {
 	pObjectMeta := metav1.ObjectMeta{
 		Name:      "test-csistoragecapacity",
 		Namespace: "test",
+		Annotations: map[string]string{
+			"test-annotation-1": "hello-1",
+			"test-annotation-2": "hello-2",
+		},
+		Labels: map[string]string{
+			"test-label-1": "hello-1",
+			"test-label-2": "hello-2",
+		},
 	}
 	vObjectMeta := metav1.ObjectMeta{
 		Name:      "test-csistoragecapacity-x-test",
 		Namespace: "kube-system",
 		Annotations: map[string]string{
-			translate.NameAnnotation:          "test-csistoragecapacity",
-			translate.NamespaceAnnotation:     "test",
-			translate.UIDAnnotation:           "",
-			translate.KindAnnotation:          storagev1.SchemeGroupVersion.WithKind("CSIStorageCapacity").String(),
-			translate.HostNameAnnotation:      "test-csistoragecapacity-x-test",
-			translate.HostNamespaceAnnotation: "kube-system",
+			"test-annotation-1":                    "hello-1",
+			"test-annotation-2":                    "hello-2",
+			translate.ManagedAnnotationsAnnotation: translate.ManagedKeysValue(pObjectMeta.Annotations),
+			translate.NameAnnotation:               "test-csistoragecapacity",
+			translate.NamespaceAnnotation:          "test",
+			translate.UIDAnnotation:                "",
+			translate.KindAnnotation:               storagev1.SchemeGroupVersion.WithKind("CSIStorageCapacity").String(),
+			translate.HostNameAnnotation:           "test-csistoragecapacity-x-test",
+			translate.HostNamespaceAnnotation:      "kube-system",
 		},
 		Labels: map[string]string{
+			"test-label-1":               "hello-1",
+			"test-label-2":               "hello-2",
 			translate.MarkerLabel:        translate.VClusterName,
 			"vcluster.loft.sh/namespace": "test",
 		},
@@ -158,19 +171,32 @@ func TestSyncStorageClass(t *testing.T) {
 	pObjectMeta := metav1.ObjectMeta{
 		Name:      "test-csistoragecapacity",
 		Namespace: "test",
+		Annotations: map[string]string{
+			"test-annotation-1": "hello-1",
+			"test-annotation-2": "hello-2",
+		},
+		Labels: map[string]string{
+			"test-label-1": "hello-1",
+			"test-label-2": "hello-2",
+		},
 	}
 	vObjectMeta := metav1.ObjectMeta{
 		Name:      "test-csistoragecapacity-x-test",
 		Namespace: "kube-system",
 		Annotations: map[string]string{
-			translate.NameAnnotation:          "test-csistoragecapacity",
-			translate.NamespaceAnnotation:     "test",
-			translate.UIDAnnotation:           "",
-			translate.KindAnnotation:          storagev1.SchemeGroupVersion.WithKind("CSIStorageCapacity").String(),
-			translate.HostNameAnnotation:      "test-csistoragecapacity-x-test",
-			translate.HostNamespaceAnnotation: "kube-system",
+			"test-annotation-1":                    "hello-1",
+			"test-annotation-2":                    "hello-2",
+			translate.ManagedAnnotationsAnnotation: translate.ManagedKeysValue(pObjectMeta.Annotations),
+			translate.NameAnnotation:               "test-csistoragecapacity",
+			translate.NamespaceAnnotation:          "test",
+			translate.UIDAnnotation:                "",
+			translate.KindAnnotation:               storagev1.SchemeGroupVersion.WithKind("CSIStorageCapacity").String(),
+			translate.HostNameAnnotation:           "test-csistoragecapacity-x-test",
+			translate.HostNamespaceAnnotation:      "kube-system",
 		},
 		Labels: map[string]string{
+			"test-label-1":               "hello-1",
+			"test-label-2":               "hello-2",
 			translate.MarkerLabel:        translate.VClusterName,
 			"vcluster.loft.sh/namespace": "test",
 		},

--- a/pkg/controllers/resources/csistoragecapacities/syncer_test.go
+++ b/pkg/controllers/resources/csistoragecapacities/syncer_test.go
@@ -40,6 +40,7 @@ func TestSyncHostStorageClass(t *testing.T) {
 			translate.HostNamespaceAnnotation: "kube-system",
 		},
 		Labels: map[string]string{
+			translate.MarkerLabel:        translate.VClusterName,
 			"vcluster.loft.sh/namespace": "test",
 		},
 		ResourceVersion: "999",
@@ -170,6 +171,7 @@ func TestSyncStorageClass(t *testing.T) {
 			translate.HostNamespaceAnnotation: "kube-system",
 		},
 		Labels: map[string]string{
+			translate.MarkerLabel:        translate.VClusterName,
 			"vcluster.loft.sh/namespace": "test",
 		},
 		ResourceVersion: "999",

--- a/pkg/controllers/resources/endpoints/syncer_test.go
+++ b/pkg/controllers/resources/endpoints/syncer_test.go
@@ -83,6 +83,7 @@ func TestExistingEndpoints(t *testing.T) {
 				translate.HostNameAnnotation:      translate.Default.HostName(nil, vEndpoints.Name, vEndpoints.Namespace).Name,
 			},
 			Labels: map[string]string{
+				translate.MarkerLabel:    translate.VClusterName,
 				translate.NamespaceLabel: vEndpoints.Namespace,
 			},
 		},
@@ -165,6 +166,7 @@ func TestSync(t *testing.T) {
 				translate.HostNameAnnotation:      translate.Default.HostName(nil, baseEndpoints.Name, baseEndpoints.Namespace).Name,
 			},
 			Labels: map[string]string{
+				translate.MarkerLabel:    translate.VClusterName,
 				translate.NamespaceLabel: baseEndpoints.Namespace,
 			},
 		},

--- a/pkg/controllers/resources/events/syncer_test.go
+++ b/pkg/controllers/resources/events/syncer_test.go
@@ -56,6 +56,9 @@ func TestSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pEvent.Name,
 			Namespace: vPod.Namespace,
+			Labels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
 		},
 		InvolvedObject: corev1.ObjectReference{
 			APIVersion:      corev1.SchemeGroupVersion.String(),

--- a/pkg/controllers/resources/events/translate.go
+++ b/pkg/controllers/resources/events/translate.go
@@ -37,6 +37,7 @@ func (s *eventSyncer) translateEvent(ctx *synccontext.SyncContext, pEvent, vEven
 	tempEvent.TypeMeta = vEvent.TypeMeta
 
 	tempEvent.DeepCopyInto(vEvent)
+	translate.SyncHostMetadataToVirtual(pEvent, vEvent, translate.ApplyMetadataOptions{})
 	vEvent.Namespace = namespace
 	vEvent.Name = name
 	return nil

--- a/pkg/controllers/resources/ingressclasses/syncer.go
+++ b/pkg/controllers/resources/ingressclasses/syncer.go
@@ -48,6 +48,7 @@ func (i *ingressClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*networkingv1.IngressClass]) (ctrl.Result, error) {
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
+	translate.SyncHostMetadataToVirtual(event.Host, vObj, translate.ApplyMetadataOptions{})
 
 	// Apply pro patches
 	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.IngressClasses.Patches, true)
@@ -71,8 +72,7 @@ func (i *ingressClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 	}()
 
 	// cast objects
-	event.Virtual.Annotations = event.Host.Annotations
-	event.Virtual.Labels = event.Host.Labels
+	translate.SyncHostMetadataToVirtual(event.Host, event.Virtual, translate.ApplyMetadataOptions{})
 	event.Virtual.Spec.Controller = event.Host.Spec.Controller
 	event.Virtual.Spec.Parameters = event.Host.Spec.Parameters
 	return ctrl.Result{}, nil

--- a/pkg/controllers/resources/ingressclasses/syncer_test.go
+++ b/pkg/controllers/resources/ingressclasses/syncer_test.go
@@ -14,12 +14,29 @@ import (
 )
 
 func TestSync(t *testing.T) {
+	const resourceName = "test-ingc"
+
+	pObj := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName,
+			Annotations: map[string]string{
+				translate.NameAnnotation: resourceName,
+				translate.UIDAnnotation:  "",
+				translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
+			},
+		},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: "test-controller",
+		},
+	}
+
 	vObjectMeta := metav1.ObjectMeta{
-		Name: "test-ingc",
+		Name: resourceName,
 		Annotations: map[string]string{
-			translate.NameAnnotation: "test-ingc",
-			translate.UIDAnnotation:  "",
-			translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
+			translate.NameAnnotation:               resourceName,
+			translate.UIDAnnotation:                "",
+			translate.KindAnnotation:               networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
+			translate.ManagedAnnotationsAnnotation: translate.ManagedKeysValue(pObj.Annotations),
 		},
 		Labels: map[string]string{
 			translate.MarkerLabel: translate.VClusterName,
@@ -31,35 +48,6 @@ func TestSync(t *testing.T) {
 		ObjectMeta: vObjectMeta,
 		Spec: networkingv1.IngressClassSpec{
 			Controller: "test-controller",
-		},
-	}
-
-	pObj := &networkingv1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: vObjectMeta.Name,
-			Labels: map[string]string{
-				translate.MarkerLabel: translate.VClusterName,
-			},
-			Annotations: map[string]string{
-				translate.NameAnnotation: "test-ingc",
-				translate.UIDAnnotation:  "",
-				translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
-			},
-		},
-		Spec: networkingv1.IngressClassSpec{
-			Controller: "test-controller",
-		},
-	}
-
-	vObjUpdated := &networkingv1.IngressClass{
-		ObjectMeta: vObjectMeta,
-		Spec: networkingv1.IngressClassSpec{
-			Controller: "test-controller",
-			Parameters: &networkingv1.IngressClassParametersReference{
-				APIGroup: strRef("test-group"),
-				Kind:     "test-kind",
-				Name:     "test-ingc-param",
-			},
 		},
 	}
 
@@ -75,6 +63,18 @@ func TestSync(t *testing.T) {
 				translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
 			},
 		},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: "test-controller",
+			Parameters: &networkingv1.IngressClassParametersReference{
+				APIGroup: strRef("test-group"),
+				Kind:     "test-kind",
+				Name:     "test-ingc-param",
+			},
+		},
+	}
+
+	vObjUpdated := &networkingv1.IngressClass{
+		ObjectMeta: vObjectMeta,
 		Spec: networkingv1.IngressClassSpec{
 			Controller: "test-controller",
 			Parameters: &networkingv1.IngressClassParametersReference{

--- a/pkg/controllers/resources/ingressclasses/syncer_test.go
+++ b/pkg/controllers/resources/ingressclasses/syncer_test.go
@@ -21,6 +21,9 @@ func TestSync(t *testing.T) {
 			translate.UIDAnnotation:  "",
 			translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
 		},
+		Labels: map[string]string{
+			translate.MarkerLabel: translate.VClusterName,
+		},
 		ResourceVersion: "999",
 	}
 

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -307,14 +307,6 @@ func (s *nodeSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncE
 
 	s.translateUpdateBackwards(event.Host, event.Virtual)
 
-	// Set the marker of managed-by vcluster so that
-	// we skip deleting the nodes which are not managed
-	// by vcluster in `SyncToHost` function
-	if len(event.Virtual.Labels) == 0 {
-		event.Virtual.Labels = map[string]string{}
-	}
-	event.Virtual.Labels[translate.MarkerLabel] = translate.VClusterName
-
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -29,7 +29,7 @@ func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.
 	applyMetadataOptions := translate.ApplyMetadataOptions{
 		ExcludeAnnotations: []string{TaintsAnnotation, RancherAgentPodRequestsAnnotation, RancherAgentPodLimitsAnnotation},
 	}
-	translate.ApplyVirtualMetadata(pNode, vNode, applyMetadataOptions)
+	translate.SyncHostMetadataToVirtual(pNode, vNode, applyMetadataOptions)
 
 	// merge taints together
 	oldPhysical := []string{}

--- a/pkg/controllers/resources/nodes/translate_test.go
+++ b/pkg/controllers/resources/nodes/translate_test.go
@@ -64,7 +64,8 @@ func TestTranslateBackwards(t *testing.T) {
 			},
 
 			expectedLabels: map[string]string{
-				"test": "test",
+				"test":                "test",
+				translate.MarkerLabel: translate.VClusterName,
 			},
 
 			expectedTaints: []corev1.Taint{
@@ -95,7 +96,9 @@ func TestTranslateBackwards(t *testing.T) {
 				},
 			},
 
-			expectedLabels: map[string]string{},
+			expectedLabels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
 			expectedAnnotations: map[string]string{
 				TaintsAnnotation: mustMarshal([]string{
 					mustMarshal(
@@ -148,8 +151,10 @@ func TestTranslateBackwards(t *testing.T) {
 			},
 
 			expectedAnnotations: map[string]string{},
-			expectedLabels:      map[string]string{},
-			expectedTaints:      []corev1.Taint{},
+			expectedLabels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
+			expectedTaints: []corev1.Taint{},
 		},
 		{
 			name: "not-ready-3",
@@ -171,7 +176,9 @@ func TestTranslateBackwards(t *testing.T) {
 				Spec:       corev1.NodeSpec{},
 			},
 			expectedAnnotations: map[string]string{},
-			expectedLabels:      map[string]string{},
+			expectedLabels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
 
 			expectedTaints: []corev1.Taint{},
 		},
@@ -215,7 +222,9 @@ func TestTranslateBackwards(t *testing.T) {
 					Effect: corev1.TaintEffectNoExecute,
 				},
 			},
-			expectedLabels: map[string]string{},
+			expectedLabels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
 		},
 		{
 			name: "custom-taint-2",
@@ -252,8 +261,10 @@ func TestTranslateBackwards(t *testing.T) {
 			},
 
 			expectedAnnotations: map[string]string{},
-			expectedLabels:      map[string]string{},
-			expectedTaints:      []corev1.Taint{},
+			expectedLabels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
+			expectedTaints: []corev1.Taint{},
 		},
 		{
 			name: "custom-taint-3",
@@ -278,7 +289,9 @@ func TestTranslateBackwards(t *testing.T) {
 			},
 
 			expectedAnnotations: map[string]string{},
-			expectedLabels:      map[string]string{},
+			expectedLabels: map[string]string{
+				translate.MarkerLabel: translate.VClusterName,
+			},
 			expectedTaints: []corev1.Taint{
 				{
 					Key:    "custom-taint",

--- a/pkg/controllers/resources/priorityclasses/syncer_test.go
+++ b/pkg/controllers/resources/priorityclasses/syncer_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"gotest.tools/assert"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -19,8 +20,13 @@ func TestSyncToHost(t *testing.T) {
 		Value:      1,
 	}
 	pObj := schedulingv1.PriorityClass{
-		ObjectMeta: metav1.ObjectMeta{Name: "vcluster-stuff-x-test-x-suffix"},
-		Value:      1,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vcluster-stuff-x-test-x-suffix",
+			Labels: map[string]string{
+				translate.MarkerLabel: translate.SafeConcatName(testingutil.DefaultTestTargetNamespace, "x", translate.VClusterName),
+			},
+		},
+		Value: 1,
 	}
 
 	pObj.Annotations = translate.HostAnnotations(&vObj, &pObj)

--- a/pkg/controllers/resources/runtimeclasses/syncer_test.go
+++ b/pkg/controllers/resources/runtimeclasses/syncer_test.go
@@ -23,6 +23,9 @@ func TestSync(t *testing.T) {
 			translate.UIDAnnotation:  "",
 			translate.KindAnnotation: nodev1.SchemeGroupVersion.WithKind("RuntimeClass").String(),
 		},
+		Labels: map[string]string{
+			translate.MarkerLabel: translate.VClusterName,
+		},
 		ResourceVersion: "999",
 	}
 

--- a/pkg/controllers/resources/secrets/to_host_syncer_test.go
+++ b/pkg/controllers/resources/secrets/to_host_syncer_test.go
@@ -51,6 +51,7 @@ func TestSync(t *testing.T) {
 				translate.HostNameAnnotation:      translate.Default.HostName(nil, baseSecret.Name, baseSecret.Namespace).Name,
 			},
 			Labels: map[string]string{
+				translate.MarkerLabel:    translate.VClusterName,
 				translate.NamespaceLabel: baseSecret.Namespace,
 				testLabel:                testLabelValue,
 			},

--- a/pkg/controllers/resources/serviceaccounts/syncer_test.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer_test.go
@@ -50,6 +50,7 @@ func TestSync(t *testing.T) {
 				translate.HostNameAnnotation:           translate.Default.HostName(nil, vSA.Name, vSA.Namespace).Name,
 			},
 			Labels: map[string]string{
+				translate.MarkerLabel:    translate.VClusterName,
 				translate.NamespaceLabel: vSA.Namespace,
 			},
 		},

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -52,6 +52,7 @@ func (s *hostStorageClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 func (s *hostStorageClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*storagev1.StorageClass]) (ctrl.Result, error) {
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)
+	translate.SyncHostMetadataToVirtual(event.Host, vObj, translate.ApplyMetadataOptions{})
 
 	// Apply pro patches
 	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.StorageClasses.Patches, true)

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -75,8 +75,7 @@ func (s *hostStorageClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 	}()
 
 	// check if there is a change
-	event.Virtual.Annotations = event.Host.Annotations
-	event.Virtual.Labels = event.Host.Labels
+	translate.ApplyVirtualMetadata(event.Host, event.Virtual, translate.ApplyMetadataOptions{})
 	event.Virtual.Provisioner = event.Host.Provisioner
 	event.Virtual.Parameters = event.Host.Parameters
 	event.Virtual.ReclaimPolicy = event.Host.ReclaimPolicy

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -75,7 +75,7 @@ func (s *hostStorageClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 	}()
 
 	// check if there is a change
-	translate.ApplyVirtualMetadata(event.Host, event.Virtual, translate.ApplyMetadataOptions{})
+	translate.SyncHostMetadataToVirtual(event.Host, event.Virtual, translate.ApplyMetadataOptions{})
 	event.Virtual.Provisioner = event.Host.Provisioner
 	event.Virtual.Parameters = event.Host.Parameters
 	event.Virtual.ReclaimPolicy = event.Host.ReclaimPolicy

--- a/pkg/controllers/resources/storageclasses/host_syncer_test.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer_test.go
@@ -48,17 +48,28 @@ func TestFromHostSync(t *testing.T) {
 			Annotations: map[string]string{
 				"example.com/annotation-a":             "test-1",
 				"example.com/annotation-b":             "test-2",
-				translate.ManagedAnnotationsAnnotation: strings.Join(slices.Collect(maps.Keys(pObject.Annotations)), "\n"),
-				translate.ManagedLabelsAnnotation:      strings.Join(slices.Collect(maps.Keys(pObject.Labels)), "\n"),
+				translate.ManagedAnnotationsAnnotation: managedKeysValue(pObject.Annotations),
+				translate.ManagedLabelsAnnotation:      managedKeysValue(pObject.Labels),
 			},
 		},
 		Provisioner: "my-provisioner",
 	}
+	pObjectUpdated := pObject.DeepCopy()
+	pObjectUpdated.Labels["example.com/label-c"] = "test-3"
+	pObjectUpdated.Parameters = map[string]string{
+		"test": "value",
+	}
+	vObjectUpdated := vObject.DeepCopy()
+	vObjectUpdated.Labels["example.com/label-c"] = "test-3"
+	vObjectUpdated.Annotations[translate.ManagedLabelsAnnotation] = managedKeysValue(pObjectUpdated.Labels)
+	vObjectUpdated.Parameters = map[string]string{
+		"test": "value",
+	}
 
 	syncertesting.RunTests(t, []*syncertesting.SyncTest{
 		{
-			Name:                 "Sync host to virtual",
-			InitialPhysicalState: []runtime.Object{pObject},
+			Name:                 "Sync new host resource to virtual",
+			InitialPhysicalState: []runtime.Object{pObject.DeepCopy()},
 			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
 				storagev1.SchemeGroupVersion.WithKind("StorageClass"): {pObject},
 			},
@@ -71,10 +82,30 @@ func TestFromHostSync(t *testing.T) {
 				assert.NilError(t, err)
 			},
 		},
+		{
+			Name:                 "Sync host changes to virtual",
+			InitialPhysicalState: []runtime.Object{pObjectUpdated.DeepCopy()},
+			InitialVirtualState:  []runtime.Object{vObject.DeepCopy()},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				storagev1.SchemeGroupVersion.WithKind("StorageClass"): {pObjectUpdated},
+			},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				storagev1.SchemeGroupVersion.WithKind("StorageClass"): {vObjectUpdated},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncerCtx, syncer := newFakeSyncer(t, ctx)
+				_, err := syncer.Sync(syncerCtx, synccontext.NewSyncEvent(pObjectUpdated, vObject.DeepCopy()))
+				assert.NilError(t, err)
+			},
+		},
 	})
 }
 
 func newFakeSyncer(t *testing.T, ctx *synccontext.RegisterContext) (*synccontext.SyncContext, *hostStorageClassSyncer) {
 	syncContext, object := syncertesting.FakeStartSyncer(t, ctx, NewHostStorageClassSyncer)
 	return syncContext, object.(*hostStorageClassSyncer)
+}
+
+func managedKeysValue(m map[string]string) string {
+	return strings.Join(slices.Sorted(maps.Keys(m)), "\n")
 }

--- a/pkg/controllers/resources/storageclasses/host_syncer_test.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer_test.go
@@ -1,0 +1,80 @@
+package storageclasses
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"gotest.tools/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestFromHostSync(t *testing.T) {
+	translate.Default = translate.NewSingleNamespaceTranslator(testingutil.DefaultTestTargetNamespace)
+	const storageClassName = "testsc"
+
+	pObject := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            storageClassName,
+			ResourceVersion: syncertesting.FakeClientResourceVersion,
+			Labels: map[string]string{
+				"example.com/label-a": "test-1",
+				"example.com/label-b": "test-2",
+			},
+			Annotations: map[string]string{
+				"example.com/annotation-a": "test-1",
+				"example.com/annotation-b": "test-2",
+			},
+		},
+		Provisioner: "my-provisioner",
+	}
+	vObject := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            storageClassName,
+			ResourceVersion: syncertesting.FakeClientResourceVersion,
+			Labels: map[string]string{
+				"example.com/label-a": "test-1",
+				"example.com/label-b": "test-2",
+				translate.MarkerLabel: translate.VClusterName,
+			},
+			Annotations: map[string]string{
+				"example.com/annotation-a":             "test-1",
+				"example.com/annotation-b":             "test-2",
+				translate.ManagedAnnotationsAnnotation: strings.Join(slices.Collect(maps.Keys(pObject.Annotations)), "\n"),
+				translate.ManagedLabelsAnnotation:      strings.Join(slices.Collect(maps.Keys(pObject.Labels)), "\n"),
+			},
+		},
+		Provisioner: "my-provisioner",
+	}
+
+	syncertesting.RunTests(t, []*syncertesting.SyncTest{
+		{
+			Name:                 "Sync host to virtual",
+			InitialPhysicalState: []runtime.Object{pObject},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				storagev1.SchemeGroupVersion.WithKind("StorageClass"): {pObject},
+			},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				storagev1.SchemeGroupVersion.WithKind("StorageClass"): {vObject},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncerCtx, syncer := newFakeSyncer(t, ctx)
+				_, err := syncer.SyncToVirtual(syncerCtx, synccontext.NewSyncToVirtualEvent(pObject))
+				assert.NilError(t, err)
+			},
+		},
+	})
+}
+
+func newFakeSyncer(t *testing.T, ctx *synccontext.RegisterContext) (*synccontext.SyncContext, *hostStorageClassSyncer) {
+	syncContext, object := syncertesting.FakeStartSyncer(t, ctx, NewHostStorageClassSyncer)
+	return syncContext, object.(*hostStorageClassSyncer)
+}

--- a/pkg/controllers/resources/storageclasses/syncer_test.go
+++ b/pkg/controllers/resources/storageclasses/syncer_test.go
@@ -32,7 +32,7 @@ func TestSync(t *testing.T) {
 			Name:            translate.Default.HostNameCluster(vObjectMeta.Name),
 			ResourceVersion: syncertesting.FakeClientResourceVersion,
 			Labels: map[string]string{
-				translate.MarkerLabel: translate.VClusterName,
+				translate.MarkerLabel: translate.SafeConcatName(testingutil.DefaultTestTargetNamespace, "x", translate.VClusterName),
 			},
 			Annotations: map[string]string{
 				translate.NameAnnotation:     "testsc",
@@ -54,7 +54,7 @@ func TestSync(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: translate.Default.HostNameCluster(vObjectMeta.Name),
 			Labels: map[string]string{
-				translate.MarkerLabel: translate.VClusterName,
+				translate.MarkerLabel: translate.SafeConcatName(testingutil.DefaultTestTargetNamespace, "x", translate.VClusterName),
 			},
 			Annotations: map[string]string{
 				translate.NameAnnotation:     "testsc",

--- a/pkg/controllers/resources/volumesnapshotcontents/syncer_test.go
+++ b/pkg/controllers/resources/volumesnapshotcontents/syncer_test.go
@@ -75,6 +75,9 @@ func TestSync(t *testing.T) {
 			translate.KindAnnotation:     volumesnapshotv1.SchemeGroupVersion.WithKind("VolumeSnapshotContent").String(),
 			translate.HostNameAnnotation: translate.Default.HostNameCluster(vPreProvisioned.Name),
 		},
+		Labels: map[string]string{
+			translate.MarkerLabel: translate.SafeConcatName(testingutil.DefaultTestTargetNamespace, "x", translate.VClusterName),
+		},
 	}
 	pPreProvisioned := &volumesnapshotv1.VolumeSnapshotContent{
 		ObjectMeta: pPreProvisionedObjectMeta,

--- a/pkg/syncer/from_host_syncer.go
+++ b/pkg/syncer/from_host_syncer.go
@@ -84,6 +84,10 @@ func (s *genericFromHostSyncer) Sync(ctx *synccontext.SyncContext, event *syncco
 	}()
 
 	s.FromHostSyncer.CopyHostObjectToVirtual(event.Virtual, event.Host)
+	applyMetadataOptions := translate.ApplyMetadataOptions{
+		SetHostNameAndNamespaceAnnotations: true,
+	}
+	translate.SyncHostMetadataToVirtual(event.Host, event.Virtual, applyMetadataOptions)
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/syncer/from_host_syncer.go
+++ b/pkg/syncer/from_host_syncer.go
@@ -84,10 +84,7 @@ func (s *genericFromHostSyncer) Sync(ctx *synccontext.SyncContext, event *syncco
 	}()
 
 	s.FromHostSyncer.CopyHostObjectToVirtual(event.Virtual, event.Host)
-	applyMetadataOptions := translate.ApplyMetadataOptions{
-		SetHostNameAndNamespaceAnnotations: true,
-	}
-	translate.SyncHostMetadataToVirtual(event.Host, event.Virtual, applyMetadataOptions)
+	translate.SyncHostMetadataToVirtual(event.Host, event.Virtual, translate.ApplyMetadataOptions{})
 
 	return ctrl.Result{}, nil
 }
@@ -99,6 +96,7 @@ func (s *genericFromHostSyncer) SyncToVirtual(ctx *synccontext.SyncContext, even
 	}
 
 	vObj := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.GetName(), Namespace: event.Host.GetNamespace()}, event.Host))
+	translate.SyncHostMetadataToVirtual(event.Host, vObj, translate.ApplyMetadataOptions{})
 
 	// make sure namespace exists
 	namespace := &corev1.Namespace{}

--- a/pkg/syncer/from_host_syncer_test.go
+++ b/pkg/syncer/from_host_syncer_test.go
@@ -1,0 +1,154 @@
+package syncer
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	"github.com/loft-sh/vcluster/pkg/syncer/translator"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+const (
+	testResourceName      = "test-name"
+	testResourceNamespace = "test-namespace"
+)
+
+func TestFromHostSyncer(t *testing.T) {
+	translate.Default = translate.NewSingleNamespaceTranslator(testingutil.DefaultTestTargetNamespace)
+
+	// Initial state of the physical object, before calling any of the sync functions.
+	pObject := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            testResourceName,
+			Namespace:       testResourceNamespace,
+			ResourceVersion: syncertesting.FakeClientResourceVersion,
+			Labels: map[string]string{
+				"example.com/label-a": "test-1",
+				"example.com/label-b": "test-2",
+			},
+			Annotations: map[string]string{
+				"example.com/annotation-a": "test-1",
+				"example.com/annotation-b": "test-2",
+			},
+		},
+		Data: map[string]string{
+			"hello": "test",
+		},
+	}
+
+	// Initial state of the virtual object, after the initial sync.
+	vObject := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            testResourceName,
+			Namespace:       testResourceNamespace,
+			ResourceVersion: syncertesting.FakeClientResourceVersion,
+			Labels: map[string]string{
+				"example.com/label-a": "test-1",
+				"example.com/label-b": "test-2",
+				translate.MarkerLabel: translate.VClusterName,
+			},
+			Annotations: map[string]string{
+				"example.com/annotation-a":             "test-1",
+				"example.com/annotation-b":             "test-2",
+				translate.ManagedAnnotationsAnnotation: managedKeysValue(pObject.Annotations),
+				translate.ManagedLabelsAnnotation:      managedKeysValue(pObject.Labels),
+			},
+		},
+		Data: map[string]string{
+			"hello": "test",
+		},
+	}
+
+	// Physical object after the update. Here the changes are made only to the metadata, as
+	// kind-specific changes (e.g. ConfigMap.Data) are tested in the kind-specific FromHost syncers.
+	pObjectUpdated := pObject.DeepCopy()
+	pObjectUpdated.Labels["example.com/label-b"] = "updated-test-2"
+	pObjectUpdated.Labels["example.com/label-c"] = "new-test-3"
+	pObjectUpdated.Labels["example.com/annotation-a"] = "updated-test-1"
+	pObjectUpdated.Labels["example.com/annotation-c"] = "new-test-3"
+
+	// Virtual object after syncing the updated physical object.
+	vObjectUpdated := vObject.DeepCopy()
+	vObjectUpdated.Labels["example.com/label-b"] = "updated-test-2"
+	vObjectUpdated.Labels["example.com/label-c"] = "new-test-3"
+	vObjectUpdated.Labels["example.com/annotation-a"] = "updated-test-1"
+	vObjectUpdated.Labels["example.com/annotation-c"] = "new-test-3"
+	vObjectUpdated.Annotations[translate.ManagedAnnotationsAnnotation] = managedKeysValue(pObjectUpdated.Annotations)
+	vObjectUpdated.Annotations[translate.ManagedLabelsAnnotation] = managedKeysValue(pObjectUpdated.Labels)
+
+	syncertesting.RunTests(t, []*syncertesting.SyncTest{
+		{
+			Name:                 "Sync new host resource to virtual",
+			InitialPhysicalState: []runtime.Object{pObject.DeepCopy()},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ConfigMap"): {pObject},
+			},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ConfigMap"): {vObject},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncerCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, NewFakeFromHostSyncer)
+				fromHostSyncer := syncer.(*genericFromHostSyncer)
+				syncToVirtualEvent := synccontext.NewSyncToVirtualEvent(client.Object(pObject))
+
+				// First call creates the missing namespace.
+				result, err := fromHostSyncer.SyncToVirtual(syncerCtx, syncToVirtualEvent)
+				assert.Check(t, result.Requeue == true)
+				assert.NilError(t, err)
+
+				// Second call creates the virtual resource.
+				_, err = fromHostSyncer.SyncToVirtual(syncerCtx, syncToVirtualEvent)
+				assert.NilError(t, err)
+			},
+		},
+	})
+}
+
+func managedKeysValue(m map[string]string) string {
+	return strings.Join(slices.Sorted(maps.Keys(m)), "\n")
+}
+
+// fakeFromHostSyncer is a simple FromHostSyncer test implementation.
+type fakeFromHostSyncer struct{}
+
+func NewFakeFromHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
+	gvk, err := apiutil.GVKForObject(&corev1.ConfigMap{}, scheme.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve GVK for object failed: %w", err)
+	}
+	fromHostSyncer := &fakeFromHostSyncer{}
+	fromHostTranslator, err := translator.NewFromHostTranslatorForGVK(ctx, gvk, fromHostSyncer.GetMappings(ctx.Config.Config))
+	if err != nil {
+		return nil, err
+	}
+	return NewFromHost(ctx, fromHostSyncer, fromHostTranslator)
+}
+
+func (s *fakeFromHostSyncer) CopyHostObjectToVirtual(_, _ client.Object) {}
+
+func (s *fakeFromHostSyncer) GetProPatches(_ config.Config) []config.TranslatePatch {
+	return nil
+}
+
+func (s *fakeFromHostSyncer) GetMappings(_ config.Config) map[string]string {
+	namePattern := fmt.Sprintf("%s/*", testResourceNamespace)
+	return map[string]string{
+		namePattern: namePattern,
+	}
+}

--- a/pkg/syncer/from_host_syncer_test.go
+++ b/pkg/syncer/from_host_syncer_test.go
@@ -135,6 +135,19 @@ func TestFromHostSyncer(t *testing.T) {
 				assert.NilError(t, err)
 			},
 		},
+		{
+			Name:                 "Delete virtual resources after host resource has been deleted",
+			InitialPhysicalState: []runtime.Object{},                             // host resource has been deleted
+			InitialVirtualState:  []runtime.Object{vObject.DeepCopy()},           // virtual resource exists, since it was previously synced
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{}, // virtual resource has been deleted after syncing
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncerCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, NewFakeFromHostSyncer)
+				fromHostSyncer := syncer.(*genericFromHostSyncer)
+				syncToHostEvent := synccontext.NewSyncToHostEvent(client.Object(vObject.DeepCopy()))
+				_, err := fromHostSyncer.SyncToHost(syncerCtx, syncToHostEvent)
+				assert.NilError(t, err)
+			},
+		},
 	})
 }
 

--- a/pkg/syncer/from_host_syncer_test.go
+++ b/pkg/syncer/from_host_syncer_test.go
@@ -155,7 +155,13 @@ func managedKeysValue(m map[string]string) string {
 	return strings.Join(slices.Sorted(maps.Keys(m)), "\n")
 }
 
-// fakeFromHostSyncer is a simple FromHostSyncer test implementation.
+// fakeFromHostSyncer is a simple FromHostSyncer test implementation. It mimics
+// a ConfigMap FromHost syncer, but it doesn't sync any ConfigMap data from host
+// to virtual, since the genericFromHostSyncer tests do not care how kind-specific
+// sync is working.
+//
+// The only important func below is GetMappings, because it specifies how host
+// resources are named after being synced to virtual.
 type fakeFromHostSyncer struct{}
 
 func NewFakeFromHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -207,6 +207,7 @@ func TestController(t *testing.T) {
 								translate.HostNamespaceAnnotation: testingutil.DefaultTestTargetNamespace,
 							},
 							Labels: map[string]string{
+								translate.MarkerLabel:    translate.VClusterName,
 								translate.NamespaceLabel: namespaceInVClusterA,
 							},
 						},
@@ -368,6 +369,7 @@ func TestReconcile(t *testing.T) {
 								translate.HostNameAnnotation:      translator.HostName(nil, "a", namespaceInVClusterA).Name,
 							},
 							Labels: map[string]string{
+								translate.MarkerLabel:    translate.VClusterName,
 								translate.NamespaceLabel: namespaceInVClusterA,
 							},
 						},
@@ -451,6 +453,7 @@ func TestReconcile(t *testing.T) {
 								translate.HostNamespaceAnnotation: testingutil.DefaultTestTargetNamespace,
 							},
 							Labels: map[string]string{
+								translate.MarkerLabel:    translate.VClusterName,
 								translate.NamespaceLabel: namespaceInVClusterA,
 							},
 						},

--- a/pkg/syncer/testing/testing.go
+++ b/pkg/syncer/testing/testing.go
@@ -225,14 +225,6 @@ func stripObject(obj runtime.Object) runtime.Object {
 		accessor.SetAnnotations(nil)
 	}
 
-	l := accessor.GetLabels()
-	if l != nil {
-		delete(l, "vcluster.loft.sh/managed-by")
-	}
-	if len(l) == 0 {
-		accessor.SetLabels(nil)
-	}
-
 	_, ok := newObj.(*unstructured.Unstructured)
 	if !ok {
 		typeAccessor, err := meta.TypeAccessor(newObj)

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -254,7 +254,7 @@ func ResetObjectMetadata(obj metav1.Object) {
 
 type ApplyMetadataOptions struct {
 	SetHostNameAndNamespaceAnnotations bool
-	ExcludeAnnotations []string
+	ExcludeAnnotations                 []string
 }
 
 // SyncHostMetadataToVirtual copies metadata from the host resource to the virtual resource.

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -253,6 +253,7 @@ func ResetObjectMetadata(obj metav1.Object) {
 }
 
 type ApplyMetadataOptions struct {
+	SetHostNameAndNamespaceAnnotations bool
 	ExcludeAnnotations []string
 }
 
@@ -275,9 +276,11 @@ type ApplyMetadataOptions struct {
 func ApplyVirtualMetadata(pObj client.Object, vObj client.Object, options ApplyMetadataOptions) {
 	labels, annotations := ApplyMetadata(pObj.GetAnnotations(), vObj.GetAnnotations(), pObj.GetLabels(), vObj.GetLabels(), options.ExcludeAnnotations...)
 	labels[MarkerLabel] = VClusterName
-	annotations[HostNameAnnotation] = pObj.GetName()
-	if pObj.GetNamespace() != "" {
-		annotations[HostNamespaceAnnotation] = pObj.GetNamespace()
+	if options.SetHostNameAndNamespaceAnnotations {
+		annotations[HostNameAnnotation] = pObj.GetName()
+		if pObj.GetNamespace() != "" {
+			annotations[HostNamespaceAnnotation] = pObj.GetNamespace()
+		}
 	}
 	vObj.SetAnnotations(annotations)
 	vObj.SetLabels(labels)

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -259,17 +259,17 @@ type ApplyMetadataOptions struct {
 // ApplyVirtualMetadata copies metadata from the host resource to the virtual resource.
 //
 // The following annotations are not copied from the host resource:
-//  - vcluster.loft.sh/managed-annotations
-//  - vcluster.loft.sh/managed-labels
+//   - vcluster.loft.sh/managed-annotations
+//   - vcluster.loft.sh/managed-labels
 //
 // In addition to copying the annotations from the host resource, this function also sets multiple vCluster annotations
 // on the virtual resource:
-//  - vcluster.loft.sh/object-host-name: host resource name, so you can easily identify from which host resource the
-//    virtual resource was created;
-//  - vcluster.loft.sh/object-host-namespace: host resource namespace (if the resource is namespaced).
+//   - vcluster.loft.sh/object-host-name: host resource name, so you can easily identify from which host resource the
+//     virtual resource was created;
+//   - vcluster.loft.sh/object-host-namespace: host resource namespace (if the resource is namespaced).
 //
 // It also sets the following labels on the virtual resource:
-//  - vcluster.loft.sh/managed-by: vCluster name, so you can know that the resource is managed by vCluster.
+//   - vcluster.loft.sh/managed-by: vCluster name, so you can know that the resource is managed by vCluster.
 //
 // When this function exists, virtual resource has annotations and labels maps created, even if they are empty.
 func ApplyVirtualMetadata(pObj client.Object, vObj client.Object, options ApplyMetadataOptions) {

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -261,15 +261,19 @@ type ApplyMetadataOptions struct {
 
 // SyncHostMetadataToVirtual copies metadata from the host resource to the virtual resource.
 //
-// The following annotations are not copied from the host resource:
-//   - vcluster.loft.sh/managed-annotations
-//   - vcluster.loft.sh/managed-labels
-//
 // In addition to copying the annotations from the host resource, this function also sets multiple vCluster annotations
 // on the virtual resource:
+//   - vcluster.loft.sh/managed-annotations: a multi-line string that contains keys of annotations that are copied from
+//     the host resource;
+//   - vcluster.loft.sh/managed-labels: a multi-line string that contains keys of labels that are copied from the host
+//     resource;
 //   - vcluster.loft.sh/object-host-name: host resource name, so you can easily identify from which host resource the
 //     virtual resource was created;
 //   - vcluster.loft.sh/object-host-namespace: host resource namespace (if the resource is namespaced).
+//
+// The following annotations are not copied from the host resource:
+//   - vcluster.loft.sh/managed-annotations
+//   - vcluster.loft.sh/managed-labels
 //
 // It also sets the following labels on the virtual resource:
 //   - vcluster.loft.sh/managed-by: vCluster name, so you can know that the resource is managed by vCluster.

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -257,7 +257,7 @@ type ApplyMetadataOptions struct {
 	ExcludeAnnotations []string
 }
 
-// ApplyVirtualMetadata copies metadata from the host resource to the virtual resource.
+// SyncHostMetadataToVirtual copies metadata from the host resource to the virtual resource.
 //
 // The following annotations are not copied from the host resource:
 //   - vcluster.loft.sh/managed-annotations
@@ -273,7 +273,7 @@ type ApplyMetadataOptions struct {
 //   - vcluster.loft.sh/managed-by: vCluster name, so you can know that the resource is managed by vCluster.
 //
 // When this function exists, virtual resource has annotations and labels maps created, even if they are empty.
-func ApplyVirtualMetadata(pObj client.Object, vObj client.Object, options ApplyMetadataOptions) {
+func SyncHostMetadataToVirtual(pObj client.Object, vObj client.Object, options ApplyMetadataOptions) {
 	labels, annotations := ApplyMetadata(pObj.GetAnnotations(), vObj.GetAnnotations(), pObj.GetLabels(), vObj.GetLabels(), options.ExcludeAnnotations...)
 	labels[MarkerLabel] = VClusterName
 	if options.SetHostNameAndNamespaceAnnotations {

--- a/pkg/util/translate/translate.go
+++ b/pkg/util/translate/translate.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -534,4 +536,10 @@ func KindExists(config *rest.Config, groupVersionKind schema.GroupVersionKind) (
 	}
 
 	return metav1.APIResource{}, kerrors.NewNotFound(schema.GroupResource{Group: groupVersionKind.Group}, groupVersionKind.Kind)
+}
+
+// ManagedKeysValue returns all map keys concatenated (and sorted) into a multi-line string (with
+// one key per line).
+func ManagedKeysValue(m map[string]string) string {
+	return strings.Join(slices.Sorted(maps.Keys(m)), "\n")
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Towards #ENG-5567


**Please provide a short message that should be published in the vcluster release notes**
Aligned how metadata is synced from host to virtual resources. Now all virtual resources that are synced from host have `vcluster.loft.sh/managed-by` label.


**What else do we need to know?** 

This PR basically doesn't add anything new, but it just (mostly) aligns how metadata is synced from host to virtual for different resource types. ~15% of are code changes, while ~85% are test additions/changes.

Here are the additions and changes:

🎯 The main change - now all virtual resources that are synced from host have `vcluster.loft.sh/managed-by` label. This enables us to then look up resources that are synced from host when we have to clean them up (after from host syncing has been disabled).

➕ New func `translate.SyncHostMetadataToVirtual(...)` has been added to `translate` package. Almost all resources now use this function to sync metadata from host to virtual. It is essentially extended version of the existing `ApplyMetadata()` func, which was already used for nodes metadata syncing (now with few more annotations and labels set).

➕ As a consequence of almost all FromHost syncers reusing the existing `ApplyMetadata(...)` func (through the new `SyncHostMetadataToVirtual`), now all virtual resources that are synced from host also have these annotations (like `Nodes` until now):
- `vcluster.loft.sh/managed-annotations` which shows which annotations have been synced from host resource
- `vcluster.loft.sh/managed-labels` which shows which annotations have been synced from host resource

ℹ️ `Nodes` FromHost syncer has minor refactoring changes, where `vcluster.loft.sh/managed-by` is not set in the syncer code, since it's now set in the `translate.SyncHostMetadataToVirtual(...)` func.

➕ The following FromHost syncers (and their tests) have been updated to use the new `translate.SyncHostMetadataToVirtual(...)` func and therefore set `vcluster.loft.sh/managed-by` label and `vcluster.loft.sh/managed-annotations` and `vcluster.loft.sh/managed-labels` annotations in the virtual resource after syncing it from host:
  - `CSIDrivers`
  - `CSINodes`
  - `IngressClasses`
  - `StorageClasses`
  - `Events`
  - generic `FromHostSyncer` implementation (used for `ConfigMaps` and `Secrets`)
  - **TODO**: Custom resources

🧪 ⚠️ `CSIStorageCapacities` FromHost syncer only has tests updated, because it currently has metadata syncing implementation which is different than `Nodes` (and almost all other resources), and changing it would be a breaking change. Since the current implementation looks suspicious (it syncs metadata from host to virtual with functions that are used for syncing the other way around - from virtual to host), I will check if this should be fixed.

🧪 New tests have been added for the following from host syncers (as they were missing before):
  - `StorageClasses`
    - Test syncing new host resource to virtual
    - Test syncing host resource changes to virtual
    - Test syncing deleted host resource to virtual
  - generic `FromHostSyncer` implementation (used for `ConfigMaps` and `Secrets`)
    - Test syncing new host resource to virtual
    - Test syncing host resource changes to virtual
    - Test syncing deleted host resource to virtual

🧪 Previously, the `vcluster.loft.sh/managed-by` label was being ignored in tests (it was stripped down before comparing existing to expected resources). Now the `vcluster.loft.sh/managed-by` label is not stripped down and it is checked in tests, since this label is functionally important (it was used also before this PR in some places to determine if the resource was synced from host to virtual). The syncer controller tests and the following syncer tests have been updated to include the label in their test code:
- ConfigMap
- Endpoints
- Nodes
- PriorityClasses
- RuntimeClasses
- Secrets
- ServiceAccounts
- StorageClasses
- VolumeSnapshotContents
