### PR TITLE
Add the "project" column for vcluster list command when driver flag is set to platform

### DIFF
--- a/pkg/cli/list_platform.go
+++ b/pkg/cli/list_platform.go
@@ -2,10 +2,16 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/loft-sh/log"
+	"github.com/loft-sh/log/table"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"k8s.io/client-go/tools/clientcmd"
@@ -32,7 +38,8 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 		return err
 	}
 
-	err = printVClusters(ctx, options, proToVClusters(proVClusters, currentContext), globalFlags, false, logger)
+	vClusters, vClusterProjectMapping := proToVClusters(proVClusters, currentContext)
+	err = printProVClusters(ctx, options, vClusters, vClusterProjectMapping, globalFlags, logger)
 	if err != nil {
 		return err
 	}
@@ -40,8 +47,9 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 	return nil
 }
 
-func proToVClusters(vClusters []*platform.VirtualClusterInstanceProject, currentContext string) []ListVCluster {
+func proToVClusters(vClusters []*platform.VirtualClusterInstanceProject, currentContext string) ([]ListVCluster, vClusterProjectMap) {
 	var output []ListVCluster
+	vClusterProjectMapping := make(vClusterProjectMap)
 	for _, vCluster := range vClusters {
 		status := string(vCluster.VirtualCluster.Status.Phase)
 		if vCluster.VirtualCluster.DeletionTimestamp != nil {
@@ -72,7 +80,62 @@ func proToVClusters(vClusters []*platform.VirtualClusterInstanceProject, current
 			Status:     status,
 			Version:    version,
 		}
+		uniqueVClusterIdentifier := vClusterOutput.Name + "_" + vClusterOutput.Namespace
+		vClusterProjectMapping[uniqueVClusterIdentifier] = vCluster.Project.Name
 		output = append(output, vClusterOutput)
 	}
-	return output
+	return output, vClusterProjectMapping
+}
+
+func printProVClusters(ctx context.Context, options *ListOptions, output []ListVCluster,
+	vClusterProjectMapping vClusterProjectMap, globalFlags *flags.GlobalFlags, logger log.Logger) error {
+	if options.Output == "json" {
+		bytes, err := json.MarshalIndent(output, "", "    ")
+		if err != nil {
+			return fmt.Errorf("json marshal vClusters: %w", err)
+		}
+
+		logger.WriteString(logrus.InfoLevel, string(bytes)+"\n")
+	} else {
+		header := []string{"NAME", "NAMESPACE", "PROJECT", "STATUS", "VERSION", "CONNECTED", "AGE"}
+		values := toTableValues(output, vClusterProjectMapping)
+		table.PrintTable(logger, header, values)
+
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		vClusters, _ := find.ListVClusters(ctx, globalFlags.Context, "", "", log.Discard)
+		if len(vClusters) > 0 {
+			logger.Infof("You also have %d virtual clusters in your current kube-context.", len(vClusters))
+			logger.Info("If you want to see them, run: 'vcluster list --driver helm' or 'vcluster use driver helm' to change the default")
+		}
+
+		// show disconnect command
+		if strings.HasPrefix(globalFlags.Context, "vcluster_") || strings.HasPrefix(globalFlags.Context, "vcluster-platform_") {
+			logger.Infof("Run `vcluster disconnect` to switch back to the parent context")
+		}
+	}
+	return nil
+}
+
+func toTableValues(vClusters []ListVCluster, vClusterProjectMapping vClusterProjectMap) [][]string {
+	var values [][]string
+	for _, vCluster := range vClusters {
+		isConnected := ""
+		if vCluster.Connected {
+			isConnected = "True"
+		}
+
+		uniqueVClusterIdentifier := vCluster.Name + "_" + vCluster.Namespace
+		values = append(values, []string{
+			vCluster.Name,
+			vCluster.Namespace,
+			vClusterProjectMapping[uniqueVClusterIdentifier],
+			vCluster.Status,
+			vCluster.Version,
+			isConnected,
+			time.Since(vCluster.Created).Round(1 * time.Second).String(),
+		})
+	}
+	return values
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6618


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster list will now have project column as well in the output in case driver flag is set to platform


**What else do we need to know?** 
I've separated out the print functions for both drivers (helm and platform). The reason for doing that is to avoid big if-else blocks which were inhibiting readability.
