### PR TITLE
Add snapshot URL to the snapshot request

### DIFF
--- a/pkg/snapshot/options.go
+++ b/pkg/snapshot/options.go
@@ -34,6 +34,20 @@ type Options struct {
 	Release *HelmRelease `json:"release,omitempty"`
 }
 
+func (o *Options) GetURL() string {
+	var snapshotURL string
+	switch o.Type {
+	case "s3":
+		snapshotURL = "s3://" + o.S3.Bucket + "/" + o.S3.Key
+	case "container":
+		snapshotURL = "container://" + o.Container.Path
+	case "oci":
+		snapshotURL = "oci://" + o.OCI.Repository
+	}
+
+	return snapshotURL
+}
+
 type HelmRelease struct {
 	ReleaseName      string `json:"releaseName"`
 	ReleaseNamespace string `json:"releaseNamespace"`

--- a/pkg/snapshot/request.go
+++ b/pkg/snapshot/request.go
@@ -50,6 +50,7 @@ type RequestMetadata struct {
 }
 
 type RequestSpec struct {
+	URL             string                   `json:"url,omitempty"`
 	IncludeVolumes  bool                     `json:"includeVolumes,omitempty"`
 	VolumeSnapshots volumes.SnapshotsRequest `json:"volumeSnapshots,omitempty"`
 	Options         Options                  `json:"-"`
@@ -88,6 +89,7 @@ func CreateSnapshotRequestResources(ctx context.Context, vClusterNamespace, vClu
 			CreationTimestamp: metav1.Now(),
 		},
 		Spec: RequestSpec{
+			URL:            options.GetURL(),
 			IncludeVolumes: includeVolumes,
 		},
 	}

--- a/pkg/snapshot/restorerequest.go
+++ b/pkg/snapshot/restorerequest.go
@@ -29,6 +29,7 @@ func (r *RestoreRequest) Done() bool {
 }
 
 type RestoreRequestSpec struct {
+	URL            string                     `json:"url,omitempty"`
 	IncludeVolumes bool                       `json:"includeVolumes,omitempty"`
 	VolumesRestore volumes.RestoreRequestSpec `json:"volumesRestore,omitempty"`
 	Options        Options                    `json:"-"`
@@ -45,6 +46,7 @@ func NewRestoreRequest(snapshotRequest Request) (RestoreRequest, error) {
 			CreationTimestamp: metav1.Now(),
 		},
 		Spec: RestoreRequestSpec{
+			URL:            snapshotRequest.Spec.URL,
 			IncludeVolumes: true,
 			VolumesRestore: volumes.RestoreRequestSpec{
 				Requests: []volumes.RestoreRequest{},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9388

**What else do we need to know?** 
This PR adds the snapshot URL to the snapshot request, so snapshot requests can be correlated to the stored snapshots.

Snapshot URL is added to the snapshot request `.spec.url` field, e.g.

```
kubectl get cm -n $vcluster nik235-snapshot-request-rxdbw -o yaml | yq '.data["snapshotRequest"]' | jq
{
  "metadata": {
    "name": "nik235-snapshot-request-rxdbw",
    "creationTimestamp": "2025-10-07T09:41:11Z"
  },
  "spec": {
    "url": "container:///data/snap-1",
    "volumeSnapshots": {}
  },
  "status": {
    "phase": "Completed",
    "volumeSnapshots": {
      "error": {}
    }
  }
}
```