### PR TITLE
Only set embedded if external datasource is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -342,7 +342,8 @@ func (c *Config) BackingStoreType() StoreType {
 }
 
 func (c *Config) EmbeddedDatabase() bool {
-	return !c.ControlPlane.BackingStore.Database.External.Enabled && !c.ControlPlane.BackingStore.Etcd.Embedded.Enabled && !c.ControlPlane.BackingStore.Etcd.Deploy.Enabled && !c.ControlPlane.BackingStore.Etcd.External.Enabled
+	return !c.ControlPlane.BackingStore.Database.External.Enabled && !c.ControlPlane.BackingStore.Etcd.Embedded.Enabled &&
+		!c.ControlPlane.BackingStore.Etcd.Deploy.Enabled && !c.ControlPlane.BackingStore.Etcd.External.Enabled && c.ControlPlane.BackingStore.Database.External.DataSource == ""
 }
 
 func (c *Config) Distro() string {


### PR DESCRIPTION
This is necessary to maintain compatibility. Pre-v0.25.0 external datasource was used regardless of whether the enabled flag was used.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes #ENG-6900


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster where using a connector without the flag "controlPlane.backingStore.database.external.enabled" would no longer work. This would cause the backingstore to change to an embedded sqlite database after upgrading from v0.24.x to v0.25.0. This would would make the vcluster appear as thought it was reset.


**What else do we need to know?**
If anyone happened to use a connector without enabled in v0.25.0 then they we will face the opposite issue after the fix. They will have been using sqlite and now will actually use the connector.
