### PR TITLE
chore(ci): skip sync-linear on next releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       release_version: ${{ steps.get_version.outputs.release_version }}
       previous_tag: ${{ steps.get_version.outputs.previous_tag }}
+      semver_parsed: ${{ steps.semver.outputs.parsed_version }}
 
     permissions:
       id-token: write # This is the key for OIDC cosign!
@@ -54,9 +55,14 @@ jobs:
           version: "v3.0.2"
       - id: get_version
         run: |
-          RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')
+          RELEASE_VERSION=$(echo "$GITHUB_REF" | sed -nE 's!refs/tags/!!p')
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "previous_tag=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)")" >> "$GITHUB_OUTPUT"
+      - name: Validate semver
+        id: semver
+        uses: loft-sh/github-actions/.github/actions/semver-validation@semver-validation/v1
+        with:
+          version: ${{ steps.get_version.outputs.release_version }}
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -120,6 +126,7 @@ jobs:
   # The workflow will only trigger on non-draft releases
   # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
   sync_linear:
+    if: ${{ !contains(needs.publish.outputs.semver_parsed, '-next') }}
     needs:
       - publish
       - publish-chart
@@ -137,6 +144,7 @@ jobs:
           LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
 
   notify_release:
+    if: ${{ always() }}
     needs:
       - publish
       - publish-chart


### PR DESCRIPTION
Don't run sync-linear job for `-next.X` releases.

**What issue type does this pull request address?**
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
related to OPS-281
