### PR TITLE
when CLI creates platform credentials secret, set vCluster service as…

### DIFF
--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/blang/semver"
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
@@ -23,6 +22,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -127,8 +127,8 @@ func ApplyPlatformSecret(
 					Kind:               "Service",
 					Name:               vClusterService.Name,
 					UID:                vClusterService.UID,
-					Controller:         ptr.Bool(true),
-					BlockOwnerDeletion: ptr.Bool(false),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(false),
 				},
 			}
 		}

--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -106,8 +106,6 @@ func ApplyPlatformSecret(
 	if err != nil && !kerrors.IsNotFound(err) {
 		return fmt.Errorf("error getting platform secret %s/%s: %w", namespace, DefaultPlatformSecretName, err)
 	} else if kerrors.IsNotFound(err) {
-		// try to find vCluster service
-		vClusterService, svcErr := kubeClient.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      DefaultPlatformSecretName,
@@ -118,6 +116,8 @@ func ApplyPlatformSecret(
 			},
 			Data: secretPayload,
 		}
+		// try to find vCluster service
+		vClusterService, svcErr := kubeClient.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		if svcErr == nil {
 			// set virtual cluster service as an owner for platform secret, so it can be cleaned up by kubernetes GC controller
 			// once virtual cluster is uninstalled


### PR DESCRIPTION
… an owner, so it gets cleaned up when virtual cluster is deleted

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of ENG-6304


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform secret is not deleted when virtual cluster no longer exists


**What else do we need to know?** 
