### PR TITLE
[ENG-7336, ENG-7342] fix: Ignore the *Class limiting when no selector is specified

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -982,6 +982,11 @@ type SyncFromHost struct {
 
 type StandardLabelSelector v1.LabelSelector
 
+func (s StandardLabelSelector) Empty() bool {
+	selector, err := s.ToSelector()
+	return err == nil && selector.Empty()
+}
+
 func (s StandardLabelSelector) Matches(obj client.Object) (bool, error) {
 	selector, err := s.ToSelector()
 	if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -48,4 +48,9 @@ var (
 	// VClusterNamespaceInHostMappingSpecialCharacter is an empty string that mean vCluster host namespace
 	// in the config.sync.fromHost.*.selector.mappings
 	VClusterNamespaceInHostMappingSpecialCharacter = ""
+
+	SystemPriorityClassesAllowList = []string{
+		"system-node-critical",
+		"system-cluster-critical",
+	}
 )

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -299,23 +299,28 @@ func recreatePersistentVolumeClaim(ctx *synccontext.SyncContext, virtualClient c
 }
 
 func (s *persistentVolumeClaimSyncer) applyLimitByClass(ctx *synccontext.SyncContext, virtual *corev1.PersistentVolumeClaim) bool {
-	// Get the host storage class and check if it matches the selector
-	if ctx.Config.Sync.FromHost.StorageClasses.Enabled.Bool() && virtual.Spec.StorageClassName != nil && *virtual.Spec.StorageClassName != "" {
-		pStorageClass := &storagev1.StorageClass{}
-		err := ctx.PhysicalClient.Get(ctx.Context, types.NamespacedName{Name: *virtual.Spec.StorageClassName}, pStorageClass)
-		if err != nil || pStorageClass.GetDeletionTimestamp() != nil {
-			s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q couldn't be reached in the host: %s", virtual.GetName(), *virtual.Spec.StorageClassName, err)
-			return true
-		}
-		matches, err := ctx.Config.Sync.FromHost.StorageClasses.Selector.Matches(pStorageClass)
-		if err != nil {
-			s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q in the host could not be checked against the selector under 'sync.fromHost.storageClasses.selector': %s", virtual.GetName(), pStorageClass.GetName(), err)
-			return true
-		}
-		if !matches {
-			s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q in the host does not match the selector under 'sync.fromHost.storageClasses.selector'", virtual.GetName(), pStorageClass.GetName())
-			return true
-		}
+	if !ctx.Config.Sync.FromHost.StorageClasses.Enabled.Bool() ||
+		ctx.Config.Sync.FromHost.StorageClasses.Selector.Empty() ||
+		virtual.Spec.StorageClassName == nil ||
+		*virtual.Spec.StorageClassName == "" {
+		return false
 	}
+
+	pStorageClass := &storagev1.StorageClass{}
+	err := ctx.PhysicalClient.Get(ctx.Context, types.NamespacedName{Name: *virtual.Spec.StorageClassName}, pStorageClass)
+	if err != nil || pStorageClass.GetDeletionTimestamp() != nil {
+		s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q couldn't be reached in the host: %s", virtual.GetName(), *virtual.Spec.StorageClassName, err)
+		return true
+	}
+	matches, err := ctx.Config.Sync.FromHost.StorageClasses.Selector.Matches(pStorageClass)
+	if err != nil {
+		s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q in the host could not be checked against the selector under 'sync.fromHost.storageClasses.selector': %s", virtual.GetName(), pStorageClass.GetName(), err)
+		return true
+	}
+	if !matches {
+		s.EventRecorder().Eventf(virtual, "Warning", "SyncWarning", "did not sync persistent volume claim %q to host because the storage class %q in the host does not match the selector under 'sync.fromHost.storageClasses.selector'", virtual.GetName(), pStorageClass.GetName())
+		return true
+	}
+
 	return false
 }

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/patcher"
 	"github.com/loft-sh/vcluster/pkg/pro"
@@ -20,11 +21,6 @@ import (
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 )
-
-var systemPriorityClassesAllowList = []string{
-	"system-node-critical",
-	"system-cluster-critical",
-}
 
 func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	fromHost := ctx.Config.Sync.FromHost.PriorityClasses.Enabled
@@ -82,7 +78,7 @@ func (s *priorityClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 }
 
 func (s *priorityClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*schedulingv1.PriorityClass]) (_ ctrl.Result, retErr error) {
-	if !slices.Contains(systemPriorityClassesAllowList, event.Host.Name) {
+	if !slices.Contains(constants.SystemPriorityClassesAllowList, event.Host.Name) {
 		matches, err := ctx.Config.Sync.FromHost.PriorityClasses.Selector.Matches(event.Host)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check priority class selector: %w", err)
@@ -122,7 +118,7 @@ func (s *priorityClassSyncer) Sync(ctx *synccontext.SyncContext, event *synccont
 }
 
 func (s *priorityClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*schedulingv1.PriorityClass]) (_ ctrl.Result, retErr error) {
-	if !slices.Contains(systemPriorityClassesAllowList, event.Host.Name) {
+	if !slices.Contains(constants.SystemPriorityClassesAllowList, event.Host.Name) {
 		matches, err := ctx.Config.Sync.FromHost.PriorityClasses.Selector.Matches(event.Host)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check priority class selector: %w", err)


### PR DESCRIPTION
This avoids applying exclusion in the following cases:
- When selector is not specified
- On Pods when priority class is a native one

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves ENG-7336
Resolves ENG-7342


**Please provide a short message that should be published in the vcluster release notes**

**What else do we need to know?** 
Then no `selector` is specified no filtering is applied.