### PR TITLE
chore: pull public images from mirror.gcr.io

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -58,7 +58,7 @@ sync:
           image:
             # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
             # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
-            registry: ""
+            registry: "mirror.gcr.io"
             # Repository is the repository of the container image, e.g. my-repo/my-image
             repository: library/alpine
             # Tag is the tag of the container image, and is the default version.
@@ -115,7 +115,7 @@ sync:
       enabled: false
       # MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
       mappingsOnly: false
-  
+
   # Configure what resources vCluster should sync from the host cluster to the virtual cluster.
   fromHost:
     # Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
@@ -300,7 +300,7 @@ controlPlane:
         requests:
           cpu: 40m
           memory: 64Mi
-  
+
   # BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
   backingStore:
     # Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
@@ -445,7 +445,7 @@ controlPlane:
         # HeadlessService holds options for the external etcd headless service.
         headlessService:
           annotations: {}
-  
+
   # Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
   proxy:
     # BindAddress under which vCluster will expose the proxy.
@@ -454,7 +454,7 @@ controlPlane:
     port: 8443
     # ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
     extraSANs: []
-  
+
   # CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
   coredns:
     # Enabled defines if coredns is enabled
@@ -516,7 +516,7 @@ controlPlane:
           labelSelector:
             matchLabels:
               k8s-app: vcluster-kube-dns
-  
+
   # Service defines options for vCluster service deployed by Helm.
   service:
     # Enabled defines if the control plane service should be enabled
@@ -530,7 +530,7 @@ controlPlane:
     # Spec allows you to configure extra service options.
     spec:
       type: ClusterIP
-  
+
   # Ingress defines options for vCluster ingress deployed by Helm.
   ingress:
     # Enabled defines if the control plane ingress should be enabled
@@ -547,7 +547,7 @@ controlPlane:
     # Spec allows you to configure extra ingress options.
     spec:
       tls: []
-  
+
   # Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
   # also implies privateNodes.enabled.
   standalone:
@@ -568,7 +568,7 @@ controlPlane:
       containerd:
         # Enabled defines if containerd should be installed and configured by vCluster.
         enabled: true
-  
+
   # StatefulSet defines options for vCluster statefulSet deployed by Helm.
   statefulSet:
     labels: {}
@@ -707,14 +707,14 @@ controlPlane:
         timeoutSeconds: 3
         # Frequency (in seconds) to perform the probe
         periodSeconds: 6
-  
+
   # ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
   serviceMonitor:
     # Enabled configures if Helm should create the service monitor.
     enabled: false
     labels: {}
     annotations: {}
-  
+
   # Advanced holds additional configuration for the vCluster control plane.
   advanced:
     # DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
@@ -790,24 +790,24 @@ controlPlane:
 privateNodes:
   # Enabled defines if dedicated nodes should be enabled.
   enabled: false
-  
+
   # ImportNodeBinaries defines to use the loft-sh/kubernetes:VERSION-full image to also copy the node binaries to the control plane. This allows upgrades and
   # joining new nodes into the cluster without having to download the binaries from the internet.
   importNodeBinaries: true
-  
+
   # Kubelet holds kubelet configuration that is used for all nodes.
   kubelet:
     # Config is the config for the kubelet that will be merged into the default kubelet config. More information can be found here:
     # https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
     config: {}
-  
+
   # AutoUpgrade holds configuration for auto upgrade.
   autoUpgrade:
     # Enabled defines if auto upgrade should be enabled.
     enabled: true
     # Concurrency is the number of nodes that can be upgraded at the same time.
     concurrency: 1
-  
+
   # JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
   joinNode:
     # Containerd holds configuration for the containerd join process.
@@ -821,14 +821,14 @@ deploy:
   localPathProvisioner:
     # Enabled defines if LocalPathProvisioner should be enabled.
     enabled: true
-  
+
   # CNI holds dedicated CNI configuration.
   cni:
     # Flannel holds dedicated Flannel configuration.
     flannel:
       # Enabled defines if Flannel should be enabled.
       enabled: true
-  
+
   # KubeProxy holds dedicated kube proxy configuration.
   kubeProxy:
     # Enabled defines if the kube proxy should be enabled.
@@ -848,7 +848,7 @@ deploy:
     # Config is the config for the kube-proxy that will be merged into the default kube-proxy config. More information can be found here:
     # https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration
     config: {}
-  
+
   # Metallb holds dedicated metallb configuration.
   metallb:
     # Enabled defines if metallb should be enabled.
