### PR TITLE
[ENG-6910] Further slim down images.txt

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
     - '{{ if not .IsSnapshot }}just clean-release{{ else }}echo "Skipping clean-release"{{ end }}'
     - '{{ if not .IsSnapshot }}just copy-assets{{ else }}echo "Skipping copy-assets"{{ end }}'
     - '{{ if not .IsSnapshot }}just generate-vcluster-latest-images {{ .Version }}{{ else }}echo "Skipping generate-vcluster-latest-images"{{ end }}'
-    - '{{ if not .IsSnapshot }}just generate-vcluster-optional-images{{ else }}echo "Skipping generate-vcluster-optional-images"{{ end }}'
+    - '{{ if not .IsSnapshot }}just generate-vcluster-optional-images {{ .Version }}{{ else }}echo "Skipping generate-vcluster-optional-images"{{ end }}'
     - '{{ if not .IsSnapshot }}just generate-matrix-specific-images {{ .Version }}{{ else }}echo "Skipping generate-matrix-specific-images"{{ end }}'
 
 source:

--- a/Justfile
+++ b/Justfile
@@ -53,7 +53,7 @@ copy-assets:
 # Generate the vcluster latest/minimal images file
 [private]
 generate-vcluster-latest-images version="0.0.0":
-  {{ASSETS_RUN}} --latest {{ version }} > ./release/images.txt
+  {{ASSETS_RUN}} {{ version }} > ./release/images.txt
 
 # Generate the vcluster optional images file
 [private]

