### PR TITLE
istio config validation + helm chart fix

### DIFF
--- a/chart/templates/_rbac.tpl
+++ b/chart/templates/_rbac.tpl
@@ -43,7 +43,9 @@
     (and .Values.integrations.metricsServer.enabled .Values.integrations.metricsServer.nodes)
     .Values.experimental.multiNamespaceMode.enabled
 	.Values.sync.fromHost.configMaps.enabled
-    .Values.sync.fromHost.secrets.enabled -}}
+    .Values.sync.fromHost.secrets.enabled
+     .Values.integrations.istio.enabled
+     -}}
 {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/chart/tests/clusterrole_test.yaml
+++ b/chart/tests/clusterrole_test.yaml
@@ -683,3 +683,23 @@ tests:
             resourceNames: [ "my-secret", "my-secret-2" ]
             resources: [ "secrets" ]
             verbs: [ "get" ]
+  - it: istio enabled
+    set:
+      integrations:
+        istio:
+          enabled: true
+    release:
+      name: my-release
+      namespace: my-namespace
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: rules
+          count: 1
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "apiextensions.k8s.io" ]
+            resources: [ "customresourcedefinitions" ]
+            verbs: [ "get", "list", "watch" ]


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

- creates cluster role if istio integration is enabled
- adds vcluster.yaml validation to reject istio CRDs in `sync.toHost.customResources` section if istio integraiton is enabled


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was not creating cluster role when istio integration is enabled


**What else do we need to know?** 
