### PR TITLE
fix: increase ephemeral-storage requests

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -595,7 +595,7 @@ controlPlane:
         memory: 2Gi
       # Requests are minimal resources that will be consumed by the container
       requests:
-        ephemeral-storage: 400Mi
+        ephemeral-storage: 600Mi
         cpu: 200m
         memory: 256Mi
     # Additional labels or annotations for the statefulSet pods.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8713


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster could be evicted due to not enough ephemeral-storage requests.


**What else do we need to know?** 
Especially important on GKE Autopilot clusters where limits are set equal to requests