### PR TITLE
Cleanup metadata of imported namespces when removing vCluster

### DIFF
--- a/pkg/cli/cleanup_namespaces.go
+++ b/pkg/cli/cleanup_namespaces.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/util/namespaces"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	vClusterMetadataPrefix = "vcluster.loft.sh/"
 )
 
 // NamespaceCleanupHandler defines the function signature for namespace cleanup operations.
@@ -79,7 +85,10 @@ func cleanupSyncedNamespaces(
 	for _, ns := range nsList.Items {
 		// Check if namespace was imported, if yes we skip deletion for 'synced' policy.
 		if ns.Annotations != nil && ns.Annotations[translate.ImportedMarkerAnnotation] == "true" {
-			logger.Infof("Namespace %s was imported, skip cleanup.", ns.Name)
+			logger.Infof("Namespace %s was imported, cleaning up import.", ns.Name)
+			if err := cleanupNamespaceMetadata(ctx, k8sClient, &ns); err != nil {
+				errs = append(errs, err)
+			}
 			continue
 		}
 
@@ -163,5 +172,30 @@ func cleanupAllNamespaces(
 	}
 
 	logger.Infof("Cleanup of vCluster '%s' namespaces finished.", vClusterName)
+	return nil
+}
+
+func cleanupNamespaceMetadata(
+	ctx context.Context,
+	k8sClient *kubernetes.Clientset,
+	ns *corev1.Namespace,
+) error {
+	for k := range ns.GetAnnotations() {
+		if strings.HasPrefix(k, vClusterMetadataPrefix) {
+			delete(ns.Annotations, k)
+		}
+	}
+
+	for k := range ns.GetLabels() {
+		if strings.HasPrefix(k, vClusterMetadataPrefix) {
+			delete(ns.Labels, k)
+		}
+	}
+
+	_, err := k8sClient.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating namespace %s after cleaning metadata: %w", ns.Name, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6976


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was not importing a namespace that was previously imported by a different, already uninstalled vcluster.

