### PR TITLE
Add pro feature config check for Hybrid scheduling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -731,6 +731,10 @@ func (c *Config) IsProFeatureEnabled() bool {
 		return true
 	}
 
+	if c.Sync.ToHost.Pods.HybridScheduling.Enabled {
+		return true
+	}
+
 	return false
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -362,6 +362,21 @@ func TestConfig_IsProFeatureEnabled(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "Hybrid scheduling is enabled",
+			config: &Config{
+				Sync: Sync{
+					ToHost: SyncToHost{
+						Pods: SyncPods{
+							HybridScheduling: HybridScheduling{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster create` did not show error when using Hybrid Scheduling pro feature without pro license.

**What else do we need to know?** 
There is already the pro feature / license check in the syncer (so syncer wouldn't start without the proper license), but the check was missing in the config check which is used by the CLI when the cluster is created (earlier in the vcluster creation process).