### PR TITLE
Add option to skip host namespace verification when saving mappings

### DIFF
--- a/pkg/controllers/generic/import_syncer.go
+++ b/pkg/controllers/generic/import_syncer.go
@@ -346,7 +346,7 @@ func (s *importer) isVirtualManaged(vObj client.Object) bool {
 	return vObj.GetAnnotations() != nil && vObj.GetAnnotations()[translate.ControllerLabel] != "" && vObj.GetAnnotations()[translate.ControllerLabel] == s.Name()
 }
 
-func (s *importer) IsManaged(ctx *synccontext.SyncContext, pObj client.Object) (bool, error) {
+func (s *importer) IsManaged(_ *synccontext.SyncContext, pObj client.Object) (bool, error) {
 	if s.syncerOptions.IsClusterScopedCRD {
 		return true, nil
 	}
@@ -355,7 +355,7 @@ func (s *importer) IsManaged(ctx *synccontext.SyncContext, pObj client.Object) (
 	}
 
 	// check if the pObj belong to a namespace managed by this vcluster
-	if !translate.Default.IsTargetedNamespace(ctx, pObj.GetNamespace()) {
+	if !translate.Default.IsTargetedNamespace(pObj.GetNamespace()) {
 		return false, nil
 	}
 

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -286,7 +286,7 @@ func (s *persistentVolumeSyncer) shouldSync(ctx *synccontext.SyncContext, pObj *
 			return true, nil, nil
 		}
 
-		return translate.Default.IsTargetedNamespace(ctx, pObj.Spec.ClaimRef.Namespace) && pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
+		return translate.Default.IsTargetedNamespace(pObj.Spec.ClaimRef.Namespace) && pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
 	}
 
 	vPvc := &corev1.PersistentVolumeClaim{}
@@ -298,7 +298,7 @@ func (s *persistentVolumeSyncer) shouldSync(ctx *synccontext.SyncContext, pObj *
 			return true, nil, nil
 		}
 
-		return translate.Default.IsTargetedNamespace(ctx, pObj.Spec.ClaimRef.Namespace) && pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
+		return translate.Default.IsTargetedNamespace(pObj.Spec.ClaimRef.Namespace) && pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
 	}
 
 	return true, vPvc, nil

--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/services"
 	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/mappings/store/verify"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
@@ -437,6 +438,7 @@ func (e *ServiceSyncer) saveMapping(ctx context.Context, result syncResult) erro
 		},
 	}
 
