### PR TITLE
Revert "fix: patch virtual instead of physical and always add host ip…

### DIFF
--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	nodev1 "k8s.io/api/node/v1"
@@ -251,6 +252,19 @@ func (s *podSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.
 		if pPod.Spec.NodeName == "" {
 			return ctrl.Result{}, nil
 		}
+
+		if s.fakeKubeletIPs {
+			nodeService, err := s.ensureNodeService(ctx, pPod)
+			if err != nil {
+				if kerrors.IsNotFound(err) {
+					return ctrl.Result{RequeueAfter: time.Second}, nil
+				}
+				return ctrl.Result{}, err
+			}
+
+			pPod.Annotations[translatepods.HostIPAnnotation] = nodeService.Spec.ClusterIP
+			pPod.Annotations[translatepods.HostIPsAnnotation] = nodeService.Spec.ClusterIP
+		}
 	}
 
 	err = pro.ApplyPatchesHostObject(ctx, nil, pPod, event.Virtual, ctx.Config.Sync.ToHost.Pods.Patches, false)
@@ -335,6 +349,21 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 		return patcher.DeleteVirtualObjectWithOptions(ctx, event.Virtual, event.Host, "node name is different between the two", &client.DeleteOptions{GracePeriodSeconds: &minimumGracePeriodInSeconds})
 	}
 
+	if s.fakeKubeletIPs && event.Host.Status.HostIP != "" {
+		nodeService, err := s.ensureNodeService(ctx, event.Host)
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return ctrl.Result{RequeueAfter: time.Second}, nil
+			}
+			return ctrl.Result{}, err
+		}
+
+		event.Host.Status.HostIP = nodeService.Spec.ClusterIP
+		event.Host.Status.HostIPs = []corev1.HostIP{
+			{IP: nodeService.Spec.ClusterIP},
+		}
+	}
+
 	// validate virtual pod before syncing it to the host cluster
 	if s.podSecurityStandard != "" {
 		valid, err := s.isPodSecurityStandardsValid(ctx, event.Virtual, ctx.Log)
@@ -395,10 +424,6 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 	// update the virtual pod if the spec has changed
 	err = s.podTranslator.Diff(ctx, event)
 	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-		}
-
 		return ctrl.Result{}, err
 	}
 
@@ -520,6 +545,17 @@ func (s *podSyncer) assignNodeToPod(ctx *synccontext.SyncContext, pObj *corev1.P
 	}
 
 	return nil
