### PR TITLE
ci: disable archives for head images build

### DIFF
--- a/.github/workflows/push-head-images.yaml
+++ b/.github/workflows/push-head-images.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --config .goreleaser.head_images.yaml --clean --skip=announce,validate
+          args: release --config .goreleaser.head_images.yaml --clean --skip=announce,archive,validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_PRIVATE_KEY: ""

--- a/.goreleaser.head_images.yaml
+++ b/.goreleaser.head_images.yaml
@@ -69,8 +69,6 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version=head"
-    extra_files:
-      - dist/vcluster_linux_amd64_v1/vcluster
     skip_push: '{{ ne .Env.CI_BRANCH "main" }}'
 
   - image_templates:
@@ -87,8 +85,6 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version=head"
-    extra_files:
-      - dist/vcluster_linux_arm64_v8.0/vcluster
     skip_push: '{{ ne .Env.CI_BRANCH "main" }}'
 
   # --- Vcluster-cli images ---
@@ -105,8 +101,6 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version=head"
-    extra_files:
-      - dist/vcluster-cli_linux_amd64_v1/vcluster
     skip_push: '{{ ne .Env.CI_BRANCH "main" }}'
 
   - image_templates:
@@ -124,8 +118,6 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version=head"
-    extra_files:
-      - dist/vcluster-cli_linux_arm64_v8.0/vcluster
     skip_push: '{{ ne .Env.CI_BRANCH "main" }}'
 
 docker_manifests:


### PR DESCRIPTION
Disables archives for the push-head-images workflow.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What else do we need to know?** 
Fixes the issue with failed builds: https://github.com/loft-sh/vcluster/actions/runs/15180935198/job/42690610054
We don't need to publish archives in this build, only docker images.