### PR TITLE
[v0.23] fix: add vcluster port-forward command to use as the background proxy… (#2872)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -275,6 +275,7 @@ jobs:
         run: |
           chmod +x ./vcluster-current
 
+          docker load --input vcluster_syncer
           kind load image-archive vcluster_syncer
           yq eval '.controlPlane.distro.${{ matrix.distribution }}.enabled = true' > ./test/vcluster-current.yaml
 
@@ -423,6 +424,7 @@ jobs:
           sed -i "s|REPLACE_TAG_NAME|${{ env.TAG_NAME }}|g" ${{ matrix.test-suite-path }}/../commonValues.yaml
           yq eval -i '.controlPlane.distro.${{ matrix.distribution }}.enabled = true'  ${{ matrix.test-suite-path }}/../commonValues.yaml
 
+          docker load --input vcluster_syncer
           kind load image-archive vcluster_syncer
 
           chmod +x vcluster && sudo mv vcluster /usr/bin
@@ -474,7 +476,12 @@ jobs:
 
           sudo chmod +x $(echo "${{ matrix.test-suite-path }}" | sed "s#./test/##g").test
 
-          VCLUSTER_SUFFIX=${{ env.VCLUSTER_SUFFIX }} VCLUSTER_NAME=${{ env.VCLUSTER_NAME }} VCLUSTER_NAMESPACE=${{ env.VCLUSTER_NAMESPACE }} MULTINAMESPACE_MODE=${{ matrix.multinamespace-mode }} ./$(echo "${{ matrix.test-suite-path }}" | sed "s#./test/##g").test -test.v --ginkgo.v --ginkgo.skip='.*NetworkPolicy.*' --ginkgo.fail-fast
+          VCLUSTER_SUFFIX=${{ env.VCLUSTER_SUFFIX }} \
+          VCLUSTER_NAME=${{ env.VCLUSTER_NAME }} \
+          VCLUSTER_NAMESPACE=${{ env.VCLUSTER_NAMESPACE }} \
+          VCLUSTER_BACKGROUND_PROXY_IMAGE=${{ env.REPOSITORY_NAME }}:${{ env.TAG_NAME }} \
+          MULTINAMESPACE_MODE=${{ matrix.multinamespace-mode }} \
+          ./$(echo "${{ matrix.test-suite-path }}" | sed "s#./test/##g").test -test.v --ginkgo.v --ginkgo.skip='.*NetworkPolicy.*' --ginkgo.fail-fast
           if kubectl logs -l app=${{ env.VCLUSTER_SUFFIX }} -n ${{ env.VCLUSTER_NAMESPACE }} -c syncer --tail=-1 -p >/dev/null 2>/dev/null; then
             echo "vCluster has restarted during testing, failing..."
             exit 1

--- a/cmd/vcluster/cmd/portforward.go
+++ b/cmd/vcluster/cmd/portforward.go
@@ -1,0 +1,459 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/loft-sh/vcluster/pkg/util/portforward"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/spdy"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/polymorphichelpers"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// PortForwardOptions contains all the options for running the port-forward cli command.
+type PortForwardOptions struct {
+	Namespace     string
+	PodName       string
+	RESTClient    restclient.Interface
+	Config        *restclient.Config
+	PodClient     corev1client.PodsGetter
+	Address       []string
+	Ports         []string
+	PortForwarder portForwarder
+	StopChannel   chan struct{}
+	ReadyChannel  chan struct{}
+}
+
+var (
+	portforwardLong = templates.LongDesc(i18n.T(`
+                Forward one or more local ports to a pod.
+
+                Use resource type/name such as deployment/mydeployment to select a pod. Resource type defaults to 'pod' if omitted.
+
+                If there are multiple pods matching the criteria, a pod will be selected automatically. The
+                forwarding session ends when the selected pod terminates, and a rerun of the command is needed
+                to resume forwarding.`))
+
+	portforwardExample = templates.Examples(i18n.T(`
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
+		vcluster port-forward pod/mypod 5000 6000
+
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in a pod selected by the deployment
+		vcluster port-forward deployment/mydeployment 5000 6000
+
+		# Listen on port 8443 locally, forwarding to the targetPort of the service's port named "https" in a pod selected by the service
+		vcluster port-forward service/myservice 8443:https
+
+		# Listen on port 8888 locally, forwarding to 5000 in the pod
+		vcluster port-forward pod/mypod 8888:5000
+
+		# Listen on port 8888 on all addresses, forwarding to 5000 in the pod
+		vcluster port-forward --address 0.0.0.0 pod/mypod 8888:5000
+
+		# Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
+		vcluster port-forward --address localhost,10.19.21.23 pod/mypod 8888:5000
+
+		# Listen on a random port locally, forwarding to 5000 in the pod
+		vcluster port-forward pod/mypod :5000`))
+)
+
+const (
+	// Amount of time to wait until at least one pod is running
+	defaultPodPortForwardWaitTimeout = 60 * time.Second
+)
+
+func NewPortForwardCommand() *cobra.Command {
+	streams := genericiooptions.IOStreams{
+		In:     os.Stdin,
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
+	opts := NewDefaultPortForwardOptions(streams)
+	cmd := &cobra.Command{
+		Use:                   "port-forward TYPE/NAME [options] [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Forward one or more local ports to a pod"),
+		Long:                  portforwardLong,
+		Example:               portforwardExample,
+	}
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).
+		WithDeprecatedPasswordFlag().
+		WithDiscoveryBurst(300).
+		WithDiscoveryQPS(50.0).
+		WithWarningPrinter(streams)
+	kubeConfigFlags.AddFlags(cmd.Flags())
+
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	matchVersionKubeConfigFlags.AddFlags(cmd.Flags())
+
+	factory := cmdutil.NewFactory(matchVersionKubeConfigFlags)
+
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodPortForwardWaitTimeout)
+	cmd.Flags().StringSliceVar(&opts.Address, "address", []string{"localhost"}, "Addresses to listen on (comma separated). Only accepts IP addresses or localhost as a value. When localhost is supplied, kubectl will try to bind on both 127.0.0.1 and ::1 and will fail if neither of these addresses are available to bind.")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		cmdutil.CheckErr(opts.Complete(factory, cmd, args))
+		cmdutil.CheckErr(opts.Validate())
+		cmdutil.CheckErr(opts.RunPortForwardContext(cmd.Context()))
+	}
+
+	return cmd
+}
+
+func NewDefaultPortForwardOptions(streams genericiooptions.IOStreams) *PortForwardOptions {
+	return &PortForwardOptions{
+		PortForwarder: &defaultPortForwarder{
+			IOStreams: streams,
+		},
+	}
+}
+
+type portForwarder interface {
+	ForwardPorts(ctx context.Context, method string, url *url.URL, opts PortForwardOptions) error
+}
+
+type defaultPortForwarder struct {
+	genericiooptions.IOStreams
+}
+
+func createDialer(method string, url *url.URL, opts PortForwardOptions) (httpstream.Dialer, error) {
+	transport, upgrader, err := spdy.RoundTripperFor(opts.Config)
+	if err != nil {
+		return nil, err
+	}
+	return spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url), nil
+}
+
+func (f *defaultPortForwarder) ForwardPorts(ctx context.Context, method string, url *url.URL, opts PortForwardOptions) error {
+	dialer, err := createDialer(method, url, opts)
+	if err != nil {
+		return err
+	}
+
+	fw, err := portforward.NewOnAddresses(dialer, opts.Address, opts.Ports, opts.StopChannel, opts.ReadyChannel, nil, f.Out, f.ErrOut)
+	if err != nil {
+		return err
+	}
+
+	return fw.ForwardPorts(ctx)
+}
+
+// splitPort splits port string which is in form of [LOCAL PORT]:REMOTE PORT
+// and returns local and remote ports separately
+func splitPort(port string) (local, remote string) {
+	parts := strings.Split(port, ":")
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+
+	return parts[0], parts[0]
+}
+
+// Translates service port to target port
+// It rewrites ports as needed if the Service port declares targetPort.
+// It returns an error when a named targetPort can't find a match in the pod, or the Service did not declare
+// the port.
+func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod corev1.Pod) ([]string, error) {
+	var translated []string
+	for _, port := range ports {
+		localPort, remotePort := splitPort(port)
+
+		portnum, err := strconv.Atoi(remotePort)
+		if err != nil {
+			svcPort, err := util.LookupServicePortNumberByName(svc, remotePort)
+			if err != nil {
+				return nil, err
+			}
+			portnum = int(svcPort)
+
+			if localPort == remotePort {
+				localPort = strconv.Itoa(portnum)
+			}
+		}
+		containerPort, err := util.LookupContainerPortNumberByServicePort(svc, pod, int32(portnum))
+		if err != nil {
+			// can't resolve a named port, or Service did not declare this port, return an error
+			return nil, err
+		}
+
+		// convert the resolved target port back to a string
+		remotePort = strconv.Itoa(int(containerPort))
+
+		if localPort != remotePort {
+			translated = append(translated, fmt.Sprintf("%s:%s", localPort, remotePort))
+		} else {
+			translated = append(translated, remotePort)
+		}
+	}
+	return translated, nil
+}
+
+// convertPodNamedPortToNumber converts named ports into port numbers
+// It returns an error when a named port can't be found in the pod containers
+func convertPodNamedPortToNumber(ports []string, pod corev1.Pod) ([]string, error) {
+	var converted []string
+	for _, port := range ports {
+		localPort, remotePort := splitPort(port)
+		if remotePort == "" {
+			return nil, fmt.Errorf("remote port cannot be empty")
+		}
+		containerPortStr := remotePort
+		_, err := strconv.Atoi(remotePort)
+		if err != nil {
+			containerPort, err := util.LookupContainerPortNumberByName(pod, remotePort)
+			if err != nil {
+				return nil, err
+			}
+
+			containerPortStr = strconv.Itoa(int(containerPort))
+		}
+
+		if localPort != remotePort {
+			converted = append(converted, fmt.Sprintf("%s:%s", localPort, containerPortStr))
+		} else {
+			converted = append(converted, containerPortStr)
+		}
+	}
+
+	return converted, nil
+}
+
+func checkUDPPorts(udpOnlyPorts sets.Set[int], ports []string, obj metav1.Object) error {
+	for _, port := range ports {
+		_, remotePort := splitPort(port)
+		portNum, err := strconv.Atoi(remotePort)
+		if err != nil {
+			switch v := obj.(type) {
+			case *corev1.Service:
+				svcPort, err := util.LookupServicePortNumberByName(*v, remotePort)
+				if err != nil {
+					return err
+				}
+				portNum = int(svcPort)
+
+			case *corev1.Pod:
+				ctPort, err := util.LookupContainerPortNumberByName(*v, remotePort)
+				if err != nil {
+					return err
+				}
+				portNum = int(ctPort)
+
+			default:
+				return fmt.Errorf("unknown object: %v", obj)
+			}
+		}
+		if udpOnlyPorts.Has(portNum) {
+			return fmt.Errorf("UDP protocol is not supported for %s", remotePort)
+		}
+	}
+	return nil
+}
+
+// checkUDPPortInService returns an error if remote port in Service is a UDP port
+// TODO: remove this check after #47862 is solved
+func checkUDPPortInService(ports []string, svc *corev1.Service) error {
+	udpPorts := sets.New[int]()
+	tcpPorts := sets.New[int]()
+	for _, port := range svc.Spec.Ports {
+		portNum := int(port.Port)
+		switch port.Protocol {
+		case corev1.ProtocolUDP:
+			udpPorts.Insert(portNum)
+		case corev1.ProtocolTCP:
+			tcpPorts.Insert(portNum)
+		default:
+		}
+	}
+	return checkUDPPorts(udpPorts.Difference(tcpPorts), ports, svc)
+}
+
+// checkUDPPortInPod returns an error if remote port in Pod is a UDP port
+// TODO: remove this check after #47862 is solved
+func checkUDPPortInPod(ports []string, pod *corev1.Pod) error {
+	udpPorts := sets.New[int]()
+	tcpPorts := sets.New[int]()
+	for _, ct := range pod.Spec.Containers {
+		for _, ctPort := range ct.Ports {
+			portNum := int(ctPort.ContainerPort)
+			switch ctPort.Protocol {
+			case corev1.ProtocolUDP:
+				udpPorts.Insert(portNum)
+			case corev1.ProtocolTCP:
+				tcpPorts.Insert(portNum)
+			default:
+			}
+		}
+	}
+	return checkUDPPorts(udpPorts.Difference(tcpPorts), ports, pod)
+}
+
+// Complete completes all the required options for port-forward cmd.
+func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	var err error
+	if len(args) < 2 {
+		return cmdutil.UsageErrorf(cmd, "TYPE/NAME and list of ports are required for port-forward")
+	}
+
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	builder := f.NewBuilder().
+		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
+		ContinueOnError().
+		NamespaceParam(o.Namespace).DefaultNamespace()
+
+	getPodTimeout, err := cmdutil.GetPodRunningTimeoutFlag(cmd)
+	if err != nil {
+		return cmdutil.UsageErrorf(cmd, "%s", err.Error())
+	}
+
+	resourceName := args[0]
+	builder.ResourceNames("pods", resourceName)
+
+	obj, err := builder.Do().Object()
+	if err != nil {
+		return err
+	}
+
+	forwardablePod, err := polymorphichelpers.AttachablePodForObjectFn(f, obj, getPodTimeout)
+	if err != nil {
+		return err
+	}
+
+	o.PodName = forwardablePod.Name
+
+	// handle service port mapping to target port if needed
+	switch t := obj.(type) {
+	case *corev1.Service:
+		err = checkUDPPortInService(args[1:], t)
+		if err != nil {
+			return err
+		}
+		o.Ports, err = translateServicePortToTargetPort(args[1:], *t, *forwardablePod)
+		if err != nil {
+			return err
+		}
+	default:
+		err = checkUDPPortInPod(args[1:], forwardablePod)
+		if err != nil {
+			return err
+		}
+		o.Ports, err = convertPodNamedPortToNumber(args[1:], *forwardablePod)
+		if err != nil {
+			return err
+		}
+	}
+
+	clientset, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+
+	o.PodClient = clientset.CoreV1()
+
+	o.Config, err = f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	o.RESTClient, err = f.RESTClient()
+	if err != nil {
+		return err
+	}
+
+	o.StopChannel = make(chan struct{}, 1)
+	o.ReadyChannel = make(chan struct{})
+	return nil
+}
+
+// Validate validates all the required options for port-forward cmd.
+func (o PortForwardOptions) Validate() error {
+	if len(o.PodName) == 0 {
+		return fmt.Errorf("pod name or resource type/name must be specified")
+	}
+
+	if len(o.Ports) < 1 {
+		return fmt.Errorf("at least 1 PORT is required for port-forward")
+	}
+
+	if o.PortForwarder == nil || o.PodClient == nil || o.RESTClient == nil || o.Config == nil {
+		return fmt.Errorf("client, client config, restClient, and portforwarder must be provided")
+	}
+	return nil
+}
+
+// RunPortForwardContext implements all the necessary functionality for port-forward cmd.
+// It ends portforwarding when an error is received from the backend, or an os.Interrupt
+// signal is received, or the provided context is done.
+func (o PortForwardOptions) RunPortForwardContext(ctx context.Context) error {
+	pod, err := o.PodClient.Pods(o.Namespace).Get(ctx, o.PodName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
+	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	defer signal.Stop(signals)
+
+	returnCtx, returnCtxCancel := context.WithCancel(ctx)
+	defer returnCtxCancel()
+
+	go func() {
+		select {
+		case <-signals:
+		case <-returnCtx.Done():
+		}
+		if o.StopChannel != nil {
+			close(o.StopChannel)
+		}
+	}()
+
+	req := o.RESTClient.Post().
+		Resource("pods").
+		Namespace(o.Namespace).
+		Name(pod.Name).
+		SubResource("portforward")
+
+	return o.PortForwarder.ForwardPorts(ctx, "POST", req.URL(), o)
+}

--- a/cmd/vcluster/cmd/root.go
+++ b/cmd/vcluster/cmd/root.go
@@ -59,6 +59,7 @@ func BuildRoot() *cobra.Command {
 	// add top level commands
 	rootCmd.AddCommand(NewStartCommand())
 	rootCmd.AddCommand(NewCpCommand())
+	rootCmd.AddCommand(NewPortForwardCommand())
 	rootCmd.AddCommand(debug.NewDebugCmd())
 	return rootCmd
 }

--- a/pkg/constants/cli.go
+++ b/pkg/constants/cli.go
@@ -1,0 +1,20 @@
+package constants
+
+import (
+	"os"
+
+	"github.com/loft-sh/vcluster/pkg/upgrade"
+)
+
+func DefaultBackgroundProxyImage(version string) string {
+	envProxyImage := os.Getenv("VCLUSTER_BACKGROUND_PROXY_IMAGE")
+	if envProxyImage != "" {
+		return envProxyImage
+	}
+
+	if version == upgrade.DevelopmentVersion {
+		return "ghcr.io/loft-sh/vcluster:dev-next"
+	}
+
+	return "ghcr.io/loft-sh/vcluster-pro:" + version
+}

--- a/pkg/server/filters/service.go
+++ b/pkg/server/filters/service.go
@@ -146,7 +146,7 @@ func updateService(ctx *synccontext.SyncContext, req *http.Request, decoder enco
 	// okay now we have to change the physical service
 	pService := &corev1.Service{}
 	pServiceName := mappings.VirtualToHost(ctx, oldVService.Name, oldVService.Namespace, mappings.Services())
-	err = ctx.PhysicalClient.Get(ctx, client.ObjectKey{Namespace: pServiceName.Namespace, Name: pServiceName.Name}, pService)
+	err = ctx.PhysicalClient.Get(ctx, pServiceName, pService)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil, kerrors.NewNotFound(corev1.Resource("services"), oldVService.Name)


### PR DESCRIPTION
Backport from `main` to `v0.23`

Original PR Nr.: #2872
Resolves: ENG-7160

### Backported Commits:
- 74e339e4 fix: add vcluster port-forward command to use as the background proxy… (#2872)

* fix: add vcluster port-forward command to use as the background proxy process until https://github.com/containerd/containerd/issues/9875 is resolved

* feat: allow setting the background proxy image via environment variable
