### PR TITLE
Disallow multiple vclusters creation inside same namespace

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1373,10 +1373,6 @@
           "type": "array",
           "description": "DenyProxyRequests denies certain requests in the vCluster proxy.",
           "pro": true
-        },
-        "reuseNamespace": {
-          "type": "boolean",
-          "description": "ReuseNamespace allows reusing the same namespace to create multiple vClusters.\nThis flag is deprecated, as this scenario will be removed entirely in upcoming releases."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1039,10 +1039,6 @@ experimental:
       extraRules: []
     role:
       extraRules: []
-  
-  # ReuseNamespace allows reusing the same namespace to create multiple vClusters.
-  # This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
-  reuseNamespace: false
 
 # Configuration related to telemetry gathered about vCluster usage.
 telemetry:

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -99,7 +99,7 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	for _, v := range vClusters {
 		if v.Namespace == vConfig.ControlPlaneNamespace && v.Name != vClusterName {
 			return fmt.Errorf("there is already a virtual cluster in namespace %s; "+
-				"creating multiple virtual clusters inside the same namespace is not allowed", vConfig.ControlPlaneNamespace)
+				"creating multiple virtual clusters inside the same namespace is not supported", vConfig.ControlPlaneNamespace)
 		}
 	}
 

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -98,8 +98,8 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	// from v0.25 onwards, creation of multiple vClusters inside the same ns is not allowed
 	for _, v := range vClusters {
 		if v.Namespace == vConfig.ControlPlaneNamespace && v.Name != vClusterName {
-			return fmt.Errorf("there is already a virtual cluster in namespace %s\n "+
-				"creating multiple vclusters inside the same namespace is not allowed", vConfig.ControlPlaneNamespace)
+			return fmt.Errorf("there is already a virtual cluster in namespace %s; "+
+				"creating multiple virtual clusters inside the same namespace is not allowed", vConfig.ControlPlaneNamespace)
 		}
 	}
 

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -94,22 +94,12 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 	if err != nil {
 		return err
 	}
-	var vClusterExists bool
+
+	// from v0.25 onwards, creation of multiple vClusters inside the same ns is not allowed
 	for _, v := range vClusters {
 		if v.Namespace == vConfig.ControlPlaneNamespace && v.Name != vClusterName {
-			vClusterExists = true
-			break
-		}
-	}
-	// add a deprecation warning for multiple vCluster creation scenario
-	if vClusterExists {
-		logger.Warnf("Please note that creating multiple virtual clusters in the same namespace " +
-			"and the 'reuseNamespace' config are deprecated and will be removed soon.")
-
-		// throw an error if reuseNamespace config is not set
-		if !vConfig.Experimental.ReuseNamespace {
-			return fmt.Errorf("there is already a virtual cluster in namespace %s. To create multiple virtual clusters "+
-				"within the same namespace, it is mandatory to set 'reuse-namespace' to true in vCluster config", vConfig.ControlPlaneNamespace)
+			return fmt.Errorf("there is already a virtual cluster in namespace %s\n "+
+				"creating multiple vclusters inside the same namespace is not allowed", vConfig.ControlPlaneNamespace)
 		}
 	}
 

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -22,8 +22,7 @@ type CreateCmd struct {
 	*flags.GlobalFlags
 	cli.CreateOptions
 
-	log            log.Logger
-	reuseNamespace bool
+	log log.Logger
 }
 
 // NewCreateCmd creates a new command
@@ -66,9 +65,6 @@ vcluster create test --namespace test
 	}
 
 	cobraCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm or platform.")
-	cobraCmd.Flags().BoolVar(&cmd.reuseNamespace, "reuse-namespace", false, "Allows to create multiple virtual clusters in a single namespace")
-	cobraCmd.Flag("reuse-namespace").Hidden = true
-	_ = cobraCmd.Flags().MarkDeprecated("reuse-namespace", "creation of multiple virtual clusters within the same namespace is deprecated.")
 
 	create.AddCommonFlags(cobraCmd, &cmd.CreateOptions)
 	create.AddHelmFlags(cobraCmd, &cmd.CreateOptions)
