### PR TITLE
List all virtual cluster instance while trying to get access key in `vcluster platform add vcluster`

### DIFF
--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -179,10 +179,11 @@ func getAccessKey(ctx context.Context, kubeClient kubernetes.Interface, platform
 	} else if err == nil {
 		serviceUID := string(service.UID)
 
-		// find existing vCluster
-		virtualClusterList, err := managementClient.Loft().ManagementV1().VirtualClusterInstances(projectutil.ProjectNamespace(project)).List(ctx, metav1.ListOptions{})
+		// Finding the virtualcluster instance without passing namespace because , virtual cluster instance that we are trying
+		// to create access key for may exist in another namespace. Hence we are listing all the virtualcluster instances
+		virtualClusterList, err := managementClient.Loft().ManagementV1().VirtualClusterInstances("").List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return "", "", fmt.Errorf("could not list virtual cluster instances in project %s: %w", project, err)
+			return "", "", fmt.Errorf("could not list virtual cluster instances: %w", err)
 		}
 
 		// try to find vCluster


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

https://github.com/loft-sh/vcluster/blob/main/pkg/platform/secret.go#L183 is returning 0 virtual cluster instances in the namespace passed to the function. This is causing a new virtual cluster instance being created [here](https://github.com/loft-sh/vcluster/blob/main/pkg/platform/secret.go#L311), even though it exists in another namespace. This leads to having 2 virtual cluster instances in two different projects

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-7352


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster `vcluster platform vcluster add --project` was allowing the user to change the project


**What else do we need to know?** 
