### PR TITLE
Add a prompt for deleting cleanup finalizers when connector secret is not found

### DIFF
--- a/pkg/cli/util/args.go
+++ b/pkg/cli/util/args.go
@@ -9,6 +9,8 @@ import (
 	"github.com/loft-sh/log/survey"
 	"github.com/loft-sh/log/terminal"
 	"github.com/spf13/cobra"
+
+	agentstoragev1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/storage/v1"
 )
 
 var (
@@ -29,7 +31,7 @@ var (
 	NegativeResponse = "no"
 )
 
-const DbConnectorSecretNotFound = "DbConnectorSecretNotFound"
+const DBConnectorSecretNotFound agentstoragev1.ConditionType = "DBConnectorSecretNotFound"
 
 func init() {
 	NamespaceNameOnlyUseLine, NamespaceNameOnlyValidator = NamedPositionalArgsValidator(true, true, "NAMESPACE_NAME")

--- a/pkg/cli/util/args.go
+++ b/pkg/cli/util/args.go
@@ -31,7 +31,11 @@ var (
 	NegativeResponse = "no"
 )
 
-const DBConnectorSecretNotFound agentstoragev1.ConditionType = "DBConnectorSecretNotFound"
+const (
+	InstanceVirtualClusterDBConnectorSynced agentstoragev1.ConditionType = "DBConnectorSynced"
+
+	DBConnectorSecretNotFound string = "DBConnectorSecretNotFound"
+)
 
 func init() {
 	NamespaceNameOnlyUseLine, NamespaceNameOnlyValidator = NamedPositionalArgsValidator(true, true, "NAMESPACE_NAME")

--- a/pkg/cli/util/args.go
+++ b/pkg/cli/util/args.go
@@ -23,7 +23,13 @@ var (
 var (
 	ErrNonInteractive   = errors.New("terminal is not interactive")
 	ErrTooManyArguments = errors.New("too many arguments specified")
+
+	// prompt responses
+	PositiveResponse = "yes"
+	NegativeResponse = "no"
 )
+
+const DbConnectorSecretNotFound = "DbConnectorSecretNotFound"
 
 func init() {
 	NamespaceNameOnlyUseLine, NamespaceNameOnlyValidator = NamedPositionalArgsValidator(true, true, "NAMESPACE_NAME")


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5245


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform deletion gets stuck due to finalizer not getting removed. Added a prompt allowing user to remove the finalizer and continue the destroy op.


**What else do we need to know?** 
The platform code changes regarding this are in [this PR](https://github.com/loft-sh/loft-enterprise/pull/4116).
The prompt would look like this:
![Screenshot from 2025-04-18 18-06-15](https://github.com/user-attachments/assets/e08672a0-895b-4988-bc94-6748d511676d)

