### PR TITLE
Add imported marked annotation to prevent deletion of imported namespaces

### DIFF
--- a/pkg/controllers/resources/namespaces/syncer.go
+++ b/pkg/controllers/resources/namespaces/syncer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/syncer/translator"
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -110,13 +111,31 @@ func (s *namespaceSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.
 func (s *namespaceSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*corev1.Namespace]) (_ ctrl.Result, retErr error) {
 	// virtual object is not here anymore, so we delete
 	if event.VirtualOld != nil || event.Host.DeletionTimestamp != nil {
+		// first, lets check if host object was imported - if so, we don't delete it
+		if event.Host.Annotations != nil && event.Host.Annotations[translate.ImportedMarkerAnnotation] == "true" {
+			ctx.Log.Infof("host object %s/%s was imported, not deleting it", event.Host.Namespace, event.Host.Name)
+			return ctrl.Result{}, nil
+		}
+
 		return patcher.DeleteHostObject(ctx, event.Host, event.VirtualOld, "virtual object was deleted")
+	}
+
+	// add marker annotation to host object and update it
+	_, err := controllerutil.CreateOrPatch(ctx, ctx.PhysicalClient, event.Host, func() error {
+		if event.Host.Annotations == nil {
+			event.Host.Annotations = map[string]string{}
+		}
+		event.Host.Annotations[translate.ImportedMarkerAnnotation] = "true"
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("create or patch host object: %w", err)
 	}
 
 	newNamespace := s.translateToVirtual(ctx, event.Host)
 	ctx.Log.Infof("create virtual namespace %s", newNamespace.Name)
 
-	err := pro.ApplyPatchesVirtualObject(ctx, nil, newNamespace, event.Host, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, newNamespace, event.Host, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/util/translate/types.go
+++ b/pkg/util/translate/types.go
@@ -7,12 +7,13 @@ import (
 )
 
 var (
-	NamespaceAnnotation     = "vcluster.loft.sh/object-namespace"
-	NameAnnotation          = "vcluster.loft.sh/object-name"
-	UIDAnnotation           = "vcluster.loft.sh/object-uid"
-	KindAnnotation          = "vcluster.loft.sh/object-kind"
-	HostNameAnnotation      = "vcluster.loft.sh/object-host-name"
-	HostNamespaceAnnotation = "vcluster.loft.sh/object-host-namespace"
+	NamespaceAnnotation      = "vcluster.loft.sh/object-namespace"
+	NameAnnotation           = "vcluster.loft.sh/object-name"
+	UIDAnnotation            = "vcluster.loft.sh/object-uid"
+	KindAnnotation           = "vcluster.loft.sh/object-kind"
+	HostNameAnnotation       = "vcluster.loft.sh/object-host-name"
+	HostNamespaceAnnotation  = "vcluster.loft.sh/object-host-namespace"
+	ImportedMarkerAnnotation = "vcluster.loft.sh/object-imported"
 )
 
 var (


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6976


**Please provide a short message that should be published in the vcluster release notes**
Adds annotation to mark namespaces that were imported from host. This way we can prevent deletion of such namespaces on host in case they get removed from vCluster or if the vCluster itself gets deleted. 
