### PR TITLE
chore: provide minimal standalone config for standalone cert rotation

### DIFF
--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -27,8 +27,19 @@ func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, 
 		return nil, err
 	}
 
+	cfg, err := ParseConfigBytes(rawFile, name, setValues)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config bytes: %w", err)
+	}
+
+	cfg.Path = path
+
+	return cfg, nil
+}
+
+func ParseConfigBytes(data []byte, name string, setValues []string) (*VirtualClusterConfig, error) {
 	// apply set values
-	rawFile, err = applySetValues(rawFile, setValues)
+	rawFile, err := applySetValues(data, setValues)
 	if err != nil {
 		return nil, fmt.Errorf("apply set values: %w", err)
 	}
@@ -45,7 +56,6 @@ func ParseConfig(path, name string, setValues []string) (*VirtualClusterConfig, 
 	retConfig := &VirtualClusterConfig{
 		Config: *rawConfig,
 		Name:   name,
-		Path:   path,
 	}
 
 	// validate config


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Part of ENG-8077


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster standalone would not rotate certs due to missing config file 


**What else do we need to know?** 
In case running standalone we provide a minimal config to perform the rotation because some internal functions rely on reading a valid vCluster config. The PR also refactors the config parsing a bit so that it's possible to parse it from a byte slice as well.