### PR TITLE
Fix vcluster delete CLI when "Prevent deletion" is enabled via platform

### DIFF
--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -77,7 +77,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	if driverType == config.PlatformDriver {
-		return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, cfg, args[0], cmd.log)
+		return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, args[0], cmd.log)
 	}
 
 	return cli.DeleteHelm(ctx, platformClient, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -71,14 +71,14 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// check if there is a platform client or we skip the info message
-	_, err = platform.InitClientFromConfig(ctx, cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cfg)
 	if err == nil {
 		config.PrintDriverInfo("delete", driverType, cmd.log)
 	}
 
 	if driverType == config.PlatformDriver {
-		return cli.DeletePlatform(ctx, &cmd.DeleteOptions, cfg, args[0], cmd.log)
+		return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, cfg, args[0], cmd.log)
 	}
 
-	return cli.DeleteHelm(ctx, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
+	return cli.DeleteHelm(ctx, platformClient, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
 }

--- a/cmd/vclusterctl/cmd/platform/delete/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/delete/vcluster.go
@@ -2,6 +2,8 @@ package deletecmd
 
 import (
 	"context"
+	"fmt"
+	"github.com/loft-sh/vcluster/pkg/platform"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
@@ -54,5 +56,13 @@ vcluster platform delete vcluster --namespace test
 
 // Run executes the functionality
 func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
-	return cli.DeletePlatform(ctx, &cmd.DeleteOptions, cmd.LoadedConfig(cmd.log), args[0], cmd.log)
+	cfg := cmd.LoadedConfig(cmd.log)
+
+	// check if there is a platform client or we skip the info message
+	platformClient, err := platform.InitClientFromConfig(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("init platform client: %w", err)
+	}
+
+	return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, cmd.LoadedConfig(cmd.log), args[0], cmd.log)
 }

--- a/cmd/vclusterctl/cmd/platform/delete/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/delete/vcluster.go
@@ -3,7 +3,6 @@ package deletecmd
 import (
 	"context"
 	"fmt"
-	"github.com/loft-sh/vcluster/pkg/platform"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
@@ -11,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	flagsdelete "github.com/loft-sh/vcluster/pkg/cli/flags/delete"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/vclusterctl/cmd/platform/delete/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/delete/vcluster.go
@@ -64,5 +64,5 @@ func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("init platform client: %w", err)
 	}
 
-	return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, cmd.LoadedConfig(cmd.log), args[0], cmd.log)
+	return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, args[0], cmd.log)
 }

