### PR TITLE
Handle catch-all cases properly in validation

### DIFF
--- a/pkg/util/namespaces/validation.go
+++ b/pkg/util/namespaces/validation.go
@@ -130,6 +130,12 @@ func validateToHostPatternNamespaceMappingPart(pattern, vclusterName, partIdenti
 	}
 
 	literalPrefixForValidation := strings.ReplaceAll(prefix, NamePlaceholder, vclusterName)
+
+	if len(literalPrefixForValidation) == 0 {
+		// This is a case where we're handling a catch-all '*' pattern - since we removed the wildcard suffix now we're working with empty string
+		return nil
+	}
+
 	if len(literalPrefixForValidation) > 32 {
 		return fmt.Errorf("%s: literal parts of %s pattern prefix '%s' (from '%s') cannot be longer than 32 characters (literal length: %d)", configPathIdentifier, partIdentifier, prefix, pattern, len(literalPrefixForValidation))
 	}


### PR DESCRIPTION
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster failed validation on valid namespace sync config with catch-all wildcard
