### PR TITLE
add --migrate-from flag to syncer command in k3s chart if migrateFrom…

### DIFF
--- a/charts/k3s/templates/syncer.yaml
+++ b/charts/k3s/templates/syncer.yaml
@@ -211,6 +211,9 @@ spec:
           - --etcd-embedded
           - --etcd-replicas={{ include "vcluster.replicas" . }}
           {{- end }}
+          {{- if .Values.embeddedEtcd.migrateFromEtcd }}
+          - --migrate-from=https://{{ .Release.Name }}-etcd:2379
+          {{- end }}
           {{- end }}
           {{- if .Values.sync.nodes.enableScheduler }}
           - --enable-scheduler
@@ -369,6 +372,9 @@ spec:
               - --datastore-cafile=/data/pki/etcd/ca.crt
               - --datastore-certfile=/data/pki/apiserver-etcd-client.crt
               - --datastore-keyfile=/data/pki/apiserver-etcd-client.key
+              {{- end }}
+              {{- if .Values.embeddedEtcd.migrateFromEtcd }}
+              - --migrate-from=https://{{ .Release.Name }}-etcd:2379
               {{- end }}
               {{- end }}
               {{- range $f := .Values.vcluster.extraArgs }}

--- a/charts/k3s/tests/syncer_test.yaml
+++ b/charts/k3s/tests/syncer_test.yaml
@@ -84,7 +84,7 @@ tests:
             cpu: "100m"
             memory: "256Mi"
             ephemeral-storage: "512Mi"
-    
+
     asserts:
       - hasDocuments:
           count: 1
@@ -97,3 +97,17 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--reserved-resource-ephemeral-storage=512Mi"
+
+  - it: should pass migrate from flag if embedded etcd is enabled
+    set:
+      pro: true
+      embeddedEtcd:
+        enabled: true
+        migrateFromEtcd: true
+
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--migrate-from=https://RELEASE-NAME-etcd:2379"

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -184,7 +184,7 @@ syncer:
     # Size of the persistent volume claim
     size: 5Gi
     # The binariesVolume is used to retrieve distro specific executables to be run by the syncer
-    # This volume doesn't need to be persistent 
+    # This volume doesn't need to be persistent
     binariesVolume:
       - name: binaries
         emptyDir: {}
@@ -229,6 +229,9 @@ vcluster:
 embeddedEtcd:
   # If embedded etcd should be enabled, this is a PRO only feature
   enabled: false
+  # To use if embeddedEtcd is enabled and you want to migrate the data
+  # from the external etcd
+  migrateFromEtcd: false
 
 # list of {validating/mutating}webhooks that the syncer should proxy.
 # This is a PRO only feature.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6039


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `--migrate-from` flag for migration from external ETCD was not passed in k3s chart


**What else do we need to know?** 
