### PR TITLE
Change vcluster snapshot create output to add check command

### DIFF
--- a/pkg/cli/snapshot_helm.go
+++ b/pkg/cli/snapshot_helm.go
@@ -142,7 +142,7 @@ func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeCli
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot request resources: %w", err)
 	}
-	log.Infof("Created snapshot request %s", snapshotRequest.Name)
+	log.Infof("Beginning snapshot creation... Currently, in the snapshots beta release, you can check the snapshot creation progress by inspecting the following ConfigMap data with the following command: kubectl get configmap -n %s %s -o json | jq '.data[\"snapshotRequest\"] | fromjson'", vCluster.Namespace, snapshotRequest.Name)
 	return nil
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What else do we need to know?** 
Change `vcluster snapshot create` output to the following:

```
vcluster snapshot create $vcluster "container:///data/snap-12.tar.gz" --include-volumes
13:52:09 info Beginning snapshot creation... Currently, in the snapshots beta release, you can check the snapshot creation progress by inspecting the following ConfigMap data with the following command: kubectl get configmap -n nik237 nik237-snapshot-request-z82gj -o json | jq '.data["snapshotRequest"] | fromjson'
```

Here, ultimately, we want to tell user (cluster admin) to run `vcluster snapshot get` command to check the snapshot creation progress, or the uploaded snapshot. Since this is not yet implemented, I think it's better to have at least some temporary message that shows how to check the snapshot creation progress.