### PR TITLE
fix: calculate vcluster has correctly

### DIFF
--- a/chart/templates/_vclusterconfighash.tpl
+++ b/chart/templates/_vclusterconfighash.tpl
@@ -1,4 +1,5 @@
 {{- define "vcluster.vClusterConfigHash" -}}
 {{- $vals := deepCopy .Values -}}
-{{- (unset $vals.privateNodes "autoNodes") | toYaml | b64enc | sha256sum | quote -}}
+{{- $_ := unset (index $vals "privateNodes") "autoNodes" -}}
+{{- toYaml $vals | b64enc | sha256sum | quote -}}
 {{- end -}}


### PR DESCRIPTION
Fixes an issue where vCluster wouldn't calculate the hash correctly and vCluster wouldn't restart