### PR TITLE
fix: Remove the deletion on `SyncToVirtual`

### DIFF
--- a/pkg/controllers/resources/ingressclasses/syncer.go
+++ b/pkg/controllers/resources/ingressclasses/syncer.go
@@ -50,7 +50,8 @@ func (i *ingressClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*networkingv1.IngressClass]) (ctrl.Result, error) {
 	if !ctx.Config.Sync.FromHost.IngressClasses.Selector.Matches(event.Host) {
-		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync ingress class %q because it does not match the selector under 'sync.fromHost.ingressClasses.selector'", event.Host.Name))
+		ctx.Log.Infof("Warning: did not sync ingress class %q because it does not match the selector under 'sync.fromHost.ingressClasses.selector'", event.Host.Name)
+		return ctrl.Result{}, nil
 	}
 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -111,7 +111,8 @@ func (s *priorityClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccont
 
 func (s *priorityClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*schedulingv1.PriorityClass]) (_ ctrl.Result, retErr error) {
 	if !ctx.Config.Sync.FromHost.PriorityClasses.Selector.Matches(event.Host) {
-		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync priority class %q because it does not match the selector under 'sync.fromHost.priorityClasses.selector'", event.Host.Name))
+		ctx.Log.Infof("Warning: did not sync priority class %q because it does not match the selector under 'sync.fromHost.priorityClasses.selector'", event.Host.Name)
+		return ctrl.Result{}, nil
 	}
 
 	// virtual object is not here anymore, so we delete

--- a/pkg/controllers/resources/runtimeclasses/syncer.go
+++ b/pkg/controllers/resources/runtimeclasses/syncer.go
@@ -50,7 +50,8 @@ func (i *runtimeClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 func (i *runtimeClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*nodev1.RuntimeClass]) (ctrl.Result, error) {
 	if !ctx.Config.Sync.FromHost.RuntimeClasses.Selector.Matches(event.Host) {
-		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync runtime class %q because it does not match the selector under 'sync.fromHost.runtimeClasses.selector'", event.Host.Name))
+		ctx.Log.Infof("Warning: did not sync runtime class %q because it does not match the selector under 'sync.fromHost.runtimeClasses.selector'", event.Host.Name)
+		return ctrl.Result{}, nil
 	}
 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -54,7 +54,8 @@ func (s *hostStorageClassSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 func (s *hostStorageClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*storagev1.StorageClass]) (ctrl.Result, error) {
 	if !ctx.Config.Sync.FromHost.StorageClasses.Selector.Matches(event.Host) {
-		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, fmt.Sprintf("did not sync storage class %q because it does not match the selector under 'sync.fromHost.storageClasses.selector'", event.Host.Name))
+		ctx.Log.Infof("Warning: did not sync storage class %q because it does not match the selector under 'sync.fromHost.storageClasses.selector'", event.Host.Name)
+		return ctrl.Result{}, nil
 	}
 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)


### PR DESCRIPTION
At this point the virtual part doesn't exist, so no need for a deletion. Just print a `Warning` instead.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Skip deletion on `SyncToVirtual` because the virtual part doesn't exist at this point.
Just log a warning instead


**What else do we need to know?** 
