### PR TITLE
Filter vclusters owned by logged in user

### DIFF
--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -63,7 +63,7 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command) error {
 		return fmt.Errorf("parse driver type: %w", err)
 	}
 	if driverType == config.PlatformDriver {
-		return cli.ListPlatform(cobraCmd.Context(), &cmd.ListOptions, cmd.GlobalFlags, cmd.log, "")
+		return cli.ListPlatform(cobraCmd.Context(), &cmd.ListOptions, cmd.GlobalFlags, cmd.log, "", false)
 	}
 
 	return cli.ListHelm(cobraCmd.Context(), &cmd.ListOptions, cmd.GlobalFlags, cmd.log)

--- a/cmd/vclusterctl/cmd/platform/list/vclusters.go
+++ b/cmd/vclusterctl/cmd/platform/list/vclusters.go
@@ -17,6 +17,7 @@ type VClustersCmd struct {
 
 	log     log.Logger
 	Project string
+	owner   bool
 }
 
 // newVClustersCmd creates a new command
@@ -47,10 +48,11 @@ vcluster platform list vclusters
 	p, _ := defaults.Get(pdefaults.KeyProject, "")
 	cobraCmd.Flags().StringVarP(&cmd.Project, "project", "p", p, "The project to use")
 	cobraCmd.Flags().StringVar(&cmd.Output, "output", "table", "Choose the format of the output. [table|json]")
+	cobraCmd.Flags().BoolVar(&cmd.owner, "owner", false, "List vClusters owned by the currently logged-in user")
 
 	return cobraCmd
 }
 
 func (cmd *VClustersCmd) Run(ctx context.Context) error {
-	return cli.ListPlatform(ctx, &cmd.ListOptions, cmd.GlobalFlags, cmd.log, cmd.Project)
+	return cli.ListPlatform(ctx, &cmd.ListOptions, cmd.GlobalFlags, cmd.log, cmd.Project, cmd.owner)
 }

--- a/cmd/vclusterctl/cmd/platform/list/vclusters.go
+++ b/cmd/vclusterctl/cmd/platform/list/vclusters.go
@@ -47,7 +47,6 @@ vcluster platform list vclusters
 
 	p, _ := defaults.Get(pdefaults.KeyProject, "")
 	cobraCmd.Flags().StringVarP(&cmd.Project, "project", "p", p, "The project to use")
-	cobraCmd.Flags().StringVar(&cmd.Output, "output", "table", "Choose the format of the output. [table|json]")
 	cobraCmd.Flags().BoolVar(&cmd.owner, "owner", false, "List virtual clusters owned by the currently logged-in user")
 
 	AddCommonFlags(cobraCmd, &cmd.ListOptions)

--- a/cmd/vclusterctl/cmd/platform/list/vclusters.go
+++ b/cmd/vclusterctl/cmd/platform/list/vclusters.go
@@ -48,7 +48,7 @@ vcluster platform list vclusters
 	p, _ := defaults.Get(pdefaults.KeyProject, "")
 	cobraCmd.Flags().StringVarP(&cmd.Project, "project", "p", p, "The project to use")
 	cobraCmd.Flags().StringVar(&cmd.Output, "output", "table", "Choose the format of the output. [table|json]")
-	cobraCmd.Flags().BoolVar(&cmd.owner, "owner", false, "List vClusters owned by the currently logged-in user")
+	cobraCmd.Flags().BoolVar(&cmd.owner, "owner", false, "List virtual clusters owned by the currently logged-in user")
 
 	return cobraCmd
 }

--- a/pkg/cli/describe_platform.go
+++ b/pkg/cli/describe_platform.go
@@ -17,7 +17,7 @@ func DescribePlatform(ctx context.Context, globalFlags *flags.GlobalFlags, outpu
 		return err
 	}
 
