### PR TITLE
feat(helm chart): update livenessProbe and startProbe for etcd Statef…

### DIFF
--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -187,7 +187,7 @@ spec:
 {{ toYaml $externalEtcd.resources | indent 10 }}
         livenessProbe:
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2381
             scheme: HTTP
           initialDelaySeconds: 10
@@ -197,7 +197,7 @@ spec:
           failureThreshold: 8
         startupProbe:
           httpGet:
-            path: /health
+            path: /health?serializable=false
             port: 2381
             scheme: HTTP
           initialDelaySeconds: 10

--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -187,7 +187,7 @@ spec:
 {{ toYaml $externalEtcd.resources | indent 10 }}
         livenessProbe:
           httpGet:
-            path: /health?exclude=NOSPACE&serializable=true
+            path: /livez
             port: 2381
             scheme: HTTP
           initialDelaySeconds: 10
@@ -197,7 +197,7 @@ spec:
           failureThreshold: 8
         startupProbe:
           httpGet:
-            path: /health?serializable=false
+            path: /readyz
             port: 2381
             scheme: HTTP
           initialDelaySeconds: 10


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**Please provide a short message that should be published in the vcluster release notes**

Update startupProbe to aviod extra checks and make pod enter running state faster.

Update livenessProbe to improve accuracy and ensure service availability when appending pod IP to Services.Endpoints.

References:
- https://github.com/kubernetes/kubeadm/issues/2567
- https://github.com/kubernetes/kubernetes/pull/110744



**What else do we need to know?** 
I have already tested it in my environment.