### PR TITLE
[ENG-7165, ENG-7207] fix(fromHost): Mark and only sync resources that are created by vCluster

### DIFF
--- a/pkg/controllers/resources/ingressclasses/syncer_test.go
+++ b/pkg/controllers/resources/ingressclasses/syncer_test.go
@@ -17,9 +17,10 @@ func TestSync(t *testing.T) {
 	vObjectMeta := metav1.ObjectMeta{
 		Name: "test-ingc",
 		Annotations: map[string]string{
-			translate.NameAnnotation: "test-ingc",
-			translate.UIDAnnotation:  "",
-			translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
+			translate.NameAnnotation:     "test-ingc",
+			translate.HostNameAnnotation: "test-ingc",
+			translate.UIDAnnotation:      "",
+			translate.KindAnnotation:     networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
 		},
 		ResourceVersion: "999",
 	}
@@ -67,9 +68,10 @@ func TestSync(t *testing.T) {
 				translate.MarkerLabel: translate.VClusterName,
 			},
 			Annotations: map[string]string{
-				translate.NameAnnotation: "test-ingc",
-				translate.UIDAnnotation:  "",
-				translate.KindAnnotation: networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
+				translate.NameAnnotation:     "test-ingc",
+				translate.HostNameAnnotation: "test-ingc",
+				translate.UIDAnnotation:      "",
+				translate.KindAnnotation:     networkingv1.SchemeGroupVersion.WithKind("IngressClass").String(),
 			},
 		},
 		Spec: networkingv1.IngressClassSpec{

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -76,6 +76,11 @@ func (s *priorityClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 }
 
 func (s *priorityClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*schedulingv1.PriorityClass]) (_ ctrl.Result, retErr error) {
+	// If the virtual object has the name annotation, it means it was created by vCluster and we can safely manage it.
+	if _, ok := event.Virtual.GetAnnotations()[translate.HostNameAnnotation]; !ok {
+		return ctrl.Result{}, nil
+	}
+
 	matches, err := ctx.Config.Sync.FromHost.PriorityClasses.Selector.Matches(event.Host)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("check priority class selector: %w", err)

--- a/pkg/controllers/resources/priorityclasses/syncer_test.go
+++ b/pkg/controllers/resources/priorityclasses/syncer_test.go
@@ -22,8 +22,8 @@ func TestSyncToHost(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "vcluster-stuff-x-test-x-suffix"},
 		Value:      1,
 	}
-
 	pObj.Annotations = translate.HostAnnotations(&vObj, &pObj)
+
 	testCases := []struct {
 		name         string
 		syncToHost   bool
@@ -109,6 +109,7 @@ func TestSyncToVirtual(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "stuff"},
 		Value:      1,
 	}
+	vObj.Annotations = translate.HostAnnotations(&vObj, &pObj)
 
 	testCases := []struct {
 		name         string

--- a/pkg/controllers/resources/priorityclasses/translate.go
+++ b/pkg/controllers/resources/priorityclasses/translate.go
@@ -22,6 +22,7 @@ func (s *priorityClassSyncer) translate(ctx *synccontext.SyncContext, vObj clien
 func (s *priorityClassSyncer) translateFromHost(ctx *synccontext.SyncContext, pObj client.Object) *schedulingv1.PriorityClass {
 	// translate the priority class
 	priorityClass := translate.VirtualMetadata(pObj.(*schedulingv1.PriorityClass), s.HostToVirtual(ctx, types.NamespacedName{Name: pObj.GetName(), Namespace: pObj.GetNamespace()}, pObj))
+	priorityClass.SetAnnotations(translate.HostAnnotations(priorityClass, pObj))
 	if priorityClass.Name == "" {
 		priorityClass.Name = pObj.GetName()
 	}
@@ -30,9 +31,9 @@ func (s *priorityClassSyncer) translateFromHost(ctx *synccontext.SyncContext, pO
 
 func (s *priorityClassSyncer) translateUpdate(event *synccontext.SyncEvent[*schedulingv1.PriorityClass]) {
 	if s.fromHost {
+		event.Virtual.Annotations = translate.VirtualAnnotations(event.Host, event.Virtual)
 		event.Virtual.PreemptionPolicy = event.Host.PreemptionPolicy
 		event.Virtual.Description = event.Host.Description
-		event.Virtual.Annotations = event.Host.Annotations
 		event.Virtual.Labels = event.Host.Labels
 	} else if s.toHost {
 		// bi-directional

--- a/pkg/controllers/resources/runtimeclasses/syncer_test.go
+++ b/pkg/controllers/resources/runtimeclasses/syncer_test.go
@@ -16,12 +16,14 @@ import (
 )
 
 func TestSync(t *testing.T) {
+	vObjectName := "test-runtimec"
 	vObjectMeta := metav1.ObjectMeta{
-		Name: "test-ingc",
+		Name: vObjectName,
 		Annotations: map[string]string{
-			translate.NameAnnotation: "test-runtimec",
-			translate.UIDAnnotation:  "",
-			translate.KindAnnotation: nodev1.SchemeGroupVersion.WithKind("RuntimeClass").String(),
+			translate.NameAnnotation:     vObjectName,
+			translate.HostNameAnnotation: vObjectName,
+			translate.UIDAnnotation:      "",
+			translate.KindAnnotation:     nodev1.SchemeGroupVersion.WithKind("RuntimeClass").String(),
 		},
 		ResourceVersion: "999",
 	}
@@ -42,11 +44,6 @@ func TestSync(t *testing.T) {
 			Name: vObjectMeta.Name,
 			Labels: map[string]string{
 				translate.MarkerLabel: translate.VClusterName,
-			},
-			Annotations: map[string]string{
-				translate.NameAnnotation: "test-runtimec",
-				translate.UIDAnnotation:  "",
-				translate.KindAnnotation: nodev1.SchemeGroupVersion.WithKind("RuntimeClass").String(),
 			},
 		},
 		Scheduling: &nodev1.Scheduling{
@@ -74,11 +71,6 @@ func TestSync(t *testing.T) {
 			Name: translate.Default.HostNameCluster(vObjectMeta.Name),
 			Labels: map[string]string{
 				translate.MarkerLabel: translate.VClusterName,
-			},
-			Annotations: map[string]string{
-				translate.NameAnnotation: "test-runtimec",
-				translate.UIDAnnotation:  "",
-				translate.KindAnnotation: nodev1.SchemeGroupVersion.WithKind("RuntimeClass").String(),
 			},
 		},
 		Scheduling: &nodev1.Scheduling{

--- a/pkg/controllers/resources/storageclasses/host_syncer_test.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer_test.go
@@ -48,6 +48,8 @@ func TestFromHostSync(t *testing.T) {
 		},
 		Provisioner: "my-provisioner",
 	}
+	vObject.Annotations = translate.HostAnnotations(vObject, pObject)
+
 	pObjectUpdated := pObject.DeepCopy()
 	pObjectUpdated.Labels["example.com/label-c"] = "test-3"
 	pObjectUpdated.Annotations["example.com/annotation-c"] = "test-3"


### PR DESCRIPTION
The intent of this PR is to solve the problem of vCluster trying to sync/manage resources that are not created by itself.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-7165


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster tries to delete/update resources that are not created by vCluster. This PR avoids it by marking the resources created by us and checking for it before the sync


**What else do we need to know?** 