-	proVClusters, err := platform.ListVClusters(ctx, platformClient, name, projectName)
+	proVClusters, err := platform.ListVClusters(ctx, platformClient, name, projectName, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -78,7 +78,7 @@ func CurrentContext() (string, *clientcmdapi.Config, error) {
 }
 
 func GetPlatformVCluster(ctx context.Context, platformClient platform.Client, name, project string, log log.Logger) (*platform.VirtualClusterInstanceProject, error) {
-	platformVClusters, err := platform.ListVClusters(ctx, platformClient, name, project)
+	platformVClusters, err := platform.ListVClusters(ctx, platformClient, name, project, false)
 	if err != nil {
 		log.Warnf("Error retrieving platform vclusters: %v", err)
 	}

--- a/pkg/cli/list_helm.go
+++ b/pkg/cli/list_helm.go
@@ -83,7 +83,7 @@ func printVClusters(ctx context.Context, options *ListOptions, output []ListVClu
 				ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 				defer cancel()
 
-				proVClusters, _ := platform.ListVClusters(ctx, platformClient, "", "")
+				proVClusters, _ := platform.ListVClusters(ctx, platformClient, "", "", false)
 				if len(proVClusters) > 0 {
 					logger.Infof("You also have %d virtual clusters in your platform driver context.", len(proVClusters))
 					logger.Info("If you want to see them, run: 'vcluster list --driver platform' or 'vcluster use driver platform' to change the default")

--- a/pkg/cli/list_platform.go
+++ b/pkg/cli/list_platform.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.GlobalFlags, logger log.Logger, projectName string) error {
+func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.GlobalFlags, logger log.Logger, projectName string, showUserOwned bool) error {
 	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).RawConfig()
 	if err != nil {
 		return err
@@ -27,7 +27,7 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 		return err
 	}
 
-	proVClusters, err := platform.ListVClusters(ctx, platformClient, "", projectName)
+	proVClusters, err := platform.ListVClusters(ctx, platformClient, "", projectName, showUserOwned)
 	if err != nil {
 		return err
 	}

--- a/pkg/platform/helper.go
+++ b/pkg/platform/helper.go
@@ -873,7 +873,7 @@ func RetrieveCaData(cluster *managementv1.Cluster) ([]byte, error) {
 
 // ListVClusters lists all virtual clusters across all projects if virtualClusterName and projectName are empty.
 // The list can be narrowed down by the given virtual cluster name and project name.
-func ListVClusters(ctx context.Context, client Client, virtualClusterName, projectName string) ([]*VirtualClusterInstanceProject, error) {
+func ListVClusters(ctx context.Context, client Client, virtualClusterName, projectName string, showUserOwned bool) ([]*VirtualClusterInstanceProject, error) {
 	managementClient, err := client.Management()
 	if err != nil {
 		return nil, err
@@ -891,14 +891,14 @@ func ListVClusters(ctx context.Context, client Client, virtualClusterName, proje
 			return nil, err
 		}
 
-		// gather space instances in those projects
+		// gather virtualcluster instances in those projects
 		if virtualClusterName != "" {
 			virtualClusterInstance, err := getProjectVirtualClusterInstance(ctx, managementClient, project, virtualClusterName)
 			if err == nil {
 				virtualClusters = append(virtualClusters, virtualClusterInstance)
 			}
 		} else {
-			virtualClusterInstances, err := getProjectVirtualClusterInstances(ctx, managementClient, project.Name)
+			virtualClusterInstances, err := getProjectVirtualClusterInstances(ctx, managementClient, project.Name, showUserOwned)
 			if err != nil {
 				return nil, err
 			}
@@ -916,7 +916,7 @@ func ListVClusters(ctx context.Context, client Client, virtualClusterName, proje
 			return nil, err
 		}
 
-		virtualClusterInstances, err := getProjectVirtualClusterInstances(ctx, managementClient, "")
+		virtualClusterInstances, err := getProjectVirtualClusterInstances(ctx, managementClient, "", showUserOwned)
 		if err != nil || len(virtualClusterInstances) == 0 {
 			return nil, err
 		}
@@ -1244,7 +1244,7 @@ func getProjectVirtualClusterInstance(ctx context.Context, managementClient kube
 	}, nil
 }
 
-func getProjectVirtualClusterInstances(ctx context.Context, managementClient kube.Interface, projectName string) ([]*managementv1.VirtualClusterInstance, error) {
+func getProjectVirtualClusterInstances(ctx context.Context, managementClient kube.Interface, projectName string, showUserOwned bool) ([]*managementv1.VirtualClusterInstance, error) {
 	virtualClusterInstanceList := &managementv1.VirtualClusterInstanceList{}
 	request := managementClient.Loft().ManagementV1().RESTClient().
 		Get().
@@ -1265,8 +1265,43 @@ func getProjectVirtualClusterInstances(ctx context.Context, managementClient kub
 			continue
 		}
 
+		if showUserOwned {
+			isOwner, err := isUserOwner(ctx, managementClient, &virtualClusterInstance)
+			if err != nil {
+				return nil, err
+			}
+			if !isOwner {
+				continue
+			}
+		}
+
 		v := virtualClusterInstance
 		virtualClusters = append(virtualClusters, &v)
 	}
 	return virtualClusters, nil
+}
+
+func isUserOwner(ctx context.Context, managementClient kube.Interface, vcInstance *managementv1.VirtualClusterInstance) (bool, error) {
+	user, _, err := GetCurrentUser(ctx, managementClient)
+	if err != nil {
+		return false, err
+	}
+
+	if user == nil {
+		return false, fmt.Errorf("no user or team found for the current logged-in user")
+	}
+
+	return vcInstance.Spec.Owner.User == user.Username || isUserTeamOwner(user.Teams, vcInstance.Spec.Owner.Team), nil
+}
+
+func isUserTeamOwner(teams []*storagev1.EntityInfo, vclusterOwnerTeam string) bool {
+	var isOwner bool
+	for _, team := range teams {
+		if team.Name == vclusterOwnerTeam {
+			isOwner = true
+			break
+
+		}
+	}
+	return isOwner
 }

--- a/pkg/platform/helper.go
+++ b/pkg/platform/helper.go
@@ -1300,7 +1300,6 @@ func isUserTeamOwner(teams []*storagev1.EntityInfo, vclusterOwnerTeam string) bo
 		if team.Name == vclusterOwnerTeam {
 			isOwner = true
 			break
-
 		}
 	}
 	return isOwner

--- a/pkg/platform/helper.go
+++ b/pkg/platform/helper.go
@@ -1295,12 +1295,10 @@ func isUserOwner(ctx context.Context, managementClient kube.Interface, vcInstanc
 }
 
 func isUserTeamOwner(teams []*storagev1.EntityInfo, vclusterOwnerTeam string) bool {
-	var isOwner bool
 	for _, team := range teams {
 		if team.Name == vclusterOwnerTeam {
-			isOwner = true
-			break
+			return true
 		}
 	}
-	return isOwner
+	return false
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6351
resolves ENG-5468


**Please provide a short message that should be published in the vcluster release notes**
Users can list vclusters by logged-in user by new flag `--owner` added to `vcluster platform list vclusters --owner`


**What else do we need to know?** 

**Tests Executed :**

**Test Setup:**
- Added 3 Users `AK`, `Test User1` and `Test User2` to vcluster platform
- Added a team `default-team` which has only 1 member `TestUser1`
- Added 4 vclusters : 1 owned by `AK` user, 1 owned by  `TestUser1`, 1 owned by team `default-team` and 1 owned by user `TestUser2`

![Screenshot from 2025-04-04 12-49-45](https://github.com/user-attachments/assets/98dae52a-9958-440f-84f7-fe82f2c9b510)

**Testcase executed**:   `go run ./cmd/vclusterctl/main.go platform list vclusters --owner`

**Expected Results:**
- User `AK` should be able to only list vcluster `vcluster-5r2ds`
- User `Test User1` should be able to list 2 vclusters vcluster owned by him and the vcluster owned by team `default-team` since he is member of the team i.e `vcluster-z8f8q` and `vcluster-d9q27`
- User `Test User2` should only be able to list 1 vcluster i.e `vcluster-74f77`

**Actual results:**
- When `AK` logs in using CLI:
![Screenshot from 2025-04-04 12-59-46](https://github.com/user-attachments/assets/d93c9d95-9ad7-42ff-bebc-25e838c1e104)

- When `Test User1` logs in using CLI:
![Screenshot from 2025-04-04 13-00-47](https://github.com/user-attachments/assets/30ddd14a-654f-40bf-b1ab-6ce187e851d2)

- When `Test User2` logs in using CLI:
![Screenshot from 2025-04-04 13-01-45](https://github.com/user-attachments/assets/6799a2ae-f0e6-4967-bc42-b9622823b34a)


