### PR TITLE
build: add update-cache workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,6 +34,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'loft-sh' # do not run on forks
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   golangci:
     name: lint
+    if: github.repository_owner == 'loft-sh' # do not run on forks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   helm-unit-tests:
     name: Execute all helm tests
+    if: github.repository_owner == 'loft-sh' # do not run on forks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,6 +37,7 @@ jobs:
 
   go-unit-test:
     name: Execute all go tests
+    if: github.repository_owner == 'loft-sh' # do not run on forks
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/update-cache.yaml
+++ b/.github/workflows/update-cache.yaml
@@ -1,0 +1,49 @@
+name: update-cache
+
+on:
+  push:
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-cache:
+    if: github.repository_owner == 'loft-sh' # do not run on forks
+    runs-on: ubuntu-latest
+    name: Build Cache
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        id: cache
+        with:
+          go-version-file: go.mod
+
+      - name: Setup GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+          version: latest
+
+      - name: Build and save syncer image
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          set -x
+          # Build syncer
+          TELEMETRY_PRIVATE_KEY="" goreleaser build --single-target --snapshot --id vcluster --clean --output ./vcluster
+          docker build -t "${{ env.REPOSITORY_NAME }}:${{ env.TAG_NAME }}" -f Dockerfile.release --build-arg TARGETARCH=amd64 --build-arg TARGETOS=linux .
+          docker save -o vcluster_syncer "${{ env.REPOSITORY_NAME }}:${{ env.TAG_NAME }}"
+          # Build cli
+          TELEMETRY_PRIVATE_KEY="" goreleaser build --single-target --snapshot --id vcluster-cli --clean --output ./vcluster
+          # Build tests for cache
+          go test -mod=vendor -test.v -c ./test/e2e


### PR DESCRIPTION
The reason we need this extra workflow is that github actions by default does not allow cache sharing across branches / forks / prs. The workaround to mitigate this issue is to build the binaries and tests as soon as a PR is merged and dependencies are changed and then this cache can be reused across all branches. For more information check https://medium.com/@everton.spader/how-to-cache-package-dependencies-between-branches-with-github-actions-e6a19f33783a