### PR TITLE
Cert rotation

### DIFF
--- a/cmd/vcluster/cmd/certs/certs.go
+++ b/cmd/vcluster/cmd/certs/certs.go
@@ -1,0 +1,22 @@
+package certs
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCertsCmd() *cobra.Command {
+	certsCmd := &cobra.Command{
+		Use:   "certs",
+		Short: "vCluster certs subcommands",
+		Long: `#######################################################
+################## vcluster certs #####################
+#######################################################
+	`,
+		Args: cobra.NoArgs,
+	}
+
+	certsCmd.AddCommand(rotate())
+	certsCmd.AddCommand(rotateCA())
+	certsCmd.AddCommand(check())
+	return certsCmd
+}

--- a/cmd/vcluster/cmd/certs/check.go
+++ b/cmd/vcluster/cmd/certs/check.go
@@ -80,7 +80,7 @@ func (cmd *checkCmd) Run() error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("walking PKI dir: %w", err)
+		return fmt.Errorf("finding certificate information: %w", err)
 	}
 
 	if err := json.NewEncoder(os.Stdout).Encode(certificateInfos); err != nil {

--- a/cmd/vcluster/cmd/certs/check.go
+++ b/cmd/vcluster/cmd/certs/check.go
@@ -1,0 +1,102 @@
+package certs
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/certs"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/spf13/cobra"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+type checkCmd struct {
+	Path string
+	log  log.Logger
+}
+
+func check() *cobra.Command {
+	cmd := &checkCmd{
+		log: log.GetInstance(),
+	}
+
+	checkCmd := &cobra.Command{
+		Use:   "check",
+		Short: "Checks the current certificates",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return cmd.Run()
+		}}
+
+	checkCmd.Flags().StringVar(&cmd.Path, "path", constants.PKIDir, "Destination path to the PKI directory")
+
+	return checkCmd
+}
+
+// Run checks the current certificates in the PKI directory and returns base information about those.
+func (cmd *checkCmd) Run() error {
+	now := time.Now()
+	var certificateInfos []certs.Info
+	err := filepath.WalkDir(cmd.Path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".crt" {
+			return nil
+		}
+
+		c, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading file %s", path)
+		}
+
+		crts, err := certutil.ParseCertsPEM(c)
+		if err != nil {
+			return err
+		}
+
+		for _, crt := range crts {
+			certificateInfos = append(certificateInfos, certs.Info{
+				Filename:   d.Name(),
+				Subject:    crt.Subject.CommonName,
+				Issuer:     crt.Issuer.CommonName,
+				ExpiryTime: crt.NotAfter,
+				Status:     certStatus(crt, now),
+			})
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("walking PKI dir: %w", err)
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(certificateInfos); err != nil {
+		return fmt.Errorf("encoding JSON: %w", err)
+	}
+
+	return nil
+}
+
+func certStatus(cert *x509.Certificate, now time.Time) string {
+	if now.Before(cert.NotBefore) {
+		return "NOT YET VALID"
+	}
+	if now.After(cert.NotAfter) {
+		return "EXPIRED"
+	}
+
+	return "OK"
+}

--- a/cmd/vcluster/cmd/certs/rotate.go
+++ b/cmd/vcluster/cmd/certs/rotate.go
@@ -1,0 +1,69 @@
+package certs
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/certs"
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/setup"
+	"github.com/spf13/cobra"
+)
+
+type rotateCmd struct {
+	log log.Logger
+}
+
+func rotate() *cobra.Command {
+	cmd := &rotateCmd{
+		log: log.GetInstance(),
+	}
+
+	rotateCmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotates control-plane client and server certs",
+		Args:  cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return cmd.Run(cobraCmd.Context(), false)
+		}}
+
+	return rotateCmd
+}
+
+func rotateCA() *cobra.Command {
+	cmd := &rotateCmd{
+		log: log.GetInstance(),
+	}
+
+	rotateCACmd := &cobra.Command{
+		Use:   "rotate-ca",
+		Short: "Rotates the CA certificate",
+		Args:  cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return cmd.Run(cobraCmd.Context(), true)
+		}}
+
+	return rotateCACmd
+}
+
+func (cmd *rotateCmd) Run(ctx context.Context, withCA bool) error {
+	vConfig, err := config.ParseConfig(constants.DefaultVClusterConfigLocation, os.Getenv("VCLUSTER_NAME"), nil)
+	if err != nil {
+		return fmt.Errorf("parsing vCluster config: %w", err)
+	}
+
+	vConfig.ControlPlaneConfig, vConfig.ControlPlaneNamespace, vConfig.ControlPlaneService, vConfig.WorkloadConfig, vConfig.WorkloadNamespace, vConfig.WorkloadService, err = pro.GetRemoteClient(vConfig)
+	if err != nil {
+		return fmt.Errorf("getting remote client: %w", err)
+	}
+
+	if err := setup.InitClients(vConfig); err != nil {
+		return fmt.Errorf("initializing clients: %w", err)
+	}
+
+	return certs.Rotate(ctx, vConfig, withCA, cmd.log)
+}

--- a/cmd/vcluster/cmd/certs/rotate.go
+++ b/cmd/vcluster/cmd/certs/rotate.go
@@ -9,8 +9,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/certs"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
-	"github.com/loft-sh/vcluster/pkg/pro"
-	"github.com/loft-sh/vcluster/pkg/setup"
 	"github.com/spf13/cobra"
 )
 
