### PR TITLE
fix(ci): allow pr creation for update-platform-minimum-version

### DIFF
--- a/.github/workflows/update-platform-minimum-version.yaml
+++ b/.github/workflows/update-platform-minimum-version.yaml
@@ -36,6 +36,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          committer: Loft Bot <loft-bot@users.noreply.github.com>
           base: main
           branch: update-platform-version-tag/${{ github.event.client_payload.tag }}
           title: "chore(deps): bump platform MinimumVersionTag to ${{ github.event.client_payload.tag }}"


### PR DESCRIPTION
Fixes the issue:

GitHub Actions is not permitted to create or approve pull requests

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix