### PR TITLE
run leader election for kube-controller-manager & scheduler in standa…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -712,10 +712,6 @@ func (c *Config) IsConfiguredForSleepMode() bool {
 	return c.External["platform"]["autoSleep"] != nil || c.External["platform"]["autoDelete"] != nil
 }
 
-func (c *Config) StandaloneHAEnabled() bool {
-	return c.ControlPlane.Standalone.Enabled && c.BackingStoreType() == StoreTypeEmbeddedEtcd
-}
-
 // ValidateChanges checks for disallowed config changes.
 func ValidateChanges(oldCfg, newCfg *Config) error {
 	if err := ValidateDistroChanges(newCfg.Distro(), oldCfg.Distro()); err != nil {

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -146,11 +146,7 @@ func StartK8S(ctx context.Context, serviceCIDR string, vConfig *config.VirtualCl
 				args = append(args, "--root-ca-file="+vConfig.VirtualClusterKubeConfig().ServerCACert)
 				args = append(args, "--service-account-private-key-file="+constants.SAKey)
 				args = append(args, "--use-service-account-credentials=true")
-				if vConfig.ControlPlane.StatefulSet.HighAvailability.Replicas > 1 || vConfig.StandaloneHAEnabled() {
-					args = append(args, "--leader-elect=true")
-				} else {
-					args = append(args, "--leader-elect=false")
-				}
+				args = append(args, "--leader-elect=true")
 
 				if vConfig.PrivateNodes.Enabled {
 					args = append(args, "--controllers=*,bootstrapsigner,tokencleaner")
@@ -197,11 +193,7 @@ func StartK8S(ctx context.Context, serviceCIDR string, vConfig *config.VirtualCl
 				args = append(args, "--authorization-kubeconfig="+constants.SchedulerConf)
 				args = append(args, "--bind-address=127.0.0.1")
 				args = append(args, "--kubeconfig="+constants.SchedulerConf)
-				if vConfig.ControlPlane.StatefulSet.HighAvailability.Replicas > 1 || vConfig.StandaloneHAEnabled() {
-					args = append(args, "--leader-elect=true")
-				} else {
-					args = append(args, "--leader-elect=false")
-				}
+				args = append(args, "--leader-elect=true")
 			}
 
 			// add extra args


### PR DESCRIPTION
…lone HA

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-7885


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster standalone (HA) kube-controller-manager & scheduler were competing for control


**What else do we need to know?** 
there are no meaningful downsides of running leader election always (k8s does it by default too) for kube-controller-manager & kube-scheduler, so we decided to enable it always too.
