### PR TITLE
Add volume snapshots e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -318,6 +318,28 @@ jobs:
           echo "kubectl config current-context: $(kubectl config current-context)"
           echo "KUBECONFIG env var: ${KUBECONFIG}"
 
+      - name: Setup snapshot-controller and CSI driver
+        run: |
+          set -x
+
+          echo "Deploy upstream CSI volume snapshot CRDs and snapshot-controller"
+          kubectl kustomize https://github.com/kubernetes-csi/external-snapshotter/client/config/crd | kubectl create -f -
+          kubectl kustomize https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller | kubectl create -f -
+
+          echo "Deploy CSI driver"
+          temp_git_dir=$(mktemp -d)
+          git clone https://github.com/kubernetes-csi/csi-driver-host-path.git $temp_git_dir
+          $temp_git_dir/deploy/kubernetes-latest/deploy.sh
+
+          echo "Deploy StorageClass and VolumeSnapshotClass"
+          kubectl apply -f $temp_git_dir/examples/csi-storageclass.yaml
+          kubectl apply -f $temp_git_dir/examples/csi-volumesnapshotclass.yaml
+          kubectl annotate volumesnapshotclass csi-hostpath-snapclass snapshot.storage.kubernetes.io/is-default-class="true"
+          rm -rf $temp_git_dir
+
+          echo "Wait for snapshot-controller to be ready"
+          kubectl wait --for=condition=Available -n kube-system deploy/snapshot-controller --timeout=60s
+
       - name: Download vcluster cli
         uses: actions/download-artifact@v5
         with:

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -89,6 +89,18 @@ func (s *persistentVolumeClaimSyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (s *persistentVolumeClaimSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*corev1.PersistentVolumeClaim]) (ctrl.Result, error) {
+	// check if host PVC is currently being restored
+	pObjName := s.VirtualToHost(ctx, types.NamespacedName{Name: event.Virtual.GetName(), Namespace: event.Virtual.GetNamespace()}, event.Virtual)
+	restoreInProgress, err := s.isHostVolumeRestoreInProgress(ctx, pObjName)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check if host volume restore is in progress: %w", err)
+	}
+	if restoreInProgress {
+		return ctrl.Result{
+			RequeueAfter: 15 * time.Second,
+		}, nil
+	}
+
 	if s.applyLimitByClass(ctx, event.Virtual) {
 		return ctrl.Result{}, nil
 	}
@@ -105,17 +117,6 @@ func (s *persistentVolumeClaimSyncer) SyncToHost(ctx *synccontext.SyncContext, e
 		return ctrl.Result{}, err
 	}
 
-	// check if host PVC is currently being restored
-	restoreInProgress, err := s.isHostVolumeRestoreInProgress(ctx, pObj)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to check if host volume restore is in progress: %w", err)
-	}
-	if restoreInProgress {
-		return ctrl.Result{
-			RequeueAfter: 15 * time.Second,
-		}, nil
-	}
-
 	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -130,7 +131,11 @@ func (s *persistentVolumeClaimSyncer) Sync(ctx *synccontext.SyncContext, event *
 	}
 
 	// check if host PVC is currently being restored
-	restoreInProgress, err := s.isHostVolumeRestoreInProgress(ctx, event.Host)
+	hostObjName := types.NamespacedName{
+		Name:      event.Host.GetName(),
+		Namespace: event.Host.GetNamespace(),
+	}
+	restoreInProgress, err := s.isHostVolumeRestoreInProgress(ctx, hostObjName)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to check if host volume restore is in progress: %w", err)
 	}
@@ -260,7 +265,7 @@ func (s *persistentVolumeClaimSyncer) ensurePersistentVolume(ctx *synccontext.Sy
 	return false, nil
 }
 
