### PR TITLE
Remove deprecated fields from config

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -123,7 +123,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
   {{- end }}
-  {{- if and .Values.integrations.externalSecrets.enabled (or .Values.integrations.externalSecrets.sync.clusterStores.enabled .Values.integrations.externalSecrets.sync.fromHost.clusterStores.enabled) }}
+  {{- if and .Values.integrations.externalSecrets.enabled .Values.integrations.externalSecrets.sync.fromHost.clusterStores.enabled }}
   - apiGroups: ["external-secrets.io"]
     resources: ["clustersecretstores"]
     verbs: ["get", "list", "watch"]

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -107,7 +107,7 @@ rules:
   - apiGroups: ["external-secrets.io"]
     resources: ["externalsecrets"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
-  {{- if or .Values.integrations.externalSecrets.sync.stores.enabled .Values.integrations.externalSecrets.sync.toHost.stores.enabled }}
+  {{- if .Values.integrations.externalSecrets.sync.toHost.stores.enabled }}
   - apiGroups: ["external-secrets.io"]
     resources: ["secretstores"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/chart/tests/clusterrole_test.yaml
+++ b/chart/tests/clusterrole_test.yaml
@@ -482,8 +482,9 @@ tests:
           webhook:
             enabled: true
           sync:
-            clusterStores:
-              enabled: true
+            fromHost:
+              clusterStores:
+                enabled: true
     release:
       name: my-release
       namespace: my-namespace

--- a/chart/tests/role_test.yaml
+++ b/chart/tests/role_test.yaml
@@ -158,9 +158,6 @@ tests:
       integrations:
         externalSecrets:
           enabled: true
-          sync:
-            externalSecrets:
-              enabled: true
     release:
       name: my-release
       namespace: my-namespace
@@ -211,10 +208,9 @@ tests:
         externalSecrets:
           enabled: true
           sync:
-            externalSecrets:
-              enabled: true
-            stores:
-              enabled: true
+            toHost:
+              stores:
+                enabled: true
     release:
       name: my-release
       namespace: my-namespace

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -230,20 +230,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "ClusterStoresSyncConfig": {
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enabled defines if this option should be enabled."
-        },
-        "selector": {
-          "$ref": "#/$defs/LabelSelector",
-          "description": "Selector defines what cluster stores should be synced"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
     "ContainerdJoin": {
       "properties": {
         "enabled": {
@@ -2128,18 +2114,6 @@
         "fromHost": {
           "$ref": "#/$defs/ExternalSecretsSyncFromHostConfig",
           "description": "FromHost defines what resources are synced from the host cluster to the virtual cluster"
-        },
-        "externalSecrets": {
-          "$ref": "#/$defs/EnableSwitch",
-          "description": "ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster."
-        },
-        "stores": {
-          "$ref": "#/$defs/EnableSwitch",
-          "description": "Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.\nDeprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead."
-        },
-        "clusterStores": {
-          "$ref": "#/$defs/ClusterStoresSyncConfig",
-          "description": "ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.\nDeprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -929,21 +929,6 @@ integrations:
           enabled: false
           selector:
             matchLabels: {}
-      # ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
-      externalSecrets:
-        enabled: true
-      # Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
-      # Deprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead.
-      stores:
-        enabled: false
-      # ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
-      # Deprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead.
-      clusterStores:
-        # Enabled defines if this option should be enabled.
-        enabled: false
-        # Selector defines what cluster stores should be synced
-        selector:
-          labels: {}
   
   # KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
   kubeVirt:

--- a/config/config.go
+++ b/config/config.go
@@ -737,20 +737,6 @@ type ExternalSecretsSync struct {
 	ToHost ExternalSecretsSyncToHostConfig `json:"toHost,omitempty"`
 	// FromHost defines what resources are synced from the host cluster to the virtual cluster
 	FromHost ExternalSecretsSyncFromHostConfig `json:"fromHost,omitempty"`
-	// ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
-	ExternalSecrets EnableSwitch `json:"externalSecrets,omitempty"`
-	// Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
-	// Deprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead.
-	Stores EnableSwitch `json:"stores,omitempty"`
-	// ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
-	// Deprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead.
-	ClusterStores ClusterStoresSyncConfig `json:"clusterStores,omitempty"`
-}
-
-type ClusterStoresSyncConfig struct {
-	EnableSwitch
-	// Selector defines what cluster stores should be synced
-	Selector LabelSelector `json:"selector,omitempty"`
 }
 
 type ExternalSecretsSyncToHostConfig struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -496,14 +496,6 @@ integrations:
           enabled: false
           selector:
             matchLabels: {}
-      externalSecrets:
-        enabled: true
-      stores:
-        enabled: false
-      clusterStores:
-        enabled: false
-        selector:
-          labels: {}
   kubeVirt:
     enabled: false
     webhook:

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -669,9 +669,9 @@ func validateExternalSecretsEnabled(
 	}
 	for crdName, crdConfig := range toHostCustomResources {
 		if crdConfig.Enabled &&
-			(crdName == "externalsecrets.external-secrets.io" && externalSecretsIntegration.Sync.ExternalSecrets.Enabled ||
-				crdName == "secretstores.external-secrets.io" && externalSecretsIntegration.Sync.Stores.Enabled ||
-				crdName == "clustersecretstores.external-secrets.io" && externalSecretsIntegration.Sync.ClusterStores.Enabled) {
+			(crdName == "externalsecrets.external-secrets.io" && externalSecretsIntegration.Enabled ||
+				crdName == "secretstores.external-secrets.io" && externalSecretsIntegration.Sync.ToHost.Stores.Enabled ||
+				crdName == "clustersecretstores.external-secrets.io" && externalSecretsIntegration.Sync.FromHost.ClusterStores.Enabled) {
 			return fmt.Errorf("external-secrets integration is enabled but external-secrets custom resource (%s) is also set in the sync.toHost.customResources. "+
 				"This is not supported, please remove the entry from sync.toHost.customResources", crdName)
 		}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1075,10 +1075,19 @@ func TestValidateToHostSyncAndExternalSecretsIntegration(t *testing.T) {
 	externalSecretsEnabled := config.ExternalSecrets{
 		Enabled: true,
 		Sync: config.ExternalSecretsSync{
-			ExternalSecrets: config.EnableSwitch{Enabled: true},
-			Stores:          config.EnableSwitch{Enabled: true},
-			ClusterStores: config.ClusterStoresSyncConfig{
-				EnableSwitch: config.EnableSwitch{Enabled: true},
+			ToHost: config.ExternalSecretsSyncToHostConfig{
+				Stores: config.EnableSwitchSelector{
+					EnableSwitch: config.EnableSwitch{
+						Enabled: true,
+					},
+				},
+			},
+			FromHost: config.ExternalSecretsSyncFromHostConfig{
+				ClusterStores: config.EnableSwitchSelector{
+					EnableSwitch: config.EnableSwitch{
+						Enabled: true,
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Remove deprecated config fields marked for removal in 0.29.0.

**Please provide a short message that should be published in the vcluster release notes**
Remove deprecated config fields for the external secret operator integration.

**What else do we need to know?** 
