### PR TITLE
fix: patch virtual instead of physical and always add host ip annotations to physical

### DIFF
--- a/pkg/controllers/resources/pods/translate/diff.go
+++ b/pkg/controllers/resources/pods/translate/diff.go
@@ -2,6 +2,7 @@ package translate
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/loft-sh/vcluster/pkg/patcher"
@@ -9,6 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,11 +85,26 @@ func (t *translator) Diff(ctx *synccontext.SyncContext, event *synccontext.SyncE
 		delete(event.Host.Annotations, OwnerSetKind)
 	}
 
+	if t.fakeKubeletIPs && event.Host.Status.HostIP != "" {
+		nodeService, err := ensureNodeService(ctx, event.Host)
+		if err != nil {
+			return err
+		}
+
+		event.Virtual.Status.HostIP = nodeService.Spec.ClusterIP
+		event.Virtual.Status.HostIPs = []corev1.HostIP{
+			{IP: nodeService.Spec.ClusterIP},
+		}
+
+		event.Host.Annotations[HostIPAnnotation] = nodeService.Spec.ClusterIP
+		event.Host.Annotations[HostIPsAnnotation] = nodeService.Spec.ClusterIP
+	}
+
 	return nil
 }
 
 func GetExcludedAnnotations(pPod *corev1.Pod) []string {
-	annotations := []string{ClusterAutoScalerAnnotation, OwnerReferences, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, VClusterLabelsAnnotation}
+	annotations := []string{ClusterAutoScalerAnnotation, OwnerReferences, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, VClusterLabelsAnnotation, HostIPAnnotation, HostIPsAnnotation}
 	if pPod != nil {
 		for _, v := range pPod.Spec.Volumes {
 			if v.Projected != nil {
@@ -111,6 +128,17 @@ func GetExcludedAnnotations(pPod *corev1.Pod) []string {
 	}
 
 	return annotations
+}
+
+func ensureNodeService(ctx *synccontext.SyncContext, pPod *corev1.Pod) (*corev1.Service, error) {
+	serviceName := translate.SafeConcatName(translate.VClusterName, "node", strings.ReplaceAll(pPod.Spec.NodeName, ".", "-"))
+
+	nodeService := &corev1.Service{}
+	err := ctx.CurrentNamespaceClient.Get(ctx.Context, types.NamespacedName{Name: serviceName, Namespace: ctx.CurrentNamespace}, nodeService)
+	if err != nil {
+		return nil, fmt.Errorf("get node service: %w", err)
+	}
+	return nodeService, nil
 }
 
 // Changeable fields within the pod:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8629


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
When `proxyKubelets.byIP` is set to true (which is the default), attempting to patch the status of the physical pod there is an edge case that when running kubelet in version < 1.28 with an apiserver >= 1.28 that it only patches `hostIP` and not `hostIPs[0]`, which will then fail at the validation with following error:
```
is invalid: status.hostIPs[0].ip: Invalid value: \"1.2.3.4\": must be equal to `hostIP`
```

As the hostIPs are only needed in the virtual context, those have been moved there. Furthermore, they physical pod will have the hostIP in its annotations regardless of virtual scheduling being enabled or not.