-func (s *persistentVolumeClaimSyncer) isHostVolumeRestoreInProgress(ctx *synccontext.SyncContext, pObj *corev1.PersistentVolumeClaim) (bool, error) {
+func (s *persistentVolumeClaimSyncer) isHostVolumeRestoreInProgress(ctx *synccontext.SyncContext, pObj types.NamespacedName) (bool, error) {
 	configMaps := &corev1.ConfigMapList{}
 	err := ctx.HostClient.List(ctx.Context, configMaps, client.InNamespace(ctx.Config.HostNamespace), client.MatchingLabels{
 		constants.RestoreRequestLabel: "",

--- a/pkg/snapshot/common.go
+++ b/pkg/snapshot/common.go
@@ -1,6 +1,8 @@
 package snapshot
 
-import "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type LongRunningRequest interface {
 	GetPhase() RequestPhase
@@ -20,6 +22,6 @@ const (
 type RequestPhase string
 
 type RequestMetadata struct {
-	Name              string  `json:"name"`
-	CreationTimestamp v1.Time `json:"creationTimestamp,omitempty"`
+	Name              string      `json:"name"`
+	CreationTimestamp metav1.Time `json:"creationTimestamp,omitempty"`
 }

--- a/pkg/snapshot/common.go
+++ b/pkg/snapshot/common.go
@@ -1,0 +1,25 @@
+package snapshot
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type LongRunningRequest interface {
+	GetPhase() RequestPhase
+}
+
+const (
+	APIVersion = "v1beta1"
+
+	RequestPhaseNotStarted              RequestPhase = ""
+	RequestPhaseCreatingVolumeSnapshots RequestPhase = "CreatingVolumeSnapshots"
+	RequestPhaseCreatingEtcdBackup      RequestPhase = "CreatingEtcdBackup"
+	RequestPhaseCompleted               RequestPhase = "Completed"
+	RequestPhasePartiallyFailed         RequestPhase = "PartiallyFailed"
+	RequestPhaseFailed                  RequestPhase = "Failed"
+)
+
+type RequestPhase string
+
+type RequestMetadata struct {
+	Name              string  `json:"name"`
+	CreationTimestamp v1.Time `json:"creationTimestamp,omitempty"`
+}

--- a/pkg/snapshot/request.go
+++ b/pkg/snapshot/request.go
@@ -17,22 +17,12 @@ import (
 
 const (
 	// APIVersion is the snapshot request API version.
-	APIVersion = "v1beta1"
 
 	RequestKey = "snapshotRequest"
 	OptionsKey = "snapshotOptions"
 
-	RequestPhaseNotStarted              RequestPhase = ""
-	RequestPhaseCreatingVolumeSnapshots RequestPhase = "CreatingVolumeSnapshots"
-	RequestPhaseCreatingEtcdBackup      RequestPhase = "CreatingEtcdBackup"
-	RequestPhaseCompleted               RequestPhase = "Completed"
-	RequestPhasePartiallyFailed         RequestPhase = "PartiallyFailed"
-	RequestPhaseFailed                  RequestPhase = "Failed"
-
 	DefaultRequestTTL = 24 * time.Hour
 )
-
-type RequestPhase string
 
 type Request struct {
 	RequestMetadata `json:"metadata,omitempty"`
@@ -44,9 +34,8 @@ func (r *Request) Done() bool {
 	return r.Status.Phase == RequestPhaseCompleted || r.Status.Phase == RequestPhaseFailed
 }
 
-type RequestMetadata struct {
-	Name              string      `json:"name"`
-	CreationTimestamp metav1.Time `json:"creationTimestamp,omitempty"`
+func (r *Request) GetPhase() RequestPhase {
+	return r.Status.Phase
 }
 
 type RequestSpec struct {

--- a/pkg/snapshot/restorerequest.go
+++ b/pkg/snapshot/restorerequest.go
@@ -28,6 +28,10 @@ func (r *RestoreRequest) Done() bool {
 		r.Status.Phase == RequestPhasePartiallyFailed
 }
 
+func (r *RestoreRequest) GetPhase() RequestPhase {
+	return r.Status.Phase
+}
+
 type RestoreRequestSpec struct {
 	IncludeVolumes bool                       `json:"includeVolumes,omitempty"`
 	VolumesRestore volumes.RestoreRequestSpec `json:"volumesRestore,omitempty"`

--- a/test/e2e/snapshot/common.go
+++ b/test/e2e/snapshot/common.go
@@ -1,0 +1,140 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/snapshot"
+	"github.com/loft-sh/vcluster/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func restoreVCluster(f *framework.Framework, snapshotPath string, controllerBasedSnapshot, restoreVolumes bool) {
+	By("Restore vCluster")
+	restoreArgs := []string{
+		"restore",
+		f.VClusterName,
+		snapshotPath,
+		"-n", f.VClusterNamespace,
+	}
+	if !controllerBasedSnapshot {
+		restoreArgs = append(
+			restoreArgs,
+			"--pod-mount", "pvc:snapshot-pvc:/snapshot-pvc")
+	}
+	if restoreVolumes {
+		restoreArgs = append(
+			restoreArgs,
+			"--restore-volumes")
+	}
+	cmd := exec.Command(
+		"vcluster",
+		restoreArgs...,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	framework.ExpectNoError(err)
+
+	waitUntilVClusterIsRunning(f)
+
+	if restoreVolumes {
+		waitForRestoreRequestToFinish(f)
+	}
+}
+
+func waitUntilVClusterIsRunning(f *framework.Framework) {
+	// wait until vCluster is running
+	err := wait.PollUntilContextTimeout(f.Context, time.Second, time.Minute*2, false, func(ctx context.Context) (done bool, err error) {
+		newPods, _ := f.HostClient.CoreV1().Pods(f.VClusterNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=vcluster",
+		})
+		p := len(newPods.Items)
+		if p > 0 {
+			// rp, running pod counter
+			rp := 0
+			for _, pod := range newPods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					rp = rp + 1
+				}
+			}
+			if rp == p {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	framework.ExpectNoError(err)
+
+	// wait until all vCluster replicas are running
+	Eventually(func() error {
+		pods, err := f.HostClient.CoreV1().Pods(f.VClusterNamespace).List(f.Context, metav1.ListOptions{
+			LabelSelector: "app=vcluster,release=" + f.VClusterName,
+		})
+		framework.ExpectNoError(err)
+
+		for _, pod := range pods.Items {
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return fmt.Errorf("pod %s has no container status", pod.Name)
+			}
+
+			for _, container := range pod.Status.ContainerStatuses {
+				if container.State.Running == nil || !container.Ready {
+					return fmt.Errorf("pod %s container %s is not running", pod.Name, container.Name)
+				}
+			}
+		}
+		return nil
+	}).WithPolling(time.Second).
+		WithTimeout(framework.PollTimeout).
+		Should(Succeed())
+
+	// refresh the connection
+	err = f.RefreshVirtualClient()
+	framework.ExpectNoError(err)
+}
+
+func waitForSnapshotRequestToFinish(f *framework.Framework) {
+	waitForRequestToFinish(f, constants.SnapshotRequestLabel, snapshot.UnmarshalSnapshotRequest)
+}
+
+func waitForRestoreRequestToFinish(f *framework.Framework) {
+	waitForRequestToFinish(f, constants.RestoreRequestLabel, snapshot.UnmarshalRestoreRequest)
+}
+
+type unmarshalRequestFunc[T snapshot.LongRunningRequest] func(request *corev1.ConfigMap) (T, error)
+
+func waitForRequestToFinish[T snapshot.LongRunningRequest](f *framework.Framework, requestLabel string, unmarshal unmarshalRequestFunc[T]) {
+	Eventually(func() error {
+		listOptions := metav1.ListOptions{
+			LabelSelector: requestLabel,
+		}
+		requestConfigMaps, err := f.HostClient.CoreV1().ConfigMaps(f.VClusterNamespace).List(f.Context, listOptions)
+		framework.ExpectNoError(err)
+		Expect(requestConfigMaps.Items).To(HaveLen(1))
+
+		// extract snapshot/restore request
+		requestConfigMap := requestConfigMaps.Items[0]
+		request, err := unmarshal(&requestConfigMap)
+		framework.ExpectNoError(err)
+
+		// check if the snapshot/restore request has been completed
+		if request.GetPhase() != snapshot.RequestPhaseCompleted {
+			return fmt.Errorf("request is not completed, current phase is %s", request.GetPhase())
+		}
+		return nil
+	}).
+		WithPolling(framework.PollInterval).
+		WithTimeout(framework.PollTimeout).
+		Should(Succeed())
+}
+
+const RequestPhaseCompleted snapshot.RequestPhase = "Completed"

--- a/test/e2e/snapshot/snapshot.go
+++ b/test/e2e/snapshot/snapshot.go
@@ -535,7 +535,7 @@ var _ = Describe("snapshot and restore", Ordered, func() {
 		})
 
 		AfterAll(func() {
-			// cleanUpTestResources(true, controllerTestNamespaceName)
+			cleanUpTestResources(true, controllerTestNamespaceName)
 		})
 	})
 })

--- a/test/e2e/snapshot/volumes.go
+++ b/test/e2e/snapshot/volumes.go
@@ -1,0 +1,165 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/loft-sh/vcluster/test/framework"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+)
+
+// createPVCWithData creates a PVC, and it writes test data into the specified test file.
+// Test file is saved under	the '/data/$testFileName' path.
+func createPVCWithData(ctx context.Context, client *kubernetes.Clientset, pvcNamespace, pvcName, testFileName, testData string) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: pvcNamespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+			StorageClassName: ptr.To("csi-hostpath-sc"),
+		},
+	}
+	_, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+
+	// deploy a Job that writes test data to the PVC
+	deployJob(ctx, client, pvc.Namespace, "write-test-data", pvc.Name, fmt.Sprintf("echo '%s' > /data/%s", testData, testFileName), testFileName)
+}
+
+func deletePVC(ctx context.Context, client *kubernetes.Clientset, pvcNamespace, pvcName string) {
+	err := client.CoreV1().PersistentVolumeClaims(pvcNamespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
+	framework.ExpectNoError(err)
+
+	Eventually(func() error {
+		pvc, err := client.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(ctx, pvcName, metav1.GetOptions{})
+		if kerrors.IsNotFound(err) {
+			// PVC deleted successfully
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get PVC %s/%s: %v", pvcNamespace, pvcName, err)
+		}
+		return fmt.Errorf("PVC %s/%s is not deleted", pvc.Namespace, pvc.Name)
+	}).WithPolling(framework.PollInterval).
+		WithTimeout(framework.PollTimeout).
+		Should(Succeed())
+}
+
+func checkPVCData(ctx context.Context, client *kubernetes.Clientset, pvcNamespace, pvcName, testFileName, testData string) {
+	script := fmt.Sprintf(`actual=$(cat "/data/%s"); expected=%q;
+if [ "$actual" = "$expected" ]; then
+  echo "OK: content matches";
+else
+  echo "FAIL: expected [$expected], got [$actual]" >&2;
+  exit 1;
+fi`, testFileName, testData)
+	deployJob(ctx, client, pvcNamespace, "check-test-data", pvcName, script, testFileName)
+}
+
+func deployJob(ctx context.Context, client *kubernetes.Clientset, jobNamespace, jobName, pvcName, command, testFile string) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-", jobName),
+			Namespace:    jobNamespace,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To(int32(0)),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{{
+						Name:    "test-job",
+						Image:   "busybox:1.36",
+						Command: []string{"sh", "-c", command},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "data",
+							MountPath: "/data",
+						}},
+						WorkingDir: "/data",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								Exec: &corev1.ExecAction{Command: []string{"sh", "-c", "test -f /data/" + testFile}},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       1,
+							FailureThreshold:    10,
+							TimeoutSeconds:      2,
+						},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	job, err := client.BatchV1().Jobs(job.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+
+	Eventually(func() error {
+		job, err = client.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get job %s/%s: %v", job.Namespace, job.Name, err)
+		}
+		if job.Status.Succeeded != 1 {
+			return fmt.Errorf("job %s/%s did not succeed", job.Namespace, job.Name)
+		}
+		return nil
+	}).WithPolling(framework.PollInterval).
+		WithTimeout(framework.PollTimeout).
+		Should(Succeed())
+
+	// delete the job
+	err = client.BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+		PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+	})
+	framework.ExpectNoError(err)
+	Eventually(func() error {
+		job, err = client.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
+		if kerrors.IsNotFound(err) {
+			// job deleted successfully
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get job %s/%s: %v", job.Namespace, job.Name, err)
+		}
+		return fmt.Errorf("job %s/%s did not delete", job.Namespace, job.Name)
+	}).WithPolling(framework.PollInterval).
+		WithTimeout(framework.PollTimeout).
+		Should(Succeed())
+
+	Eventually(func() error {
+		jobPods, err := client.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("job-name=%s", job.Name),
+		})
+		if len(jobPods.Items) == 0 {
+			// job Pod deleted successfully
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get pods for job %s/%s: %v", job.Namespace, job.Name, err)
+		}
+		return fmt.Errorf("pods for job %s/%s have not been deleted", job.Namespace, job.Name)
+	}).WithPolling(framework.PollInterval).
+		WithTimeout(framework.PollTimeout).
+		Should(Succeed())
+}

