### PR TITLE
[ENG-6782] feat(class limits): Add label selectors to fromHost resources

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1050,6 +1050,34 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "EnableAutoSwitchWithPatchesAndSelector": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "selector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "Selector defines the selector to use for the resource. If not set, all resources of that type will be synced."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "EnableSwitch": {
       "properties": {
         "enabled": {
@@ -1072,6 +1100,27 @@
           },
           "type": "array",
           "description": "Patches patch the resource according to the provided specification."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableSwitchWithPatchesAndSelector": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "selector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "Selector defines the selector to use for the resource. If not set, all resources of that type will be synced."
         }
       },
       "additionalProperties": false,
@@ -2274,6 +2323,24 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "LabelSelectorRequirement": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "LabelsAndAnnotations": {
       "properties": {
         "annotations": {
@@ -3326,6 +3393,24 @@
       "type": "object",
       "description": "SleepModeAutoSleep holds configuration for allowing a vCluster to sleep its workloads automatically"
     },
+    "StandardLabelSelector": {
+      "properties": {
+        "matchLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "matchExpressions": {
+          "items": {
+            "$ref": "#/$defs/LabelSelectorRequirement"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "StatefulSetImage": {
       "properties": {
         "registry": {
@@ -3390,19 +3475,19 @@
           "description": "Events defines if events should get synced from the host cluster to the virtual cluster, but not back."
         },
         "ingressClasses": {
-          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
           "description": "IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back."
         },
         "runtimeClasses": {
-          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
           "description": "RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back."
         },
         "priorityClasses": {
-          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
           "description": "PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back."
         },
         "storageClasses": {
-          "$ref": "#/$defs/EnableAutoSwitchWithPatches",
+          "$ref": "#/$defs/EnableAutoSwitchWithPatchesAndSelector",
           "description": "StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled."
         },
         "csiNodes": {

--- a/config/diff.go
+++ b/config/diff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 )
@@ -165,4 +166,11 @@ func (f *StrBool) MarshalJSON() ([]byte, error) {
 	default:
 		return []byte("\"" + *f + "\""), nil
 	}
+}
+
+func (f *StrBool) Bool() bool {
+	if f == nil {
+		return false
+	}
+	return strings.ToLower(string(*f)) == "true"
 }

--- a/pkg/controllers/resources/ingressclasses/syncer.go
+++ b/pkg/controllers/resources/ingressclasses/syncer.go
@@ -3,33 +3,35 @@ package ingressclasses
 import (
 	"fmt"
 
-	"github.com/loft-sh/vcluster/pkg/mappings/generic"
-	"github.com/loft-sh/vcluster/pkg/patcher"
-	"github.com/loft-sh/vcluster/pkg/pro"
-	"github.com/loft-sh/vcluster/pkg/syncer"
-	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
-	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
-	"github.com/loft-sh/vcluster/pkg/util/translate"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/loft-sh/vcluster/pkg/mappings/generic"
+	"github.com/loft-sh/vcluster/pkg/patcher"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/syncer"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/syncer/translator"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 )
 
-func New(_ *synccontext.RegisterContext) (syncertypes.Object, error) {
+func New(registerCtx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	mapper, err := generic.NewMirrorMapper(&networkingv1.IngressClass{})
 	if err != nil {
 		return nil, err
 	}
 
 	return &ingressClassSyncer{
-		Mapper: mapper,
+		GenericTranslator: translator.NewGenericTranslator(registerCtx, "ingressclass", &networkingv1.IngressClass{}, mapper),
 	}, nil
 }
 
 type ingressClassSyncer struct {
-	synccontext.Mapper
+	syncertypes.GenericTranslator
 }
 
 func (i *ingressClassSyncer) Name() string {
@@ -47,6 +49,10 @@ func (i *ingressClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*networkingv1.IngressClass]) (ctrl.Result, error) {
+	if !ctx.Config.Sync.FromHost.IngressClasses.Selector.Matches(event.Host) {
+		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync ingress class %q because it does not match the selector under 'sync.fromHost.ingressClasses.selector'", event.Host.Name))
+	}
+
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
@@ -60,6 +66,10 @@ func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 }
 
 func (i *ingressClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*networkingv1.IngressClass]) (_ ctrl.Result, retErr error) {
+	if !ctx.Config.Sync.FromHost.IngressClasses.Selector.Matches(event.Host) {
+		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, fmt.Sprintf("did not sync ingress class %q because it does not match the selector under 'sync.fromHost.ingressClasses.selector'", event.Host.Name))
+	}
+
 	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.FromHost.IngressClasses.Patches, true))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -3,6 +3,12 @@ package persistentvolumeclaims
 import (
 	"fmt"
 
+	storagev1 "k8s.io/api/storage/v1"
+
+	"github.com/pkg/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/persistentvolumes"
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/patcher"
@@ -12,17 +18,15 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/translator"
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
-	"github.com/pkg/errors"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
 
-	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 )
 
 var (
@@ -82,6 +86,10 @@ func (s *persistentVolumeClaimSyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (s *persistentVolumeClaimSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*corev1.PersistentVolumeClaim]) (ctrl.Result, error) {
+	if s.applyLimitByClass(ctx, event.Virtual) {
+		return ctrl.Result{}, nil
+	}
+
 	if event.HostOld != nil || event.Virtual.DeletionTimestamp != nil {
 		return patcher.DeleteVirtualObjectWithOptions(ctx, event.Virtual, event.HostOld, "host object was deleted", &client.DeleteOptions{
 			GracePeriodSeconds: &zero,
@@ -103,6 +111,10 @@ func (s *persistentVolumeClaimSyncer) SyncToHost(ctx *synccontext.SyncContext, e
 }
 
 func (s *persistentVolumeClaimSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*corev1.PersistentVolumeClaim]) (_ ctrl.Result, retErr error) {
+	if s.applyLimitByClass(ctx, event.Virtual) {
+		return ctrl.Result{}, nil
+	}
+
 	// if pvs are deleted check the corresponding pvc is deleted as well
 	if event.Host.DeletionTimestamp != nil {
 		if event.Virtual.DeletionTimestamp == nil {
@@ -284,4 +296,21 @@ func recreatePersistentVolumeClaim(ctx *synccontext.SyncContext, virtualClient c
 	}
 
 	return vPVC, nil
+}
+
+func (s *persistentVolumeClaimSyncer) applyLimitByClass(ctx *synccontext.SyncContext, virtual *corev1.PersistentVolumeClaim) bool {
+	// Get the host storage class and check if it matches the selector
+	if ctx.Config.Sync.FromHost.StorageClasses.Enabled.Bool() && virtual.Spec.StorageClassName != nil && *virtual.Spec.StorageClassName != "" {
+		pStorageClass := &storagev1.StorageClass{}
+		err := ctx.PhysicalClient.Get(ctx.Context, types.NamespacedName{Name: *virtual.Spec.StorageClassName}, pStorageClass)
+		if err != nil || pStorageClass.GetDeletionTimestamp() != nil {
+			s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q couldn't be reached in the host: %s", virtual.GetName(), *virtual.Spec.StorageClassName, err)
+			return true
+		}
+		if !ctx.Config.Sync.FromHost.StorageClasses.Selector.Matches(pStorageClass) {
+			s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q in the host does not match the selector under 'sync.fromHost.storageClasses.selector'", virtual.GetName(), pStorageClass.GetName())
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controllers/resources/runtimeclasses/syncer.go
+++ b/pkg/controllers/resources/runtimeclasses/syncer.go
@@ -3,33 +3,35 @@ package runtimeclasses
 import (
 	"fmt"
 
-	"github.com/loft-sh/vcluster/pkg/mappings/generic"
-	"github.com/loft-sh/vcluster/pkg/patcher"
-	"github.com/loft-sh/vcluster/pkg/pro"
-	"github.com/loft-sh/vcluster/pkg/syncer"
-	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
-	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
-	"github.com/loft-sh/vcluster/pkg/util/translate"
 	nodev1 "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/loft-sh/vcluster/pkg/mappings/generic"
+	"github.com/loft-sh/vcluster/pkg/patcher"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/syncer"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/syncer/translator"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 )
 
-func New(_ *synccontext.RegisterContext) (syncertypes.Object, error) {
+func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	mapper, err := generic.NewMirrorMapper(&nodev1.RuntimeClass{})
 	if err != nil {
 		return nil, err
 	}
 
 	return &runtimeClassSyncer{
-		Mapper: mapper,
+		GenericTranslator: translator.NewGenericTranslator(ctx, "runtimeclass", &nodev1.RuntimeClass{}, mapper),
 	}, nil
 }
 
 type runtimeClassSyncer struct {
-	synccontext.Mapper
+	syncertypes.GenericTranslator
 }
 
 func (i *runtimeClassSyncer) Name() string {
@@ -47,6 +49,10 @@ func (i *runtimeClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (i *runtimeClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*nodev1.RuntimeClass]) (ctrl.Result, error) {
+	if !ctx.Config.Sync.FromHost.RuntimeClasses.Selector.Matches(event.Host) {
+		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync runtime class %q because it does not match the selector under 'sync.fromHost.runtimeClasses.selector'", event.Host.Name))
+	}
+
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
@@ -60,6 +66,10 @@ func (i *runtimeClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 }
 
 func (i *runtimeClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*nodev1.RuntimeClass]) (_ ctrl.Result, retErr error) {
+	if !ctx.Config.Sync.FromHost.RuntimeClasses.Selector.Matches(event.Host) {
+		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, fmt.Sprintf("did not sync runtime class %q because it does not match the selector under 'sync.fromHost.runtimeClasses.selector'", event.Host.Name))
+	}
+
 	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.FromHost.RuntimeClasses.Patches, true))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -3,18 +3,20 @@ package storageclasses
 import (
 	"fmt"
 
-	"github.com/loft-sh/vcluster/pkg/mappings"
-	"github.com/loft-sh/vcluster/pkg/patcher"
-	"github.com/loft-sh/vcluster/pkg/pro"
-	"github.com/loft-sh/vcluster/pkg/syncer"
-	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
-	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
-	"github.com/loft-sh/vcluster/pkg/util/translate"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/patcher"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/syncer"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/syncer/translator"
+	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 )
 
 func NewHostStorageClassSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
@@ -24,12 +26,12 @@ func NewHostStorageClassSyncer(ctx *synccontext.RegisterContext) (syncertypes.Ob
 	}
 
 	return &hostStorageClassSyncer{
-		Mapper: mapper,
+		GenericTranslator: translator.NewGenericTranslator(ctx, "storageclass", &storagev1.StorageClass{}, mapper),
 	}, nil
 }
 
 type hostStorageClassSyncer struct {
-	synccontext.Mapper
+	syncertypes.GenericTranslator
 }
 
 func (s *hostStorageClassSyncer) UseUncachedPhysicalClient() bool {
@@ -51,6 +53,10 @@ func (s *hostStorageClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (s *hostStorageClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*storagev1.StorageClass]) (ctrl.Result, error) {
+	if !ctx.Config.Sync.FromHost.StorageClasses.Selector.Matches(event.Host) {
+		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync storage class %q because it does not match the selector under 'sync.fromHost.storageClasses.selector'", event.Host.Name))
+	}
+
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)
 
 	// Apply pro patches
@@ -64,6 +70,10 @@ func (s *hostStorageClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, eve
 }
 
 func (s *hostStorageClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*storagev1.StorageClass]) (_ ctrl.Result, retErr error) {
+	if !ctx.Config.Sync.FromHost.StorageClasses.Selector.Matches(event.Host) {
+		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, fmt.Sprintf("did not sync storage class %q because it does not match the selector under 'sync.fromHost.storageClasses.selector'", event.Host.Name))
+	}
+
 	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.FromHost.StorageClasses.Patches, true))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6782


**Please provide a short message that should be published in the vcluster release notes**
Add label selectors to fromHost resources
That's the list of selectors and it's resources:
- sync.fromHost.ingressClasses.selector -> Ingress
- sync.fromHost.storageClasses.selector -> PersistentVolumeClaim & PersistentVolume
- sync.fromHost.runtimeClasses.selector -> Pod
- sync.fromHost.priorityClasses.selector -> Pod

**What else do we need to know?** 
