### PR TITLE
Fix platform login UX

### DIFF
--- a/cmd/vclusterctl/cmd/platform/login.go
+++ b/cmd/vclusterctl/cmd/platform/login.go
@@ -124,6 +124,9 @@ func (cmd *LoginCmd) Run(ctx context.Context, args []string) error {
 	var err error
 	if cmd.AccessKey != "" {
 		err = loginClient.LoginWithAccessKey(url, cmd.AccessKey, cmd.Insecure)
+	} else if cfg.Platform.AccessKey != "" {
+		cmd.AccessKey = cfg.Platform.AccessKey
+		err = loginClient.LoginWithAccessKey(url, cmd.AccessKey, cmd.Insecure)
 	} else {
 		err = loginClient.Login(url, cmd.Insecure, cmd.Log)
 	}

--- a/cmd/vclusterctl/cmd/platform/login.go
+++ b/cmd/vclusterctl/cmd/platform/login.go
@@ -125,8 +125,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, args []string) error {
 	if cmd.AccessKey != "" {
 		err = loginClient.LoginWithAccessKey(url, cmd.AccessKey, cmd.Insecure)
 	} else if cfg.Platform.AccessKey != "" {
-		cmd.AccessKey = cfg.Platform.AccessKey
-		err = loginClient.LoginWithAccessKey(url, cmd.AccessKey, cmd.Insecure)
+		err = loginClient.LoginWithAccessKey(url, cfg.Platform.AccessKey, cmd.Insecure)
 	} else {
 		err = loginClient.Login(url, cmd.Insecure, cmd.Log)
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-4877


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster platform login opened a browser every time to login. Now, if access-key is stored in platform config, it will use that to login. Only if the access-key is not provided in the command line args and also not stored in the platform config, then it will open the browser to login.

**What else do we need to know?** 
