### PR TITLE
[v0.26] Handle catch-all cases properly (#3036)

### DIFF
--- a/pkg/util/namespaces/validation.go
+++ b/pkg/util/namespaces/validation.go
@@ -130,6 +130,12 @@ func validateToHostPatternNamespaceMappingPart(pattern, vclusterName, partIdenti
 	}
 
 	literalPrefixForValidation := strings.ReplaceAll(prefix, NamePlaceholder, vclusterName)
+
+	if len(literalPrefixForValidation) == 0 {
+		// This is a case where we're handling a catch-all '*' pattern - since we removed the wildcard suffix now we're working with empty string
+		return nil
+	}
+
 	if len(literalPrefixForValidation) > 32 {
 		return fmt.Errorf("%s: literal parts of %s pattern prefix '%s' (from '%s') cannot be longer than 32 characters (literal length: %d)", configPathIdentifier, partIdentifier, prefix, pattern, len(literalPrefixForValidation))
 	}


### PR DESCRIPTION
Backport from `main` to `v0.26`

Original PR Nr.: #3036

### Backported Commits:
- b0a4d317 Handle catch-all cases properly (#3036)
