### PR TITLE
[v0.24] Fix vcluster delete CLI when "Prevent deletion" is enabled via platform

### DIFF
--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -71,14 +71,14 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// check if there is a platform client or we skip the info message
-	_, err = platform.InitClientFromConfig(ctx, cfg)
+	platformClient, err := platform.InitClientFromConfig(ctx, cfg)
 	if err == nil {
 		config.PrintDriverInfo("delete", driverType, cmd.log)
 	}
 
 	if driverType == config.PlatformDriver {
-		return cli.DeletePlatform(ctx, &cmd.DeleteOptions, cfg, args[0], cmd.log)
+		return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, args[0], cmd.log)
 	}
 
-	return cli.DeleteHelm(ctx, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
+	return cli.DeleteHelm(ctx, platformClient, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
 }

--- a/cmd/vclusterctl/cmd/platform/delete/vcluster.go
+++ b/cmd/vclusterctl/cmd/platform/delete/vcluster.go
@@ -2,6 +2,7 @@ package deletecmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
@@ -9,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	flagsdelete "github.com/loft-sh/vcluster/pkg/cli/flags/delete"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/spf13/cobra"
 )
 
@@ -54,5 +56,13 @@ vcluster platform delete vcluster --namespace test
 
 // Run executes the functionality
 func (cmd *VClusterCmd) Run(ctx context.Context, args []string) error {
-	return cli.DeletePlatform(ctx, &cmd.DeleteOptions, cmd.LoadedConfig(cmd.log), args[0], cmd.log)
+	cfg := cmd.LoadedConfig(cmd.log)
+
+	// check if there is a platform client or we skip the info message
+	platformClient, err := platform.InitClientFromConfig(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("init platform client: %w", err)
+	}
+
+	return cli.DeletePlatform(ctx, platformClient, &cmd.DeleteOptions, args[0], cmd.log)
 }

