### PR TITLE
fix: Permissions needed for Hybrid Scheduling

### DIFF
--- a/chart/templates/_rbac.tpl
+++ b/chart/templates/_rbac.tpl
@@ -28,6 +28,7 @@
     .Values.sync.toHost.volumeSnapshotContents.enabled
     .Values.sync.fromHost.volumeSnapshotClasses.enabled
     .Values.controlPlane.advanced.virtualScheduler.enabled
+    .Values.sync.toHost.pods.hybridScheduling.enabled
     .Values.sync.fromHost.ingressClasses.enabled
     .Values.sync.fromHost.runtimeClasses.enabled
     (eq (toString .Values.sync.fromHost.storageClasses.enabled) "true")

--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -39,7 +39,7 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["update", "patch"]
   {{- end }}
-  {{- if .Values.controlPlane.advanced.virtualScheduler.enabled }}
+  {{- if or .Values.controlPlane.advanced.virtualScheduler.enabled .Values.sync.toHost.pods.hybridScheduling.enabled }}
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["get", "watch", "list"]

--- a/chart/tests/clusterrole_test.yaml
+++ b/chart/tests/clusterrole_test.yaml
@@ -68,6 +68,23 @@ tests:
             resources: [ "storageclasses", "csinodes", "csidrivers", "csistoragecapacities" ]
             verbs: [ "get", "watch", "list" ]
 
+  - it: enable hybrid scheduling
+    set:
+      sync:
+        toHost:
+          pods:
+            hybridScheduling:
+              enabled: true
+    asserts:
+    - hasDocuments:
+        count: 1
+    - contains:
+        path: rules
+        content:
+          apiGroups: [ "storage.k8s.io" ]
+          resources: [ "storageclasses", "csinodes", "csidrivers", "csistoragecapacities" ]
+          verbs: [ "get", "watch", "list" ]
+
   - it: enable csinodes
     set:
       sync:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6840


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster logs errors when Hybrid Scheduling is enabled without also enabling FromHost sync for CSINodes, CSIStorageCapacities and CSIDrivers.


**What else do we need to know?** 
