### PR TITLE
Lint vcluster config: Warn about hybrid scheduling without effect

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -327,6 +327,11 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 		return err
 	}
 
+	warnings := pkgconfig.Lint(*vClusterConfig)
+	for _, warning := range warnings {
+		cmd.log.Warnf(warning)
+	}
+
 	if vClusterConfig.Sync.ToHost.Namespaces.Enabled {
 		if err := namespaces.ValidateNamespaceSyncConfig(vClusterConfig, vClusterName, cmd.Namespace); err != nil {
 			return err

--- a/pkg/config/lint.go
+++ b/pkg/config/lint.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"github.com/loft-sh/vcluster/config"
+)
+
 const (
 	// HybridSchedulingNoEffectWarning is displayed when both the virtual scheduler and the hybrid
 	// scheduling are enabled, but no host schedulers have been added.
@@ -10,13 +14,13 @@ const (
 		"scheduler, to sync.toHost.pods.hybridScheduling.hostSchedulers, or disabling the hybrid scheduling."
 )
 
-// LintConfig checks the virtual cluster config and returns warnings for the parts of the config
+// Lint checks the virtual cluster config and returns warnings for the parts of the config
 // that should be probably corrected, but are not breaking any functionality in the cluster.
-func LintConfig(vConfig *VirtualClusterConfig) []string {
+func Lint(config config.Config) []string {
 	var warnings []string
-	if vConfig.IsVirtualSchedulerEnabled() &&
-		vConfig.Sync.ToHost.Pods.HybridScheduling.Enabled &&
-		len(vConfig.Sync.ToHost.Pods.HybridScheduling.HostSchedulers) == 0 {
+	if config.IsVirtualSchedulerEnabled() &&
+		config.Sync.ToHost.Pods.HybridScheduling.Enabled &&
+		len(config.Sync.ToHost.Pods.HybridScheduling.HostSchedulers) == 0 {
 		warnings = append(warnings, HybridSchedulingNoEffectWarning)
 	}
 

--- a/pkg/config/lint.go
+++ b/pkg/config/lint.go
@@ -11,7 +11,7 @@ const (
 		"but you have not added any host scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers config, " +
 		"so all the pods will be scheduled by the default scheduler in the virtual cluster. Enabling " +
 		"the hybrid scheduling does not have any effect here. Consider either adding at least one host " +
-		"scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers, or disabling the hybrid scheduling."
+		"scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers, or disable the hybrid scheduling."
 )
 
 // Lint checks the virtual cluster config and returns warnings for the parts of the config

--- a/pkg/config/lint.go
+++ b/pkg/config/lint.go
@@ -10,7 +10,7 @@ const (
 	HybridSchedulingNoEffectWarning = "You have enabled both the virtual scheduler and the hybrid scheduling, " +
 		"but you have not added any host scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers config, " +
 		"so all the pods will be scheduled by the default scheduler in the virtual cluster. Enabling " +
-		"the hybrid scheduling  does not have any effect here. Consider either adding at least one host " +
+		"the hybrid scheduling does not have any effect here. Consider either adding at least one host " +
 		"scheduler, to sync.toHost.pods.hybridScheduling.hostSchedulers, or disabling the hybrid scheduling."
 )
 

--- a/pkg/config/lint.go
+++ b/pkg/config/lint.go
@@ -1,0 +1,24 @@
+package config
+
+const (
+	// HybridSchedulingNoEffectWarning is displayed when both the virtual scheduler and the hybrid
+	// scheduling are enabled, but no host schedulers have been added.
+	HybridSchedulingNoEffectWarning = "You have enabled both the virtual scheduler and the hybrid scheduling, " +
+		"but you have not added any host scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers config, " +
+		"so all the pods will be scheduled by the default scheduler in the virtual cluster. Enabling " +
+		"the hybrid scheduling  does not have any effect here. Consider either adding at least one host " +
+		"scheduler, to sync.toHost.pods.hybridScheduling.hostSchedulers, or disabling the hybrid scheduling."
+)
+
+// LintConfig checks the virtual cluster config and returns warnings for the parts of the config
+// that should be probably corrected, but are not breaking any functionality in the cluster.
+func LintConfig(vConfig *VirtualClusterConfig) []string {
+	var warnings []string
+	if vConfig.IsVirtualSchedulerEnabled() &&
+		vConfig.Sync.ToHost.Pods.HybridScheduling.Enabled &&
+		len(vConfig.Sync.ToHost.Pods.HybridScheduling.HostSchedulers) == 0 {
+		warnings = append(warnings, HybridSchedulingNoEffectWarning)
+	}
+
+	return warnings
+}

--- a/pkg/config/lint.go
+++ b/pkg/config/lint.go
@@ -11,7 +11,7 @@ const (
 		"but you have not added any host scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers config, " +
 		"so all the pods will be scheduled by the default scheduler in the virtual cluster. Enabling " +
 		"the hybrid scheduling does not have any effect here. Consider either adding at least one host " +
-		"scheduler, to sync.toHost.pods.hybridScheduling.hostSchedulers, or disabling the hybrid scheduling."
+		"scheduler to sync.toHost.pods.hybridScheduling.hostSchedulers, or disabling the hybrid scheduling."
 )
 
 // Lint checks the virtual cluster config and returns warnings for the parts of the config

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/strvals"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"github.com/loft-sh/vcluster/pkg/util/stringutil"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -53,9 +54,10 @@ func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, 
 		return nil, err
 	}
 
-	warnings := LintConfig(retConfig)
+	configLogger := loghelper.New("vcluster-config")
+	warnings := Lint(retConfig.Config)
 	for _, warning := range warnings {
-		fmt.Printf("Warning: %s\n", warning)
+		configLogger.Infof("Warning: %s", warning)
 	}
 
 	return retConfig, nil

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -53,6 +53,11 @@ func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, 
 		return nil, err
 	}
 
+	warnings := LintConfig(retConfig)
+	for _, warning := range warnings {
+		fmt.Printf("Warning: %s\n", warning)
+	}
+
 	return retConfig, nil
 }
 

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -54,7 +54,7 @@ func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, 
 		return nil, err
 	}
 
-	configLogger := loghelper.New("vcluster-config")
+	configLogger := loghelper.New("config")
 	warnings := Lint(retConfig.Config)
 	for _, warning := range warnings {
 		configLogger.Infof("Warning: %s", warning)

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
+	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/pods/scheduling"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/pods/token"
 	"github.com/loft-sh/vcluster/pkg/mappings"
@@ -101,6 +102,11 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		ctx.Config.Sync.ToHost.Pods.HybridScheduling.HostSchedulers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create scheduling config: %w", err)
+	}
+	if ctx.Config.IsVirtualSchedulerEnabled() &&
+		ctx.Config.Sync.ToHost.Pods.HybridScheduling.Enabled &&
+		len(ctx.Config.Sync.ToHost.Pods.HybridScheduling.HostSchedulers) == 0 {
+		fmt.Printf("Warning: %s", config.HybridSchedulingNoEffectWarning)
 	}
 
 	return &podSyncer{

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
-	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/pods/scheduling"
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/pods/token"
 	"github.com/loft-sh/vcluster/pkg/mappings"
@@ -102,11 +101,6 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		ctx.Config.Sync.ToHost.Pods.HybridScheduling.HostSchedulers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create scheduling config: %w", err)
-	}
-	if ctx.Config.IsVirtualSchedulerEnabled() &&
-		ctx.Config.Sync.ToHost.Pods.HybridScheduling.Enabled &&
-		len(ctx.Config.Sync.ToHost.Pods.HybridScheduling.HostSchedulers) == 0 {
-		fmt.Printf("Warning: %s", config.HybridSchedulingNoEffectWarning)
 	}
 
 	return &podSyncer{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-7235


**Please provide a short message that should be published in the vcluster release notes**
Added warning when the virtual scheduler and the hybrid scheduling are both enabled, but the host schedulers have not been set.


**What else do we need to know?** 