@@ -54,15 +52,6 @@ func (cmd *rotateCmd) Run(ctx context.Context, withCA bool) error {
 	vConfig, err := config.ParseConfig(constants.DefaultVClusterConfigLocation, os.Getenv("VCLUSTER_NAME"), nil)
 	if err != nil {
 		return fmt.Errorf("parsing vCluster config: %w", err)
-	}
-
-	vConfig.ControlPlaneConfig, vConfig.ControlPlaneNamespace, vConfig.ControlPlaneService, vConfig.WorkloadConfig, vConfig.WorkloadNamespace, vConfig.WorkloadService, err = pro.GetRemoteClient(vConfig)
-	if err != nil {
-		return fmt.Errorf("getting remote client: %w", err)
-	}
-
-	if err := setup.InitClients(vConfig); err != nil {
-		return fmt.Errorf("initializing clients: %w", err)
 	}
 
 	return certs.Rotate(ctx, vConfig, withCA, cmd.log)

--- a/cmd/vcluster/cmd/root.go
+++ b/cmd/vcluster/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	loftlogr "github.com/loft-sh/log/logr"
+	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/certs"
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/debug"
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/node"
 	"github.com/spf13/cobra"
@@ -64,5 +65,6 @@ func BuildRoot() *cobra.Command {
 	rootCmd.AddCommand(NewPortForwardCommand())
 	rootCmd.AddCommand(debug.NewDebugCmd())
 	rootCmd.AddCommand(node.NewNodeCmd())
+	rootCmd.AddCommand(certs.NewCertsCmd())
 	return rootCmd
 }

--- a/cmd/vcluster/cmd/snapshot.go
+++ b/cmd/vcluster/cmd/snapshot.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/certs"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/etcd"
@@ -351,7 +352,7 @@ func generateCertificates(ctx context.Context, vConfig *config.VirtualClusterCon
 
 	// generate etcd certificates
 	certificatesDir := constants.PKIDir
-	err = setup.GenerateCerts(ctx, serviceCIDR, certificatesDir, vConfig)
+	err = certs.Generate(ctx, serviceCIDR, certificatesDir, vConfig)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/vcluster/cmd/snapshot.go
+++ b/cmd/vcluster/cmd/snapshot.go
@@ -19,7 +19,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/etcd"
 	"github.com/loft-sh/vcluster/pkg/k8s"
 	"github.com/loft-sh/vcluster/pkg/pro"
-	"github.com/loft-sh/vcluster/pkg/setup"
+	setupconfig "github.com/loft-sh/vcluster/pkg/setup/config"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
 	"github.com/loft-sh/vcluster/pkg/util/servicecidr"
 	"github.com/spf13/cobra"
@@ -339,7 +339,7 @@ func generateCertificates(ctx context.Context, vConfig *config.VirtualClusterCon
 	if err != nil {
 		return "", err
 	}
-	err = setup.InitClients(vConfig)
+	err = setupconfig.InitClients(vConfig)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -16,6 +16,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/pro"
 	"github.com/loft-sh/vcluster/pkg/scheme"
 	"github.com/loft-sh/vcluster/pkg/setup"
+	setupconfig "github.com/loft-sh/vcluster/pkg/setup/config"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/telemetry"
 	"github.com/pkg/errors"
@@ -75,7 +76,7 @@ func StartInCluster(ctx context.Context, options *StartOptions) error {
 	}
 
 	// init config
-	err = setup.InitAndValidateConfig(ctx, vConfig)
+	err = setupconfig.InitAndValidateConfig(ctx, vConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/certs/certs.go
+++ b/cmd/vclusterctl/cmd/certs/certs.go
@@ -1,0 +1,23 @@
+package certs
+
+import (
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/spf13/cobra"
+)
+
+func NewCertsCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	certsCmd := &cobra.Command{
+		Use:   "certs",
+		Short: "vCluster certs subcommands",
+		Long: `#######################################################
+################### vcluster certs ####################
+#######################################################
+	`,
+		Args: cobra.NoArgs,
+	}
+
+	certsCmd.AddCommand(rotate(globalFlags))
+	certsCmd.AddCommand(rotateCA(globalFlags))
+	certsCmd.AddCommand(check(globalFlags))
+	return certsCmd
+}

--- a/cmd/vclusterctl/cmd/certs/check.go
+++ b/cmd/vclusterctl/cmd/certs/check.go
@@ -1,0 +1,47 @@
+package certs
+
+import (
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/certs"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/spf13/cobra"
+)
+
+type checkCmd struct {
+	*flags.GlobalFlags
+
+	Output string
+	log    log.Logger
+}
+
+func check(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &checkCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	useLine, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+	checkCmd := &cobra.Command{
+		Use:   "check" + useLine,
+		Short: "Checks the current certificates",
+		Long: `##############################################################
+################### vcluster certs check #####################
+##############################################################
+Checks the current certificates.
+
+Examples:
+vcluster -n test certs check test
+##############################################################
+	`,
+		Args:              nameValidator,
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return certs.Check(cobraCmd.Context(), args[0], cmd.GlobalFlags, cmd.Output, cmd.log)
+		}}
+
+	checkCmd.Flags().StringVar(&cmd.Output, "output", "table", "Choose the format of the output. [table|json]")
+
+	return checkCmd
+}

--- a/cmd/vclusterctl/cmd/certs/rotate.go
+++ b/cmd/vclusterctl/cmd/certs/rotate.go
@@ -1,0 +1,83 @@
+package certs
+
+import (
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/certs"
+	"github.com/loft-sh/vcluster/pkg/cli/completion"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/util"
+	"github.com/spf13/cobra"
+)
+
+type rotateCmd struct {
+	*flags.GlobalFlags
+	log log.Logger
+}
+
+func rotate(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &rotateCmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	useLine, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+	rotateCmd := &cobra.Command{
+		Use:   "rotate" + useLine,
+		Short: "Rotates control-plane client and server certs",
+		Long: `##############################################################
+################### vcluster certs rotate ####################
+##############################################################
+Rotates the control-plane client and server leaf certificates
+of the given virtual cluster.
+
+Examples:
+vcluster -n test certs rotate test
+##############################################################
+	`,
+		Args:              nameValidator,
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return certs.Rotate(cobraCmd.Context(), args[0], certs.RotationCmdCerts, cmd.GlobalFlags, cmd.log)
+		}}
+
+	return rotateCmd
+}
+
+type rotateCACmd struct {
+	*flags.GlobalFlags
+	log log.Logger
+}
+
+func rotateCA(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &rotateCACmd{
+		GlobalFlags: globalFlags,
+		log:         log.GetInstance(),
+	}
+
+	useLine, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+	rotateCACmd := &cobra.Command{
+		Use:   "rotate-ca" + useLine,
+		Short: "Rotates the CA certificate",
+		Long: `##############################################################
+################## vcluster certs rotate-ca ##################
+##############################################################
+Rotates the CA certificates of the given virtual cluster using
+the current CA certificates.
+The CA files (ca.{crt,key}) can be placed in the PKI directory
+(either /data/pki or /var/lib/vcluster/pki) to issue new leaf
+certificates to be signed by that CA.
+If the ca.crt file is a bundle containing multiple certificates
+the new CA cert must be the first one in the bundle.
+
+Examples:
+vcluster certs rotate-ca test
+##############################################################
+	`,
+		Args:              nameValidator,
+		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return certs.Rotate(cobraCmd.Context(), args[0], certs.RotationCmdCACerts, cmd.GlobalFlags, cmd.log)
+		}}
+
+	return rotateCACmd
+}

--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -7,26 +7,26 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/debug"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/node"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/registry"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/token"
-	"github.com/loft-sh/vcluster/pkg/platform/defaults"
-	"github.com/mitchellh/go-homedir"
-
 	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/certs"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/convert"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/credits"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/debug"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/node"
 	cmdplatform "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/platform/set"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/registry"
 	cmdtelemetry "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/telemetry"
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/token"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/use"
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/loft-sh/vcluster/pkg/telemetry"
 	"github.com/loft-sh/vcluster/pkg/upgrade"