--- a/hack/assets/assets.go
+++ b/hack/assets/assets.go
@@ -19,10 +19,12 @@ import (
 const (
 	k8s = "k8s"
 	k3s = "k3s"
+
+	etcd = "etcd"
 )
 
 var usage = fmt.Sprintf(`Usage:
-  go run -mod vendor ./hack/assets/cmd/main.go [v]X.Y.Z [--latest] [--optional]
+  go run -mod vendor ./hack/assets/cmd/main.go [v]X.Y.Z [--optional]
   go run -mod vendor ./hack/assets/cmd/main.go [v]X.Y.Z [--kubernetes-distro <%s>] [--kubernetes-version X.Y.Z]
   go run -mod vendor ./hack/assets/cmd/main.go --list-distros
   go run -mod vendor ./hack/assets/cmd/main.go --list-versions`,
@@ -32,7 +34,6 @@ var usage = fmt.Sprintf(`Usage:
 func Main() {
 	listDistros := pflag.Bool("list-distros", false, "Only the list of supported Kubernetes distros is returned")
 	listVersions := pflag.Bool("list-versions", false, "Only the list of supported Kubernetes versions is returned")
-	latest := pflag.Bool("latest", false, "Only the latest image of each group is returned")
 	optional := pflag.Bool("optional", false, "Include all images except the latest")
 
 	k8sSupportedVersions := GetSupportedKubernetesVersions()
@@ -74,19 +75,9 @@ func Main() {
 		os.Exit(1)
 	}
 
-	if *latest && *kubernetesVersion != "" {
-		fmt.Println("Flags --latest and --kubernetes-version are not compatible")
-		os.Exit(1)
-	}
-
-	if *latest && *optional {
-		fmt.Println("Flags --latest and --optional are not compatible")
-		os.Exit(1)
-	}
-
 	cleanTag := strings.TrimLeft(pflag.Arg(0), "v")
 
-	images := GetImages(cleanTag, *latest, *optional, *kubernetesVersion, *kubernetesDistro)
+	images := GetImages(cleanTag, *optional, *kubernetesVersion, *kubernetesDistro)
 	for _, img := range images {
 		fmt.Println(img)
 	}
@@ -98,10 +89,10 @@ func GetSupportedDistros() []string {
 }
 
 // GetImages returns a list of images based on the given parameters
-func GetImages(cleanTag string, latest bool, optional bool, kubernetesVersion string, kubernetesDistro string) []string {
-	images := GetVclusterImages(latest, optional, cleanTag)
+func GetImages(cleanTag string, optional bool, kubernetesVersion string, kubernetesDistro string) []string {
+	images := GetVclusterImages(optional, cleanTag)
 	images = UniqueAppend(images,
-		GetImageList(latest, optional, kubernetesVersion, GetVclusterDependencyImageMaps(kubernetesDistro))...,
+		GetImageList(optional, kubernetesVersion, GetVclusterDependencyImageMaps(kubernetesDistro))...,
 	)
 	return images
 }
@@ -116,7 +107,7 @@ func GetSupportedKubernetesVersions() []string {
 // GetImageList returns a list of images based on the given groups
 // If latest is true, only the latest image of each group is returned
 // If kubernetesVersion is specified, only the images matching the version are returned
-func GetImageList(latest bool, optional bool, kubernetesVersion string, groups []map[string]string) []string {
+func GetImageList(optional bool, kubernetesVersion string, groups []map[string]string) []string {
 	selectedImages := make([]string, 0, len(groups))
 	for _, g := range groups {
 		if len(g) == 0 {
@@ -129,34 +120,34 @@ func GetImageList(latest bool, optional bool, kubernetesVersion string, groups [
 			continue
 		}
 		sortedImages := slices.Compact(getSortedDescValues(g))
-		if latest {
-			selectedImages = append(selectedImages, sortedImages[0])
-			continue
-		}
 		if optional {
+			// k3s and etcd images are all optional
+			if strings.Contains(sortedImages[0], k3s) || strings.Contains(sortedImages[0], etcd) {
+				selectedImages = append(selectedImages, sortedImages...)
+				continue
+			}
+			// if not k3s nor etcd, we take all images except the latest one (first in the sorted list)
 			selectedImages = append(selectedImages, sortedImages[1:]...)
 			continue
 		}
-		selectedImages = append(selectedImages, sortedImages[:]...)
+
+		// If we are not in optional mode, we only take the latest image. Except for k3s and etcd images that are always optional
+		if !strings.Contains(sortedImages[0], k3s) && !strings.Contains(sortedImages[0], etcd) {
+			selectedImages = append(selectedImages, sortedImages[0])
+		}
 	}
 	return selectedImages
 }
 
 // GetVclusterImages returns a list of vcluster images
-func GetVclusterImages(latest, optional bool, cleanTag string) []string {
-	images := []string{
-		"ghcr.io/loft-sh/vcluster-oss:" + cleanTag,
-		config.DefaultHostsRewriteImage,
-	}
-	if !optional {
-		if latest {
-			images = nil
+func GetVclusterImages(optional bool, cleanTag string) []string {
+	if optional {
+		return []string{
+			"ghcr.io/loft-sh/vcluster-oss:" + cleanTag,
+			config.DefaultHostsRewriteImage,
 		}
-		images = append(images,
-			"ghcr.io/loft-sh/vcluster-pro:"+cleanTag,
-		)
 	}
-	return images
+	return []string{"ghcr.io/loft-sh/vcluster-pro:" + cleanTag}
 }
 
 // GetVclusterDependencyImageMaps returns a list of maps containing vcluster image versions
@@ -166,34 +157,23 @@ func GetVclusterDependencyImageMaps(distro string) []map[string]string {
 	case k8s:
 		ret = append(ret,
 			vclusterconfig.K8SVersionMap,
-			getFullOptional(vclusterconfig.K8SEtcdVersionMap))
+			vclusterconfig.K8SEtcdVersionMap)
 	case k3s:
-		ret = append(ret, getFullOptional(vclusterconfig.K3SVersionMap))
+		ret = append(ret, vclusterconfig.K3SVersionMap)
 	default: // All distros
 		ret = append(ret,
 			vclusterconfig.K8SVersionMap,
-			getFullOptional(vclusterconfig.K8SEtcdVersionMap),
-			getFullOptional(vclusterconfig.K3SVersionMap),
+			vclusterconfig.K8SEtcdVersionMap,
+			vclusterconfig.K3SVersionMap,
 		)
 	}
 	ret = append(ret, constants.CoreDNSVersionMap)
 	return ret
 }
 
-// getFullOptional returns a map with an empty string key and value added.
-// This is used to ensure that the latest image is also pushed to the optional part of the list.
-// This is combined with the sorting function that puts the empty string at the beginning of the list (which is the latest one)
-func getFullOptional(m map[string]string) map[string]string {
-	m[""] = ""
-	return m
-}
-
 // UniqueAppend Appends unique elements to the slice
 func UniqueAppend(slice []string, elem ...string) []string {
 	for _, e := range elem {
-		if e == "" {
-			continue
-		}
 		if !slices.Contains(slice, e) {
 			slice = append(slice, e)
 		}
@@ -215,10 +195,7 @@ func getSortedDescValues(versionImageMap map[string]string) []string {
 // Comparison function for versions in descending order
 // Empty string is treated a greater than any other element
 func versionsDescCmp(x, y string) int {
-	if y == "" {
-		return 1
-	}
-	if x == "" || version.MustParse(x).GreaterThan(version.MustParse(y)) {
+	if version.MustParse(x).GreaterThan(version.MustParse(y)) {
 		return -1
 	}
 	return 1


### PR DESCRIPTION
Example output for version 1.2.3:


```
$ go run -mod vendor ./hack/assets/cmd/main.go 1.2.3 --latest
ghcr.io/loft-sh/vcluster-pro:1.2.3
ghcr.io/loft-sh/kubernetes:v1.32.1
coredns/coredns:1.11.3
```

```
$ go run -mod vendor ./hack/assets/cmd/main.go 1.2.3 --optional
ghcr.io/loft-sh/vcluster-oss:1.2.3
library/alpine:3.20
ghcr.io/loft-sh/kubernetes:v1.31.1
ghcr.io/loft-sh/kubernetes:v1.30.2
registry.k8s.io/etcd:3.5.21-0
registry.k8s.io/etcd:3.5.15-0
registry.k8s.io/etcd:3.5.13-0
rancher/k3s:v1.32.1-k3s1
rancher/k3s:v1.31.1-k3s1
rancher/k3s:v1.30.2-k3s1
```

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-6910


**Please provide a short message that should be published in the vcluster release notes**
Further slim down images.txt


**What else do we need to know?** 
