### PR TITLE
Added platform login info to describe the persisted login credentials location

### DIFF
--- a/cmd/vclusterctl/cmd/platform/login.go
+++ b/cmd/vclusterctl/cmd/platform/login.go
@@ -133,6 +133,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	cmd.Log.Infof("Login credentials are stored in %q", cmd.Config)
 	cmd.Log.Donef(product.Replace("Successfully logged into Loft instance %s"), ansi.Color(url, "white+b"))
 
 	// skip log into docker registries?


### PR DESCRIPTION

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-4853


**Please provide a short message that should be published in the vcluster release notes**
Let the user know that the login credentials are stored in the local vcluster config. Mainly relevant for new users who might attempt to reuse an instance(e.g. delete the cluster, deploy another). The Platform login details of persists.