### PR TITLE
fix: revert fake kubelet ip in pod syncer

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -43,8 +43,6 @@ const (
 	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
 	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
 	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
-	HostIPAnnotation                     = "vcluster.loft.sh/host-ip"
-	HostIPsAnnotation                    = "vcluster.loft.sh/host-ips"
 )
 
 var (
@@ -121,7 +119,6 @@ func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder record.EventR
 		hostPriorityClassesSyncEnabled: ctx.Config.Sync.FromHost.PriorityClasses.Enabled,
 		priorityClassesSyncEnabled:     ctx.Config.Sync.ToHost.PriorityClasses.Enabled,
 		schedulingConfig:               schedulingConfig,
-		fakeKubeletIPs:                 ctx.Config.Networking.Advanced.ProxyKubelets.ByIP,
 
 		mountPhysicalHostPaths: ctx.Config.ControlPlane.HostPathMapper.Enabled && !ctx.Config.ControlPlane.HostPathMapper.Central,
 
@@ -152,7 +149,6 @@ type translator struct {
 	hostPriorityClassesSyncEnabled bool
 	priorityClassesSyncEnabled     bool
 	schedulingConfig               scheduling.Config
-	fakeKubeletIPs                 bool
 
 	virtualLogsPath       string
 	virtualPodLogsPath    string
@@ -442,7 +438,7 @@ func (t *translator) translateVolumes(ctx *synccontext.SyncContext, pPod *corev1
 		}
 		if pPod.Spec.Volumes[i].DownwardAPI != nil {
 			for j := range pPod.Spec.Volumes[i].DownwardAPI.Items {
-				translateFieldRef(pPod.Spec.Volumes[i].DownwardAPI.Items[j].FieldRef, t.fakeKubeletIPs)
+				translateFieldRef(pPod.Spec.Volumes[i].DownwardAPI.Items[j].FieldRef)
 			}
 		}
 		if pPod.Spec.Volumes[i].ISCSI != nil && pPod.Spec.Volumes[i].ISCSI.SecretRef != nil {
@@ -508,7 +504,7 @@ func (t *translator) translateProjectedVolume(
 		}
 		if projectedVolume.Sources[i].DownwardAPI != nil {
 			for j := range projectedVolume.Sources[i].DownwardAPI.Items {
-				translateFieldRef(projectedVolume.Sources[i].DownwardAPI.Items[j].FieldRef, t.fakeKubeletIPs)
+				translateFieldRef(projectedVolume.Sources[i].DownwardAPI.Items[j].FieldRef)
 			}
 		}
 		if projectedVolume.Sources[i].ServiceAccountToken != nil {
@@ -607,7 +603,7 @@ func (t *translator) translateProjectedVolume(
 	return nil
 }
 
-func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector, fakeKubeletIPs bool) {
+func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector) {
 	if fieldSelector == nil {
 		return
 	}
@@ -630,22 +626,13 @@ func translateFieldRef(fieldSelector *corev1.ObjectFieldSelector, fakeKubeletIPs
 		fieldSelector.FieldPath = "metadata.annotations['" + UIDAnnotation + "']"
 	case "spec.serviceAccountName":
 		fieldSelector.FieldPath = "metadata.annotations['" + ServiceAccountNameAnnotation + "']"
-	// translate downward API references for status.hostIP(s) only when both virtual scheduler & fakeKubeletIPs are enabled
-	case "status.hostIP":
-		if fakeKubeletIPs {
-			fieldSelector.FieldPath = "metadata.annotations['" + HostIPAnnotation + "']"
-		}
-	case "status.hostIPs":
-		if fakeKubeletIPs {
-			fieldSelector.FieldPath = "metadata.annotations['" + HostIPsAnnotation + "']"
-		}
 	}
 }
 
 func (t *translator) TranslateContainerEnv(ctx *synccontext.SyncContext, envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, vPod *corev1.Pod, serviceEnvMap map[string]string) ([]corev1.EnvVar, []corev1.EnvFromSource, error) {
 	envNameMap := make(map[string]struct{})
 	for j, env := range envVar {
-		translateDownwardAPI(&envVar[j], t.fakeKubeletIPs)
+		translateDownwardAPI(&envVar[j])
 		if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Name != "" {
 			envVar[j].ValueFrom.ConfigMapKeyRef.Name = mappings.VirtualToHostName(ctx, envVar[j].ValueFrom.ConfigMapKeyRef.Name, vPod.Namespace, mappings.ConfigMaps())
 		}
@@ -686,14 +673,14 @@ func (t *translator) TranslateContainerEnv(ctx *synccontext.SyncContext, envVar 
 	return envVar, envFrom, nil
 }
 
-func translateDownwardAPI(env *corev1.EnvVar, fakeKubeletIPs bool) {
+func translateDownwardAPI(env *corev1.EnvVar) {
 	if env.ValueFrom == nil {
 		return
 	}
 	if env.ValueFrom.FieldRef == nil {
 		return
 	}
-	translateFieldRef(env.ValueFrom.FieldRef, fakeKubeletIPs)
+	translateFieldRef(env.ValueFrom.FieldRef)
 }
 
 func (t *translator) translateDNSConfig(pPod *corev1.Pod, vPod *corev1.Pod, nameServer string) {

--- a/test/e2e/syncer/pods/pods.go
+++ b/test/e2e/syncer/pods/pods.go
@@ -82,9 +82,6 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		pod, err := f.HostClient.CoreV1().Pods(pPodName.Namespace).Get(f.Context, pPodName.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
-		// ignore HostIP differences
-		resetHostIP(vpod, pod)
-
 		// Since k8s 1.32, status.QOSClass field has become immutable,
 		// hence we have stopeed syncing it. So ignore
 		// the differences in the status.QOSClass field
@@ -217,9 +214,6 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		pPodName := translate.Default.HostName(nil, podName, ns)
 		pod, err := f.HostClient.CoreV1().Pods(pPodName.Namespace).Get(f.Context, pPodName.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
-
-		// ignore HostIP differences
-		resetHostIP(vpod, pod)
 
 		// Since k8s 1.32, status.QOSClass field has become immutable,
 		// hence we have stopeed syncing it. So ignore
@@ -771,11 +765,6 @@ var _ = ginkgo.Describe("Pods are running in the host cluster", func() {
 		framework.ExpectEqual(vPod.Labels[additionalLabelKey], pPod.Labels[additionalLabelKey])
 	})
 })
-
-func resetHostIP(vpod, pod *corev1.Pod) {
-	vpod.Status.HostIP, pod.Status.HostIP = "", ""
-	vpod.Status.HostIPs, pod.Status.HostIPs = nil, nil
-}
 
 func ignoreQOSClassDiff(vpod, pod *corev1.Pod) {
 	pod.Status.QOSClass = vpod.Status.QOSClass


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8968
ENG-9030


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would set Pod's `status.hostIP` to the fake IP.


**What else do we need to know?** 
