### PR TITLE
fix: add CGO_ENABLED=0 to devspace history commands

### DIFF
--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -4,8 +4,8 @@ set +e  # Continue on errors
 COLOR_CYAN="\033[0;36m"
 COLOR_RESET="\033[0m"
 
-RUN_CMD="go run -mod vendor cmd/vcluster/main.go start"
-DEBUG_CMD="dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- start"
+RUN_CMD="CGO_ENABLED=0 go run -mod vendor cmd/vcluster/main.go start"
+DEBUG_CMD="CGO_ENABLED=0 dlv debug ./cmd/vcluster/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=\"-mod=vendor\" -- start"
 
 echo -e "${COLOR_CYAN}
    ____              ____


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
Otherwise the commands will error with `collect2: fatal error: cannot find 'ld'`