+	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -138,6 +138,7 @@ func BuildRoot(log log.Logger) (*cobra.Command, *flags.GlobalFlags, error) {
 	rootCmd.AddCommand(token.NewTokenCmd(globalFlags))
 	rootCmd.AddCommand(node.NewNodeCmd(globalFlags))
 	rootCmd.AddCommand(registry.NewRegistryCmd(globalFlags))
+	rootCmd.AddCommand(certs.NewCertsCmd(globalFlags))
 
 	// add platform commands
 	platformCmd, err := cmdplatform.NewPlatformCmd(globalFlags)

--- a/pkg/certs/rotate.go
+++ b/pkg/certs/rotate.go
@@ -32,7 +32,7 @@ type Info struct {
 // Rotate rotates the certificates in the PKI directory.
 // If running non-standalone it also updates the cert secret to contain the newly created certificates.
 // Depending on the withCA argument this either means rotation the leaf certificates (withCA=false)
-// or the whole PKI infra (withCA=true). In both cases the current SA pub and private key are untouched.
+// or the whole PKI infra (withCA=true). In both cases the current SA pub and private keys are untouched.
 func Rotate(ctx context.Context,
 	vConfig *config.VirtualClusterConfig,
 	withCA bool,

--- a/pkg/certs/rotate.go
+++ b/pkg/certs/rotate.go
@@ -1,0 +1,219 @@
+package certs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/util/servicecidr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Info struct {
+	Filename   string    `json:"filename,omitempty"`
+	Subject    string    `json:"subject,omitempty"`
+	Issuer     string    `json:"issuer,omitempty"`
+	ExpiryTime time.Time `json:"expiryTime"`
+	Status     string    `json:"status,omitempty"` // "OK", "EXPIRED"
+}
+
+// Rotate rotates the certificates in the PKI directory.
+// If running non-standalone it also updates the cert secret to contain the newly created certificates.
+// Depending on the withCA argument this either means rotation the leaf certificates (withCA=false)
+// or the whole PKI infra (withCA=true). In both cases the current SA pub and private key are untouched.
+// IMPORTANT NOTE: The function expects the clients in vConfig to be populated.
+func Rotate(ctx context.Context,
+	vConfig *config.VirtualClusterConfig,
+	withCA bool,
+	log log.Logger) error {
+	serviceCIDR, err := servicecidr.GetServiceCIDR(ctx, &vConfig.Config, vConfig.WorkloadClient, vConfig.WorkloadService, vConfig.WorkloadNamespace)
+	if err != nil {
+		return fmt.Errorf("getting service cidr: %w", err)
+	}
+
+	kubeadmConfig, err := GenerateInitKubeadmConfig(serviceCIDR, constants.PKIDir, vConfig)
+	if err != nil {
+		return fmt.Errorf("generating kubeadm config: %w", err)
+	}
+
+	var validityPeriod time.Duration
+	dev, period := os.Getenv("DEVELOPMENT"), os.Getenv("VCLUSTER_CERTS_VALIDITYPERIOD")
+	if dev == "true" && period != "" {
+		validityPeriod, err = time.ParseDuration(period)
+		if err != nil {
+			return fmt.Errorf("parsing duration format: %w", err)
+		}
+
+		log.Info("Setting custom cert validity period")
+		kubeadmConfig.CertificateValidityPeriod = &metav1.Duration{Duration: validityPeriod}
+		if withCA {
+			kubeadmConfig.CACertificateValidityPeriod = &metav1.Duration{Duration: validityPeriod}
+		}
+	}
+
+	log.Info("Backing up previous PKI directory")
+	backupDirName := fmt.Sprintf("%d", time.Now().Unix())
+	backupDir := filepath.Join(constants.PKIDir, "../pki.bak/"+backupDirName)
+	if err := backupDirectory(constants.PKIDir, backupDir); err != nil {
+		return fmt.Errorf("backing up PKI directory")
+	}
+	log.Infof("Backup available at %s", backupDir)
+
+	excludeFuncs := []excludeFunc{excludeSAFiles}
+	if !withCA {
+		excludeFuncs = append(excludeFuncs, excludeCAFiles)
+	}
+
+	log.Info("Removing relevant certificate files from PKI directory")
+	if err := removeFiles(constants.PKIDir, excludeFuncs...); err != nil {
+		return fmt.Errorf("removing files from PKI directory: %w", err)
+	}
+
+	if err := generateCertificates(constants.PKIDir, kubeadmConfig); err != nil {
+		return fmt.Errorf("creating pki assets: %w", err)
+	}
+
+	// In standalone there is no host secret so we skip updating the secret.
+	if vConfig.ControlPlane.Standalone.Enabled {
+		return nil
+	}
+
+	// Update the secret so in case of a restart without persistence we don't loose data.
+	return updateSecret(ctx, vConfig.ControlPlaneNamespace, CertSecretName(vConfig.Name), constants.PKIDir, vConfig.ControlPlaneClient)
+}
+
+func backupDirectory(src, dst string) error {
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0755)
+		}
+
+		return copyFile(path, dstPath)
+	})
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, srcInfo.Mode())
+}
+
+type excludeFunc func(name string) bool
+
+func removeFiles(path string, excludeFuncs ...excludeFunc) error {
+	return filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		for _, shouldExclude := range excludeFuncs {
+			if shouldExclude(d.Name()) {
+				return nil
+			}
+		}
+
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing %s: %w", path, err)
+		}
+
+		return nil
+	})
+}
+
+func excludeCAFiles(name string) bool {
+	if name == CACertName {
+		return true
+	}
+	if name == CAKeyName {
+		return true
+	}
+	if strings.HasSuffix(name, fmt.Sprintf("-%s", CACertName)) {
+		return true
+	}
+	if strings.HasSuffix(name, fmt.Sprintf("-%s", CAKeyName)) {
+		return true
+	}
+	return false
+}
+
+func excludeSAFiles(name string) bool {
+	if name == ServiceAccountPublicKeyName {
+		return true
+	}
+	if name == ServiceAccountPrivateKeyName {
+		return true
+	}
+	return false
+}
+
+func updateSecret(ctx context.Context, secretNamespace, secretName, pkiPath string, client kubernetes.Interface) error {
+	secret, err := client.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting cert secret %s: %w", secretName, err)
+	}
+
+	data := map[string][]byte{}
+	for k, v := range certMap {
+		d, err := os.ReadFile(filepath.Join(pkiPath, k))
+		if err != nil {
+			return fmt.Errorf("reading file %s: %w", k, err)
+		}
+
+		data[v] = d
+	}
+	secret.Data = data
+
+	_, err = client.CoreV1().Secrets(secretNamespace).Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating cert secret %s: %w", secretName, err)
+	}
+
+	return nil
+}

