### PR TITLE
fix: update pod hostIP syncing to better handle missing node service

### DIFF
--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -683,6 +684,23 @@ func TestSync(t *testing.T) {
 				syncContext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
 				_, err := syncer.(*podSyncer).Sync(syncContext, synccontext.NewSyncEventWithOld(pPodFakeKubelet, pPodFakeKubelet, vPodWithNodeName, vPodWithNodeName))
 				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                 "Fake Kubelet enabled with Node sync and node service not found",
+			InitialVirtualState:  []runtime.Object{testNode.DeepCopy(), vPodWithNodeName, vNamespace.DeepCopy()},
+			InitialPhysicalState: []runtime.Object{testNode.DeepCopy(), pPodFakeKubelet.DeepCopy()},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {vPodWithNodeName},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				ctx.Config.Sync.FromHost.Nodes.Selector.All = true
+				ctx.Config.Networking.Advanced.ProxyKubelets.ByIP = true
+				syncContext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+
+				result, err := syncer.(*podSyncer).Sync(syncContext, synccontext.NewSyncEventWithOld(pPodFakeKubelet, pPodFakeKubelet, vPodWithNodeName, vPodWithNodeName))
+				assert.NilError(t, err)
+				assert.Equal(t, result.RequeueAfter, time.Second, "Should requeue if node service is not found")
 			},
 		},
 		{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8084

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster creates an invalid patch when syncing pod hostIPs

**What else do we need to know?** 
This is a timing issue between the pod & node service creation. The node / node service is created lazily when the first pod on that node is created, but the pod syncer did not handle the node service not found error, created an invalid patch, and the error resulted in an event getting recorded.