### PR TITLE
bugfix: disallow users from creating a vCluster in the platform namespace

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.controlPlane.service.enabled }}
+{{- $platform_svc_exists := lookup "v1" "Service" .Release.Namespace "loft" }}
+{{- if $platform_svc_exists }}
+{{- fail (printf "a vCluster platform installation exists in the namespace '%s'. Aborting install" .Release.Namespace) }}
+{{- else if .Values.controlPlane.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -59,6 +59,8 @@ const LoftRouterDomainSecret = "loft-router-domain"
 
 const DefaultPlatformNamespace = "vcluster-platform"
 
+const DefaultPlatformServiceName = "loft"
+
 const defaultTimeout = 10 * time.Minute
 
 const timeoutEnvVariable = "LOFT_TIMEOUT"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-5603

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was allowed to be installed in the platform namespace


**What else do we need to know?** 

### Test Results:

**_Helm_**

1. When the platform installation exists, and the helm command is targeted towards the same namespace, it throws an error and exits.
![image](https://github.com/user-attachments/assets/2b4d5934-f2b1-4e2e-8355-9d58e989d064)
2. When the helm install is targeted to a different namespace, it proceeds correctly.
![image](https://github.com/user-attachments/assets/15b5c8bc-37b9-4f86-9f41-6efd0082aa95)


**_vCluster CLI_**

1. When the platform installation exists, and the CLI command is targeted towards the same namespace, it throws an error and exits.
![image](https://github.com/user-attachments/assets/78c29aef-2edc-423d-8654-b88383e0cd8f)
2. When the command is targeted towards a different namespace, it proceeds correctly.
![image](https://github.com/user-attachments/assets/6c67cac4-2268-4371-a7ce-157df79a4ca5)
