### PR TITLE
set cluster name in the kubeconfig for standalone

### DIFF
--- a/pkg/kubeadm/config.go
+++ b/pkg/kubeadm/config.go
@@ -14,6 +14,10 @@ func InitKubeadmConfig(vConfig *config.VirtualClusterConfig, kubernetesVersion, 
 	}
 
 	kubeadmConfig.ClusterName = "kubernetes"
+	if vConfig.ControlPlane.Standalone.Enabled {
+		// for standalone, set the cluster name to name from the config
+		kubeadmConfig.ClusterName = vConfig.Name
+	}
 	kubeadmConfig.NodeRegistration.Name = vConfig.Name
 	kubeadmConfig.Etcd.Local = &kubeadmapi.LocalEtcd{
 		ServerCertSANs: extraEtcdSans,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of ENG-8987


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster standalone was hardcoding cluster name to "kubernetes" in the kubeconfig


**What else do we need to know?** 