--- a/pkg/cli/delete_platform.go
+++ b/pkg/cli/delete_platform.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/loft-sh/log"
-	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/kube"
@@ -14,10 +13,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func DeletePlatform(ctx context.Context, options *DeleteOptions, config *config.CLI, vClusterName string, log log.Logger) error {
-	platformClient, err := platform.InitClientFromConfig(ctx, config)
-	if err != nil {
-		return err
+func DeletePlatform(ctx context.Context, platformClient platform.Client, options *DeleteOptions, vClusterName string, log log.Logger) error {
+	if platformClient == nil {
+		return fmt.Errorf("platform client not set")
 	}
 
 	// retrieve the vcluster

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -281,7 +281,10 @@ func ListVClusters(ctx context.Context, context, name, namespace string, log log
 	}
 	// Find virtual cluster instances, so we can pair them with OSS virtual clusters.
 	virtualClusterInstancesList, err := kubeClient.Loft().StorageV1().VirtualClusterInstances("").List(ctx, listOptions)
-	if err != nil {
+	if kerrors.IsForbidden(err) {
+		log.Debug("user does not have permission to list VirtualClusterInstances")
+		return vClusters, nil
+	} else if err != nil {
 		return nil, fmt.Errorf("failed to list virtual cluster instances: %w", err)
 	}
 	virtualClusterInstances := map[string]*storagev1.VirtualClusterInstance{}

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -11,36 +11,43 @@ import (
 	"github.com/loft-sh/log/survey"
 	"github.com/loft-sh/log/terminal"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/kube"
 	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-const VirtualClusterSelector = "app=vcluster"
+const (
+	NonDeletableAnnotation = "loft.sh/non-deletable"
+	VirtualClusterSelector = "app=vcluster"
+)
 
 type VCluster struct {
-	ClientFactory clientcmd.ClientConfig `json:"-"`
-	Pods          []corev1.Pod           `json:"-"`
-	Deployment    *appsv1.Deployment     `json:"-"`
-	StatefulSet   *appsv1.StatefulSet    `json:"-"`
-	Created       metav1.Time
-	Name          string
-	Namespace     string
-	ServiceName   string
-	Annotations   map[string]string
-	Labels        map[string]string
-	Status        Status
-	Context       string
-	Version       string
+	ClientFactory          clientcmd.ClientConfig            `json:"-"`
+	Pods                   []corev1.Pod                      `json:"-"`
+	Deployment             *appsv1.Deployment                `json:"-"`
+	StatefulSet            *appsv1.StatefulSet               `json:"-"`
+	VirtualClusterInstance *storagev1.VirtualClusterInstance `json:"-"`
+	Created                metav1.Time
+	Name                   string
+	Namespace              string
+	ServiceName            string
+	Annotations            map[string]string
+	Labels                 map[string]string
+	Status                 Status
+	Context                string
+	Version                string
 }
 
 type Status string
@@ -182,6 +189,30 @@ func (v *VCluster) GetLabels() map[string]string {
 	return v.Labels
 }
 
+// HasPreventDeletionEnabled returns true if the virtual cluster has "Prevent Deletion" enabled in the platform, otherwise
+// it returns false.
+// This check works only when:
+//   - you are running vcluster CLI while connected to the host cluster where VirtualClusterInstance resource is available, or
+//   - for clusters that are created or updated with platform version 4.3.0 or newer.
+func (v *VCluster) HasPreventDeletionEnabled() bool {
+	if v.VirtualClusterInstance != nil {
+		// When the vcluster CLI has access to the VirtualClusterInstance resource, we check if the loft.sh/non-deletable
+		// annotation is set there.
+		// This check does not work when accessing the virtual cluster from a connected host cluster, because VirtualClusterInstance
+		// resource is not present on the connected host cluster.
+		if nonDeletable, ok := v.VirtualClusterInstance.Annotations[NonDeletableAnnotation]; ok && nonDeletable == "true" {
+			return true
+		}
+	}
+	// In cases when the vcluster CLI does not have access to the VirtualClusterInstance resource, we check if the
+	// loft.sh/non-deletable annotation is set on the vcluster StatefulSet/Deployment.
+	// This check works only if the virtual cluster is created or updated with a platform version 4.3.0 or newer.
+	if nonDeletable, ok := v.Annotations[NonDeletableAnnotation]; ok && nonDeletable == "true" {
+		return true
+	}
+	return false
+}
+
 func FormatOptions(format string, options [][]string) []string {
 	if len(options) == 0 {
 		return []string{}
@@ -223,16 +254,60 @@ func ListVClusters(ctx context.Context, context, name, namespace string, log log
 			return nil, err
 		}
 	}
+	kubeClient, err := createKubeClient(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %w", err)
+	}
 
-	ossVClusters, err := ListOSSVClusters(ctx, context, name, namespace)
+	vClusters, err := ListOSSVClusters(ctx, kubeClient, context, name, namespace)
 	if err != nil {
 		log.Warnf("Error retrieving vclusters: %v", err)
 	}
 
-	return ossVClusters, nil
+	// check if VirtualClusterInstances CRD exists
+	virtualClusterInstanceAvailable, err := isVirtualClusterInstanceResourceAvailable(kubeClient.Discovery())
+	if !virtualClusterInstanceAvailable {
+		// VirtualClusterInstances CRD not found. This usually the case with OSS vCluster.
+		if err != nil {
+			log.Warnf("Error when checking if VirtualClusterInstance resources are available: %v", err)
+		}
+		log.Debug("VirtualClusterInstance resources are not available on the server.")
+		return vClusters, nil
+	}
+
+	listOptions := metav1.ListOptions{}
+	if name != "" {
+		listOptions.FieldSelector = "metadata.name=" + name
+	}
+	// Find virtual cluster instances, so we can pair them with OSS virtual clusters.
+	virtualClusterInstancesList, err := kubeClient.Loft().StorageV1().VirtualClusterInstances("").List(ctx, listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list virtual cluster instances: %w", err)
+	}
+	virtualClusterInstances := map[string]*storagev1.VirtualClusterInstance{}
+	for _, virtualClusterInstance := range virtualClusterInstancesList.Items {
+		vClusterNamespacedName := types.NamespacedName{
+			Namespace: virtualClusterInstance.Spec.ClusterRef.Namespace,
+			Name:      virtualClusterInstance.Spec.ClusterRef.VirtualCluster,
+		}.String()
+		virtualClusterInstances[vClusterNamespacedName] = &virtualClusterInstance
+	}
+
+	// Pair found VirtualClusterInstances with OSS virtual clusters.
+	for i := range vClusters {
+		namespacedName := types.NamespacedName{
+			Namespace: vClusters[i].Namespace,
+			Name:      vClusters[i].Name,
+		}.String()
+		if virtualClusterInstance, ok := virtualClusterInstances[namespacedName]; ok {
+			vClusters[i].VirtualClusterInstance = virtualClusterInstance
+		}
+	}
+
+	return vClusters, nil
 }
 
-func ListOSSVClusters(ctx context.Context, context, name, namespace string) ([]VCluster, error) {
+func ListOSSVClusters(ctx context.Context, kubeClient kube.Interface, context, name, namespace string) ([]VCluster, error) {
 	var err error
 
 	timeout := time.Minute
@@ -241,18 +316,24 @@ func ListOSSVClusters(ctx context.Context, context, name, namespace string) ([]V
 		timeout = time.Second * 5
 	}
 
-	vclusters, err := findInContext(ctx, context, name, namespace, timeout, false)
+	vclusters, err := findInContext(ctx, kubeClient, context, name, namespace, timeout)
 	if err != nil && vClusterName == "" {
 		return nil, errors.Wrap(err, "find vcluster")
 	}
 
 	if vClusterName != "" {
-		parentContextVClusters, err := findInContext(ctx, vClusterContext, name, namespace, time.Minute, true)
+		parentContextClient, err := createKubeClient(vClusterContext)
 		if err != nil {
-			return nil, errors.Wrap(err, "find vcluster")
-		}
+			logger := log.GetInstance()
+			logger.Warn("parent context unreachable - No vClusters listed from parent context")
+		} else {
+			parentContextVClusters, err := findInContext(ctx, parentContextClient, vClusterContext, name, namespace, time.Minute)
+			if err != nil {
+				return nil, errors.Wrap(err, "find vcluster")
+			}
 
-		vclusters = append(vclusters, parentContextVClusters...)
+			vclusters = append(vclusters, parentContextVClusters...)
+		}
 	}
 
 	return vclusters, nil
@@ -302,25 +383,9 @@ func VClusterFromContext(originalContext string) (name string, namespace string,
 	return originalContext, "", ""
 }
 
-func findInContext(ctx context.Context, context, name, namespace string, timeout time.Duration, isParentContext bool) ([]VCluster, error) {
+func findInContext(ctx context.Context, kubeClient kube.Interface, context, name, namespace string, timeout time.Duration) ([]VCluster, error) {
 	vclusters := []VCluster{}
-	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{
-		CurrentContext: context,
-	})
-	restConfig, err := kubeClientConfig.ClientConfig()
-	if err != nil {
-		// we can ignore this error for parent context, it just means that the kubeconfig set doesn't have parent config in it.
-		if isParentContext {
-			logger := log.GetInstance()
-			logger.Warn("parent context unreachable - No vClusters listed from parent context")
-			return vclusters, nil
-		}
-		return nil, errors.Wrap(err, "load kube config")
-	}
-	kubeClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "create kube client")
-	}
+	kubeClientConfig := createKubeClientConfig(context)
 
 	// statefulset based vclusters
 	statefulSets, err := getStatefulSets(ctx, kubeClient, namespace, kubeClientConfig, timeout)
@@ -383,7 +448,7 @@ func findInContext(ctx context.Context, context, name, namespace string, timeout
 	return vclusters, nil
 }
 
-func getVCluster(ctx context.Context, object client.Object, context, release string, client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig) (VCluster, error) {
+func getVCluster(ctx context.Context, object client.Object, context, release string, client kube.Interface, kubeClientConfig clientcmd.ClientConfig) (VCluster, error) {
 	namespace := object.GetNamespace()
 	created := object.GetCreationTimestamp()
 	releaseName := ""
@@ -448,7 +513,7 @@ func getVCluster(ctx context.Context, object client.Object, context, release str
 	}, nil
 }
 
-func getPods(ctx context.Context, client *kubernetes.Clientset, kubeClientConfig clientcmd.ClientConfig, namespace, podSelector string) (*corev1.PodList, error) {
+func getPods(ctx context.Context, client kube.Interface, kubeClientConfig clientcmd.ClientConfig, namespace, podSelector string) (*corev1.PodList, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
@@ -470,7 +535,7 @@ func getPods(ctx context.Context, client *kubernetes.Clientset, kubeClientConfig
 	return podList, nil
 }
 
-func getDeployments(ctx context.Context, client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.DeploymentList, error) {
+func getDeployments(ctx context.Context, client kube.Interface, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.DeploymentList, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -492,7 +557,7 @@ func getDeployments(ctx context.Context, client *kubernetes.Clientset, namespace
 	return deploymentList, nil
 }
 
-func getStatefulSets(ctx context.Context, client *kubernetes.Clientset, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.StatefulSetList, error) {
+func getStatefulSets(ctx context.Context, client kube.Interface, namespace string, kubeClientConfig clientcmd.ClientConfig, timeout time.Duration) (*appsv1.StatefulSetList, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -594,4 +659,22 @@ func isPaused(v client.Object) bool {
 	labels := v.GetLabels()
 
 	return annotations[constants.PausedAnnotation(false)] == "true" || labels[sleepmode.Label] == "true"
+}
+
+// isVirtualClusterInstanceResourceAvailable checks if VirtualClusterInstance resources from storage.loft.sh/v1 exist
+// on the server.
+func isVirtualClusterInstanceResourceAvailable(discoveryClient discovery.DiscoveryInterface) (bool, error) {
+	resources, err := discoveryClient.ServerResourcesForGroupVersion(storagev1.SchemeGroupVersion.String())
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("failed to retrieve server resources for group/version '%s': %w", storagev1.GroupVersion.String(), err)
+	}
+
+	for _, resource := range resources.APIResources {
+		if strings.ToLower(resource.Name) == "virtualclusterinstances" {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/cli/find/kubeclient.go
+++ b/pkg/cli/find/kubeclient.go
@@ -1,0 +1,30 @@
+package find
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/vcluster/pkg/platform/kube"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func createKubeClientConfig(context string) clientcmd.ClientConfig {
+	configOverrides := &clientcmd.ConfigOverrides{
+		CurrentContext: context,
+	}
+	kubeClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), configOverrides)
+	return kubeClientConfig
+}
+
+func createKubeClient(context string) (kube.Interface, error) {
+	kubeClientConfig := createKubeClientConfig(context)
+	restConfig, err := kubeClientConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube client config: %w", err)
+	}
+	kubeClient, err := kube.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	return kubeClient, nil
+}


### PR DESCRIPTION
Manually backport #2697 and #2725 (additional fix).

towards ENG-5839

## Original PR description

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
ENG-6256


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster delete` command would delete virtual clusters with `loft.sh/non-deletable: true`.


**What else do we need to know?** 

This fix has certain limitations. See the following scenarios where those limitations are described.

**1\. You are logged into the host cluster (where the platform runs).**

✅ In this case `vcluster delete` can always see if "Prevent deletion" is enabled for any cluster, so command fails correctly for protected clusters.

In this scenario it also doesn't matter if you are logged into the platform or not, and platform version does not matter, because `vcluster delete` directly checks `VirtualClusterInstance` CR.

**2\. You are logged into the connected host cluster (the platform is running on a different host cluster).**

Here we have two different sub-cases:

- ✅ You are logged into the platform. In this case `vcluster delete` fails correctly for any cluster that has "Prevent deletion" enabled, because it first tries to delete the virtual cluster via platform, which fails as expected.

- ⚠️ When you are NOT logged into the platform, there are few additional conditions for the check to work.
    - ✅ Virtual cluster is created with platform version 4.3.0 or newer (or had its config updated with platform version 4.3.0 or newer). `vcluster delete` fails correctly, as it checks the StatefulSet/Deployment annotation that is added in platform version 4.3.0.
   - :x: Virtual cluster is created with platform version older than 4.3.0 (and didn't have its config updated with platform version 4.3.0 or newer). `vcluster delete` still incorrectly deletes the cluster, because it doesn't see neither VirtualClusterInstance CR nor the annotation that the platform 4.3.0 sets.