--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -265,9 +265,6 @@ func (cmd *deleteHelm) deleteVClusterInPlatform(ctx context.Context, platformCli
 	cmd.log.Debugf("found %d matching virtualclusterinstances", len(toDelete))
 
 	for _, virtualClusterInstance := range toDelete {
-		if nonDeletableValue, ok := virtualClusterInstance.Annotations[NonDeletableAnnotation]; ok && nonDeletableValue == "true" {
-			return fmt.Errorf("deletion of virtual cluster %s is prevented, disable \"Prevent Deletion\" via platform in order to delete this virtual cluster", vClusterName)
-		}
 		cmd.log.Infof("Delete virtual cluster instance %s/%s in platform", virtualClusterInstance.Namespace, virtualClusterInstance.Name)
 		err = managementClient.Loft().ManagementV1().VirtualClusterInstances(virtualClusterInstance.Namespace).Delete(ctx, virtualClusterInstance.Name, metav1.DeleteOptions{})
 		if err != nil {

--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -73,11 +73,8 @@ func DeleteHelm(ctx context.Context, platformClient platform.Client, options *De
 	}
 
 	// Check if vCluster is created via platform and has deletion prevention enabled
-	if vCluster.VirtualClusterInstance != nil {
-		// check if virtual cluster is protected
-		if nonDeletable, ok := vCluster.VirtualClusterInstance.Annotations[NonDeletableAnnotation]; ok && nonDeletable == "true" {
-			return fmt.Errorf("deletion of virtual cluster %s is prevented, disable \"Prevent Deletion\" via platform in order to delete this virtual cluster", vClusterName)
-		}
+	if vCluster.HasPreventDeletionEnabled() {
+		return fmt.Errorf("deletion of virtual cluster %s is prevented, disable \"Prevent Deletion\" via platform in order to delete this virtual cluster", vClusterName)
 	}
 
 	// prepare client

--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -50,7 +50,7 @@ type deleteHelm struct {
 	log log.Logger
 }
 
-func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+func DeleteHelm(ctx context.Context, platformClient platform.Client, options *DeleteOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	cmd := deleteHelm{
 		GlobalFlags:   globalFlags,
 		DeleteOptions: options,
@@ -76,6 +76,14 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 	err = cmd.prepare(vCluster)
 	if err != nil {
 		return err
+	}
+
+	if platformClient != nil {
+		cmd.log.Debugf("deleting vcluster in platform")
+		err = cmd.deleteVClusterInPlatform(ctx, platformClient, vClusterName)
+		if err != nil {
+			return fmt.Errorf("deleting vcluster in platform failed: %w", err)
+		}
 	}
 
 	// test for helm
@@ -104,12 +112,6 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 		}
 	}
 
-	// get service uid
-	vClusterService, err := cmd.kubeClient.CoreV1().Services(cmd.Namespace).Get(ctx, vClusterName, metav1.GetOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("error retrieving vcluster service: %w", err)
-	}
-
 	// we have to delete the chart
 	cmd.log.Infof("Delete vcluster %s...", vClusterName)
 	err = helm.NewClient(cmd.rawConfig, cmd.log, helmBinaryPath).Delete(vClusterName, cmd.Namespace)
@@ -121,17 +123,6 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 	// delete priorityclasses
 	if err = deletePriorityClasses(ctx, cmd, vClusterName); err != nil {
 		return err
-	}
-
-	// try to delete the vCluster in the platform
-	if vClusterService != nil {
-		cmd.log.Debugf("deleting vcluster in platform")
-		err = cmd.deleteVClusterInPlatform(ctx, vClusterService)
-		if err != nil {
-			return err
-		}
-	} else {
-		cmd.log.Warn("vcluster service not found, could not delete in platform")
 	}
 
 	// try to delete the pvc
@@ -235,13 +226,7 @@ func DeleteHelm(ctx context.Context, options *DeleteOptions, globalFlags *flags.
 	return nil
 }
 
-func (cmd *deleteHelm) deleteVClusterInPlatform(ctx context.Context, vClusterService *corev1.Service) error {
-	platformClient, err := platform.InitClientFromConfig(ctx, cmd.LoadedConfig(cmd.log))
-	if err != nil {
-		cmd.log.Debugf("Error creating platform client: %v", err)
-		return nil
-	}
-
+func (cmd *deleteHelm) deleteVClusterInPlatform(ctx context.Context, platformClient platform.Client, vClusterName string) error {
 	managementClient, err := platformClient.Management()
 	if err != nil {
 		cmd.log.Debugf("Error creating management client: %v", err)
@@ -254,7 +239,16 @@ func (cmd *deleteHelm) deleteVClusterInPlatform(ctx context.Context, vClusterSer
 		return nil
 	}
 
-	toDelete := []managementv1.VirtualClusterInstance{}
+	// get service uid
+	vClusterService, err := cmd.kubeClient.CoreV1().Services(cmd.Namespace).Get(ctx, vClusterName, metav1.GetOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("error retrieving vcluster service: %w", err)
+	} else if kerrors.IsNotFound(err) {
+		cmd.log.Warn("vcluster service not found, could not delete in platform")
+		return nil
+	}
+
+	var toDelete []managementv1.VirtualClusterInstance
 	for _, virtualClusterInstance := range virtualClusterInstances.Items {
 		if virtualClusterInstance.Status.ServiceUID != "" && virtualClusterInstance.Status.ServiceUID == string(vClusterService.UID) {
 			toDelete = append(toDelete, virtualClusterInstance)
@@ -263,6 +257,9 @@ func (cmd *deleteHelm) deleteVClusterInPlatform(ctx context.Context, vClusterSer
 	cmd.log.Debugf("found %d matching virtualclusterinstances", len(toDelete))
 
 	for _, virtualClusterInstance := range toDelete {
+		if nonDeletableValue, ok := virtualClusterInstance.Annotations[NonDeletableAnnotation]; ok && nonDeletableValue == "true" {
+			return fmt.Errorf("deletion of virtual cluster %s is prevented, disable \"Prevent Deletion\" via platform in order to delete this virtual cluster", vClusterName)
+		}
 		cmd.log.Infof("Delete virtual cluster instance %s/%s in platform", virtualClusterInstance.Namespace, virtualClusterInstance.Name)
 		err = managementClient.Loft().ManagementV1().VirtualClusterInstances(virtualClusterInstance.Namespace).Delete(ctx, virtualClusterInstance.Name, metav1.DeleteOptions{})
 		if err != nil {

--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -72,6 +72,14 @@ func DeleteHelm(ctx context.Context, platformClient platform.Client, options *De
 		return nil
 	}
 
+	// Check if vCluster is created via platform and has deletion prevention enabled
+	if vCluster.VirtualClusterInstance != nil {
+		// check if virtual cluster is protected
+		if nonDeletable, ok := vCluster.VirtualClusterInstance.Annotations[NonDeletableAnnotation]; ok && nonDeletable == "true" {
+			return fmt.Errorf("deletion of virtual cluster %s is prevented, disable \"Prevent Deletion\" via platform in order to delete this virtual cluster", vClusterName)
+		}
+	}
+
 	// prepare client
 	err = cmd.prepare(vCluster)
 	if err != nil {

--- a/pkg/cli/delete_platform.go
+++ b/pkg/cli/delete_platform.go
@@ -13,10 +13,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	NonDeletableAnnotation = "loft.sh/non-deletable"
-)
-
 func DeletePlatform(ctx context.Context, platformClient platform.Client, options *DeleteOptions, vClusterName string, log log.Logger) error {
 	if platformClient == nil {
 		return fmt.Errorf("platform client not set")

--- a/pkg/cli/delete_platform.go
+++ b/pkg/cli/delete_platform.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/loft-sh/log"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/kube"
@@ -18,7 +17,7 @@ const (
 	NonDeletableAnnotation = "loft.sh/non-deletable"
 )
 
-func DeletePlatform(ctx context.Context, platformClient platform.Client, options *DeleteOptions, config *config.CLI, vClusterName string, log log.Logger) error {
+func DeletePlatform(ctx context.Context, platformClient platform.Client, options *DeleteOptions, vClusterName string, log log.Logger) error {
 	if platformClient == nil {
 		return fmt.Errorf("platform client not set")
 	}

--- a/pkg/cli/delete_platform.go
+++ b/pkg/cli/delete_platform.go
@@ -14,10 +14,13 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func DeletePlatform(ctx context.Context, options *DeleteOptions, config *config.CLI, vClusterName string, log log.Logger) error {
-	platformClient, err := platform.InitClientFromConfig(ctx, config)
-	if err != nil {
-		return err
+const (
+	NonDeletableAnnotation = "loft.sh/non-deletable"
+)
+
+func DeletePlatform(ctx context.Context, platformClient platform.Client, options *DeleteOptions, config *config.CLI, vClusterName string, log log.Logger) error {
+	if platformClient == nil {
+		return fmt.Errorf("platform client not set")
 	}
 
 	// retrieve the vcluster

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -237,7 +237,7 @@ func ListVClusters(ctx context.Context, context, name, namespace string, log log
 	}
 
 	// check if VirtualClusterInstances CRD exists
-	_, err = kubeClient.ApiExtensions().ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "virtualclusterinstances.management.loft.sh", metav1.GetOptions{})
+	_, err = kubeClient.APIExtensions().ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "virtualclusterinstances.management.loft.sh", metav1.GetOptions{})
 	if err != nil {
 		// VirtualClusterInstances CRD not found. This usually the case with OSS vCluster.
 		if kerrors.IsNotFound(err) {

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -244,6 +244,18 @@ func ListVClusters(ctx context.Context, context, name, namespace string, log log
 		log.Warnf("Error retrieving vclusters: %v", err)
 	}
 
+	// check if VirtualClusterInstances CRD exists
+	_, err = kubeClient.ApiExtensions().ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "virtualclusterinstances.management.loft.sh", metav1.GetOptions{})
+	if err != nil {
+		// VirtualClusterInstances CRD not found. This usually the case with OSS vCluster.
+		if kerrors.IsNotFound(err) {
+			log.Debug("virtualclusterinstances.management.loft.sh CustomResourceDefinition not found, will not check virtual cluster on the platform")
+		} else {
+			log.Warnf("Error retrieving virtualclusterinstances.management.loft.sh CRD: %v", err)
+		}
+		return vClusters, nil
+	}
+
 	listOptions := metav1.ListOptions{}
 	if name != "" {
 		listOptions.FieldSelector = "metadata.name=" + name

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -665,7 +665,9 @@ func isPaused(v client.Object) bool {
 // on the server.
 func isVirtualClusterInstanceResourceAvailable(discoveryClient discovery.DiscoveryInterface) (bool, error) {
 	resources, err := discoveryClient.ServerResourcesForGroupVersion(storagev1.SchemeGroupVersion.String())
-	if err != nil {
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
 		return false, fmt.Errorf("failed to retrieve server resources for group/version '%s': %w", storagev1.GroupVersion.String(), err)
 	}
 

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -666,7 +666,7 @@ func isPaused(v client.Object) bool {
 func isVirtualClusterInstanceResourceAvailable(discoveryClient discovery.DiscoveryInterface) (bool, error) {
 	resources, err := discoveryClient.ServerResourcesForGroupVersion(storagev1.SchemeGroupVersion.String())
 	if err != nil {
-		return false, fmt.Errorf("failed to retrieve server resources for group/version '%s': %v", storagev1.GroupVersion.String(), err)
+		return false, fmt.Errorf("failed to retrieve server resources for group/version '%s': %w", storagev1.GroupVersion.String(), err)
 	}
 
 	for _, resource := range resources.APIResources {

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -7,11 +7,14 @@ import (
 	"strings"
 	"time"
 
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/survey"
 	"github.com/loft-sh/log/terminal"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/kube"
 	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
@@ -20,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -28,19 +30,20 @@ import (
 const VirtualClusterSelector = "app=vcluster"
 
 type VCluster struct {
-	ClientFactory clientcmd.ClientConfig `json:"-"`
-	Pods          []corev1.Pod           `json:"-"`
-	Deployment    *appsv1.Deployment     `json:"-"`
-	StatefulSet   *appsv1.StatefulSet    `json:"-"`
-	Created       metav1.Time
-	Name          string
-	Namespace     string
-	ServiceName   string
-	Annotations   map[string]string
-	Labels        map[string]string
-	Status        Status
-	Context       string
-	Version       string
+	ClientFactory          clientcmd.ClientConfig               `json:"-"`
+	Pods                   []corev1.Pod                         `json:"-"`
+	Deployment             *appsv1.Deployment                   `json:"-"`
+	StatefulSet            *appsv1.StatefulSet                  `json:"-"`
+	VirtualClusterInstance *managementv1.VirtualClusterInstance `json:"-"`
+	Created                metav1.Time
+	Name                   string
+	Namespace              string
+	ServiceName            string
+	Annotations            map[string]string
+	Labels                 map[string]string
+	Status                 Status
+	Context                string
+	Version                string
 }
 
 type Status string
@@ -224,15 +227,51 @@ func ListVClusters(ctx context.Context, context, name, namespace string, log log
 		}
 	}
 
-	ossVClusters, err := ListOSSVClusters(ctx, context, name, namespace)
+	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
+		CurrentContext: context,
+	})
+	restConfig, err := kubeClientConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube client config: %w", err)
+	}
+	kubeClient, err := kube.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	vClusters, err := ListOSSVClusters(ctx, kubeClient, context, name, namespace)
 	if err != nil {
 		log.Warnf("Error retrieving vclusters: %v", err)
 	}
 
-	return ossVClusters, nil
+	virtualClusterInstancesList, err := kubeClient.Loft().ManagementV1().VirtualClusterInstances(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list virtual cluster instances: %w", err)
+	}
+	var virtualClusterInstances map[string]*managementv1.VirtualClusterInstance
+	for _, virtualClusterInstance := range virtualClusterInstancesList.Items {
+		namespacedName := types.NamespacedName{
+			Namespace: virtualClusterInstance.Namespace,
+			Name:      virtualClusterInstance.Name,
+		}.String()
+		virtualClusterInstances[namespacedName] = &virtualClusterInstance
+	}
+
+	// Pair found VirtualClusterInstances to OSS virtual clusters.
+	for i := range vClusters {
+		namespacedName := types.NamespacedName{
+			Namespace: vClusters[i].Namespace,
+			Name:      vClusters[i].Name,
+		}.String()
+		if virtualClusterInstance, ok := virtualClusterInstances[namespacedName]; ok {
+			vClusters[i].VirtualClusterInstance = virtualClusterInstance
+		}
+	}
+
+	return vClusters, nil
 }
 
-func ListOSSVClusters(ctx context.Context, context, name, namespace string) ([]VCluster, error) {
+func ListOSSVClusters(ctx context.Context, kubeClient kube.Interface, context, name, namespace string) ([]VCluster, error) {
 	var err error
 
 	timeout := time.Minute
@@ -241,13 +280,13 @@ func ListOSSVClusters(ctx context.Context, context, name, namespace string) ([]V
 		timeout = time.Second * 5
 	}
 
-	vclusters, err := findInContext(ctx, context, name, namespace, timeout, false)
+	vclusters, err := findInContext(ctx, kubeClient, context, name, namespace, timeout, false)
 	if err != nil && vClusterName == "" {
 		return nil, errors.Wrap(err, "find vcluster")
 	}
 
 	if vClusterName != "" {
-		parentContextVClusters, err := findInContext(ctx, vClusterContext, name, namespace, time.Minute, true)
+		parentContextVClusters, err := findInContext(ctx, kubeClient, vClusterContext, name, namespace, time.Minute, true)
 		if err != nil {
 			return nil, errors.Wrap(err, "find vcluster")
 		}
@@ -302,25 +341,11 @@ func VClusterFromContext(originalContext string) (name string, namespace string,
 	return originalContext, "", ""
 }
 
-func findInContext(ctx context.Context, context, name, namespace string, timeout time.Duration, isParentContext bool) ([]VCluster, error) {
+func findInContext(ctx context.Context, kubeClient kube.Interface, context, name, namespace string, timeout time.Duration, isParentContext bool) ([]VCluster, error) {
 	vclusters := []VCluster{}
 	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
 		CurrentContext: context,
 	})
-	restConfig, err := kubeClientConfig.ClientConfig()
-	if err != nil {
-		// we can ignore this error for parent context, it just means that the kubeconfig set doesn't have parent config in it.
-		if isParentContext {
-			logger := log.GetInstance()
-			logger.Warn("parent context unreachable - No vClusters listed from parent context")
-			return vclusters, nil
-		}
-		return nil, errors.Wrap(err, "load kube config")
-	}
-	kubeClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "create kube client")
-	}
 
 	// statefulset based vclusters
 	statefulSets, err := getStatefulSets(ctx, kubeClient, namespace, kubeClientConfig, timeout)
@@ -383,7 +408,7 @@ func findInContext(ctx context.Context, context, name, namespace string, timeout
 	return vclusters, nil
 }
 
-func getVCluster(ctx context.Context, object client.Object, context, release string, client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig) (VCluster, error) {
+func getVCluster(ctx context.Context, object client.Object, context, release string, client kube.Interface, kubeClientConfig clientcmd.ClientConfig) (VCluster, error) {
 	namespace := object.GetNamespace()
 	created := object.GetCreationTimestamp()
 	releaseName := ""
@@ -448,7 +473,7 @@ func getVCluster(ctx context.Context, object client.Object, context, release str
 	}, nil
 }
 
-func getPods(ctx context.Context, client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig, namespace, podSelector string) (*corev1.PodList, error) {
+func getPods(ctx context.Context, client kube.Interface, kubeClientConfig clientcmd.ClientConfig, namespace, podSelector string) (*corev1.PodList, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
@@ -470,7 +495,7 @@ func getPods(ctx context.Context, client *kubernetes.Clientset, kubeClientConfig
 	return podList, nil
 }
 
-func getDeployments(ctx context.Context, client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.DeploymentList, error) {
+func getDeployments(ctx context.Context, client kube.Interface, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.DeploymentList, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -492,7 +517,7 @@ func getDeployments(ctx context.Context, client *kubernetes.Clientset, namespace
 	return deploymentList, nil
 }
 
-func getStatefulSets(ctx context.Context, client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.StatefulSetList, error) {
+func getStatefulSets(ctx context.Context, client kube.Interface, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.StatefulSetList, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/pkg/cli/find/kubeclient.go
+++ b/pkg/cli/find/kubeclient.go
@@ -1,0 +1,30 @@
+package find
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/vcluster/pkg/platform/kube"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func createKubeClientConfig(context string) clientcmd.ClientConfig {
+	configOverrides := &clientcmd.ConfigOverrides{
+		CurrentContext: context,
+	}
+	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), configOverrides)
+	return kubeClientConfig
+}
+
+func createKubeClient(context string) (kube.Interface, error) {
+	kubeClientConfig := createKubeClientConfig(context)
+	restConfig, err := kubeClientConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube client config: %w", err)
+	}
+	kubeClient, err := kube.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	return kubeClient, nil
+}

--- a/pkg/platform/kube/client.go
+++ b/pkg/platform/kube/client.go
@@ -13,7 +13,7 @@ import (
 
 type Interface interface {
 	kubernetes.Interface
-	ApiExtensions() apiextensions.Interface
+	APIExtensions() apiextensions.Interface
 	Loft() loftclient.Interface
 	Agent() agentloftclient.Interface
 }
@@ -54,7 +54,7 @@ type client struct {
 	agentLoftClient     agentloftclient.Interface
 }
 
-func (c *client) ApiExtensions() apiextensions.Interface {
+func (c *client) APIExtensions() apiextensions.Interface {
 	return c.apiExtensionsClient
 }
 

--- a/pkg/platform/kube/client.go
+++ b/pkg/platform/kube/client.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 type Interface interface {
 	kubernetes.Interface
-	APIExtensions() apiextensions.Interface
 	Loft() loftclient.Interface
 	Agent() agentloftclient.Interface
 }
@@ -22,11 +20,6 @@ func NewForConfig(c *rest.Config) (Interface, error) {
 	kubeClient, err := kubernetes.NewForConfig(c)
 	if err != nil {
 		return nil, errors.Wrap(err, "create kube client")
-	}
-
-	apiExtensionsClient, err := apiextensions.NewForConfig(c)
-	if err != nil {
-		return nil, errors.Wrap(err, "create api extensions client")
 	}
 
 	loftClient, err := loftclient.NewForConfig(c)
@@ -40,22 +33,16 @@ func NewForConfig(c *rest.Config) (Interface, error) {
 	}
 
 	return &client{
-		Interface:           kubeClient,
-		apiExtensionsClient: apiExtensionsClient,
-		loftClient:          loftClient,
-		agentLoftClient:     agentLoftClient,
+		Interface:       kubeClient,
+		loftClient:      loftClient,
+		agentLoftClient: agentLoftClient,
 	}, nil
 }
 
 type client struct {
 	kubernetes.Interface
-	apiExtensionsClient apiextensions.Interface
-	loftClient          loftclient.Interface
-	agentLoftClient     agentloftclient.Interface
-}
-
-func (c *client) APIExtensions() apiextensions.Interface {
-	return c.apiExtensionsClient
+	loftClient      loftclient.Interface
+	agentLoftClient agentloftclient.Interface
 }
 
 func (c *client) Loft() loftclient.Interface {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
fixes ENG-6256


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster delete` command would delete virtual clusters with `loft.sh/non-deletable: true`.


**What else do we need to know?** 

This fix has certain limitations. See the following scenarios where those limitations are described.

**1\. You are logged into the host cluster (where the platform runs).**

✅ In this case `vcluster delete` can always see if "Prevent deletion" is enabled for any cluster, so command fails correctly for protected clusters.

In this scenario it also doesn't matter if you are logged into the platform or not, and platform version does not matter, because `vcluster delete` directly checks `VirtualClusterInstance` CR.

**2\. You are logged into the connected host cluster (the platform is running on a different host cluster).**

Here we have two different sub-cases:

- ✅ You are logged into the platform. In this case `vcluster delete` fails correctly for any cluster that has "Prevent deletion" enabled, because it first tries to delete the virtual cluster via platform, which fails as expected.

- ⚠️ When you are NOT logged into the platform, there are few additional conditions for the check to work.
    - ✅ Virtual cluster is created with platform version 4.3.0 or newer (or had its config updated with platform version 4.3.0 or newer). `vcluster delete` fails correctly, as it checks the StatefulSet/Deployment annotation that is added in platform version 4.3.0.
   - :x: Virtual cluster is created with platform version older than 4.3.0 (and didn't have its config updated with platform version 4.3.0 or newer). `vcluster delete` still incorrectly deletes the cluster, because it doesn't see neither VirtualClusterInstance CR nor the annotation that the platform 4.3.0 sets.