### PR TITLE
fix: using insecure in exportKubeConfig

### DIFF
--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -261,8 +261,20 @@ func CreateVClusterKubeConfigForExport(ctx context.Context, virtualConfig *rest.
 				Server:                   options.ExportKubeConfig.Server,
 				Extensions:               make(map[string]runtime.Object),
 				CertificateAuthorityData: cluster.CertificateAuthorityData,
-				InsecureSkipTLSVerify:    options.ExportKubeConfig.Insecure,
 			}
+		}
+	}
+
+	// is insecure?
+	if options.ExportKubeConfig.Insecure {
+		// set insecure skip tls verify and remove certificate authority data
+		for key, cluster := range syncerConfigToExport.Clusters {
+			if cluster == nil {
+				continue
+			}
+
+			syncerConfigToExport.Clusters[key].InsecureSkipTLSVerify = true
+			syncerConfigToExport.Clusters[key].CertificateAuthorityData = nil
 		}
 	}
 

--- a/pkg/setup/controllers_test.go
+++ b/pkg/setup/controllers_test.go
@@ -158,6 +158,50 @@ func TestExportKubeConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Export default kubeconfig with insecure",
+			syncerConfig: clientcmdapi.Config{
+				CurrentContext: testContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					testUser: {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {
+						CertificateAuthorityData: []byte("test-ca"),
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					testContext: {
+						Cluster:  testCluster,
+						AuthInfo: testUser,
+					},
+				},
+			},
+			options: CreateKubeConfigOptions{
+				ControlPlaneProxy: testControlPlaneProxy,
+				ExportKubeConfig: config.ExportKubeConfigProperties{
+					Insecure: true,
+				},
+			},
+			expectedKubeConfig: clientcmdapi.Config{
+				CurrentContext: testContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					testUser: {},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					testCluster: {
+						Server:                fmt.Sprintf("https://localhost:%d", testControlPlanePort),
+						InsecureSkipTLSVerify: true,
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					testContext: {
+						Cluster:  testCluster,
+						AuthInfo: testUser,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where using `exportKubeConfig.insecure` would yield an error when trying to connect to the vCluster since insecure and ca data would be set for the server.
