### PR TITLE
vcluster platform connect: fix server path for kubeconfig

### DIFF
--- a/pkg/platform/helper.go
+++ b/pkg/platform/helper.go
@@ -678,13 +678,14 @@ func CreateClusterContextOptions(platformClient Client, config string, cluster *
 		CurrentNamespace: spaceName,
 		SetActive:        setActive,
 	}
-	host := platformClient.Config().Platform.Host
 	directHost, directInsecure := getDirectEndpointAndInsecureFromClusterAnnotations(cluster)
 
 	if directHost != "" {
-		host = directHost
+		contextOptions.Server = directHost + "/kubernetes/cluster"
+	} else {
+		contextOptions.Server = platformClient.Config().Platform.Host + "/kubernetes/cluster/" + cluster.Name
 	}
-	contextOptions.Server = host + "/kubernetes/cluster/" + cluster.Name
+
 	contextOptions.InsecureSkipTLSVerify = platformClient.Config().Platform.Insecure
 
 	if directInsecure != "" {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-6899


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform connect cluster had invalid .server path


**What else do we need to know?** 
