### PR TITLE
Fixing the flaky test in e2e_limit_classes

### DIFF
--- a/test/e2e_limit_classes/limitClasses/storageClasses.go
+++ b/test/e2e_limit_classes/limitClasses/storageClasses.go
@@ -113,21 +113,21 @@ var _ = ginkgo.Describe("Test limitclass on fromHost", ginkgo.Ordered, func() {
 		_, err = f.HostClient.CoreV1().PersistentVolumeClaims(testNamespace).Get(f.Context, fssdClassName, metav1.GetOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 
-		ginkgo.By("There should be a warning message event in the describe of the created ingress")
-		eventList, err := f.VClusterClient.CoreV1().Events(testNamespace).List(f.Context, metav1.ListOptions{
-			FieldSelector: fmt.Sprintf("involvedObject.kind=PersistentVolumeClaim,involvedObject.name=%s", fstoragePvc),
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		var found bool
-		for _, event := range eventList.Items {
-			if event.Type == corev1.EventTypeWarning && event.Reason == "SyncWarning" {
-				found = true
-				expectedSubstring := fmt.Sprintf(`did not sync persistent volume claim "%s" to host because the storage class "%s" in the host does not match the selector under 'sync.fromHost.storageClasses.selector'`, fstoragePvc, fsClassName)
-				gomega.Expect(event.Message).To(gomega.ContainSubstring(expectedSubstring))
-				break
+		ginkgo.By("There should be a warning message event in the describe of the created PVC")
+		gomega.Eventually(func() bool {
+			eventList, err := f.VClusterClient.CoreV1().Events(testNamespace).List(f.Context, metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("involvedObject.kind=PersistentVolumeClaim,involvedObject.name=%s", fstoragePvc),
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			for _, event := range eventList.Items {
+				if event.Type == corev1.EventTypeWarning && event.Reason == "SyncWarning" {
+					expectedSubstring := fmt.Sprintf(`did not sync persistent volume claim "%s" to host because the storage class "%s" in the host does not match the selector under 'sync.fromHost.storageClasses.selector'`, fstoragePvc, fsClassName)
+					gomega.Expect(event.Message).To(gomega.ContainSubstring(expectedSubstring))
+					return true
+				}
 			}
-		}
-		gomega.Expect(found).To(gomega.BeTrue(), "Expected to find a SyncWarning event for the ingress with unavailable ingressClass")
+			return false
+		}).WithTimeout(time.Minute).WithPolling(time.Second).Should(gomega.BeTrue(), "Timed out waiting for SyncWarning event for PVC %s", fstoragePvc)
 	})
 
 	ginkgo.It("should sync vcluster PVCs using allowed storageClass to host", func() {


### PR DESCRIPTION
What issue type does this pull request address? (keep at least one, remove the others)
/kind test

What does this pull request do? Which issues does it resolve? (use resolves #<issue_number> if possible)
resolves #
Warning Message for the unavailable classes in resources created was not found within the given time. Added gomega eventually so that event will be consistently checked before triggering the error.

Please provide a short message that should be published in the vcluster release notes
Fixing the flaky test in e2e_limit_classes for ingressClasses and storageClasses.