+}
+
+func (s *podSyncer) ensureNodeService(ctx *synccontext.SyncContext, pPod *corev1.Pod) (*corev1.Service, error) {
+	serviceName := translate.SafeConcatName(translate.VClusterName, "node", strings.ReplaceAll(pPod.Spec.NodeName, ".", "-"))
+
+	nodeService := &corev1.Service{}
+	err := ctx.CurrentNamespaceClient.Get(ctx.Context, types.NamespacedName{Name: serviceName, Namespace: ctx.CurrentNamespace}, nodeService)
+	if err != nil {
+		return nil, fmt.Errorf("get node service: %w", err)
+	}
+	return nodeService, nil
 }
 
 func (s *podSyncer) applyLimitByClasses(ctx *synccontext.SyncContext, virtual *corev1.Pod) bool {

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -602,10 +602,6 @@ func TestSync(t *testing.T) {
 		{IP: "3.3.3.3"},
 	}
 
-	pPodFakeKubeletHostIPs := pPodFakeKubelet.DeepCopy()
-	pPodFakeKubeletHostIPs.Annotations[podtranslate.HostIPAnnotation] = pVclusterService.Spec.ClusterIP
-	pPodFakeKubeletHostIPs.Annotations[podtranslate.HostIPsAnnotation] = pVclusterService.Spec.ClusterIP
-
 	vPodWithNodeName := &corev1.Pod{
 		ObjectMeta: vObjectMeta,
 		Spec: corev1.PodSpec{
@@ -679,13 +675,8 @@ func TestSync(t *testing.T) {
 			Name:                 "Fake Kubelet enabled with Node sync",
 			InitialVirtualState:  []runtime.Object{testNode.DeepCopy(), vPodWithNodeName, vNamespace.DeepCopy()},
 			InitialPhysicalState: []runtime.Object{testNode.DeepCopy(), pVclusterNodeService.DeepCopy(), pPodFakeKubelet.DeepCopy()},
-			// The virtual pod should have the host IPs of the node service in its status.
 			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
 				corev1.SchemeGroupVersion.WithKind("Pod"): {vPodWithHostIP},
-			},
-			// The physical pod should have the host IPs of the node service in its annotations.
-			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
-				corev1.SchemeGroupVersion.WithKind("Pod"): {pPodFakeKubeletHostIPs},
 			},
 			Sync: func(ctx *synccontext.RegisterContext) {
 				ctx.Config.Sync.FromHost.Nodes.Selector.All = true

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -442,7 +442,7 @@ func (t *translator) translateVolumes(ctx *synccontext.SyncContext, pPod *corev1
 		}
 		if pPod.Spec.Volumes[i].DownwardAPI != nil {
 			for j := range pPod.Spec.Volumes[i].DownwardAPI.Items {
-				translateFieldRef(pPod.Spec.Volumes[i].DownwardAPI.Items[j].FieldRef, t.fakeKubeletIPs)
+				translateFieldRef(pPod.Spec.Volumes[i].DownwardAPI.Items[j].FieldRef, t.fakeKubeletIPs, t.schedulingConfig.IsSchedulerFromVirtualCluster(pPod.Spec.SchedulerName))
 			}
 		}
 		if pPod.Spec.Volumes[i].ISCSI != nil && pPod.Spec.Volumes[i].ISCSI.SecretRef != nil {
@@ -508,7 +508,7 @@ func (t *translator) translateProjectedVolume(
 		}
 		if projectedVolume.Sources[i].DownwardAPI != nil {
 			for j := range projectedVolume.Sources[i].DownwardAPI.Items {
-				translateFieldRef(projectedVolume.Sources[i].DownwardAPI.Items[j].FieldRef, t.fakeKubeletIPs)
+				translateFieldRef(projectedVolume.Sources[i].DownwardAPI.Items[j].FieldRef, t.fakeKubeletIPs, t.schedulingConfig.IsSchedulerFromVirtualCluster(pPod.Spec.SchedulerName))
 			}
 		}
 		if projectedVolume.Sources[i].ServiceAccountToken != nil {
@@ -607,7 +607,7 @@ func (t *translator) translateProjectedVolume(
 	return nil
 }
 
-func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector, fakeKubeletIPs bool) {
+func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector, fakeKubeletIPs, enableScheduler bool) {
 	if fieldSelector == nil {
 		return
 	}
@@ -632,11 +632,11 @@ func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector, fakeKubeletIPs
 		fieldSelector.FieldPath = "metadata.annotations['" + ServiceAccountNameAnnotation + "']"
 	// translate downward API references for status.hostIP(s) only when both virtual scheduler & fakeKubeletIPs are enabled
 	case "status.hostIP":
-		if fakeKubeletIPs {
+		if fakeKubeletIPs && enableScheduler {
 			fieldSelector.FieldPath = "metadata.annotations['" + HostIPAnnotation + "']"
 		}
 	case "status.hostIPs":
-		if fakeKubeletIPs {
+		if fakeKubeletIPs && enableScheduler {
 			fieldSelector.FieldPath = "metadata.annotations['" + HostIPsAnnotation + "']"
 		}
 	}
@@ -645,7 +645,7 @@ func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector, fakeKubeletIPs
 func (t *translator) TranslateContainerEnv(ctx *synccontext.SyncContext, envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, vPod *corev1.Pod, serviceEnvMap map[string]string) ([]corev1.EnvVar, []corev1.EnvFromSource, error) {
 	envNameMap := make(map[string]struct{})
 	for j, env := range envVar {
-		translateDownwardAPI(&envVar[j], t.fakeKubeletIPs)
+		translateDownwardAPI(&envVar[j], t.fakeKubeletIPs, t.schedulingConfig.IsSchedulerFromVirtualCluster(vPod.Spec.SchedulerName))
 		if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Name != "" {
 			envVar[j].ValueFrom.ConfigMapKeyRef.Name = mappings.VirtualToHostName(ctx, envVar[j].ValueFrom.ConfigMapKeyRef.Name, vPod.Namespace, mappings.ConfigMaps())
 		}
@@ -686,14 +686,14 @@ func (t *translator) TranslateContainerEnv(ctx *synccontext.SyncContext, envVar 
 	return envVar, envFrom, nil
 }
 
-func translateDownwardAPI(env *corev1.EnvVar, fakeKubeletIPs bool) {
+func translateDownwardAPI(env *corev1.EnvVar, fakeKubeletIPs, enableScheduler bool) {
 	if env.ValueFrom == nil {
 		return
 	}
 	if env.ValueFrom.FieldRef == nil {
 		return
 	}
-	translateFieldRef(env.ValueFrom.FieldRef, fakeKubeletIPs)
+	translateFieldRef(env.ValueFrom.FieldRef, fakeKubeletIPs, enableScheduler)
 }
 
 func (t *translator) translateDNSConfig(pPod *corev1.Pod, vPod *corev1.Pod, nameServer string) {


### PR DESCRIPTION
… annotations to physical (#3147)"

This reverts commit e599865a2c6a302470543b3e7af5f23abbcc9af0.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
Reverting, as this somehow breaks `toHost.pods.patches`. Need to investigate why and adjust the implementation.