### PR TITLE
bugfix: do not assign a copy of platform config

### DIFF
--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -346,10 +346,10 @@ func (c *client) LoginWithAccessKey(host, accessKey string, insecure bool) error
 }
 
 func (c *client) mgmtLogin(host, accessKey string, insecure bool) error {
-	platformCfg := c.Config().Platform
-	platformCfg.Host = host
-	platformCfg.AccessKey = accessKey
-	platformCfg.Insecure = insecure
+	cfg := c.Config()
+	cfg.Platform.Host = host
+	cfg.Platform.AccessKey = accessKey
+	cfg.Platform.Insecure = insecure
 
 	// verify the connection works
 	managementClient, err := c.Management()


### PR DESCRIPTION
modify c.config inst…ead in  pkg/platform/client.go#client.mgmtLogin()

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform login was using incorrect access key


**What else do we need to know?** 
