### PR TITLE
chore: bumps kubectl version

### DIFF
--- a/pkg/constants/cli.go
+++ b/pkg/constants/cli.go
@@ -1,3 +1,3 @@
 package constants
 
-const DefaultBackgroundProxyImage = "bitnami/kubectl:1.29"
+const DefaultBackgroundProxyImage = "bitnami/kubectl:1.33"


### PR DESCRIPTION
Bumps background proxy version of kubectl

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the vcluster release notes**
Bumps kubectl version


**What else do we need to know?** 