--- a/pkg/cli/certs/check_helm.go
+++ b/pkg/cli/certs/check_helm.go
@@ -1,0 +1,99 @@
+package certs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/log/table"
+	"github.com/loft-sh/vcluster/pkg/certs"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/util/podhelper"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Check executes the check command in the backend by piping its output to stdout.
+func Check(ctx context.Context, vClusterName string, globalFlags *flags.GlobalFlags, output string, log log.Logger) error {
+	vCluster, err := find.GetVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
+	if err != nil {
+		return err
+	}
+
+	// TODO(johannesfrey): Add min version check
+
+	var targetPod *corev1.Pod
+	for _, pod := range vCluster.Pods {
+		if vCluster.StatefulSet != nil && strings.HasSuffix(pod.Name, "-0") {
+			targetPod = &pod
+			break
+		} else if vCluster.Deployment != nil {
+			targetPod = &pod
+			break
+		}
+	}
+	if targetPod == nil {
+		return fmt.Errorf("couldn't find a running pod for vCluster %s", vCluster.Name)
+	}
+
+	kubeConfig, err := vCluster.ClientFactory.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	reader, writer := io.Pipe()
+	go func() {
+		defer func() {
+			if err := writer.Close(); err != nil {
+				fmt.Printf("closing writer: %v\n", err)
+			}
+		}()
+
+		err := podhelper.ExecStream(ctx, kubeConfig, &podhelper.ExecStreamOptions{
+			Pod:       targetPod.Name,
+			Namespace: vCluster.Namespace,
+			Container: "syncer",
+			Command:   []string{"sh", "-c", "/vcluster certs check"},
+			Stdout:    writer,
+			Stderr:    os.Stdout,
+		})
+		if err != nil {
+			fmt.Printf("executing %q in syncer pod: %v\n", "certs check", err)
+			return
+		}
+	}()
+
+	var certificateInfos []certs.Info
+	decoder := json.NewDecoder(reader)
+	for {
+		if err := decoder.Decode(&certificateInfos); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("decoding: %w", err)
+		}
+	}
+
+	if output == "json" {
+		bytes, err := json.MarshalIndent(certificateInfos, "", "    ")
+		if err != nil {
+			return fmt.Errorf("json marshal vClusters: %w", err)
+		}
+
+		log.WriteString(logrus.InfoLevel, string(bytes)+"\n")
+	} else {
+		header := []string{"FILENAME", "SUBJECT", "ISSUER", "EXPIRES ON", "STATUS"}
+		var values [][]string
+		for _, certInfo := range certificateInfos {
+			values = append(values, []string{certInfo.Filename, certInfo.Subject, certInfo.Issuer, certInfo.ExpiryTime.Format("Jan 02, 2006 15:04 MST"), certInfo.Status})
+		}
+		table.PrintTable(log, header, values)
+	}
+
+	return nil
+}

--- a/pkg/cli/certs/check_helm.go
+++ b/pkg/cli/certs/check_helm.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/table"
 	"github.com/loft-sh/vcluster/pkg/certs"
@@ -25,7 +26,14 @@ func Check(ctx context.Context, vClusterName string, globalFlags *flags.GlobalFl
 		return err
 	}
 
