### PR TITLE
[v0.25] Snapshot List and Delete (#3021)

### DIFF
--- a/cmd/vcluster/cmd/root.go
+++ b/cmd/vcluster/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	loftlogr "github.com/loft-sh/log/logr"
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/debug"
+	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/snapshot"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,8 +59,8 @@ func BuildRoot() *cobra.Command {
 
 	// add top level commands
 	rootCmd.AddCommand(NewStartCommand())
-	rootCmd.AddCommand(NewSnapshotCommand())
-	rootCmd.AddCommand(NewRestoreCommand())
+	rootCmd.AddCommand(snapshot.NewSnapshotCommand())
+	rootCmd.AddCommand(snapshot.NewRestoreCommand())
 	rootCmd.AddCommand(NewPortForwardCommand())
 	rootCmd.AddCommand(debug.NewDebugCmd())
 	return rootCmd

--- a/cmd/vcluster/cmd/snapshot/delete.go
+++ b/cmd/vcluster/cmd/snapshot/delete.go
@@ -1,0 +1,27 @@
+package snapshot
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "delete vCluster snapshot",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			options := &Options{}
+			envOptions, err := parseOptionsFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to parse options from environment: %w", err)
+			}
+			options.Snapshot = *envOptions
+
+			return options.Delete(cmd.Context())
+		},
+	}
+
+	return cmd
+}

--- a/cmd/vcluster/cmd/snapshot/list.go
+++ b/cmd/vcluster/cmd/snapshot/list.go
@@ -1,0 +1,42 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list vCluster snapshots",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			options := &Options{}
+			envOptions, err := parseOptionsFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to parse options from environment: %w", err)
+			}
+			options.Snapshot = *envOptions
+
+			snapshots, err := options.List(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("failed to list snapshots: %w", err)
+			}
+
+			encodedBytes, err := json.Marshal(snapshots)
+			if err != nil {
+				return fmt.Errorf("failed to marshal json: %w", err)
+			}
+
+			if _, err := os.Stdout.Write(encodedBytes); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/vcluster/cmd/snapshot/restore.go
+++ b/cmd/vcluster/cmd/snapshot/restore.go
@@ -1,4 +1,4 @@
-package cmd
+package snapshot
 
 import (
 	"archive/tar"
@@ -39,18 +39,18 @@ var (
 
 func NewRestoreCommand() *cobra.Command {
 	options := &RestoreOptions{}
-	envOptions, err := parseOptionsFromEnv()
-	if err != nil {
-		klog.Warningf("Error parsing environment variables: %v", err)
-	} else {
-		options.Snapshot = *envOptions
-	}
 
 	cmd := &cobra.Command{
 		Use:   "restore",
 		Short: "restore a vCluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			envOptions, err := parseOptionsFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to parse options from environment: %w", err)
+			}
+			options.Snapshot = *envOptions
+
 			return options.Run(cmd.Context())
 		},
 	}
@@ -71,7 +71,7 @@ func (o *RestoreOptions) Run(ctx context.Context) error {
 	}
 
 	// make sure to validate options
