### PR TITLE
fix: CLI from expecting secret name when listing secrets

### DIFF
--- a/cmd/vclusterctl/cmd/platform/get/secret.go
+++ b/cmd/vclusterctl/cmd/platform/get/secret.go
@@ -54,12 +54,23 @@ vcluster platform get secret test-secret.key
 vcluster platform get secret test-secret.key --project myproject
 ########################################################
 	`)
+
 	useLine, validator := util.NamedPositionalArgsValidator(true, true, "SECRET_NAME")
 	c := &cobra.Command{
 		Use:   "secret" + useLine,
 		Short: "Returns the key value of a project / shared secret",
 		Long:  description,
-		Args:  validator,
+		Args: func(cmd *cobra.Command, args []string) error {
+			// bypass validation if the "all" flag is set
+			all, err := cmd.Flags().GetBool("all")
+			if err != nil {
+				return err
+			}
+			if !all {
+				return validator(cmd, args)
+			}
+			return nil
+		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},


### PR DESCRIPTION
CLI expects secret name when trying to list all secrets in a namespace

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5650


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster CLI fails to list all secrets due to missing secret name


**What else do we need to know?** 
