### PR TITLE
delete external ETCD after migration

### DIFF
--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -126,6 +126,16 @@ rules:
     resources: [ "referencegrants" ]
     verbs: [ "create", "delete", "patch", "update", "get", "list", "watch" ]
   {{- end }}
+  {{- if and (not .Values.controlPlane.backingStore.etcd.deploy.enabled) .Values.controlPlane.backingStore.etcd.embedded.enabled .Values.controlPlane.backingStore.etcd.embedded.migrateFromDeployedEtcd }}
+  - apiGroups: [ "apps" ]
+    resources: [ "statefulsets" ]
+    resourceNames: [ "{{ .Release.Name }}-etcd" ]
+    verbs: [ "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "services" ]
+    resourceNames: [ "{{ .Release.Name }}-etcd", "{{ .Release.Name }}-etcd-headless" ]
+    verbs: [ "delete" ]
+  {{- end }}
   {{- include "vcluster.customResources.roleExtraRules" . | indent 2 }}
   {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
   {{- include "vcluster.generic.roleExtraRules" . | indent 2 }}

--- a/chart/tests/role_test.yaml
+++ b/chart/tests/role_test.yaml
@@ -423,3 +423,32 @@ tests:
             resources: ["leases"]
             verbs:
               ["create", "delete", "patch", "update", "get", "list", "watch"]
+
+  - it: external to embedded etcd migration
+    set:
+      controlPlane:
+        backingStore:
+          etcd:
+            embedded:
+              enabled: true
+              migrateFromDeployedEtcd: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apps"]
+            resources: ["statefulsets"]
+            resourceNames: ["RELEASE-NAME-etcd"]
+            verbs: [ "delete" ]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [ "" ]
+            resources: [ "services" ]
+            resourceNames: [ "RELEASE-NAME-etcd", "RELEASE-NAME-etcd-headless" ]
+            verbs: [ "delete" ]

--- a/cmd/vcluster/cmd/snapshot.go
+++ b/cmd/vcluster/cmd/snapshot.go
@@ -320,6 +320,7 @@ func startEmbeddedBackingStore(ctx context.Context, vConfig *config.VirtualClust
 			"",
 			false,
 			false,
+			nil,
 		)
 		if err != nil {
 			return fmt.Errorf("start embedded etcd: %w", err)

--- a/pkg/pro/embedded_etcd.go
+++ b/pkg/pro/embedded_etcd.go
@@ -1,7 +1,11 @@
 package pro
 
-import "context"
+import (
+	"context"
 
-var StartEmbeddedEtcd = func(_ context.Context, _, _, _ string, _, _ int, _ string, _, _ bool) error {
+	"k8s.io/client-go/kubernetes"
+)
+
+var StartEmbeddedEtcd = func(_ context.Context, _, _, _ string, _, _ int, _ string, _, _ bool, _ kubernetes.Interface) error {
 	return NewFeatureError("embedded etcd")
 }

--- a/pkg/setup/initialize.go
+++ b/pkg/setup/initialize.go
@@ -92,6 +92,7 @@ func initialize(ctx context.Context, options *config.VirtualClusterConfig) error
 				migrateFrom,
 				true,
 				options.ControlPlane.StatefulSet.Scheduling.PodManagementPolicy != "Parallel",
+				options.WorkloadClient,
 			)
 			if err != nil {
 				return fmt.Errorf("start embedded etcd: %w", err)
@@ -136,6 +137,7 @@ func initialize(ctx context.Context, options *config.VirtualClusterConfig) error
 				migrateFrom,
 				true,
 				options.ControlPlane.StatefulSet.Scheduling.PodManagementPolicy != "Parallel",
+				options.WorkloadClient,
 			)
 			if err != nil {
 				return fmt.Errorf("start embedded etcd: %w", err)


### PR DESCRIPTION
* allow for external etcd statefulset & services deletion after migration to embedded
* pass workload client to embedded etcd function

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of ENG-5634


**Please provide a short message that should be published in the vcluster release notes**
add RBAC needed for external etcd deletion after migration to embedded


**What else do we need to know?** 
this is needed for deleting external etcd statefulset & services after successful migration to embedded etcd (implemented in the pro)