+	ctx = context.WithValue(ctx, verify.SkipHostNamespaceCheck, true)
 	err := e.SyncContext.Mappings.Store().AddReferenceAndSave(ctx, mapping, mapping)
 	if err != nil {
 		return fmt.Errorf("error while saving mapping %s: %w", mapping.String(), err)

--- a/pkg/mappings/store/store.go
+++ b/pkg/mappings/store/store.go
@@ -25,7 +25,7 @@ const (
 	GarbageCollectionTimeout  = 15 * time.Second
 )
 
-type VerifyMapping func(mapping synccontext.NameMapping) bool
+type VerifyMapping func(ctx context.Context, mapping synccontext.NameMapping) bool
 
 func NewStore(ctx context.Context, cachedVirtualClient, cachedHostClient client.Client, backend Backend) (synccontext.MappingsStore, error) {
 	return NewStoreWithVerifyMapping(ctx, cachedVirtualClient, cachedHostClient, backend, nil)
@@ -275,7 +275,7 @@ func (s *Store) start(ctx context.Context) error {
 
 	for _, mapping := range mappings {
 		// verify mapping if needed
-		if s.verifyMapping != nil && !s.verifyMapping(mapping.NameMapping) {
+		if s.verifyMapping != nil && !s.verifyMapping(ctx, mapping.NameMapping) {
 			continue
 		}
 
@@ -323,7 +323,7 @@ func (s *Store) handleEvent(ctx context.Context, watchEvent BackendWatchResponse
 		}
 
 		// verify mapping if needed
-		if event.Type == BackendWatchEventTypeUpdate && s.verifyMapping != nil && !s.verifyMapping(event.Mapping.NameMapping) {
+		if event.Type == BackendWatchEventTypeUpdate && s.verifyMapping != nil && !s.verifyMapping(ctx, event.Mapping.NameMapping) {
 			continue
 		}
 
@@ -444,7 +444,7 @@ func (s *Store) AddReference(ctx context.Context, nameMapping, belongsTo synccon
 	}
 
 	// verify mapping if needed
-	if s.verifyMapping != nil && !s.verifyMapping(nameMapping) {
+	if s.verifyMapping != nil && !s.verifyMapping(ctx, nameMapping) {
 		return nil
 	}
 

--- a/pkg/mappings/store/verify/verify.go
+++ b/pkg/mappings/store/verify/verify.go
@@ -1,26 +1,37 @@
 package verify
 
 import (
+	"context"
+
 	"github.com/loft-sh/vcluster/pkg/mappings/store"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func NewVerifyMapping(ctx *synccontext.SyncContext) store.VerifyMapping {
-	return func(mapping synccontext.NameMapping) bool {
+const (
+	SkipHostNamespaceCheck = "mappings.store.verify.SkipHostNamespaceCheck"
+)
+
+func NewVerifyMapping() store.VerifyMapping {
+	return func(ctx context.Context, mapping synccontext.NameMapping) bool {
 		return CheckHostObject(ctx, mapping.Host())
 	}
 }
 
-func CheckHostObject(ctx *synccontext.SyncContext, hostObject synccontext.Object) bool {
+func CheckHostObject(ctx context.Context, hostObject synccontext.Object) bool {
+	skipHostNamespaceCheck, ok := ctx.Value(SkipHostNamespaceCheck).(bool)
+	if ok && skipHostNamespaceCheck {
+		return true
+	}
+
 	// we don't allow mappings that are not within targeted namespaces
-	if hostObject.Namespace != "" && !translate.Default.IsTargetedNamespace(ctx, hostObject.Namespace) {
+	if hostObject.Namespace != "" && !translate.Default.IsTargetedNamespace(hostObject.Namespace) {
 		return false
 	}
 
 	// we don't allow namespace mappings that are not within targeted namespaces
-	if hostObject.GroupVersionKind.String() == corev1.SchemeGroupVersion.WithKind("Namespace").String() && !translate.Default.IsTargetedNamespace(ctx, hostObject.Name) {
+	if hostObject.GroupVersionKind.String() == corev1.SchemeGroupVersion.WithKind("Namespace").String() && !translate.Default.IsTargetedNamespace(hostObject.Name) {
 		return false
 	}
 

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -404,7 +404,7 @@ func initControllerContext(
 		virtualManager.GetClient(),
 		localManager.GetClient(),
 		store.NewEtcdBackend(etcdClient),
-		verify.NewVerifyMapping(controllerContext.ToRegisterContext().ToSyncContext("verify-mapping")),
+		verify.NewVerifyMapping(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("start mapping store: %w", err)

--- a/pkg/syncer/testing/context.go
+++ b/pkg/syncer/testing/context.go
@@ -71,7 +71,7 @@ func NewFakeRegisterContext(vConfig *config.VirtualClusterConfig, pClient *testi
 	}
 
 	// create new store
-	mappingsStore, _ := store.NewStoreWithVerifyMapping(ctx, vClient, pClient, store.NewMemoryBackend(), verify.NewVerifyMapping(registerCtx.ToSyncContext("verify-mapping")))
+	mappingsStore, _ := store.NewStoreWithVerifyMapping(ctx, vClient, pClient, store.NewMemoryBackend(), verify.NewVerifyMapping())
 	registerCtx.Mappings = mappings.NewMappingsRegistry(mappingsStore)
 
 	// make sure we do not ensure any CRDs

--- a/pkg/util/translate/multi_namespace.go
+++ b/pkg/util/translate/multi_namespace.go
@@ -59,7 +59,7 @@ func (s *multiNamespace) IsManaged(ctx *synccontext.SyncContext, pObj client.Obj
 	// If obj is not in the synced namespace OR
 	// If object-name annotation is not set OR
 	// If object-name annotation is different from actual name
-	if !s.IsTargetedNamespace(ctx, pObj.GetNamespace()) || pObj.GetAnnotations()[NameAnnotation] == "" {
+	if !s.IsTargetedNamespace(pObj.GetNamespace()) || pObj.GetAnnotations()[NameAnnotation] == "" {
 		return false
 	} else if pObj.GetAnnotations()[KindAnnotation] != "" {
 		gvk, err := apiutil.GVKForObject(pObj, scheme.Scheme)
@@ -87,7 +87,7 @@ func (s *multiNamespace) LabelsToTranslate() map[string]bool {
 	}
 }
 
-func (s *multiNamespace) IsTargetedNamespace(_ *synccontext.SyncContext, pNamespace string) bool {
+func (s *multiNamespace) IsTargetedNamespace(pNamespace string) bool {
 	return strings.HasPrefix(pNamespace, s.getNamespacePrefix()) && strings.HasSuffix(pNamespace, getNamespaceSuffix(s.currentNamespace, VClusterName))
 }
 

--- a/pkg/util/translate/single_namespace.go
+++ b/pkg/util/translate/single_namespace.go
@@ -81,7 +81,7 @@ func (s *singleNamespace) IsManaged(ctx *synccontext.SyncContext, pObj client.Ob
 	}
 
 	// is object not in our target namespace?
-	if !s.IsTargetedNamespace(ctx, pObj.GetNamespace()) {
+	if !s.IsTargetedNamespace(pObj.GetNamespace()) {
 		return false
 	}
 
@@ -131,7 +131,7 @@ func (s *singleNamespace) IsManaged(ctx *synccontext.SyncContext, pObj client.Ob
 	return true
 }
 
-func (s *singleNamespace) IsTargetedNamespace(_ *synccontext.SyncContext, pNamespace string) bool {
+func (s *singleNamespace) IsTargetedNamespace(pNamespace string) bool {
 	return pNamespace == s.targetNamespace
 }
 

--- a/pkg/util/translate/types.go
+++ b/pkg/util/translate/types.go
@@ -41,7 +41,7 @@ type Translator interface {
 	IsManaged(ctx *synccontext.SyncContext, pObj client.Object) bool
 
 	// IsTargetedNamespace checks if the provided namespace is a sync target for vcluster
-	IsTargetedNamespace(ctx *synccontext.SyncContext, namespace string) bool
+	IsTargetedNamespace(namespace string) bool
 
 	// MarkerLabelCluster returns the marker label for the cluster scoped object
 	MarkerLabelCluster() string


### PR DESCRIPTION
> [!warning]
> Do not merge!

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
towards #ENG-5567


**Please provide a short message that should be published in the vcluster release notes**
Added option to skip host namespace verification when saving mappings for replicated services.


**What else do we need to know?** 
Services can be replicated from any namespace on host/virtual cluster to any namespace on virtual/host cluster, so the existing host resource namespace verification does not apply in this case.

This PR builds on top of https://github.com/loft-sh/vcluster/pull/2658 and ATM the purpose of this PR is just to review the potential solutions for #ENG-5567.