### PR TITLE
chore(ci): add codeowners for github actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /.github/workflows/e2e.yaml @FabianKramm
 /.github/workflows/e2e.yaml @loft-sh/eng-qa
 /.github/workflows/release.yaml @FabianKramm
+/.github/workflows/ @Piotr1215 @sydorovdmytro
 
 /chart/ @FabianKramm @hidalgopl
 


### PR DESCRIPTION
Define code owners for Github action workflows.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
related to OPS-171

**What else do we need to know?** 
We want to be automatically assigned to PRs created by Dependabot with Github actions updates.