### PR TITLE
Adds coredns version mapping for k8s 1.33

### DIFF
--- a/pkg/constants/coredns.go
+++ b/pkg/constants/coredns.go
@@ -6,6 +6,7 @@ var CoreDNSVersionMap = map[string]string{
 	"1.32": "coredns/coredns:1.11.3",
 	"1.31": "coredns/coredns:1.11.3",
 	"1.30": "coredns/coredns:1.11.3",
+	"1.33": "coredns/coredns:1.12.0",
 }
 
 var (

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	DefaultImage    = "coredns/coredns:1.11.3"
+	DefaultImage    = "coredns/coredns:1.12.0"
 	VarImage        = "IMAGE"
 	VarHostDNS      = "HOST_CLUSTER_DNS"
 	VarRunAsUser    = "RUN_AS_USER"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-8049

## ⚠️ Note ⚠️
This version hasn't officially made it into the coredns docs yet.  There's a PR with version `0.12.0` [here](https://github.com/coredns/deployment/pull/306/files?w=1)
