### PR TITLE
feat: add ability to force sync an event into default namespace

### DIFF
--- a/pkg/controllers/resources/events/translate.go
+++ b/pkg/controllers/resources/events/translate.go
@@ -1,8 +1,10 @@
 package events
 
 import (
+	"errors"
 	"strings"
 
+	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/mappings/resources"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
@@ -13,6 +15,10 @@ func (s *eventSyncer) translateEvent(ctx *synccontext.SyncContext, pEvent, vEven
 	// retrieve involved object
 	involvedObject, err := resources.GetInvolvedObject(ctx, pEvent)
 	if err != nil {
+		if pEvent.GetAnnotations()[constants.SyncResourceAnnotation] == "true" &&
+			(errors.Is(err, resources.ErrNilPhysicalObject) || errors.Is(err, resources.ErrKindNotAccepted) || errors.Is(err, resources.ErrNotFound)) {
+			return s.forceTranslateEvent(pEvent, vEvent)
+		}
 		return err
 	}
 	tempEvent := pEvent.DeepCopy()
@@ -49,4 +55,21 @@ func hostEventNameToVirtual(hostName string, hostInvolvedObjectName, virtualInvo
 	}
 
 	return hostName
+}
+
+func (s *eventSyncer) forceTranslateEvent(pEvent, vEvent *corev1.Event) error {
+	tempEvent := pEvent.DeepCopy()
+
+	// keep the metadata from the virtual object
+	translate.ResetObjectMetadata(tempEvent)
+	tempEvent.ObjectMeta = vEvent.ObjectMeta
+	tempEvent.TypeMeta = vEvent.TypeMeta
+
+	tempEvent.DeepCopyInto(vEvent)
+	delete(vEvent.Annotations, constants.SyncResourceAnnotation)
+	vEvent.Namespace = "default"
+	vEvent.InvolvedObject = corev1.ObjectReference{
+		Namespace: vEvent.Namespace,
+	}
+	return nil
 }

--- a/pkg/controllers/resources/events/translate.go
+++ b/pkg/controllers/resources/events/translate.go
@@ -67,7 +67,7 @@ func (s *eventSyncer) forceTranslateEvent(pEvent, vEvent *corev1.Event) error {
 
 	tempEvent.DeepCopyInto(vEvent)
 	delete(vEvent.Annotations, constants.SyncResourceAnnotation)
-	vEvent.Namespace = "default"
+	vEvent.Namespace = resources.ForceSyncedEventNamespace
 	vEvent.InvolvedObject = corev1.ObjectReference{
 		Namespace: vEvent.Namespace,
 	}

--- a/pkg/mappings/resources/events.go
+++ b/pkg/mappings/resources/events.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const ForceSyncedEventNamespace = "default"
+
 var AcceptedKinds = map[schema.GroupVersionKind]bool{
 	corev1.SchemeGroupVersion.WithKind("Pod"):       true,
 	corev1.SchemeGroupVersion.WithKind("Service"):   true,
@@ -52,7 +54,7 @@ func (s *eventMapper) HostToVirtual(ctx *synccontext.SyncContext, req types.Name
 			klog.Infof("Error retrieving involved object for %s/%s: %v", req.Namespace, req.Name, err)
 		} else if pObj.GetAnnotations()[constants.SyncResourceAnnotation] == "true" {
 			return types.NamespacedName{
-				Namespace: "default",
+				Namespace: ForceSyncedEventNamespace,
 				Name:      pObj.GetName(),
 			}
 		}

--- a/pkg/mappings/resources/events.go
+++ b/pkg/mappings/resources/events.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +50,11 @@ func (s *eventMapper) HostToVirtual(ctx *synccontext.SyncContext, req types.Name
 		err = IgnoreAcceptableErrors(err)
 		if err != nil {
 			klog.Infof("Error retrieving involved object for %s/%s: %v", req.Namespace, req.Name, err)
+		} else if pObj.GetAnnotations()[constants.SyncResourceAnnotation] == "true" {
+			return types.NamespacedName{
+				Namespace: "default",
+				Name:      pObj.GetName(),
+			}
 		}
 
 		return types.NamespacedName{}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/loft-sh/vcluster/test/e2e/node"
 	_ "github.com/loft-sh/vcluster/test/e2e/servicesync"
 	_ "github.com/loft-sh/vcluster/test/e2e/snapshot"
+	_ "github.com/loft-sh/vcluster/test/e2e/syncer/events"
 	_ "github.com/loft-sh/vcluster/test/e2e/syncer/fromhost"
 	_ "github.com/loft-sh/vcluster/test/e2e/syncer/networkpolicies"
 	_ "github.com/loft-sh/vcluster/test/e2e/syncer/pods"

--- a/test/e2e/syncer/events/events.go
+++ b/test/e2e/syncer/events/events.go
@@ -1,0 +1,70 @@
+package fromhost
+
+import (
+	"time"
+
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/reference"
+)
+
+var _ = ginkgo.Describe("Events can be force synced using an annotation", ginkgo.Ordered, func() {
+	var (
+		f              *framework.Framework
+		event1         *corev1.Event
+		dummyConfigMap *corev1.ConfigMap
+		event1Name     = "dummy"
+		event1Message  = "test msg"
+	)
+
+	ginkgo.BeforeAll(func() {
+		f = framework.DefaultFramework
+		event1 = &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      event1Name,
+				Namespace: f.VClusterNamespace,
+				Annotations: map[string]string{
+					"vcluster.loft.sh/force-sync": "true",
+				},
+			},
+			Message: event1Message,
+		}
+		dummyConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dummy-unrelated",
+				Namespace: f.VClusterNamespace,
+			},
+		}
+	})
+
+	ginkgo.AfterAll(func() {
+		framework.ExpectNoError(f.HostClient.CoreV1().Events(event1.GetNamespace()).Delete(f.Context, event1.GetName(), metav1.DeleteOptions{}))
+		framework.ExpectNoError(f.HostClient.CoreV1().ConfigMaps(dummyConfigMap.GetNamespace()).Delete(f.Context, dummyConfigMap.GetName(), metav1.DeleteOptions{}))
+	})
+
+	ginkgo.It("Secrets are synced to virtual cluster", func() {
+		involvedObj, err := f.HostClient.CoreV1().ConfigMaps(event1.GetNamespace()).Create(f.Context, dummyConfigMap, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		ref, err := reference.GetReference(scheme.Scheme, involvedObj)
+		framework.ExpectNoError(err)
+		event1.InvolvedObject = *ref
+
+		_, err = f.HostClient.CoreV1().Events(event1.GetNamespace()).Create(f.Context, event1, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			virtual1, err := f.VClusterClient.CoreV1().Events("default").Get(f.Context, event1Name, metav1.GetOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(virtual1.Message).To(gomega.Equal(event1.Message))
+		}).
+			WithPolling(time.Second).
+			WithTimeout(framework.PollTimeout / 4).
+			Should(gomega.Succeed())
+	})
+
+})


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6860


**Please provide a short message that should be published in the vcluster release notes**
Added ability to force sync Events that don't have an `involvedObject` that is synced from vCluster. These events will be synced into the default namespace.

**What else do we need to know?** 
