### PR TITLE
Expose etcd snapshot creation/upload errors

### DIFF
--- a/pkg/snapshot/controller.go
+++ b/pkg/snapshot/controller.go
@@ -151,8 +151,9 @@ func (c *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	defer func() {
 		if retErr != nil {
 			// something went wrong, recorde error and update snapshot request phase to Failed
-			c.eventRecorder.Eventf(&configMap, corev1.EventTypeWarning, "SnapshotRequestFailed", "Snapshot request %s/%s has failed with error: %v", configMap.Namespace, configMap.Name, retErr)
 			snapshotRequest.Status.Phase = RequestPhaseFailed
+			snapshotRequest.Status.Error.Message = retErr.Error()
+			c.eventRecorder.Eventf(&configMap, corev1.EventTypeWarning, "SnapshotRequestFailed", "Snapshot request %s/%s has failed with error: %v", configMap.Namespace, configMap.Name, retErr)
 		}
 		updateErr := c.updateRequest(ctx, configMapBeforeChange, &configMap, *snapshotRequest)
 		if updateErr != nil {

--- a/pkg/snapshot/request.go
+++ b/pkg/snapshot/request.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
+	snapshotTypes "github.com/loft-sh/vcluster/pkg/snapshot/types"
 	"github.com/loft-sh/vcluster/pkg/snapshot/volumes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,8 +58,9 @@ type RequestSpec struct {
 }
 
 type RequestStatus struct {
-	Phase           RequestPhase            `json:"phase,omitempty"`
-	VolumeSnapshots volumes.SnapshotsStatus `json:"volumeSnapshots,omitempty"`
+	Phase           RequestPhase                `json:"phase,omitempty"`
+	VolumeSnapshots volumes.SnapshotsStatus     `json:"volumeSnapshots,omitempty"`
+	Error           snapshotTypes.SnapshotError `json:"error,omitempty"`
 }
 
 // CreateSnapshotRequestResources creates snapshot request ConfigMap and Secret in the cluster. It returns the created

--- a/pkg/snapshot/types/error.go
+++ b/pkg/snapshot/types/error.go
@@ -1,0 +1,11 @@
+package types
+
+// SnapshotError describes the error that occurred while taking the snapshot.
+type SnapshotError struct {
+	Message string `json:"message,omitempty"`
+}
+
+// Equals checks if the snapshot error is identical to another snapshot error.
+func (err SnapshotError) Equals(other SnapshotError) bool {
+	return err.Message == other.Message
+}

--- a/pkg/snapshot/volumes/request.go
+++ b/pkg/snapshot/volumes/request.go
@@ -1,6 +1,9 @@
 package volumes
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	snapshotTypes "github.com/loft-sh/vcluster/pkg/snapshot/types"
+	corev1 "k8s.io/api/core/v1"
+)
 
 const (
 	SnapshotClassNameLabel = "vcluster.loft.sh/csi-volumesnapshot-class"
@@ -34,9 +37,9 @@ type SnapshotRequestPhase string
 
 // SnapshotsStatus shows the current status of the snapshot request.
 type SnapshotsStatus struct {
-	Phase     SnapshotRequestPhase      `json:"phase,omitempty"`
-	Snapshots map[string]SnapshotStatus `json:"snapshots,omitempty"`
-	Error     SnapshotError             `json:"error,omitempty"`
+	Phase     SnapshotRequestPhase        `json:"phase,omitempty"`
+	Snapshots map[string]SnapshotStatus   `json:"snapshots,omitempty"`
+	Error     snapshotTypes.SnapshotError `json:"error,omitempty"`
 }
 
 // Done returns true if the process of taking all volume snapshots has finished, otherwise it
@@ -64,9 +67,9 @@ func (s SnapshotsStatus) Done() bool {
 
 // SnapshotStatus shows the current status of a single PVC snapshot.
 type SnapshotStatus struct {
-	Phase          SnapshotRequestPhase `json:"phase,omitempty"`
-	SnapshotHandle string               `json:"snapshotHandle,omitempty"`
-	Error          SnapshotError        `json:"error,omitempty"`
+	Phase          SnapshotRequestPhase        `json:"phase,omitempty"`
+	SnapshotHandle string                      `json:"snapshotHandle,omitempty"`
+	Error          snapshotTypes.SnapshotError `json:"error,omitempty"`
 }
 
 // Equals checks if the snapshot status is identical to another snapshot status.
@@ -80,14 +83,4 @@ func (s SnapshotStatus) Equals(other SnapshotStatus) bool {
 // false.
 func (s SnapshotStatus) Done() bool {
 	return s.Phase == RequestPhaseCompleted || s.Phase == RequestPhaseSkipped || s.Phase == RequestPhaseFailed
-}
-
-// SnapshotError describes the error that occurred while taking the snapshot.
-type SnapshotError struct {
-	Message string `json:"message,omitempty"`
-}
-
-// Equals checks if the snapshot error is identical to another snapshot error.
-func (err SnapshotError) Equals(other SnapshotError) bool {
-	return err.Message == other.Message
 }


### PR DESCRIPTION
e.g. S3 upload errors

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9295


**What else do we need to know?** 
This PR adds etcd snapshot creation/upload errors to the snapshot request `.status.error.message` field.

For example:

```
kubectl get cm -n $vcluster nik235-snapshot-request-pdm9j -o yaml | yq '.data["snapshotRequest"]' | jq
{
  "metadata": {
    "name": "nik235-snapshot-request-pdm9j",
    "creationTimestamp": "2025-10-07T10:59:55Z"
  },
  "spec": {
    "url": "s3://where-is/my-bucket",
    "volumeSnapshots": {}
  },
  "status": {
    "phase": "Failed",
    "volumeSnapshots": {
      "error": {}
    },
    "error": {
      "message": "failed to reconcile etcd backup creation for snapshot request nik235/nik235-snapshot-request-pdm9j: failed to run snapshot client: failed to create store: failed to init s3 object store: operation error S3: HeadBucket, exceeded maximum number of attempts, 3, get identity: get credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, exceeded maximum number of attempts, 3, request send failed, Get \"http://169.254.169.254/latest/meta-data/iam/security-credentials/\": dial tcp 169.254.169.254:80: connect: connection refused"
    }
  }
}
```