-	// TODO(johannesfrey): Add min version check
+	// check if check command is supported
+	version, err := semver.Parse(strings.TrimPrefix(vCluster.Version, "v"))
+	if err == nil {
+		// only check if version matches if vCluster actually has a parsable version
+		if version.LT(semver.MustParse(minVersion)) {
+			return fmt.Errorf("cert check is not supported in vCluster version %s", vCluster.Version)
+		}
+	}
 
 	var targetPod *corev1.Pod
 	for _, pod := range vCluster.Pods {

--- a/pkg/cli/certs/rotate_helm.go
+++ b/pkg/cli/certs/rotate_helm.go
@@ -1,0 +1,157 @@
+package certs
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/lifecycle"
+	"github.com/loft-sh/vcluster/pkg/util/podhelper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type RotationCmd string
+
+const (
+	RotationCmdCerts   RotationCmd = "rotate"
+	RotationCmdCACerts RotationCmd = "rotate-ca"
+)
+
+// Rotate triggers the rotate commands in the backend.
+// Depending on if the virtual cluster has persistence it either:
+// - Pauses the current virtual cluster, spawns an extra pod, executes the rotation and resumes the virtual cluster.
+// - Executes the rotation directly in the currently running syncer pod.
+func Rotate(ctx context.Context, vClusterName string, rotationCmd RotationCmd, globalFlags *flags.GlobalFlags, log log.Logger) error {
+	vCluster, err := find.GetVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
+	if err != nil {
+		return err
+	}
+
+	// TODO(johannesfrey): Add min version check
+
+	kubeConfig, err := vCluster.ClientFactory.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	var cmd string
+	dev, validityPeriod := os.Getenv("DEVELOPMENT"), os.Getenv("VCLUSTER_CERTS_VALIDITYPERIOD")
+	if dev == "true" && validityPeriod != "" {
+		cmd = fmt.Sprintf("DEVELOPMENT=true VCLUSTER_CERTS_VALIDITYPERIOD=%s ", validityPeriod)
+	}
+
+	switch rotationCmd {
+	case RotationCmdCerts:
+		cmd = fmt.Sprintf("%s/vcluster certs %s", cmd, RotationCmdCerts)
+	case RotationCmdCACerts:
+		cmd = fmt.Sprintf("%s/vcluster certs %s", cmd, RotationCmdCACerts)
+	default:
+		return fmt.Errorf("unknown rotation command: %s", rotationCmd)
+	}
+
+	return execRotate(ctx, "certs-rotate", cmd, kubeClient, vCluster, log)
+}
+
+func execRotate(ctx context.Context, containerName, cmd string, kubeClient *kubernetes.Clientset, vCluster *find.VCluster, log log.Logger) error {
+	// TODO(johannesfrey): For standalone the flow would need to be something like:
+	// - systemctl stop vcluster.service
+	// - /var/lib/vcluster/bin/vcluster certs rotate
+	// - systemctl start vcluster.service
+
+	pvc, err := usesPVC(vCluster)
+	if err != nil {
+		return fmt.Errorf("checking for persistence: %w", err)
+	}
+
+	// If the vCluster has persistence we have to pause it in order to be able to mount
+	// the data dir to the extra pod.
+	if pvc {
+		log.Infof("Pausing vCluster %s", vCluster.Name)
+		if err := lifecycle.PauseVCluster(ctx, kubeClient, vCluster.Name, vCluster.Namespace, true, log); err != nil {
+			return err
+		}
+
+		log.Infof("Running %s pod", containerName)
+		err = podhelper.RunSyncerPod(ctx, containerName, kubeClient, []string{"sh", "-c", cmd}, vCluster, nil, log)
+		if err != nil {
+			return fmt.Errorf("running %s pod: %w", containerName, err)
+		}
+
+		log.Infof("Resuming vCluster %s after it was paused", vCluster.Name)
+		return lifecycle.ResumeVCluster(ctx, kubeClient, vCluster.Name, vCluster.Namespace, true, log)
+	}
+
+	if len(vCluster.Pods) == 0 {
+		return fmt.Errorf("no target pod found in vCluster %s", vCluster.Name)
+	}
+
+	kubeConfig, err := vCluster.ClientFactory.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	log.Info("Executing in syncer pod")
+	err = podhelper.ExecStream(ctx, kubeConfig, &podhelper.ExecStreamOptions{
+		Pod:       vCluster.Pods[0].Name,
+		Namespace: vCluster.Namespace,
+		Container: "syncer",
+		Command:   []string{"sh", "-c", cmd},
+		Stdout:    os.Stdout,
+		Stderr:    os.Stdout,
+	})
+	if err != nil {
+		return fmt.Errorf("executing command in syncer pod")
+	}
+
+	return lifecycle.DeletePods(ctx, kubeClient, "app=vcluster,release="+vCluster.Name, vCluster.Namespace)
+}
+
+func usesPVC(vCluster *find.VCluster) (bool, error) {
+	var podSpec *corev1.PodSpec
+	if vCluster.StatefulSet != nil {
+		podSpec = &vCluster.StatefulSet.Spec.Template.Spec
+	} else if vCluster.Deployment != nil {
+		podSpec = &vCluster.Deployment.Spec.Template.Spec
+	} else {
+		return false, fmt.Errorf("vCluster %s has no StatefulSet or Deployment", vCluster.Name)
+	}
+
+	var syncerContainer *corev1.Container
+	for _, container := range podSpec.Containers {
+		if container.Name == "syncer" {
+			syncerContainer = &container
+			break
+		}
+	}
+	if syncerContainer == nil {
+		return false, fmt.Errorf("couldn't find syncer container")
+	}
+
+	for _, volumeMount := range syncerContainer.VolumeMounts {
+		if volumeMount.Name == "data" {
+			if vCluster.StatefulSet != nil {
+				for _, vct := range vCluster.StatefulSet.Spec.VolumeClaimTemplates {
+					if vct.Name == volumeMount.Name {
+						return true, nil
+					}
+				}
+			}
+			for _, volume := range podSpec.Volumes {
+				if volume.Name == volumeMount.Name && volume.PersistentVolumeClaim != nil {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/cli/certs/rotate_helm.go
+++ b/pkg/cli/certs/rotate_helm.go
@@ -62,7 +62,7 @@ func Rotate(ctx context.Context, vClusterName string, rotationCmd RotationCmd, g
 		return fmt.Errorf("listing potential etcd statefulsets: %w", err)
 	}
 	if len(sts.Items) > 0 {
-		if sts.Items[0].Status.AvailableReplicas > 1 {
+		if sts.Items[0].Status.AvailableReplicas > 1 && rotationCmd == RotationCmdCACerts {
 			return fmt.Errorf("cert rotation with CA is currently not supported for deployed etcd in HA mode")
 		}
 		restartETCD = true

--- a/pkg/setup/config/config.go
+++ b/pkg/setup/config/config.go
@@ -1,4 +1,4 @@
-package setup
+package config
 
 import (
 	"context"

--- a/pkg/util/podhelper/pod.go
+++ b/pkg/util/podhelper/pod.go
@@ -1,0 +1,237 @@
+package podhelper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"slices"
+	"syscall"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+func RunSyncerPod(
+	ctx context.Context,
+	containerName string,
+	kubeClient *kubernetes.Clientset,
+	command []string,
+	vCluster *find.VCluster,
+	writer io.Writer,
+	log log.Logger,
+) error {
+	// create pod
+	pod, err := CreateSyncerPod(
+		ctx,
+		containerName,
+		kubeClient,
+		command,
+		vCluster,
+		log,
+	)
+	if err != nil {
+		return err
+	}
+
+	// create interrupt channel
+	sigint := make(chan os.Signal, 1)
+	defer func() {
+		// make sure we won't interfere with interrupts anymore
+		signal.Stop(sigint)
+
+		// delete the pod when we are done
+		_ = kubeClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	}()
+
+	// also delete on interrupt
+	go func() {
+		// interrupt signal sent from terminal
+		signal.Notify(sigint, os.Interrupt)
+		// sigterm signal sent from kubernetes
+		signal.Notify(sigint, syscall.SIGTERM)
+
+		// wait until we get killed
+		<-sigint
+
+		// cleanup pod
+		err = kubeClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
+			GracePeriodSeconds: ptr.To(int64(1)),
+		})
+		if err != nil {
+			klog.Warningf("Error deleting %s pod: %v", containerName, err)
+		}
+		os.Exit(1)
+	}()
+
+	// wait for pod to become ready
+	err = WaitForReadyPod(ctx, kubeClient, pod.Namespace, pod.Name, containerName, log)
+	if err != nil {
+		return fmt.Errorf("waiting for %s pod to become ready: %w", containerName, err)
+	}
+
+	// now log the pod
+	reader, err := kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Follow: true,
+	}).Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("stream %s pod logs: %w", containerName, err)
+	}
+	defer reader.Close()
+
+	// stream into writer or os.Stdout
+	if writer == nil {
+		writer = os.Stdout
+	}
+	_, err = io.Copy(writer, reader)
+	if err != nil {
+		return fmt.Errorf("write pod logs: %w", err)
+	}
+
+	// check pod for exit code
+	exitCode, err := WaitForCompletedPod(ctx, kubeClient, pod.Namespace, pod.Name, containerName, time.Minute)
+	if err != nil {
+		return err
+	}
+
+	// check exit code of pod
+	if exitCode != 0 {
+		return fmt.Errorf("%s pod failed: exit code %d", containerName, exitCode)
+	}
+
+	return nil
+}
+
+func CreateSyncerPod(
+	ctx context.Context,
+	containerName string,
+	kubeClient *kubernetes.Clientset,
+	command []string,
+	vCluster *find.VCluster,
+	log log.Logger,
+) (*corev1.Pod, error) {
+	// get pod spec
+	var podSpec *corev1.PodSpec
+	if vCluster.StatefulSet != nil {
+		podSpec = &vCluster.StatefulSet.Spec.Template.Spec
+	} else if vCluster.Deployment != nil {
+		podSpec = &vCluster.Deployment.Spec.Template.Spec
+	} else {
+		return nil, fmt.Errorf("vCluster %s has no StatefulSet or Deployment", vCluster.Name)
+	}
+
+	var syncerContainer *corev1.Container
+	for _, container := range podSpec.Containers {
+		if container.Name == "syncer" {
+			syncerContainer = &container
+			break
+		}
+	}
+	if syncerContainer == nil {
+		return nil, fmt.Errorf("couldn't find syncer container")
+	}
+
+	// build args
+	env := syncerContainer.Env
+
+	// this is needed for embedded etcd as it otherwise wouldn't
+	// start the embedded etcd cluster correctly
+	env = slices.DeleteFunc(env, func(envVar corev1.EnvVar) bool {
+		return envVar.Name == "POD_NAME"
+	})
+	env = append(env, corev1.EnvVar{
+		Name:  "POD_NAME",
+		Value: vCluster.Name + "-0",
+	})
+
+	// add debug
+	if log.GetLevel() >= logrus.DebugLevel {
+		env = append(env, corev1.EnvVar{
+			Name:  "DEBUG",
+			Value: "true",
+		})
+	}
+
+	// build the pod spec
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("vcluster-%s-", containerName),
+			Namespace:    vCluster.Namespace,
+			Labels: map[string]string{
+				"app": fmt.Sprintf("vcluster-%ss", containerName),
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			ServiceAccountName:            podSpec.ServiceAccountName,
+			TerminationGracePeriodSeconds: ptr.To(int64(1)),
+			NodeSelector:                  podSpec.NodeSelector,
+			Affinity:                      podSpec.Affinity,
+			Tolerations:                   podSpec.Tolerations,
+			SecurityContext:               podSpec.SecurityContext,
+			ImagePullSecrets:              podSpec.ImagePullSecrets,
+			Volumes:                       podSpec.Volumes,
+			Containers: []corev1.Container{
+				{
+					Name:            containerName,
+					Image:           syncerContainer.Image,
+					Command:         command,
+					SecurityContext: syncerContainer.SecurityContext,
+					Env:             env,
+					EnvFrom:         syncerContainer.EnvFrom,
+					VolumeMounts:    syncerContainer.VolumeMounts,
+				},
+			},
+		},
+	}
+
+	// add persistent volume claim volume if necessary
+	for _, volumeMount := range syncerContainer.VolumeMounts {
+		if volumeMount.Name == "data" {
+			// check if its part of the pod spec
+			found := false
+			for _, volume := range newPod.Spec.Volumes {
+				if volume.Name == volumeMount.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				newPod.Spec.Volumes = append(newPod.Spec.Volumes, corev1.Volume{
+					Name: volumeMount.Name,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "data-" + vCluster.Name + "-0",
+						},
+					},
+				})
+			}
+		}
+	}
+
+	newPod, err := kubeClient.CoreV1().Pods(vCluster.Namespace).Create(ctx, newPod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("creating pod: %w", err)
+	}
+
+	// print pod in debug mode
+	if log.GetLevel() >= logrus.DebugLevel {
+		out, err := yaml.Marshal(newPod)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling pod: %w", err)
+		}
+
+		log.Debugf("Created %s pod: %s", containerName, string(out))
+	}
+
+	return newPod, nil
+}

