### PR TITLE
fix(ci): setup-kind action outdated cache version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -109,10 +109,11 @@ jobs:
           version: "v3.11.0"
 
       - name: Set up kind k8s cluster
-        uses: engineerd/setup-kind@v0.5.0
+        uses: loft-sh/setup-kind@master
         with:
           version: "v0.26.0"
           image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+          skipClusterLogsExport: "true"
 
       - name: Testing kind cluster set-up
         run: |
@@ -181,10 +182,11 @@ jobs:
           version: "v3.11.0"
 
       - name: Set up kind k8s cluster
-        uses: engineerd/setup-kind@v0.5.0
+        uses: loft-sh/setup-kind@master
         with:
           version: "v0.26.0"
           image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+          skipClusterLogsExport: "true"
 
       - name: Testing kind cluster set-up
         run: |
@@ -287,10 +289,11 @@ jobs:
           version: "v3.11.0"
 
       - name: Set up kind k8s cluster
-        uses: engineerd/setup-kind@v0.5.0
+        uses: loft-sh/setup-kind@master
         with:
           version: "v0.26.0"
           image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+          skipClusterLogsExport: "true"
 
       - name: Testing kind cluster set-up
         run: |


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
References OPS-176


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
The outdated cache version causes the action to take over 10 minutes. There is no fix in the official repository yet, that's why forking the action and referencing in workflows.