### PR TITLE
chore(ci): decouple helm release action

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,44 @@
+name: Publish Chart
+
+on:
+  workflow_call:
+    inputs:
+      release_version:
+        description: "The release version to publish"
+        required: true
+        type: string
+      ref:
+        description: "The git ref to checkout"
+        required: true
+        type: string
+
+jobs:
+  publish-chart:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Validate semantic version
+        id: semver
+        uses: loft-sh/github-actions/.github/actions/semver-validation@semver-validation/v1
+        with:
+          version: "${{ inputs.release_version }}"
+      - name: Check validation result
+        run: '[[ "${{ steps.semver.outputs.is_valid }}" == "true" ]] || (echo "Invalid version: ${{ inputs.release_version }}" && exit 1)'
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: azure/setup-helm@v4
+        with:
+          version: "v3.0.2"
+      - name: Publish Helm chart
+        run: |
+          set -euo pipefail
+          echo "Publishing Helm chart for version ${{ inputs.release_version }}"
+          helm plugin install https://github.com/chartmuseum/helm-push.git || true
+          helm repo add chartmuseum $CHART_MUSEUM_URL --username $CHART_MUSEUM_USER --password $CHART_MUSEUM_PASSWORD
+          helm cm-push --force --version="${{ inputs.release_version }}" --app-version="${{ inputs.release_version }}" chart chartmuseum
+        env:
+          CHART_MUSEUM_URL: "https://charts.loft.sh/"
+          CHART_MUSEUM_USER: ${{ secrets.CHART_MUSEUM_USER }}
+          CHART_MUSEUM_PASSWORD: ${{ secrets.CHART_MUSEUM_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,23 +111,12 @@ jobs:
   publish-chart:
     if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [publish]
-    runs-on: ubuntu-22.04
+    uses: ./.github/workflows/publish-chart.yaml
+    with:
+      release_version: ${{ needs.publish.outputs.release_version }}
+      ref: ${{ github.ref }}
+    secrets: inherit
 
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
-        with:
-          version: "v3.0.2"
-      - run: |
-          RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/v!!p')
-          helm plugin install https://github.com/chartmuseum/helm-push.git
-          helm repo add chartmuseum $CHART_MUSEUM_URL --username $CHART_MUSEUM_USER --password $CHART_MUSEUM_PASSWORD
-          helm cm-push --force --version="$RELEASE_VERSION" --app-version="$RELEASE_VERSION" chart chartmuseum
-        env:
-          CHART_MUSEUM_URL: "https://charts.loft.sh/"
-          CHART_MUSEUM_USER: ${{ secrets.CHART_MUSEUM_USER }}
-          CHART_MUSEUM_PASSWORD: ${{ secrets.CHART_MUSEUM_PASSWORD }}
   # The workflow will only trigger on non-draft releases
   # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
   sync_linear:
@@ -215,8 +204,8 @@ jobs:
         with:
           version: ${{ needs.publish.outputs.release_version }}
           previous_tag: ${{ needs.publish.outputs.previous_tag }}
-          changes: 'See changelog link below'
-          target_repo: 'loft-sh/vcluster'
-          product: 'vCluster'
+          changes: "See changelog link below"
+          target_repo: "loft-sh/vcluster"
+          product: "vCluster"
           base_branch: ${{ steps.get_base_branch.outputs.base_branch }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }}


### PR DESCRIPTION
Use a standalone workflow to publish the Helm chart. This makes it possible to be triggered by another workflow or from external repositories.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
related to OPS-206
