### PR TITLE
add validation to exportKubeConfig.Server

### DIFF
--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -635,6 +635,31 @@ func TestValidateExportKubeConfig(t *testing.T) {
 			},
 			expectedError: errExportKubeConfigAdditionalSecretWithoutNameAndNamespace,
 		},
+		{
+			name: "Setting only exportKubeConfig.server is invalid",
+			exportKubeConfig: config.ExportKubeConfig{
+				ExportKubeConfigProperties: config.ExportKubeConfigProperties{
+					Server: "my-server",
+				},
+			},
+			expectedError: errExportKubeConfigServerNotValid,
+		},
+		{
+			name: "Setting only exportKubeConfig.server is valid with https://",
+			exportKubeConfig: config.ExportKubeConfig{
+				ExportKubeConfigProperties: config.ExportKubeConfigProperties{
+					Server: "https://my-server.com",
+				},
+			},
+		},
+		{
+			name: "Setting only exportKubeConfig.server is valid with https:// and port",
+			exportKubeConfig: config.ExportKubeConfig{
+				ExportKubeConfigProperties: config.ExportKubeConfigProperties{
+					Server: "https://my-server.com:443",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was not validating exportKubeConfig.server field


**What else do we need to know?** 
