### PR TITLE
fix: also set loftHost if host and no-tunnel flags are set at the sam…

### DIFF
--- a/cmd/vclusterctl/cmd/platform/start.go
+++ b/cmd/vclusterctl/cmd/platform/start.go
@@ -94,6 +94,10 @@ func (cmd *StartCmd) Run(ctx context.Context) error {
 		}
 	}
 
+	if cmd.NoTunnel && cmd.Host == "" {
+		return fmt.Errorf("%q flag must be set when %q is set to true", "host", "no-tunnel")
+	}
+
 	// if < v4.0.0 then use ChartName loft
 	parsedVersion, err := semver.Parse(strings.TrimPrefix(cmd.Version, "v"))
 	if err != nil {

--- a/pkg/cli/start/upgrade.go
+++ b/pkg/cli/start/upgrade.go
@@ -23,6 +23,10 @@ func (l *LoftStarter) upgradeLoft() error {
 	}
 	if l.Host != "" {
 		extraArgs = append(extraArgs, "--set", "ingress.enabled=true", "--set", "ingress.host="+l.Host)
+
+		if l.NoTunnel {
+			extraArgs = append(extraArgs, "--set", "config.loftHost="+l.Host)
+		}
 	}
 	if l.Version != "" {
 		extraArgs = append(extraArgs, "--version", l.Version)


### PR DESCRIPTION
…e time

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-7988


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would not set loftHost if platform start is called with no-tunnel. 


**What else do we need to know?** 