@@ -859,14 +859,14 @@ deploy:
       addresses: []
       # L2Advertisement defines if L2 advertisement should be enabled for the IP address pool.
       l2Advertisement: true
-  
+
   # IngressNginx holds dedicated ingress-nginx configuration.
   ingressNginx:
     # Enabled defines if ingress-nginx should be enabled.
     enabled: false
     # DefaultIngressClass defines if the deployed ingress class should be the default ingress class.
     defaultIngressClass: true
-  
+
   # MetricsServer holds dedicated metrics server configuration.
   metricsServer:
     # Enabled defines if metrics server should be enabled.
@@ -882,7 +882,7 @@ integrations:
     nodes: true
     # Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
     pods: true
-  
+
   # ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
   # - ExternalSecrets will be synced from the virtual cluster to the host cluster.
   # - SecretStores will be synced from the virtual cluster to the host cluster and then bi-directionally.
@@ -930,7 +930,7 @@ integrations:
         # Selector defines what cluster stores should be synced
         selector:
           labels: {}
-  
+
   # KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
   kubeVirt:
     # Enabled signals if the integration should be enabled
@@ -958,7 +958,7 @@ integrations:
       # If VirtualMachineInstanceMigrations should get synced
       virtualMachineInstanceMigrations:
         enabled: true
-  
+
   # CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
   # - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
   # - ClusterIssuers will be synced from the host cluster to the virtual cluster.
@@ -982,7 +982,7 @@ integrations:
           # Selector defines what cluster issuers should be imported.
           selector:
             labels: {}
-  
+
   # Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
   istio:
     # Enabled defines if this option should be enabled.
@@ -1006,7 +1006,7 @@ rbac:
     overwriteRules: []
     # ExtraRules will add rules to the role.
     extraRules: []
-  
+
   # ClusterRole holds virtual cluster cluster role configuration
   clusterRole:
     # Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
@@ -1020,7 +1020,7 @@ rbac:
 networking:
   # PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true.
   podCIDR: "10.244.0.0/16"
-  
+
   # ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
   replicateServices:
     # ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
@@ -1029,10 +1029,10 @@ networking:
     toHost: []
     # FromHost defines the services that should get synced from the host to the virtual cluster.
     fromHost: []
-  
+
   # ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
   resolveDNS: []
-  
+
   # Advanced holds advanced network options.
   advanced:
     # ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
@@ -1081,7 +1081,7 @@ policies:
       matchExpressions: []
     # Scopes are the resource quota scopes
     scopes: []
-  
+
   # LimitRange specifies limit range options.
   limitRange:
     # Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
@@ -1103,7 +1103,7 @@ policies:
     min: {}
     # Max are the max limits for the limit range
     max: {}
-  
+
   # NetworkPolicy specifies network policy options.
   networkPolicy:
     # Enabled defines if the network policy should be deployed by vCluster.
@@ -1137,7 +1137,7 @@ policies:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-  
+
   # CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
   centralAdmission:
     # ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
@@ -1149,13 +1149,13 @@ policies:
 exportKubeConfig:
   # Context is the name of the context within the generated kubeconfig to use.
   context: ""
-  
+
   # Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
   server: ""
-  
+
   # If tls should get skipped for the server
   insecure: false
-  
+
   # ServiceAccount can be used to generate a service account token instead of the default certificates.
   serviceAccount:
     # Name of the service account to be used to generate a service account token instead of the default certificates.
@@ -1165,7 +1165,7 @@ exportKubeConfig:
     namespace: ""
     # ClusterRole to assign to the service account.
     clusterRole: ""
-  
+
   # Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
   # If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
   # vCluster creates the config in this other secret.
@@ -1192,12 +1192,12 @@ experimental:
     targetNamespace: ""
     # SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
     setOwner: true
-  
+
   # IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
   isolatedControlPlane:
     # Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
     headless: false
-  
+
   # Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
   deploy:
     # Host defines what manifests to deploy into the host cluster
@@ -1214,7 +1214,7 @@ experimental:
       manifestsTemplate: ""
       # Helm are Helm charts that should get deployed into the virtual cluster
       helm: []
-  
+
   # GenericSync holds options to generically sync resources from virtual cluster to host.
   genericSync:
     clusterRole:

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -29,7 +29,7 @@ sync:
         enabled: true
         initContainer:
           image:
-            registry: ""
+            registry: "mirror.gcr.io"
             repository: library/alpine
             tag: "3.20"
           resources:


### PR DESCRIPTION
Avoid DockerHub rate limits by using mirror.gcr.io.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves OPS-237


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue with Docker Hub rate limits by pulling images from mirror.gcr.io