### PR TITLE
feat: RewriteHosts initContainer image may use override image

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2255,15 +2255,15 @@
       "properties": {
         "registry": {
           "type": "string",
-          "description": "Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally\noverridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub."
+          "description": "Registry is the registry of the container image reference, e.g. ghcr.io."
         },
         "repository": {
           "type": "string",
-          "description": "Repository is the repository of the container image, e.g. my-repo/my-image"
+          "description": "Repository is the repository of the container image reference, e.g. my-repo/my-image."
         },
         "tag": {
           "type": "string",
-          "description": "Tag is the tag of the container image, and is the default version."
+          "description": "Tag is the tag of the container image reference, and is the default version."
         }
       },
       "additionalProperties": false,
@@ -4314,7 +4314,7 @@
     "SyncRewriteHostsInitContainer": {
       "properties": {
         "image": {
-          "type": "string",
+          "$ref": "#/$defs/Image",
           "description": "Image is the image virtual cluster should use to rewrite this FQDN."
         },
         "resources": {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2255,15 +2255,15 @@
       "properties": {
         "registry": {
           "type": "string",
-          "description": "Registry is the registry of the container image reference, e.g. ghcr.io."
+          "description": "Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally\noverridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub."
         },
         "repository": {
           "type": "string",
-          "description": "Repository is the repository of the container image reference, e.g. my-repo/my-image."
+          "description": "Repository is the repository of the container image, e.g. my-repo/my-image"
         },
         "tag": {
           "type": "string",
-          "description": "Tag is the tag of the container image reference, and is the default version."
+          "description": "Tag is the tag of the container image, and is the default version."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,11 +56,12 @@ sync:
         initContainer:
           # Image is the image virtual cluster should use to rewrite this FQDN.
           image:
-            # Registry is the registry of the container image reference, e.g. ghcr.io.
+            # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+            # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
             registry: ""
-            # Repository is the repository of the container image reference, e.g. my-repo/my-image.
+            # Repository is the repository of the container image, e.g. my-repo/my-image
             repository: library/alpine
-            # Tag is the tag of the container image reference, and is the default version.
+            # Tag is the tag of the container image, and is the default version.
             tag: "3.20"
           # Resources are the resources that should be assigned to the init container for each stateful set init container.
           resources:
@@ -230,11 +231,12 @@ controlPlane:
       imagePullPolicy: ""
       # Image is the distro image
       image:
-        # Registry is the registry of the container image reference, e.g. ghcr.io.
+        # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+        # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
         registry: ghcr.io
-        # Repository is the repository of the container image reference, e.g. my-repo/my-image.
+        # Repository is the repository of the container image, e.g. my-repo/my-image
         repository: "loft-sh/kubernetes"
-        # Tag is the tag of the container image reference, and is the default version.
+        # Tag is the tag of the container image, and is the default version.
         tag: "v1.33.1"
       # APIServer holds configuration specific to starting the api server.
       apiServer:
@@ -281,11 +283,12 @@ controlPlane:
       imagePullPolicy: ""
       # Image is the distro image
       image:
-        # Registry is the registry of the container image reference, e.g. ghcr.io.
+        # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+        # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
         registry: ""
-        # Repository is the repository of the container image reference, e.g. my-repo/my-image.
+        # Repository is the repository of the container image, e.g. my-repo/my-image
         repository: "rancher/k3s"
-        # Tag is the tag of the container image reference, and is the default version.
+        # Tag is the tag of the container image, and is the default version.
         tag: "v1.33.1-k3s1"
       # Security options can be used for the distro init container
       securityContext: {}
@@ -368,11 +371,12 @@ controlPlane:
           labels: {}
           # Image is the image to use for the external etcd statefulSet
           image:
-            # Registry is the registry of the container image reference, e.g. ghcr.io.
+            # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+            # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
             registry: "registry.k8s.io"
-            # Repository is the repository of the container image reference, e.g. my-repo/my-image.
+            # Repository is the repository of the container image, e.g. my-repo/my-image
             repository: "etcd"
-            # Tag is the tag of the container image reference, and is the default version.
+            # Tag is the tag of the container image, and is the default version.
             tag: "3.5.21-0"
           # ImagePullPolicy is the pull policy for the external etcd image
           imagePullPolicy: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,7 +55,13 @@ sync:
         # InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
         initContainer:
           # Image is the image virtual cluster should use to rewrite this FQDN.
-          image: "library/alpine:3.20"
+          image:
+            # Registry is the registry of the container image reference, e.g. ghcr.io.
+            registry: ""
+            # Repository is the repository of the container image reference, e.g. my-repo/my-image.
+            repository: library/alpine
+            # Tag is the tag of the container image reference, and is the default version.
+            tag: "3.20"
           # Resources are the resources that should be assigned to the init container for each stateful set init container.
           resources:
             # Limits are resource limits for the container
@@ -224,12 +230,11 @@ controlPlane:
       imagePullPolicy: ""
       # Image is the distro image
       image:
-        # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
-        # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+        # Registry is the registry of the container image reference, e.g. ghcr.io.
         registry: ghcr.io
-        # Repository is the repository of the container image, e.g. my-repo/my-image
+        # Repository is the repository of the container image reference, e.g. my-repo/my-image.
         repository: "loft-sh/kubernetes"
-        # Tag is the tag of the container image, and is the default version.
+        # Tag is the tag of the container image reference, and is the default version.
         tag: "v1.33.1"
       # APIServer holds configuration specific to starting the api server.
       apiServer:
@@ -276,12 +281,11 @@ controlPlane:
       imagePullPolicy: ""
       # Image is the distro image
       image:
-        # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
-        # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+        # Registry is the registry of the container image reference, e.g. ghcr.io.
         registry: ""
-        # Repository is the repository of the container image, e.g. my-repo/my-image
+        # Repository is the repository of the container image reference, e.g. my-repo/my-image.
         repository: "rancher/k3s"
-        # Tag is the tag of the container image, and is the default version.
+        # Tag is the tag of the container image reference, and is the default version.
         tag: "v1.33.1-k3s1"
       # Security options can be used for the distro init container
       securityContext: {}
@@ -364,12 +368,11 @@ controlPlane:
           labels: {}
           # Image is the image to use for the external etcd statefulSet
           image:
-            # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
-            # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+            # Registry is the registry of the container image reference, e.g. ghcr.io.
             registry: "registry.k8s.io"
-            # Repository is the repository of the container image, e.g. my-repo/my-image
+            # Repository is the repository of the container image reference, e.g. my-repo/my-image.
             repository: "etcd"
-            # Tag is the tag of the container image, and is the default version.
+            # Tag is the tag of the container image reference, and is the default version.
             tag: "3.5.21-0"
           # ImagePullPolicy is the pull policy for the external etcd image
           imagePullPolicy: ""

--- a/config/config.go
+++ b/config/config.go
@@ -1315,7 +1315,7 @@ type SyncRewriteHosts struct {
 
 type SyncRewriteHostsInitContainer struct {
 	// Image is the image virtual cluster should use to rewrite this FQDN.
-	Image string `json:"image,omitempty"`
+	Image Image `json:"image,omitempty"`
 
 	// Resources are the resources that should be assigned to the init container for each stateful set init container.
 	Resources Resources `json:"resources,omitempty"`
@@ -1722,15 +1722,18 @@ type StatefulSetImage struct {
 }
 
 type Image struct {
-	// Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
-	// overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+	// Registry is the registry of the container image reference, e.g. ghcr.io.
 	Registry string `json:"registry,omitempty"`
 
-	// Repository is the repository of the container image, e.g. my-repo/my-image
+	// Repository is the repository of the container image reference, e.g. my-repo/my-image.
 	Repository string `json:"repository,omitempty"`
 
-	// Tag is the tag of the container image, and is the default version.
+	// Tag is the tag of the container image reference, and is the default version.
 	Tag string `json:"tag,omitempty"`
+}
+
+func (i Image) String() string {
+	return fmt.Sprintf("%s/%s:%s", strings.TrimSuffix(i.Registry, "/"), i.Repository, i.Tag)
 }
 
 type ImagePullSecretName struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1722,18 +1722,34 @@ type StatefulSetImage struct {
 }
 
 type Image struct {
-	// Registry is the registry of the container image reference, e.g. ghcr.io.
+	// Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+	// overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
 	Registry string `json:"registry,omitempty"`
 
-	// Repository is the repository of the container image reference, e.g. my-repo/my-image.
+	// Repository is the repository of the container image, e.g. my-repo/my-image
 	Repository string `json:"repository,omitempty"`
 
-	// Tag is the tag of the container image reference, and is the default version.
+	// Tag is the tag of the container image, and is the default version.
 	Tag string `json:"tag,omitempty"`
 }
 
 func (i Image) String() string {
-	return fmt.Sprintf("%s/%s:%s", strings.TrimSuffix(i.Registry, "/"), i.Repository, i.Tag)
+	ref := i.Registry
+	if ref != "" {
+		ref += "/"
+	}
+
+	if !strings.Contains(i.Repository, "/") {
+		if ref != "" {
+			ref += "library/"
+		}
+	}
+	ref += i.Repository
+
+	if i.Tag != "" {
+		ref += ":" + i.Tag
+	}
+	return ref
 }
 
 type ImagePullSecretName struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -385,3 +385,59 @@ func TestConfig_IsProFeatureEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestImage_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    Image
+		expected string
+	}{
+		{
+			name: "complete image reference",
+			image: Image{
+				Registry:   "registry.k8s.io",
+				Repository: "coredns/coredns",
+				Tag:        "1.11.3",
+			},
+			expected: "registry.k8s.io/coredns/coredns:1.11.3",
+		},
+		{
+			name: "may omit registry",
+			image: Image{
+				Repository: "coredns/coredns",
+				Tag:        "1.11.3",
+			},
+			expected: "coredns/coredns:1.11.3",
+		},
+		{
+			name: "may omit registry and repo",
+			image: Image{
+				Repository: "alpine",
+				Tag:        "3.20",
+			},
+			expected: "alpine:3.20",
+		},
+		{
+			name: "omit repo but not registry is library",
+			image: Image{
+				Registry:   "ghcr.io",
+				Repository: "alpine",
+				Tag:        "3.20",
+			},
+			expected: "ghcr.io/library/alpine:3.20",
+		},
+		{
+			name: "may omit tag",
+			image: Image{
+				Repository: "alpine",
+			},
+			expected: "alpine",
+		},
+	}
+
+	for _, tt := range tests {
+		if actual := tt.image.String(); actual != tt.expected {
+			t.Errorf("%s: expected %s, got %s", tt.name, tt.expected, actual)
+		}
+	}
+}

--- a/config/legacyconfig/migrate.go
+++ b/config/legacyconfig/migrate.go
@@ -927,7 +927,7 @@ func migrateFlag(distro, key, value string, newConfig *config.Config) error {
 			return fmt.Errorf("value is missing")
 		}
 
-		newConfig.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image = value
+		convertImage(value, &newConfig.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image)
 	case "cluster-domain":
 		if value == "" {
 			return fmt.Errorf("value is missing")

--- a/config/legacyconfig/migrate_test.go
+++ b/config/legacyconfig/migrate_test.go
@@ -695,6 +695,34 @@ exportKubeConfig:
   context: my-context
   server: https://my-vcluster.example.com`,
 		},
+		{
+			Name:   "migrate rewriteHosts image",
+			Distro: "k8s",
+			In: `syncer:
+  extraArgs:
+  - --override-hosts-container-image=my.registry:5000/some/repo:a-tag`,
+			Expected: `controlPlane:
+  backingStore:
+    etcd:
+      deploy:
+        enabled: true
+  distro:
+    k8s:
+      enabled: true
+  statefulSet:
+    scheduling:
+      podManagementPolicy: OrderedReady
+sync:
+  toHost:
+    pods:
+      rewriteHosts:
+        initContainer:
+          image:
+            registry: my.registry:5000
+            repository: some/repo
+            tag: a-tag
+`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -28,7 +28,10 @@ sync:
       rewriteHosts:
         enabled: true
         initContainer:
-          image: "library/alpine:3.20"
+          image:
+            registry: ""
+            repository: library/alpine
+            tag: "3.20"
           resources:
             limits:
               cpu: 30m

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,7 +148,7 @@ func (v VirtualClusterConfig) LegacyOptions() (*legacyconfig.LegacyVirtualCluste
 		EnforceNodeSelector:         true,
 		PluginListenAddress:         "localhost:10099",
 		OverrideHosts:               v.Sync.ToHost.Pods.RewriteHosts.Enabled,
-		OverrideHostsContainerImage: v.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image,
+		OverrideHostsContainerImage: v.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image.String(),
 		ServiceAccountTokenSecrets:  v.Sync.ToHost.Pods.UseSecretsForSATokens,
 		ClusterDomain:               v.Networking.Advanced.ClusterDomain,
 		LeaderElect:                 v.ControlPlane.StatefulSet.HighAvailability.Replicas > 1,

--- a/pkg/controllers/resources/pods/translate/hosts.go
+++ b/pkg/controllers/resources/pods/translate/hosts.go
@@ -1,8 +1,6 @@
 package translate
 
 import (
-	"strings"
-
 	"github.com/loft-sh/vcluster/pkg/coredns"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -27,16 +25,11 @@ var (
 
 func (t *translator) rewritePodHostnameFQDN(pPod *corev1.Pod, fromHost, toHostname, toHostnameFQDN string) {
 	if pPod.Annotations == nil || pPod.Annotations[DisableSubdomainRewriteAnnotation] != "true" || pPod.Annotations[HostsRewrittenAnnotation] != "true" {
-		image := t.overrideHostsImage
-		if t.defaultImageRegistry != "" {
-			image = strings.TrimSuffix(t.defaultImageRegistry, "/") + "/" + image
-		}
-
 		userID := coredns.GetUserID()
 		groupID := coredns.GetGroupID()
 		initContainer := corev1.Container{
 			Name:    HostsRewriteContainerName,
-			Image:   image,
+			Image:   t.overrideHostsImage,
 			Command: []string{"sh"},
 			Args:    []string{"-c", "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)" + fromHost + "$/\\1 " + toHostnameFQDN + " " + toHostname + "/' /etc/hosts > /hosts/hosts"},
 			SecurityContext: &corev1.SecurityContext{

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/scheme"
 	generictesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
@@ -299,6 +301,105 @@ func TestVolumeTranslation(t *testing.T) {
 			if len(testCase.expectedVolumeMounts) > 0 {
 				assert.Assert(t, cmp.DeepEqual(pPod.Spec.Containers[0].VolumeMounts, testCase.expectedVolumeMounts), "Unexpected translation of the Volume Mounts in the '%s' test case", testCase.name)
 			}
+		})
+	}
+}
+
+func TestRewriteHostsTranslation(t *testing.T) {
+	testCases := []struct {
+		name      string
+		configMod func(*config.VirtualClusterConfig)
+		pod       corev1.Pod
+		test      func(*testing.T, *corev1.Pod)
+	}{
+		{
+			name: "Add init container that rewrites /etc/hosts",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-name",
+					Namespace: "test-ns",
+				},
+				Spec: corev1.PodSpec{
+					Subdomain: "subdomain",
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+			test: func(t *testing.T, p *corev1.Pod) {
+				assert.Equal(t, len(p.Spec.InitContainers), 1)
+				initC := p.Spec.InitContainers[0]
+				assert.Equal(t, initC.Args[1], `sed -E -e 's/^(\d+.\d+.\d+.\d+\s+)pod-name$/\1 pod-name.subdomain.test-ns.cluster.local pod-name/' /etc/hosts > /hosts/hosts`)
+				cont := p.Spec.Containers[0]
+				assert.Equal(t, len(cont.VolumeMounts), 1)
+				assert.Equal(t, cont.VolumeMounts[0].MountPath, "/etc/hosts")
+			},
+		},
+		{
+			name: "Use default registry if specified",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-name",
+					Namespace: "test-ns",
+				},
+				Spec: corev1.PodSpec{
+					Subdomain: "subdomain",
+				},
+			},
+			configMod: func(c *config.VirtualClusterConfig) {
+				c.ControlPlane.Advanced.DefaultImageRegistry = "my-registry"
+			},
+			test: func(t *testing.T, p *corev1.Pod) {
+				assert.Equal(t, len(p.Spec.InitContainers), 1)
+				initC := p.Spec.InitContainers[0]
+				assert.Equal(t, initC.Image, "my-registry/library/alpine:3.20")
+			},
+		},
+		{
+			name: "Use image overrides if specified",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-name",
+					Namespace: "test-ns",
+				},
+				Spec: corev1.PodSpec{
+					Subdomain: "subdomain",
+				},
+			},
+			configMod: func(c *config.VirtualClusterConfig) {
+				c.ControlPlane.Advanced.DefaultImageRegistry = "my-registry"
+				c.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image = vclusterconfig.Image{
+					Registry:   "private",
+					Repository: "minimal-sed",
+					Tag:        "very-specific-tag",
+				}
+			},
+			test: func(t *testing.T, p *corev1.Pod) {
+				assert.Equal(t, len(p.Spec.InitContainers), 1)
+				initC := p.Spec.InitContainers[0]
+				assert.Equal(t, initC.Image, "private/minimal-sed:very-specific-tag")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := testingutil.NewFakeConfig()
+			if testCase.configMod != nil {
+				testCase.configMod(cfg)
+			}
+			pClient := testingutil.NewFakeClient(scheme.Scheme)
+			vClient := testingutil.NewFakeClient(scheme.Scheme)
+			registerCtx := generictesting.NewFakeRegisterContext(cfg, pClient, vClient)
+			fakeRecorder := record.NewFakeRecorder(10)
+
+			tr, err := NewTranslator(registerCtx, fakeRecorder)
+			assert.NilError(t, err)
+
+			pod := testCase.pod.DeepCopy()
+			tr.(*translator).rewritePodHostnameFQDN(pod, pod.Name, pod.Name, fmt.Sprintf("%s.%s.%s.cluster.local", pod.Name, pod.Spec.Subdomain, pod.Namespace))
+
+			testCase.test(t, pod)
 		})
 	}
 }

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -370,14 +370,14 @@ func TestRewriteHostsTranslation(t *testing.T) {
 				c.ControlPlane.Advanced.DefaultImageRegistry = "my-registry"
 				c.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image = vclusterconfig.Image{
 					Registry:   "private",
-					Repository: "minimal-sed",
+					Repository: "minimal/sed",
 					Tag:        "very-specific-tag",
 				}
 			},
 			test: func(t *testing.T, p *corev1.Pod) {
 				assert.Equal(t, len(p.Spec.InitContainers), 1)
 				initC := p.Spec.InitContainers[0]
-				assert.Equal(t, initC.Image, "private/minimal-sed:very-specific-tag")
+				assert.Equal(t, initC.Image, "private/minimal/sed:very-specific-tag")
 			},
 		},
 	}


### PR DESCRIPTION
BREAKING CHANGE: Change config.sync.toHost.pods.rewriteHosts.initContainer.image from string to struct.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This changes the config for the "rewriteHosts" feature to be in line with other places.
The init container will now also use the `config.controlPlane.advanced.defaultRegistry`.

**Please provide a short message that should be published in the vcluster release notes**
Allow to use a custom registry for the rewriteHosts init container.
BREAKING CHANGE: replaced the config string `sync.toHost.pods.rewriteHosts.initContainer.image` with object that takes `registry`, `repository`, `tag`.

**What else do we need to know?** 
