### PR TITLE
feat(values): add ingressclassname option in ingress

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
 {{ toYaml .Values.controlPlane.ingress.labels | indent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.controlPlane.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName | quote }}
+  {{- end }}
   {{- with .Values.controlPlane.ingress.spec }}
   {{- tpl (toYaml .) $ | nindent 2 }}
   {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -545,6 +545,10 @@
           "type": "string",
           "description": "PathType is the path type of the ingress"
         },
+        "ingressClassName": {
+          "type": "string",
+          "description": "IngressClassName allows targeting a specific ingress controller (e.g. nginx, traefik, cloudflare)"
+        },
         "spec": {
           "type": "object",
           "description": "Spec allows you to configure extra ingress options."

--- a/config/config.go
+++ b/config/config.go
@@ -2281,6 +2281,9 @@ type ControlPlaneIngress struct {
 	// PathType is the path type of the ingress
 	PathType string `json:"pathType,omitempty"`
 
+	// IngressClassName allows targeting a specific ingress controller (e.g. nginx, traefik, cloudflare)
+	IngressClassName string `json:"ingressClassName,omitempty"`
+
 	// Spec allows you to configure extra ingress options.
 	Spec map[string]interface{} `json:"spec,omitempty"`
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves # https://github.com/loft-sh/vcluster/issues/3017#issuecomment-3260089993


**Please provide a short message that should be published in the vcluster release notes**
Enchance the ingress configuration to add an option option to add ingressclassname so user can choose the ingress controller that will handle the ingrerss.


**What else do we need to know?** 
There is also this PR opened on https://github.com/loft-sh/vcluster-docs  to enchance the docs https://github.com/loft-sh/vcluster-docs/pull/1127 