--- a/pkg/util/podhelper/pod.go
+++ b/pkg/util/podhelper/pod.go
@@ -167,7 +167,7 @@ func CreateSyncerPod(
 			GenerateName: fmt.Sprintf("vcluster-%s-", containerName),
 			Namespace:    vCluster.Namespace,
 			Labels: map[string]string{
-				"app": fmt.Sprintf("vcluster-%ss", containerName),
+				"app": fmt.Sprintf("vcluster-%s", containerName),
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/util/podhelper/wait.go
+++ b/pkg/util/podhelper/wait.go
@@ -1,0 +1,121 @@
+package podhelper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/util/clihelper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+func WaitForReadyPod(ctx context.Context, kubeClient kubernetes.Interface, namespace, name, container string, log log.Logger) error {
+	now := time.Now()
+	err := wait.PollUntilContextTimeout(ctx, time.Second*2, time.Minute*2, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			// this is a fatal
+			return false, fmt.Errorf("error trying to retrieve pod %s/%s: %w", namespace, name, err)
+		}
+
+		found := false
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.State.Running != nil && containerStatus.Ready {
+				if containerStatus.Name == container {
+					found = true
+				}
+
+				continue
+			} else if containerStatus.State.Terminated != nil || (containerStatus.State.Waiting != nil && clihelper.CriticalStatus[containerStatus.State.Waiting.Reason]) {
+				// if the container is completed that is fine as well
+				if containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 0 {
+					found = true
+					continue
+				}
+
+				reason := ""
+				message := ""
+				if containerStatus.State.Terminated != nil {
+					reason = containerStatus.State.Terminated.Reason
+					message = containerStatus.State.Terminated.Message
+				} else if containerStatus.State.Waiting != nil {
+					reason = containerStatus.State.Waiting.Reason
+					message = containerStatus.State.Waiting.Message
+				}
+
+				out, err := kubeClient.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+					Container: container,
+				}).Do(context.Background()).Raw()
+				if err != nil {
+					return false, fmt.Errorf("there seems to be an issue with pod %s/%s starting up: %s (%s)", namespace, name, message, reason)
+				}
+
+				return false, fmt.Errorf("there seems to be an issue with pod %s (%s - %s), logs:\n%s", name, message, reason, string(out))
+			} else if containerStatus.State.Waiting != nil && time.Now().After(now.Add(time.Second*10)) {
+				if containerStatus.State.Waiting.Message != "" {
+					log.Infof("Please keep waiting, %s container is still starting up: %s (%s)", container, containerStatus.State.Waiting.Message, containerStatus.State.Waiting.Reason)
+				} else if containerStatus.State.Waiting.Reason != "" {
+					log.Infof("Please keep waiting, %s container is still starting up: %s", container, containerStatus.State.Waiting.Reason)
+				} else {
+					log.Infof("Please keep waiting, %s container is still starting up...", container)
+				}
+
+				now = time.Now()
+			}
+
+			return false, nil
+		}
+
+		return found, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WaitForCompletedPod(ctx context.Context, kubeClient *kubernetes.Clientset, namespace, name, container string, timeout time.Duration) (int32, error) {
+	exitCode := int32(-1)
+	err := wait.PollUntilContextTimeout(ctx, time.Second*2, timeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			// this is a fatal
+			return false, fmt.Errorf("error trying to retrieve pod %s/%s: %w", namespace, name, err)
+		}
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.Name != container {
+				continue
+			}
+
+			if containerStatus.State.Running != nil {
+				return false, nil
+			} else if containerStatus.State.Terminated != nil {
+				exitCode = containerStatus.State.Terminated.ExitCode
+				return true, nil
+			} else if containerStatus.State.Waiting != nil {
+				if containerStatus.State.Waiting.Message != "" {
+					return false, fmt.Errorf("error: %s container is waiting: %s (%s)", container, containerStatus.State.Waiting.Message, containerStatus.State.Waiting.Reason)
+				} else if containerStatus.State.Waiting.Reason != "" {
+					return false, fmt.Errorf("error: %s container is waiting: %s", container, containerStatus.State.Waiting.Reason)
+				}
+
+				return false, fmt.Errorf("error: %s container is waiting", container)
+			}
+
+			return false, nil
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return exitCode, err
+	}
+
+	return exitCode, nil
+}

