### PR TITLE
Fix: advanced.defaultRegistry takes precedence over image.registry field

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -95,8 +95,8 @@ func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder record.EventR
 
 	overrideHostsImage := ctx.Config.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image
 	overrideHostsImage.Registry = cmp.Or(
-		overrideHostsImage.Registry,
 		ctx.Config.ControlPlane.Advanced.DefaultImageRegistry,
+		overrideHostsImage.Registry,
 		"docker.io",
 	)
 

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -336,7 +336,7 @@ func TestRewriteHostsTranslation(t *testing.T) {
 			},
 		},
 		{
-			name: "Use default registry if specified",
+			name: "Default registry has precedence over specified registry",
 			pod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod-name",
@@ -348,6 +348,7 @@ func TestRewriteHostsTranslation(t *testing.T) {
 			},
 			configMod: func(c *config.VirtualClusterConfig) {
 				c.ControlPlane.Advanced.DefaultImageRegistry = "my-registry"
+				c.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image.Registry = "mirror.gcr.io"
 			},
 			test: func(t *testing.T, p *corev1.Pod) {
 				assert.Equal(t, len(p.Spec.InitContainers), 1)
@@ -367,7 +368,6 @@ func TestRewriteHostsTranslation(t *testing.T) {
 				},
 			},
 			configMod: func(c *config.VirtualClusterConfig) {
-				c.ControlPlane.Advanced.DefaultImageRegistry = "my-registry"
 				c.Sync.ToHost.Pods.RewriteHosts.InitContainer.Image = vclusterconfig.Image{
 					Registry:   "private",
 					Repository: "minimal/sed",


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8053

**Please provide a short message that should be published in the vcluster release notes**

**What else do we need to know?** 
