### PR TITLE
Add basic ServiceSyncer unit tests

### DIFF
--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -7,7 +7,11 @@ import (
 	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -44,9 +48,11 @@ func TestFromHostRegister(t *testing.T) {
 
 func TestFromHostReconcile(t *testing.T) {
 	testCases := []struct {
-		Name     string
-		Mappings map[string]types.NamespacedName
-		Request  ctrl.Request
+		Name                    string
+		Mappings                map[string]types.NamespacedName
+		Request                 ctrl.Request
+		InitialHostServices     []runtime.Object
+		ExpectedVirtualServices []runtime.Object
 	}{
 		{
 			Name: "Service is not synced",
@@ -78,15 +84,70 @@ func TestFromHostReconcile(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Sync host service to new virtual service",
+			InitialHostServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "host-namespace",
+						Name:      "host-service",
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "host-app",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name: "http",
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+			ExpectedVirtualServices: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "virtual-namespace",
+						Name:      "virtual-service",
+						Labels: map[string]string{
+							translate.ControllerLabel: "vcluster",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Ports: []corev1.ServicePort{
+							{
+								Name: "http",
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+			Mappings: map[string]types.NamespacedName{
+				"host-namespace/host-service": {
+					Namespace: "virtual-namespace",
+					Name:      "virtual-service",
+				},
+			},
+			Request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "host-namespace",
+					Name:      "host-service",
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			name := "test-map-host-service-syncer"
-			pClient := testingutil.NewFakeClient(scheme.Scheme)
+			pClient := testingutil.NewFakeClient(scheme.Scheme, testCase.InitialHostServices...)
 			vClient := testingutil.NewFakeClient(scheme.Scheme)
 			fakeConfig := testingutil.NewFakeConfig()
 			fakeContext := syncertesting.NewFakeRegisterContext(fakeConfig, pClient, vClient)
+			serviceGVK := corev1.SchemeGroupVersion.WithKind("Service")
 
 			// create new FromHost syncer
 			serviceSyncer := &ServiceSyncer{
@@ -106,6 +167,22 @@ func TestFromHostReconcile(t *testing.T) {
 
 			// Check that reconcile executes without errors
 			assert.NilError(t, err)
+
+			// Check expected resources
+			if testCase.ExpectedVirtualServices != nil {
+				compareErr := syncertesting.CompareObjs(
+					fakeContext,
+					t,
+					testCase.Name+" virtual state",
+					fakeContext.VirtualManager.GetClient(),
+					serviceGVK,
+					scheme.Scheme,
+					testCase.ExpectedVirtualServices,
+					nil)
+				if err != nil {
+					t.Fatalf("%s - Virtual State mismatch %v", testCase.Name, compareErr)
+				}
+			}
 		})
 	}
 }

--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -1,0 +1,39 @@
+package servicesync
+
+import (
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRegister(t *testing.T) {
+	name := "test-map-host-service-syncer"
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	fakeConfig := testingutil.NewFakeConfig()
+	fakeContext := syncertesting.NewFakeRegisterContext(fakeConfig, pClient, vClient)
+	fakeMapping := map[string]types.NamespacedName{
+		"host-namespace/host-service": {
+			Namespace: "virtual-namespace",
+			Name:      "virtual-service",
+		},
+	}
+	serviceSyncer := &ServiceSyncer{
+		Name:            name,
+		SyncContext:     fakeContext.ToSyncContext(name),
+		SyncServices:    fakeMapping,
+		CreateNamespace: true,
+		CreateEndpoints: true,
+		From:            fakeContext.PhysicalManager,
+		To:              fakeContext.VirtualManager,
+		Log:             loghelper.New(name),
+	}
+
+	err := serviceSyncer.Register()
+	assert.NilError(t, err)
+}

--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -179,7 +179,7 @@ func TestFromHostReconcile(t *testing.T) {
 					scheme.Scheme,
 					testCase.ExpectedVirtualServices,
 					nil)
-				if err != nil {
+				if compareErr != nil {
 					t.Fatalf("%s - Virtual State mismatch %v", testCase.Name, compareErr)
 				}
 			}

--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestRegister(t *testing.T) {
+func TestFromHostRegister(t *testing.T) {
 	name := "test-map-host-service-syncer"
 	pClient := testingutil.NewFakeClient(scheme.Scheme)
 	vClient := testingutil.NewFakeClient(scheme.Scheme)
@@ -23,15 +23,18 @@ func TestRegister(t *testing.T) {
 			Name:      "virtual-service",
 		},
 	}
+
+	// create new FromHost syncer
 	serviceSyncer := &ServiceSyncer{
-		Name:            name,
-		SyncContext:     fakeContext.ToSyncContext(name),
-		SyncServices:    fakeMapping,
-		CreateNamespace: true,
-		CreateEndpoints: true,
-		From:            fakeContext.PhysicalManager,
-		To:              fakeContext.VirtualManager,
-		Log:             loghelper.New(name),
+		Name:                  name,
+		SyncContext:           fakeContext.ToSyncContext(name),
+		SyncServices:          fakeMapping,
+		CreateNamespace:       true,
+		CreateEndpoints:       true,
+		From:                  fakeContext.PhysicalManager,
+		IsVirtualToHostSyncer: false,
+		To:                    fakeContext.VirtualManager,
+		Log:                   loghelper.New(name),
 	}
 
 	err := serviceSyncer.Register()

--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -55,7 +55,7 @@ func TestFromHostReconcile(t *testing.T) {
 		ExpectedVirtualServices []runtime.Object
 	}{
 		{
-			Name: "Service is not synced",
+			Name: "Reconcile without errors when service is not synced",
 			Mappings: map[string]types.NamespacedName{
 				"host-namespace/host-service": {
 					Namespace: "virtual-namespace",

--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -63,6 +63,21 @@ func TestFromHostReconcile(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Reconcile without errors when host and virtual services are not found",
+			Mappings: map[string]types.NamespacedName{
+				"host-namespace/host-service": {
+					Namespace: "virtual-namespace",
+					Name:      "virtual-service",
+				},
+			},
+			Request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "host-namespace",
+					Name:      "host-service",
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
towards #ENG-5567

**Please provide a short message that should be published in the vcluster release notes**
Add basic unit tests for ServiceSyncer.


**What else do we need to know?** 
This PR is adding basic unit tests that would serve as a basic safety net when making changes needed to fix #ENG-5567. It's not trying to cover all possible service replication scenarios and there are definitely more tests that should be added.

Work on #ENG-5567 got stuck (pending decision on how to proceed forward), but these tests I wrote while doing that work add value on their own, so opening a PR here to add them, regardless of how we proceed with work on #ENG-5567.