### PR TITLE
requeue endpoint reconcile when the service is created after the endpoint

### DIFF
--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -1,9 +1,16 @@
 package endpoints
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/patcher"
@@ -14,13 +21,8 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/translator"
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
-	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
@@ -62,32 +64,27 @@ func (s *endpointsSyncer) Syncer() syncertypes.Sync[client.Object] {
 
 var _ syncertypes.ControllerModifier = &endpointsSyncer{}
 
-func (s *endpointsSyncer) ModifyController(ctx *synccontext.RegisterContext, bld *builder.Builder) (*builder.Builder, error) {
-    klog.Info("Starting to modify the controller to watch for Service changes and reconcile Endpoints")
+func (s *endpointsSyncer) ModifyController(_ *synccontext.RegisterContext, bld *builder.Builder) (*builder.Builder, error) {
+	klog.Info("Starting to modify the controller to watch for Service changes and reconcile Endpoints")
 
-    // Watch for changes to Services and reconcile Endpoints
-    bld = bld.Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {
-        service, ok := obj.(*corev1.Service)
-        if !ok || service == nil {
-            klog.Info("Received an object that is not a Service or is nil, skipping")
-            return []ctrl.Request{}
-        }
+	// Watch for changes to Services and reconcile Endpoints
+	return bld.Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {
+		service, ok := obj.(*corev1.Service)
+		if !ok || service == nil {
+			klog.Info("Received an object that is not a Service or is nil, skipping")
+			return []ctrl.Request{}
+		}
 
-        klog.Infof("Enqueuing reconciliation request of Endpoint for Service: %s/%s", service.Namespace, service.Name)
-
-        // Enqueue a request to reconcile the corresponding Endpoints
-        return []ctrl.Request{
-            {
-                NamespacedName: types.NamespacedName{
-                    Namespace: service.Namespace,
-                    Name:      service.Name,
-                },
-            },
-        }
-    }))
-
-    return bld, nil
+		// Enqueue a request to reconcile the corresponding Endpoints
+		return []ctrl.Request{{
+			NamespacedName: types.NamespacedName{
+				Namespace: service.Namespace,
+				Name:      service.Name,
+			},
+		}}
+	})), nil
 }
+
 //nolint:staticcheck // SA1019: corev1.Endpoints is deprecated, but still required for compatibility
 func (s *endpointsSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*corev1.Endpoints]) (ctrl.Result, error) {
 	if event.HostOld != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2719 
fixes ENG-6661


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster does not sync the endpoint to host cluster if the endpoint is created before the service.


**What else do we need to know?** 
When an endpoint is created before its corresponding service, it does not sync to the host cluster because reconciliation is skipped due to the absence of the service in the vcluster. This PR adds the code to trigger endpoint reconciliation after the service is created, ensuring the associated endpoint is also synced to the host cluster.
