### PR TITLE
fix(linear-sync): prevent false positives from PRs merged after release

### DIFF
--- a/hack/linear-sync/main.go
+++ b/hack/linear-sync/main.go
@@ -22,7 +22,7 @@ var (
 	ErrMissingReleaseTag  = errors.New("release tag must be set")
 )
 
-var LoggerKey struct{}
+var LoggerKey = struct{ name string }{"logger"}
 
 func main() {
 	if err := run(context.Background(), io.Writer(os.Stderr), os.Args); err != nil {
@@ -38,17 +38,18 @@ func run(
 ) error {
 	flagset := flag.NewFlagSet(args[0], flag.ExitOnError)
 	var (
-		owner                   = flagset.String("owner", "loft-sh", "The GitHub owner of the repository")
-		repo                    = flagset.String("repo", "vcluster", "The GitHub repository to generate the changelog for")
-		githubToken             = flagset.String("token", "", "The GitHub token to use for authentication")
-		previousTag             = flagset.String("previous-tag", "", "The previous tag to generate the changelog for (if not set, the last stable release will be used)")
-		releaseTag              = flagset.String("release-tag", "", "The tag of the new release")
-		debug                   = flagset.Bool("debug", false, "Enable debug logging")
-		linearToken             = flagset.String("linear-token", "", "The Linear token to use for authentication")
-		releasedStateName       = flagset.String("released-state-name", "Released", "The name of the state to use for the released state")
+		owner                    = flagset.String("owner", "loft-sh", "The GitHub owner of the repository")
+		repo                     = flagset.String("repo", "vcluster", "The GitHub repository to generate the changelog for")
+		githubToken              = flagset.String("token", "", "The GitHub token to use for authentication")
+		previousTag              = flagset.String("previous-tag", "", "The previous tag to generate the changelog for (if not set, the last stable release will be used)")
+		releaseTag               = flagset.String("release-tag", "", "The tag of the new release")
+		debug                    = flagset.Bool("debug", false, "Enable debug logging")
+		linearToken              = flagset.String("linear-token", "", "The Linear token to use for authentication")
+		releasedStateName        = flagset.String("released-state-name", "Released", "The name of the state to use for the released state")
 		readyForReleaseStateName = flagset.String("ready-for-release-state-name", "Ready for Release", "The name of the state that indicates an issue is ready to be released")
-		linearTeamName          = flagset.String("linear-team-name", "vCluster / Platform", "The name of the team to use for the linear team")
-		dryRun                  = flagset.Bool("dry-run", false, "Do not actually move issues to the released state")
+		linearTeamName           = flagset.String("linear-team-name", "vCluster / Platform", "The name of the team to use for the linear team")
+		dryRun                   = flagset.Bool("dry-run", false, "Do not actually move issues to the released state")
+		strictFiltering          = flagset.Bool("strict-filtering", true, "Only include PRs that were actually merged before the release was published (recommended to avoid false positives)")
 	)
 	if err := flagset.Parse(args[1:]); err != nil {
 		return fmt.Errorf("parse flags: %w", err)
@@ -139,9 +140,20 @@ func run(
 		return fmt.Errorf("fetch all PRs until: %w", err)
 	}
 
-	pullRequests := NewLinearPullRequests(prs)
-
-	logger.Info("Found merged pull requests between releases", "count", len(pullRequests), "previous", stableTag, "current", *releaseTag)
+	var pullRequests []LinearPullRequest
+	if *strictFiltering {
+		// Filter PRs to only include those that were actually part of this release
+		filteredPRs, err := pullrequests.FetchPRsForRelease(ctx, gqlClient, *owner, *repo, stableTag, *releaseTag, currentRelease.PublishedAt.Time)
+		if err != nil {
+			return fmt.Errorf("filter PRs for release: %w", err)
+		}
+		pullRequests = NewLinearPullRequests(filteredPRs)
+		logger.Info("Found merged pull requests for release", "total", len(prs), "filtered", len(pullRequests), "previous", stableTag, "current", *releaseTag)
+	} else {
+		// Use all PRs between tags (original behavior)
+		pullRequests = NewLinearPullRequests(prs)
+		logger.Info("Found merged pull requests between releases", "count", len(pullRequests), "previous", stableTag, "current", *releaseTag)
+	}
 
 	releasedIssues := []string{}
 


### PR DESCRIPTION
Add an extra time-based filtering logic to exclude PRs merged after the release cut.

Introduce `--strict-filtering` flag (default: true) for opt-out capability.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves OPS-281