--- a/test/e2e_certs/certs/rotate.go
+++ b/test/e2e_certs/certs/rotate.go
@@ -1,0 +1,236 @@
+package certs
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+
+	certscmd "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd/certs"
+	"github.com/loft-sh/vcluster/pkg/certs"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("vCluster cert rotation tests", ginkgo.Ordered, func() {
+	var (
+		f                          *framework.Framework
+		secret                     *corev1.Secret
+		err                        error
+		apiserverCertBefore        *x509.Certificate
+		apiserverFingerprintBefore string
+		caCertBefore               *x509.Certificate
+		caFingerprintBefore        string
+	)
+
+	ginkgo.JustBeforeEach(func() {
+		f = framework.DefaultFramework
+	})
+
+	ginkgo.It("should obtain the current cert secret", func() {
+		secret, err = f.HostClient.CoreV1().Secrets(f.VClusterNamespace).Get(f.Context, certs.CertSecretName(f.VClusterName), metav1.GetOptions{})
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("should get the fingerprints from the cert secret", func() {
+		apiserverCertBefore, err = parseCertFromPEM(secret.Data[certs.APIServerCertName])
+		framework.ExpectNoError(err)
+		apiserverFingerprintBefore = certFingerprint(apiserverCertBefore)
+
+		caCertBefore, err = parseCertFromPEM(secret.Data[certs.CACertName])
+		framework.ExpectNoError(err)
+		caFingerprintBefore = certFingerprint(caCertBefore)
+	})
+
+	ginkgo.Context("vCluster \"certs rotate\"", ginkgo.Ordered, func() {
+		ginkgo.It("should execute \"certs rotate\" command", func() {
+			certsCmd := certscmd.NewCertsCmd(&flags.GlobalFlags{Namespace: f.VClusterNamespace})
+			certsCmd.SetArgs([]string{"rotate", f.VClusterName})
+			err = certsCmd.Execute()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should successfully restart the vCluster pod", func() {
+			gomega.Eventually(func() error {
+				pods, err := f.HostClient.CoreV1().Pods(f.VClusterNamespace).List(f.Context, metav1.ListOptions{
+					LabelSelector: "app=vcluster,release=" + f.VClusterName,
+				})
+				framework.ExpectNoError(err)
+
+				for _, pod := range pods.Items {
+					if len(pod.Status.ContainerStatuses) == 0 {
+						return fmt.Errorf("pod %s has no container status", pod.Name)
+					}
+
+					for _, container := range pod.Status.ContainerStatuses {
+						if container.State.Running == nil || !container.Ready {
+							return fmt.Errorf("pod %s container %s is not running", pod.Name, container.Name)
+						}
+					}
+				}
+
+				return nil
+			}).WithPolling(time.Second).
+				WithTimeout(framework.PollTimeoutLong).
+				Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should obtain the certs secret with new certificates", func() {
+			gomega.Eventually(func() error {
+				secret, err = f.HostClient.CoreV1().Secrets(f.VClusterNamespace).Get(f.Context, certs.CertSecretName(f.VClusterName), metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}).WithPolling(time.Second).
+				WithTimeout(framework.PollTimeout).
+				Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should check that the CA certificate fingerprint and its expiry time did not change", func() {
+			certAfter, err := parseCertFromPEM(secret.Data[certs.CACertName])
+			framework.ExpectNoError(err)
+
+			fingerprintAfter := certFingerprint(certAfter)
+
+			// fingerprint should be equal.
+			gomega.Expect(caFingerprintBefore).To(gomega.Equal(fingerprintAfter))
+
+			// expiry date should be equal.
+			gomega.Expect(certAfter.NotAfter).To(gomega.Equal(caCertBefore.NotAfter))
+
+			// save fingerprint for next round
+			caFingerprintBefore = fingerprintAfter
+		})
+
+		ginkgo.It("should check that the certificate fingerprint is different and that it expires later", func() {
+			apiserverCertAfter, err := parseCertFromPEM(secret.Data[certs.APIServerCertName])
+			framework.ExpectNoError(err)
+
+			fingerprintAfter := certFingerprint(apiserverCertAfter)
+
+			// fingerprint should be different.
+			gomega.Expect(apiserverFingerprintBefore).ToNot(gomega.Equal(fingerprintAfter))
+
+			// new certificate should expire later than the old one.
+			gomega.Expect(apiserverCertAfter.NotAfter.After(apiserverCertBefore.NotAfter)).To(gomega.BeTrue())
+
+			// save fingerprint for next round
+			apiserverFingerprintBefore = fingerprintAfter
+		})
+	})
+
+	ginkgo.It("should wait until the virtual cluster is ready again", func() {
+		framework.ExpectNoError(f.WaitForVClusterReady())
+	})
+
+	ginkgo.Context("vCluster \"certs rotate-ca\"", ginkgo.Ordered, func() {
+		ginkgo.It("should execute \"certs rotate-ca\" command", func() {
+			certsCmd := certscmd.NewCertsCmd(&flags.GlobalFlags{Namespace: f.VClusterNamespace})
+			certsCmd.SetArgs([]string{"rotate-ca", f.VClusterName})
+			err = certsCmd.Execute()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should successfully restart the vCluster pod", func() {
+			gomega.Eventually(func() error {
+				pods, err := f.HostClient.CoreV1().Pods(f.VClusterNamespace).List(f.Context, metav1.ListOptions{
+					LabelSelector: "app=vcluster,release=" + f.VClusterName,
+				})
+				framework.ExpectNoError(err)
+
+				for _, pod := range pods.Items {
+					if len(pod.Status.ContainerStatuses) == 0 {
+						return fmt.Errorf("pod %s has no container status", pod.Name)
+					}
+
+					for _, container := range pod.Status.ContainerStatuses {
+						if container.State.Running == nil || !container.Ready {
+							return fmt.Errorf("pod %s container %s is not running", pod.Name, container.Name)
+						}
+					}
+				}
+
+				return nil
+			}).WithPolling(time.Second).
+				WithTimeout(framework.PollTimeoutLong).
+				Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should obtain the current cert secret", func() {
+			secret, err = f.HostClient.CoreV1().Secrets(f.VClusterNamespace).Get(f.Context, certs.CertSecretName(f.VClusterName), metav1.GetOptions{})
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should check that the certificate fingerprints are different and that they expire later", func() {
+			apiserverCertAfter, err := parseCertFromPEM(secret.Data[certs.APIServerCertName])
+			framework.ExpectNoError(err)
+			caCertAfter, err := parseCertFromPEM(secret.Data[certs.CACertName])
+			framework.ExpectNoError(err)
+
+			apiserverFingerprintAfter := certFingerprint(apiserverCertAfter)
+			caFingerprintAfter := certFingerprint(caCertAfter)
+
+			// fingerprints should be different.
+			gomega.Expect(apiserverFingerprintBefore).ToNot(gomega.Equal(apiserverFingerprintAfter))
+			gomega.Expect(caFingerprintBefore).ToNot(gomega.Equal(caFingerprintAfter))
+
+			// new certificates should expire later than the old ones.
+			gomega.Expect(apiserverCertAfter.NotAfter.After(apiserverCertBefore.NotAfter)).To(gomega.BeTrue())
+			gomega.Expect(caCertAfter.NotAfter.After(caCertBefore.NotAfter)).To(gomega.BeTrue())
+		})
+	})
+
+	ginkgo.It("should wait until the virtual cluster is ready again", func() {
+		framework.ExpectNoError(f.WaitForVClusterReady())
+	})
+
+	ginkgo.AfterAll(func() {
+		// Wait for virtual cluster to be ready after cert rotation and refresh the virtual client.
+		framework.ExpectNoError(f.WaitForVClusterReady())
+		framework.ExpectNoError(f.RefreshVirtualClient())
+	})
+
+})
+
+func parseCertFromPEM(pemData []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return nil, fmt.Errorf("decoding to PEM block")
+	}
+
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("not a certificate")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %w", err)
+	}
+
+	return cert, nil
+}
+
+func certFingerprint(cert *x509.Certificate) string {
+	hash := sha256.Sum256(cert.Raw)
+	fingerprint := hex.EncodeToString(hash[:])
+
+	// Format as colon-separated hex pairs (like OpenSSL output)
+	var formatted strings.Builder
+	for i := 0; i < len(fingerprint); i += 2 {
+		if i > 0 {
+			formatted.WriteString(":")
+		}
+		formatted.WriteString(strings.ToUpper(fingerprint[i : i+2]))
+	}
+
+	return formatted.String()
+}

--- a/test/e2e_certs/certs/rotate.go
+++ b/test/e2e_certs/certs/rotate.go
@@ -57,7 +57,8 @@ var _ = ginkgo.Describe("vCluster cert rotation tests", ginkgo.Ordered, func() {
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.It("should successfully restart the vCluster pod", func() {
+		ginkgo.It("should wait until the virtual cluster is ready again", func() {
+			framework.ExpectNoError(f.WaitForVClusterReady())
 			gomega.Eventually(func() error {
 				pods, err := f.HostClient.CoreV1().Pods(f.VClusterNamespace).List(f.Context, metav1.ListOptions{
 					LabelSelector: "app=vcluster,release=" + f.VClusterName,
@@ -128,10 +129,6 @@ var _ = ginkgo.Describe("vCluster cert rotation tests", ginkgo.Ordered, func() {
 		})
 	})
 
-	ginkgo.It("should wait until the virtual cluster is ready again", func() {
-		framework.ExpectNoError(f.WaitForVClusterReady())
-	})
-
 	ginkgo.Context("vCluster \"certs rotate-ca\"", ginkgo.Ordered, func() {
 		ginkgo.It("should execute \"certs rotate-ca\" command", func() {
 			certsCmd := certscmd.NewCertsCmd(&flags.GlobalFlags{Namespace: f.VClusterNamespace})
@@ -140,7 +137,8 @@ var _ = ginkgo.Describe("vCluster cert rotation tests", ginkgo.Ordered, func() {
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.It("should successfully restart the vCluster pod", func() {
+		ginkgo.It("should wait until the virtual cluster is ready again", func() {
+			framework.ExpectNoError(f.WaitForVClusterReady())
 			gomega.Eventually(func() error {
 				pods, err := f.HostClient.CoreV1().Pods(f.VClusterNamespace).List(f.Context, metav1.ListOptions{
 					LabelSelector: "app=vcluster,release=" + f.VClusterName,

--- a/test/e2e_certs/certs/rotate.go
+++ b/test/e2e_certs/certs/rotate.go
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("vCluster cert rotation tests", ginkgo.Ordered, func() {
 			caFingerprintBefore = fingerprintAfter
 		})
 
-		ginkgo.It("should check that the certificate fingerprint is different and that it expires later", func() {
+		ginkgo.It("should check that the apiservcer certificate fingerprint is different and that it expires later", func() {
 			apiserverCertAfter, err := parseCertFromPEM(secret.Data[certs.APIServerCertName])
 			framework.ExpectNoError(err)
 
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe("vCluster cert rotation tests", ginkgo.Ordered, func() {
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.It("should check that the certificate fingerprints are different and that they expire later", func() {
+		ginkgo.It("should check that the CA and apiserver certificate fingerprints are different and that they expire later", func() {
 			apiserverCertAfter, err := parseCertFromPEM(secret.Data[certs.APIServerCertName])
 			framework.ExpectNoError(err)
 			caCertAfter, err := parseCertFromPEM(secret.Data[certs.CACertName])

--- a/test/e2e_certs/e2e_suite_test.go
+++ b/test/e2e_certs/e2e_suite_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/test/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	// Enable cloud provider aut
+	// Enable cloud provider auth
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	// Register tests
+	_ "github.com/loft-sh/vcluster/test/e2e_certs/certs"
+)
+
+// TestRunE2ETests checks configuration parameters (specified through flags) and then runs
+// E2E tests using the Ginkgo runner.
+// If a "report directory" is specified, one or more JUnit test reports will be
+// generated in this directory, and cluster logs will also be saved.
+// This function is called on each Ginkgo node in parallel mode.
+func TestRunE2ETests(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	err := framework.CreateFramework(context.Background())
+	if err != nil {
+		log.GetInstance().Fatalf("Error setting up framework: %v", err)
+	}
+
+	var _ = ginkgo.AfterSuite(func() {
+		err = framework.DefaultFramework.Cleanup()
+		if err != nil {
+			log.GetInstance().Warnf("Error executing testsuite cleanup: %v", err)
+		}
+	})
+
+	ginkgo.RunSpecs(t, "VCluster e2ecerts suite")
+}

--- a/test/e2e_certs/values.yaml
+++ b/test/e2e_certs/values.yaml
@@ -1,0 +1,1 @@
+# empty values file to avoid no file or dir error


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-7787
resolves ENG-7788
resolves ENG-7789


**Please provide a short message that should be published in the vcluster release notes**
Add vcluster cert rotation commands

**What else do we need to know?**
This PR introduces following new commands:
- `vcluster certs rotate`: Rotate client/server leaf certificates using the current CA.
- `vcluster certs rorate-ca`: Rotate all certificates including the CA.
- `vcluster certs check`: Display basic infos about the current certificates.

Most of the actual rotation functionality is under `cmd/vcluster/cmd/certs` resp. `/pkg/certs/rotate.go` in order to be able to rotate on the file system level, which makes it compatible to "standalone", which has no notion of a host cluster. Nevertheless the cert secret is still updated in case we are non-standalone because otherwise virtual clusters without persistence would not see the new certificates after the restart.
The CLI counterparts under `cmd/vclusterctl/cmd/certs` are merely responsible to exec the commands above either by pausing and resuming the virtual cluster and starting a standalone pod or directly executing inside the virtual cluster pod (depending if there's persistence or not).

This PR already provides some rudimentary e2e tests. More will be added to this [branch](https://github.com/loft-sh/vcluster/pull/2985) in parallel in order to "unblock" reviews of the main PR here.. 