### PR TITLE
fix: Clean up Released PVs in virtual cluster

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -309,6 +309,9 @@ func (s *persistentVolumeSyncer) shouldSync(ctx *synccontext.SyncContext, pObj *
 		} else if translate.Default.IsManaged(ctx, pObj) {
 			return true, nil, nil
 		}
+		if translate.Default.IsTargetedNamespace(ctx, pObj.Spec.ClaimRef.Namespace) && pObj.Status.Phase == corev1.VolumeReleased {
+			return true, nil, nil
+		}
 
 		return translate.Default.IsTargetedNamespace(ctx, pObj.Spec.ClaimRef.Namespace) && pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
 	}

--- a/test/e2e/values.yaml
+++ b/test/e2e/values.yaml
@@ -69,3 +69,10 @@ sync:
           "from-host-sync-test-2/dummy": "barfoo2/dummy"
           "default/my-secret": "barfoo2/secret-my"
           "/my-secret-in-default-ns": "barfoo2/secret-from-default-ns"
+    storageClasses:
+      enabled: true
+  toHost:
+    persistentVolumeClaims:
+      enabled: true
+    persistentVolumes:
+      enabled: true

--- a/test/framework/util.go
+++ b/test/framework/util.go
@@ -180,6 +180,32 @@ func (f *Framework) WaitForServiceToUpdate(client *kubernetes.Clientset, service
 	})
 }
 
+func (f *Framework) WaitForPVCDeletion(namespace, name string) error {
+	return wait.PollUntilContextTimeout(f.Context, time.Second*5, PollTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := f.VClusterClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func (f *Framework) WaitForPVDeletion(name string) error {
+	return wait.PollUntilContextTimeout(f.Context, time.Second*5, PollTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := f.VClusterClient.CoreV1().PersistentVolumes().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
+
 // Some vcluster operations list Service, e.g. pod translation.
 // To ensure expected results of such operation we need to wait until newly created Service is in syncer controller cache,
 // otherwise syncer will operate on slightly outdated resources, which is not good for test stability.


### PR DESCRIPTION
A Released PV would not trigger a sync on the Delete event from the host.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2939 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the deletion of a Released PV in the host cluster would not be propagate to the virtual cluster until vcluster was restarted or the object modified again.

**What else do we need to know?** 
This change does not change anything in the behavior of the syncer itself.
It changes what events are enqueued for reconciliation through the `shouldSync` and therefore `IsManaged` function of the PV syncer.
Therefore, its unit tests are not the right place for a regression test.