@@ -101,6 +97,5 @@ func (cmd *CreateCmd) Run(ctx context.Context, args []string) error {
 	if driver == config.PlatformDriver {
 		return cli.CreatePlatform(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log)
 	}
-
-	return cli.CreateHelm(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log, cmd.reuseNamespace)
+	return cli.CreateHelm(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2071,10 +2071,6 @@ type Experimental struct {
 
 	// DenyProxyRequests denies certain requests in the vCluster proxy.
 	DenyProxyRequests []DenyRule `json:"denyProxyRequests,omitempty" product:"pro"`
-
-	// ReuseNamespace allows reusing the same namespace to create multiple vClusters.
-	// This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
-	ReuseNamespace bool `json:"reuseNamespace,omitempty"`
 }
 
 func (e Experimental) JSONSchemaExtend(base *jsonschema.Schema) {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -581,7 +581,5 @@ experimental:
     role:
       extraRules: []
 
-  reuseNamespace: false
-
 telemetry:
   enabled: true

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -149,8 +149,8 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	// from v0.25 onwards, creation of multiple vClusters inside the same ns is not allowed
 	for _, v := range vClusters {
 		if v.Namespace == cmd.Namespace && v.Name != vClusterName {
-			return fmt.Errorf("there is already a virtual cluster in namespace %s\n "+
-				"creating multiple vclusters inside the same namespace is not allowed", cmd.Namespace)
+			return fmt.Errorf("there is already a virtual cluster in namespace %s; "+
+				"creating multiple virtual clusters inside the same namespace is not allowed", cmd.Namespace)
 		}
 	}
 

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -112,7 +112,7 @@ type createHelm struct {
 	localCluster     bool
 }
 
-func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger, reuseNamespace bool) error {
+func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	cmd := &createHelm{
 		GlobalFlags:   globalFlags,
 		CreateOptions: options,
@@ -140,19 +140,18 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	if err != nil {
 		return err
 	}
+
 	vClusters, err := find.ListVClusters(ctx, cmd.Context, "", cmd.Namespace, log)
 	if err != nil {
 		return err
 	}
 
-	if !reuseNamespace {
-		for _, v := range vClusters {
-			if v.Namespace == cmd.Namespace && v.Name != vClusterName {
-				return fmt.Errorf("there is already a virtual cluster in namespace %s", cmd.Namespace)
-			}
+	// from v0.25 onwards, creation of multiple vClusters inside the same ns is not allowed
+	for _, v := range vClusters {
+		if v.Namespace == cmd.Namespace && v.Name != vClusterName {
+			return fmt.Errorf("there is already a virtual cluster in namespace %s\n "+
+				"creating multiple vclusters inside the same namespace is not allowed", cmd.Namespace)
 		}
-	} else {
-		cmd.log.Warn("Creation of multiple virtual clusters within the same namespace is deprecated and will be removed soon.")
 	}
 
 	err = cmd.prepare(ctx, vClusterName)
@@ -304,12 +303,6 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	err = pkgconfig.ValidateAllSyncPatches(vClusterConfig.Sync)
 	if err != nil {
 		return err
-	}
-
-	// multiple vCluster creation inside same ns should fail if `reuseNamespace` is not set as true in vCluster config
-	if reuseNamespace && !vClusterConfig.Experimental.ReuseNamespace {
-		return fmt.Errorf("there is already a virtual cluster in namespace %s; to create multiple virtual clusters "+
-			"within the same namespace, please set 'reuse-namespace' to true in vCluster config", cmd.Namespace)
 	}
 
 	if vClusterConfig.Experimental.IsolatedControlPlane.Headless {

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -150,7 +150,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 	for _, v := range vClusters {
 		if v.Namespace == cmd.Namespace && v.Name != vClusterName {
 			return fmt.Errorf("there is already a virtual cluster in namespace %s; "+
-				"creating multiple virtual clusters inside the same namespace is not allowed", cmd.Namespace)
+				"creating multiple virtual clusters inside the same namespace is not supported", cmd.Namespace)
 		}
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5920


**Please provide a short message that should be published in the vcluster release notes**
- v0.25 onwards, the user will not be allowed to create multiple vclusters inside same namespace.
- `reuse-namespace` flag and config both have been removed now.


**What else do we need to know?** 