-	err = validateOptions(vConfig, &o.Snapshot, true)
+	err = validateOptions(vConfig, &o.Snapshot, true, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/vcluster/cmd/snapshot/snapshot.go
+++ b/cmd/vcluster/cmd/snapshot/snapshot.go
@@ -1,4 +1,4 @@
-package cmd
+package snapshot
 
 import (
 	"archive/tar"
@@ -20,6 +20,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/pro"
 	"github.com/loft-sh/vcluster/pkg/setup"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/snapshot/types"
 	"github.com/loft-sh/vcluster/pkg/util/servicecidr"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -27,32 +28,34 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type SnapshotOptions struct {
+type Options struct {
 	Snapshot snapshot.Options
 }
 
 func NewSnapshotCommand() *cobra.Command {
-	options := &SnapshotOptions{}
-	envOptions, err := parseOptionsFromEnv()
-	if err != nil {
-		klog.Warningf("Error parsing environment variables: %v", err)
-	} else {
-		options.Snapshot = *envOptions
-	}
-
 	cmd := &cobra.Command{
 		Use:   "snapshot",
 		Short: "snapshot a vCluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			options := &Options{}
+			envOptions, err := parseOptionsFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to parse options from environment: %w", err)
+			}
+			options.Snapshot = *envOptions
+
 			return options.Run(cmd.Context())
 		},
 	}
 
+	cmd.AddCommand(NewListCmd())
+	cmd.AddCommand(NewDeleteCmd())
+
 	return cmd
 }
 
-func (o *SnapshotOptions) Run(ctx context.Context) error {
+func (o *Options) Run(ctx context.Context) error {
 	// parse vCluster config
 	vConfig, err := config.ParseConfig(constants.DefaultVClusterConfigLocation, os.Getenv("VCLUSTER_NAME"), nil)
 	if err != nil {
@@ -60,7 +63,7 @@ func (o *SnapshotOptions) Run(ctx context.Context) error {
 	}
 
 	// make sure to validate options
-	err = validateOptions(vConfig, &o.Snapshot, false)
+	err = validateOptions(vConfig, &o.Snapshot, false, false)
 	if err != nil {
 		return err
 	}
@@ -88,7 +91,58 @@ func (o *SnapshotOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-func (o *SnapshotOptions) writeSnapshot(ctx context.Context, etcdClient etcd.Client, objectStore snapshot.Storage) error {
+func (o *Options) List(ctx context.Context) ([]types.Snapshot, error) {
+	// parse vCluster config
+	vConfig, err := config.ParseConfig(constants.DefaultVClusterConfigLocation, os.Getenv("VCLUSTER_NAME"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// make sure to validate options
+	err = validateOptions(vConfig, &o.Snapshot, false, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// create store
+	objectStore, err := snapshot.CreateStore(ctx, &o.Snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create store: %w", err)
+	}
+
+	// list snapshots
+	return objectStore.List(ctx)
+}
+
+func (o *Options) Delete(ctx context.Context) error {
+	// parse vCluster config
+	vConfig, err := config.ParseConfig(constants.DefaultVClusterConfigLocation, os.Getenv("VCLUSTER_NAME"), nil)
+	if err != nil {
+		return err
+	}
+
+	// make sure to validate options
+	err = validateOptions(vConfig, &o.Snapshot, false, false)
+	if err != nil {
+		return err
+	}
+
+	// create store
+	objectStore, err := snapshot.CreateStore(ctx, &o.Snapshot)
+	if err != nil {
+		return fmt.Errorf("failed to create store: %w", err)
+	}
+
+	// delete snapshot
+	if err := objectStore.Delete(ctx); err != nil {
+		return err
+	}
+
+	klog.Infof("Successfully deleted snapshot %s", objectStore.Target())
+	return nil
+}
+
+func (o *Options) writeSnapshot(ctx context.Context, etcdClient etcd.Client, objectStore types.Storage) error {
 	// now stream objects from etcd to object store
 	errChan := make(chan error)
 	reader, writer, err := os.Pipe()
@@ -168,9 +222,9 @@ func (o *SnapshotOptions) writeSnapshot(ctx context.Context, etcdClient etcd.Cli
 	}
 }
 
-func validateOptions(vConfig *config.VirtualClusterConfig, options *snapshot.Options, isRestore bool) error {
+func validateOptions(vConfig *config.VirtualClusterConfig, options *snapshot.Options, isRestore, isList bool) error {
 	// storage needs to be either s3 or file
-	err := snapshot.Validate(options)
+	err := snapshot.Validate(options, isList)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/snapshot_helm.go
+++ b/pkg/cli/snapshot_helm.go
@@ -56,7 +56,7 @@ func fillSnapshotOptions(snapshotURL string, snapshotOptions *snapshot.Options) 
 	}
 
 	// storage needs to be either s3 or file
-	err = snapshot.Validate(snapshotOptions)
+	err = snapshot.Validate(snapshotOptions, false)
 	if err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}

--- a/pkg/snapshot/container/store.go
+++ b/pkg/snapshot/container/store.go
@@ -2,9 +2,14 @@ package container
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/snapshot/types"
 )
 
 type Options struct {
@@ -43,4 +48,64 @@ func (s *Store) PutObject(_ context.Context, body io.Reader) error {
 
 	_, err = io.Copy(f, body)
 	return err
+}
+
+func (s *Store) List(_ context.Context) ([]types.Snapshot, error) {
+	path := s.path
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if !fileInfo.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	var snapshots []types.Snapshot
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		eInfo, err := entry.Info()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+
+		if eInfo.IsDir() {
+			continue
+		}
+
+		if !strings.HasSuffix(entry.Name(), "tar.gz") {
+			continue
+		}
+
+		snapshots = append(snapshots, types.Snapshot{
+			ID:        entry.Name(),
+			URL:       "container://" + path + "/" + entry.Name(),
+			Timestamp: eInfo.ModTime(),
+		})
+	}
+	return snapshots, nil
+}
+
+func (s *Store) Delete(_ context.Context) error {
+	fileInfo, err := os.Stat(s.path)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo.IsDir() {
+		return fmt.Errorf("not a snapshot file")
+	}
+
+	if !strings.HasSuffix(s.path, "tar.gz") {
+		return fmt.Errorf("not a snapshot file")
+	}
+
+	return os.Remove(s.path)
 }

--- a/pkg/snapshot/oci/store.go
+++ b/pkg/snapshot/oci/store.go
@@ -2,14 +2,17 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	remotev1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/loft-sh/vcluster/pkg/snapshot/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	oras "oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
@@ -158,6 +161,91 @@ func (s *Store) GetObject(ctx context.Context) (io.ReadCloser, error) {
 	}
 
 	return etcdReader, nil
+}
+
+func (s *Store) List(ctx context.Context) ([]types.Snapshot, error) {
+	repository, err := name.NewRepository(s.options.Repository)
+	if err != nil {
+		if !errors.Is(err, &name.ErrBadName{}) {
+			return nil, err
+		}
+
+		// Fall back to parsing is as a tag, then use the repository.
+		if ref, err := name.ParseReference(s.options.Repository); err == nil {
+			repository = ref.Context()
+		} else {
+			return nil, err
+		}
+	}
+
+	tags, err := remote.List(
+		repository,
+		remote.WithContext(ctx),
+		remote.WithAuth(&authn.Basic{
+			Username: s.options.Username,
+			Password: s.options.Password,
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshots []types.Snapshot
+	for _, tag := range tags {
+		repoTag := repository.Tag(tag)
+		img, err := remote.Image(repoTag, remote.WithContext(ctx), remote.WithAuth(&authn.Basic{
+			Username: s.options.Username,
+			Password: s.options.Password,
+		}))
+		if err != nil {
+			return nil, err
+		}
+
+		if ok, err := hasLayerWithMediaType(img, EtcdLayerMediaType); err != nil || !ok {
+			continue
+		}
+
+		if manifest, err := img.Manifest(); err != nil {
+			continue
+		} else if manifest != nil {
+			createdTime, _ := time.Parse(
+				time.RFC3339,
+				manifest.Annotations[v1.AnnotationCreated],
+			)
+
+			snapshots = append(snapshots, types.Snapshot{
+				ID:        tag,
+				URL:       repoTag.String(),
+				Timestamp: createdTime,
+			})
+		}
+	}
+	return snapshots, nil
+}
+
+func (s *Store) Delete(_ context.Context) error {
+	return fmt.Errorf("deleting OCI snapshots is not supported")
+}
+
+func hasLayerWithMediaType(img remotev1.Image, mediaType string) (bool, error) {
+	layers, err := img.Layers()
+	if err != nil {
+		return false, err
+	}
+
+	// search config layer
+	for _, layer := range layers {
+		mt, err := layer.MediaType()
+		if err != nil {
+			return false, fmt.Errorf("get layer: %w", err)
+		}
+
+		if mediaType == string(mt) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func FindLayerWithMediaType(img remotev1.Image, mediaType string) (io.ReadCloser, error) {

--- a/pkg/snapshot/s3/store.go
+++ b/pkg/snapshot/s3/store.go
@@ -23,16 +23,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/go-logr/logr"
-
+	"github.com/loft-sh/vcluster/pkg/snapshot/types"
 	"github.com/pkg/errors"
 )
 
@@ -196,13 +198,13 @@ func (o *ObjectStore) Init(config *Options) error {
 		}
 		o.checksumAlg = config.ChecksumAlgorithm
 	} else {
-		o.checksumAlg = string(types.ChecksumAlgorithmCrc32)
+		o.checksumAlg = string(s3types.ChecksumAlgorithmCrc32)
 	}
 	return nil
 }
 
 func validChecksumAlg(alg string) bool {
-	typedAlg := types.ChecksumAlgorithm(alg)
+	typedAlg := s3types.ChecksumAlgorithm(alg)
 	return alg == "" || slices.Contains(typedAlg.Values(), typedAlg)
 }
 
@@ -235,11 +237,7 @@ func readCustomerKey(customerKeyEncryptionFile string) (string, error) {
 }
 
 func (o *ObjectStore) Target() string {
-	target := "s3://" + o.bucket + "/" + o.key
-	if o.region != "" {
-		target += "?region=" + o.region
-	}
-	return target
+	return toS3URL(o.bucket, o.key, o.region)
 }
 
 func (o *ObjectStore) PutObject(ctx context.Context, body io.Reader) error {
@@ -263,11 +261,11 @@ func (o *ObjectStore) PutObject(ctx context.Context, body io.Reader) error {
 		input.SSECustomerKeyMD5 = &o.sseCustomerKeyMd5
 	// otherwise, use the SSE algorithm specified, if any
 	case o.serverSideEncryption != "":
-		input.ServerSideEncryption = types.ServerSideEncryption(o.serverSideEncryption)
+		input.ServerSideEncryption = s3types.ServerSideEncryption(o.serverSideEncryption)
 	}
 
 	if o.checksumAlg != "" {
-		input.ChecksumAlgorithm = types.ChecksumAlgorithm(o.checksumAlg)
+		input.ChecksumAlgorithm = s3types.ChecksumAlgorithm(o.checksumAlg)
 	}
 
 	_, err := o.s3Uploader.Upload(ctx, input)
@@ -294,7 +292,74 @@ func (o *ObjectStore) GetObject(ctx context.Context) (io.ReadCloser, error) {
 	return output.Body, nil
 }
 
+func (o *ObjectStore) List(ctx context.Context) ([]types.Snapshot, error) {
+	prefix := o.key
+	if strings.HasSuffix(prefix, "tar.gz") {
+		// Use the "parent dir" as the prefix if a file was given
+		prefix = filepath.Dir(prefix)
+
+		// Handle if the key is at the root of the bucket.
+		if prefix == "." {
+			prefix = ""
+		}
+	}
+
+	paginator := s3.NewListObjectsV2Paginator(o.s3, &s3.ListObjectsV2Input{
+		Bucket: aws.String(o.bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	snapshots := make([]types.Snapshot, 0)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, obj := range output.Contents {
+			if obj.Key == nil || obj.LastModified == nil {
+				continue
+			}
+
+			// Skip non *.tar.gz objects
+			if !strings.HasSuffix(*obj.Key, "tar.gz") {
+				continue
+			}
+
+			// Skip objects not in the "current directory"
+			id := strings.TrimPrefix(strings.TrimPrefix(*obj.Key, prefix), "/")
+			if filepath.Dir(id) != "." {
+				continue
+			}
+
+			// ID is the relative object name
+			snapshots = append(snapshots, types.Snapshot{
+				ID:        id,
+				URL:       toS3URL(o.bucket, *obj.Key, o.region),
+				Timestamp: *obj.LastModified,
+			})
+		}
+	}
+	return snapshots, nil
+}
+
+func (o *ObjectStore) Delete(ctx context.Context) error {
+	_, err := o.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(o.bucket),
+		Key:    aws.String(o.key),
+	})
+	return err
+}
+
 // this is required because os pipes cause trouble with aws uploader
 type wrapper struct {
 	io.Reader
+}
+
+func toS3URL(bucket, key, region string) string {
+	url := "s3://" + bucket + "/" + key
+	if region != "" {
+		url += "?region=" + region
+	}
+	return url
 }

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -3,7 +3,6 @@ package snapshot
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"path"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/snapshot/oci"
 	"github.com/loft-sh/vcluster/pkg/snapshot/options"
 	"github.com/loft-sh/vcluster/pkg/snapshot/s3"
+	"github.com/loft-sh/vcluster/pkg/snapshot/types"
 	"k8s.io/klog/v2"
 )
 
@@ -45,13 +45,7 @@ type VClusterConfig struct {
 	Values       string `json:"values"`
 }
 
-type Storage interface {
-	Target() string
-	PutObject(ctx context.Context, body io.Reader) error
-	GetObject(ctx context.Context) (io.ReadCloser, error)
-}
-
-func CreateStore(ctx context.Context, options *Options) (Storage, error) {
+func CreateStore(ctx context.Context, options *Options) (types.Storage, error) {
 	if options.Type == "s3" {
 		objectStore := s3.NewStore(klog.FromContext(ctx))
 		err := objectStore.Init(&options.S3)
@@ -125,10 +119,10 @@ func Parse(snapshotURL string, snapshotOptions *Options) error {
 	return nil
 }
 
-func Validate(options *Options) error {
+func Validate(options *Options, isList bool) error {
 	// storage needs to be either s3 or file
 	if options.Type == "s3" {
-		if options.S3.Key == "" {
+		if !isList && options.S3.Key == "" {
 			return fmt.Errorf("key must be specified via s3://BUCKET/KEY")
 		}
 		if options.S3.Bucket == "" {

--- a/pkg/snapshot/types/types.go
+++ b/pkg/snapshot/types/types.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+type Snapshot struct {
+	ID        string    `json:"id"`
+	URL       string    `json:"url"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type Storage interface {
+	Target() string
+	PutObject(ctx context.Context, body io.Reader) error
+	GetObject(ctx context.Context) (io.ReadCloser, error)
+	List(ctx context.Context) ([]Snapshot, error)
+	Delete(ctx context.Context) error
+}


### PR DESCRIPTION
Backport from `main` to `v0.25`

Original PR Nr.: #3021

### Backported Commits:
- 1e45f69f Snapshot List and Delete (#3021)

* feat: implement vcluster snapshot list command

* feat: implement vcluster snapshot delete command

* fix: update snapshot validation for list command

* fix: modify commands to error if the configuration cannot be parsed from the environment

* fix: use full URL in list results

* fix: only list objects in the &quot;current directory&quot; of the bucket

The default s3 behavior is to list everything under a prefix. If a bucket is used for multiple purposes, this could include non-snapshot resources.

* fix: handle list input with file key at the bucket root
