### PR TITLE
chore: bumps helm and kine version to fix CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG KINE_VERSION="v0.13.8"
+ARG KINE_VERSION="v0.13.14"
 FROM rancher/kine:${KINE_VERSION} AS kine
 
 # Build program
@@ -9,7 +9,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG BUILD_VERSION=dev
 ARG TELEMETRY_PRIVATE_KEY=""
-ARG HELM_VERSION="v3.17.0"
+ARG HELM_VERSION="v3.17.3"
 
 # Install kubectl for development
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl

--- a/Dockerfile.cli.release
+++ b/Dockerfile.cli.release
@@ -1,7 +1,7 @@
 # we use alpine for easier debugging
 FROM alpine:3.21
 
-ARG HELM_VERSION="v3.17.0"
+ARG HELM_VERSION="v3.17.3"
 ARG TARGETARCH
 
 # Set root path as working directory

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-ARG KINE_VERSION="v0.13.8"
+ARG KINE_VERSION="v0.13.14"
 FROM rancher/kine:${KINE_VERSION} AS kine
 
 # Build the manager binary
@@ -9,7 +9,7 @@ WORKDIR /vcluster-dev
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG HELM_VERSION="v3.17.0"
+ARG HELM_VERSION="v3.17.3"
 
 # Add curl
 RUN apk add --no-cache curl


### PR DESCRIPTION
This PR bumps the version of helm to 3.17.3 and kine to 0.13.14 to fix CVE

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5980


**Please provide a short message that should be published in the vcluster release notes**
Bumped helm (3.17.3) and kine (0.13.14) versions

**What else do we need to know?** 
