### PR TITLE
ci: add qemu and buildx actions for push-head-images

### DIFF
--- a/.github/workflows/push-head-images.yaml
+++ b/.github/workflows/push-head-images.yaml
@@ -65,6 +65,17 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v1
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Cosgin
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: "v2.2.3"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Installs QEMU and buildx actions for multiarch docker builds.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
