### PR TITLE
fix: Fixes the name of the management context on its creation

### DIFF
--- a/pkg/platform/kubeconfig/kubeconfig.go
+++ b/pkg/platform/kubeconfig/kubeconfig.go
@@ -45,7 +45,7 @@ func SpaceContextName(clusterName, namespaceName string) string {
 }
 
 func ManagementContextName() string {
-	return "vcluster-platform-management"
+	return "vcluster-platform_management"
 }
 
 // DeleteContext deletes the context with the given name from the kube config


### PR DESCRIPTION
Actually the creation is creating with a `-` (minus sign) instead of a `_` (underscore).
When creating with the underscore, the disconnect code starts to work again.

I'm not sure if this could break somebodies scripts.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-8294

