### PR TITLE
fix(servicesync): correctly set service clusterIP

### DIFF
--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -220,7 +220,7 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 			},
 			Spec: corev1.ServiceSpec{
 				Ports:     fromService.Spec.Ports,
-				ClusterIP: corev1.ClusterIPNone,
+				ClusterIP: fromService.Spec.ClusterIP,
 			},
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** 

https://github.com/loft-sh/vcluster/issues/1926


**Please provide a short message that should be published in the vcluster release notes**

When I use syncer `--map-host-service` args to sync the serivce from the physical k8s cluster inside vcluster, the ClusterIP is None, which is present in every version of vcluster.

So I modified `servicesync.go` and built the image locally and tested it on a production vcluster and it works, synchronizing both the headless service and the clusterIP serivce.

Note that `ClusterIP: fromService.Spec.ClusterIP` is sufficient, there is no need to determine if `fromService.Spec.ClusterIP` is `corev1.ClusterIPNone`.