### PR TITLE
Add sync direction to mappings in store (only for replicated services)

### DIFF
--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -417,12 +417,15 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 
 func (e *ServiceSyncer) saveMapping(ctx context.Context, result syncResult) error {
 	var pObj, vObj client.Object
+	var syncDirection synccontext.SyncDirection
 	if e.IsVirtualToHostSyncer {
 		vObj = result.fromObject
 		pObj = result.toObject
+		syncDirection = synccontext.SyncVirtualToHost
 	} else {
 		vObj = result.toObject
 		pObj = result.fromObject
+		syncDirection = synccontext.SyncHostToVirtual
 	}
 
 	// Save synced service to mappings store
@@ -436,6 +439,7 @@ func (e *ServiceSyncer) saveMapping(ctx context.Context, result syncResult) erro
 			Namespace: vObj.GetNamespace(),
 			Name:      vObj.GetName(),
 		},
+		SyncDirection: syncDirection,
 	}
 
 	ctx = context.WithValue(ctx, verify.SkipHostNamespaceCheck, true)

--- a/pkg/syncer/synccontext/mapper.go
+++ b/pkg/syncer/synccontext/mapper.go
@@ -47,8 +47,14 @@ type MappingsStore interface {
 	// HasHostObject checks if the store has a mapping for the host object
 	HasHostObject(ctx context.Context, pObj Object) bool
 
+	// HasHostObjectSyncedFromVirtual checks if the store has a mapping for the host object that was synced from virtual
+	HasHostObjectSyncedFromVirtual(ctx context.Context, pObj Object) bool
+
 	// HasVirtualObject checks if the store has a mapping for the virtual object
 	HasVirtualObject(ctx context.Context, pObj Object) bool
+
+	// HasVirtualObjectSyncedFromHost checks if the store has a mapping for the virtual object that was synced from host
+	HasVirtualObjectSyncedFromHost(ctx context.Context, vObj Object) bool
 
 	// AddReferenceAndSave adds a reference mapping and directly saves the mapping
 	AddReferenceAndSave(ctx context.Context, nameMapping, belongsTo NameMapping) error
@@ -177,11 +183,13 @@ func NewNameMappingFrom(pObj, vObj client.Object) (NameMapping, error) {
 type NameMapping struct {
 	schema.GroupVersionKind
 
-	VirtualName types.NamespacedName
-	HostName    types.NamespacedName
+	VirtualName   types.NamespacedName
+	HostName      types.NamespacedName
+	SyncDirection SyncDirection
 }
 
 func (n NameMapping) Equals(other NameMapping) bool {
+	// TODO check if SyncDirection should be included into equality check, as this might affect the existing mappings
 	return n.Host().Equals(other.Host()) && n.Virtual().Equals(other.Virtual())
 }
 
@@ -208,5 +216,6 @@ func (n NameMapping) String() string {
 		n.GroupVersionKind.String(),
 		n.VirtualName.String(),
 		n.HostName.String(),
+		string(n.SyncDirection),
 	}, ";")
 }


### PR DESCRIPTION
> [!warning]
> Do not merge!

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
towards #ENG-5567


**Please provide a short message that should be published in the vcluster release notes**
Added sync direction to mappings in store (for replicated services).


**What else do we need to know?** 
When replication/sync config is removed fro vCluster config, we need to know which service to delete. By saving sync direction in the mappings store, we can know which service, host or virtual, is the original, and which one is the replica.

This PR builds on top of https://github.com/loft-sh/vcluster/pull/2659 and ATM the purpose of this PR is just to review the potential solutions for #ENG-5567.