### PR TITLE
feat: add --kms-key-id and --server-side-encryption flags 

### DIFF
--- a/cmd/vclusterctl/cmd/snapshot.go
+++ b/cmd/vclusterctl/cmd/snapshot.go
@@ -54,5 +54,6 @@ vcluster snapshot my-vcluster container:///data/my-local-snapshot.tar.gz
 
 	// add storage flags
 	pod.AddFlags(cobraCmd.Flags(), &cmd.Pod, false)
+	snapshot.AddFlags(cobraCmd.Flags(), &cmd.Snapshot)
 	return cobraCmd
 }

--- a/pkg/snapshot/s3/store.go
+++ b/pkg/snapshot/s3/store.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"slices"
 
+	"k8s.io/klog/v2"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -254,15 +256,18 @@ func (o *ObjectStore) PutObject(ctx context.Context, body io.Reader) error {
 	// if kmsKeyID is not empty, assume a server-side encryption (SSE)
 	// algorithm of "aws:kms"
 	case o.kmsKeyID != "":
+		klog.FromContext(ctx).Info("using aws:kms server-side encryption (SSE-KMS)", "kmsKeyId", o.kmsKeyID)
 		input.ServerSideEncryption = "aws:kms"
 		input.SSEKMSKeyId = &o.kmsKeyID
 	// if sseCustomerKey is not empty, assume SSE-C encryption with AES256 algorithm
 	case o.sseCustomerKey != "":
+		klog.FromContext(ctx).Info("using aws server-side encryption (SSE-C) with customer provided key")
 		input.SSECustomerAlgorithm = aws.String("AES256")
 		input.SSECustomerKey = &o.sseCustomerKey
 		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	// otherwise, use the SSE algorithm specified, if any
 	case o.serverSideEncryption != "":
+		klog.FromContext(ctx).Info("using aws server-side encryption (SSE)", "server-side-encryption", o.serverSideEncryption)
 		input.ServerSideEncryption = types.ServerSideEncryption(o.serverSideEncryption)
 	}
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/spf13/pflag"
+
 	"github.com/loft-sh/vcluster/pkg/snapshot/container"
 	"github.com/loft-sh/vcluster/pkg/snapshot/oci"
 	"github.com/loft-sh/vcluster/pkg/snapshot/options"
@@ -147,4 +149,10 @@ func Validate(options *Options) error {
 	}
 
 	return nil
+}
+
+func AddFlags(flags *pflag.FlagSet, options *Options) {
+	flags.StringVarP(&options.S3.KmsKeyID, "kms-key-id", "", "", "AWS KMS key ID that is configured for given S3 bucket. If set, aws-kms SSE will be used")
+	flags.StringVarP(&options.S3.CustomerKeyEncryptionFile, "customer-key-encryption-file", "", "", "AWS customer key encryption file used for SSE-C. Mutually exclusive with kms-key-id")
+	flags.StringVarP(&options.S3.ServerSideEncryption, "server-side-encryption", "", "", "AWS Server-Side encryption algorithm")
 }


### PR DESCRIPTION
for using SSE in vcluster snapshot with s3 bucket as a backend

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6850


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
