### PR TITLE
[v0.24] Platform should start with last released stable version, by default

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.0.0-alpha.18"
+	MinimumVersionTag = "v4.2.3"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 

--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -50,7 +50,7 @@ func LatestCompatibleVersion(ctx context.Context) (string, error) {
 		return MinimumVersionTag, nil
 	}
 
-	eligibleReleases := lo.FilterMap(releases, func(release *github.RepositoryRelease, _ int) (semver.Version, bool) {
+	eligibleStableReleases := lo.FilterMap(releases, func(release *github.RepositoryRelease, _ int) (semver.Version, bool) {
 		tagName := release.GetTagName()
 		if tagName == "" {
 			return semver.Version{}, false
@@ -61,15 +61,19 @@ func LatestCompatibleVersion(ctx context.Context) (string, error) {
 			return semver.Version{}, false
 		}
 
+		// skip the pre-releases (alpha, rc etc.), in semVer stable releases don't contain "-"
+		if strings.Contains(ghVersion.String(), "-") {
+			return semver.Version{}, false
+		}
 		return ghVersion, ghVersion.GTE(MinimumVersion)
 	})
 
-	sort.Slice(eligibleReleases, func(i, j int) bool {
-		return eligibleReleases[i].LT(eligibleReleases[j])
+	sort.Slice(eligibleStableReleases, func(i, j int) bool {
+		return eligibleStableReleases[i].LT(eligibleStableReleases[j])
 	})
 
-	if len(eligibleReleases) > 0 {
-		return "v" + eligibleReleases[len(eligibleReleases)-1].String(), nil
+	if len(eligibleStableReleases) > 0 {
+		return "v" + eligibleStableReleases[len(eligibleStableReleases)-1].String(), nil
 	}
 
 	return MinimumVersionTag, nil

--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -61,8 +61,8 @@ func LatestCompatibleVersion(ctx context.Context) (string, error) {
 			return semver.Version{}, false
 		}
 
-		// skip the pre-releases (alpha, rc etc.), in semVer stable releases don't contain "-"
-		if strings.Contains(ghVersion.String(), "-") {
+		// skip the pre-releases (alpha, rc, etc.)
+		if len(ghVersion.Pre) != 0 {
 			return semver.Version{}, false
 		}
 		return ghVersion, ghVersion.GTE(MinimumVersion)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6469


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform start command installs the platform with latest version even if that is an alpha or rc version. Ideally, it should start with last stable release version, for eg. v4.2.3


**What else do we need to know?** 
