### PR TITLE
support multiple wildcards in patch.Translate and patch.Set

### DIFF
--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -84,6 +84,7 @@ func (p Patch) Translate(path string, translate func(path string, val interface{
 
 	// get last map / array
 	curs, ok := p.getValue(parsedPath, 1)
+
 	if !ok {
 		return nil
 	}
@@ -91,6 +92,7 @@ func (p Patch) Translate(path string, translate func(path string, val interface{
 	// get last element
 	for _, cur := range curs {
 		segment := parsedPath[len(parsedPath)-1]
+
 		switch t := cur.Value.(type) {
 		case []interface{}:
 			if segment == "*" {
@@ -100,8 +102,7 @@ func (p Patch) Translate(path string, translate func(path string, val interface{
 						return err
 					}
 				}
-
-				return nil
+				continue
 			}
 
 			index, err := strconv.Atoi(segment)
@@ -129,7 +130,7 @@ func (p Patch) Translate(path string, translate func(path string, val interface{
 					}
 				}
 
-				return nil
+				continue
 			}
 
 			val, ok := t[segment]
@@ -242,7 +243,7 @@ func (p Patch) Set(path string, value interface{}) {
 					cur[k] = value
 				}
 
-				return
+				continue
 			}
 
 			cur[segment] = value
@@ -252,7 +253,7 @@ func (p Patch) Set(path string, value interface{}) {
 					cur[k] = value
 				}
 
-				return
+				continue
 			}
 
 			index, err := strconv.Atoi(segment)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of ENG-6763


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was not patching if path has multiple wildcards


**What else do we need to know?** 

`getNextValue` returns a list correctly for patch path like `spec.servers[*].hosts[*]`. But in the Translate & Set we were returning after processing first element if it was equal to `"*"` so only first element in that list was processed
