### PR TITLE
fix(issues/2889): Close os.Stdout when using `vcluster connect <vcluster-id> --print`

### DIFF
--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -167,6 +167,7 @@ func writeKubeConfig(kubeConfig *clientcmdapi.Config, vClusterName string, optio
 		if err != nil {
 			return err
 		}
+		_ = os.Stdout.Close()
 	} else if options.UpdateCurrent {
 		var clusterConfig *clientcmdapi.Cluster
 		for _, c := range kubeConfig.Clusters {


### PR DESCRIPTION
**What issue type does this pull request address?** 

/kind bugfix


**What does this pull request do? Which issues does it resolve?**

resolve #2889 


**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where running `vcluster connect <vcluster-id> --print | tee ./vcluster.yaml` appended unwanted port fowarding output to the generated file, such as: 
~~~
Forwarding from 127.0.0.1:10641 -> 8443
Forwarding from [::1]:10641 -> 8443
~~~

I found the unwanted output coming from [portforward.go](https://github.com/loft-sh/vcluster/blob/74e339e4dce0e3ff0befaae05be10f3fdffb66bb/pkg/util/portforward/portforward.go#L339-L341), which is part of kubernetes source code. Changing the source code directly would be a pain to maintain, so I tackled the issue in the `--print` logic of the `connect` command instead.
The code is as follows:

~~~go
	if options.Print {
		_, err = os.Stdout.Write(out)
		if err != nil {
			return err
		}
		_ = os.Stdout.Close() // Add it 
	}
~~~

**What else do we need to know?** 
I'm not sure what the unintended error of `os.Stdout.Close()` would be.