### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,19 @@
 
 Deploy your first virtual cluster with minimal effort:
 
+#### Step 1: Install vCluster CLI
 ```bash
 brew install loft-sh/tap/vcluster
+```
+#### Prerequisite: Set Up a Kubernetes Cluster
+Before creating a virtual cluster, ensure you have access to a running Kubernetes cluster. Examples of lightweight clusters you can use:
+- [kind](https://kind.sigs.k8s.io/)
+- [minikube](https://minikube.sigs.k8s.io/)
+- [Docker Desktop (with Kubernetes enabled)](https://www.docker.com/products/docker-desktop/)
+
+#### Step 2: Create a Virtual Cluster in the `team-x` namespace
+
+```bash
 vcluster create my-vcluster --namespace team-x
 ```
 


### PR DESCRIPTION
Right now the Getting Started guide shows brew install ... and then immediately vcluster create .... For someone brand new, they might assume vcluster is self-contained and will “just run” without realizing it requires a Kubernetes cluster underneath. Adding a prerequisite to prevent confusion. Otherwise, first-time users who run the command on a laptop without a cluster will just get connection errors from the CLI.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
