### PR TITLE
fix: Don't use `-mod vendor` when running linear-sync

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,7 +133,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Update linear issues
-        run: go run -mod vendor . -release-tag="${{ needs.publish.outputs.release_version }}"
+        run: go run . -release-tag="${{ needs.publish.outputs.release_version }}"
         working-directory: hack/linear-sync
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What else do we need to know?** 
`vendor` directory does not exist in `hack/linear-sync` nor in any other `hack/*` module/directory, so updating the run command here (and not adding `vendor` directory).