--- a/test/e2e/snapshot/volumes.go
+++ b/test/e2e/snapshot/volumes.go
@@ -51,7 +51,7 @@ func deletePVC(ctx context.Context, client *kubernetes.Clientset, pvcNamespace, 
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("failed to get PVC %s/%s: %v", pvcNamespace, pvcName, err)
+			return fmt.Errorf("failed to get PVC %s/%s: %w", pvcNamespace, pvcName, err)
 		}
 		return fmt.Errorf("PVC %s/%s is not deleted", pvc.Namespace, pvc.Name)
 	}).WithPolling(framework.PollInterval).
@@ -118,7 +118,7 @@ func deployJob(ctx context.Context, client *kubernetes.Clientset, jobNamespace, 
 	Eventually(func() error {
 		job, err = client.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get job %s/%s: %v", job.Namespace, job.Name, err)
+			return fmt.Errorf("failed to get job %s/%s: %w", job.Namespace, job.Name, err)
 		}
 		if job.Status.Succeeded != 1 {
 			return fmt.Errorf("job %s/%s did not succeed", job.Namespace, job.Name)
@@ -140,7 +140,7 @@ func deployJob(ctx context.Context, client *kubernetes.Clientset, jobNamespace, 
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("failed to get job %s/%s: %v", job.Namespace, job.Name, err)
+			return fmt.Errorf("failed to get job %s/%s: %w", job.Namespace, job.Name, err)
 		}
 		return fmt.Errorf("job %s/%s did not delete", job.Namespace, job.Name)
 	}).WithPolling(framework.PollInterval).
@@ -156,7 +156,7 @@ func deployJob(ctx context.Context, client *kubernetes.Clientset, jobNamespace, 
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("failed to get pods for job %s/%s: %v", job.Namespace, job.Name, err)
+			return fmt.Errorf("failed to get pods for job %s/%s: %w", job.Namespace, job.Name, err)
 		}
 		return fmt.Errorf("pods for job %s/%s have not been deleted", job.Namespace, job.Name)
 	}).WithPolling(framework.PollInterval).


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9291

**What else do we need to know?** 
Besides adding basic e2e tests, there are few other minor changes here:
- PVC syncer: check if there is an ongoing restore earlier in PVC syncing
- vcluster restore: when restoring a PVC resource, and when that PVC will be restored from the snapshot in the host cluster, delete PVC's volume name, because the new volume has to be created