### PR TITLE
sync istio patches in pod controller .Sync

### DIFF
--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -367,6 +367,14 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
 	}
+
+	// apply istio patches. This is needed when the sync is triggered by the label update in the virtual namespace object.
+	// we need to then update / set this label on the pod object.
+	err = pro.ApplyIstioPatches(ctx, nil, event.Host, event.Virtual)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	defer func() {
 		if err := patch.Patch(ctx, event.Host, event.Virtual); err != nil {
 			retErr = utilerrors.NewAggregate([]error{retErr, err})


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6760


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was applying istio patches only on host object creation


**What else do we need to know?**
otherwise the pods won't be labeled if the namespace was label after the pod creation
