### PR TITLE
Reverts set patches

### DIFF
--- a/pkg/controllers/resources/configmaps/to_host_syncer.go
+++ b/pkg/controllers/resources/configmaps/to_host_syncer.go
@@ -78,7 +78,7 @@ func (s *configMapSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncco
 	}
 
 	pObj := translate.HostMetadata(event.Virtual, s.VirtualToHost(ctx, types.NamespacedName{Name: event.Virtual.Name, Namespace: event.Virtual.Namespace}, event.Virtual))
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -97,7 +97,7 @@ func (s *configMapSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syn
 		return ctrl.Result{}, nil
 	}
 
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/csidrivers/syncer.go
+++ b/pkg/controllers/resources/csidrivers/syncer.go
@@ -50,7 +50,7 @@ func (s *csidriverSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syn
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.CSIDrivers.Patches, true)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSIDrivers.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/csinodes/syncer.go
+++ b/pkg/controllers/resources/csinodes/syncer.go
@@ -63,7 +63,7 @@ func (s *csinodeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.CSINodes.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSINodes.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/csistoragecapacities/syncer.go
+++ b/pkg/controllers/resources/csistoragecapacities/syncer.go
@@ -66,7 +66,7 @@ func (s *csistoragecapacitySyncer) SyncToVirtual(ctx *synccontext.SyncContext, e
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.CSIStorageCapacities.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSIStorageCapacities.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -92,7 +92,7 @@ func (s *endpointsSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncco
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.Endpoints.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.Endpoints.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/events/syncer.go
+++ b/pkg/controllers/resources/events/syncer.go
@@ -90,7 +90,7 @@ func (s *eventSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccon
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.Events.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.Events.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/ingressclasses/syncer.go
+++ b/pkg/controllers/resources/ingressclasses/syncer.go
@@ -61,7 +61,7 @@ func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.IngressClasses.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.IngressClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/ingresses/syncer.go
+++ b/pkg/controllers/resources/ingresses/syncer.go
@@ -75,7 +75,7 @@ func (s *ingressSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccont
 		return ctrl.Result{}, err
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -120,7 +120,7 @@ func (s *ingressSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 	}
 
 	vIngress := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host), s.excludedAnnotations...)
-	err := pro.ApplyPatchesVirtualObject(ctx, vIngress, event.Host, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vIngress, event.Host, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/namespaces/syncer.go
+++ b/pkg/controllers/resources/namespaces/syncer.go
@@ -81,7 +81,7 @@ func (s *namespaceSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncco
 	newNamespace := s.translateToHost(ctx, event.Virtual)
 	ctx.Log.Infof("create physical namespace %s", newNamespace.Name)
 
-	err := pro.ApplyPatchesHostObject(ctx, newNamespace, event.Virtual, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newNamespace, event.Virtual, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -132,7 +132,7 @@ func (s *namespaceSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syn
 	newNamespace := s.translateToVirtual(ctx, event.Host)
 	ctx.Log.Infof("create virtual namespace %s", newNamespace.Name)
 
-	err = pro.ApplyPatchesVirtualObject(ctx, newNamespace, event.Host, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, newNamespace, event.Host, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/networkpolicies/syncer.go
+++ b/pkg/controllers/resources/networkpolicies/syncer.go
@@ -52,7 +52,7 @@ func (s *networkPolicySyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.NetworkPolicies.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.NetworkPolicies.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -338,7 +338,7 @@ func (s *nodeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccont
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, virtualNode, event.Host, ctx.Config.Sync.FromHost.Nodes.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, virtualNode, event.Host, ctx.Config.Sync.FromHost.Nodes.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -102,7 +102,7 @@ func (s *persistentVolumeClaimSyncer) SyncToHost(ctx *synccontext.SyncContext, e
 		return ctrl.Result{}, err
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -179,7 +179,7 @@ func (s *persistentVolumeClaimSyncer) SyncToVirtual(ctx *synccontext.SyncContext
 	}
 
 	vPvc := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host), s.excludedAnnotations...)
-	err := pro.ApplyPatchesVirtualObject(ctx, vPvc, event.Host, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vPvc, event.Host, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -120,7 +120,7 @@ func (s *persistentVolumeSyncer) SyncToHost(ctx *synccontext.SyncContext, event 
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesHostObject(ctx, pPv, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pPv, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}
@@ -268,7 +268,7 @@ func (s *persistentVolumeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, eve
 	} else if sync {
 		// create the persistent volume
 		vObj := s.translateBackwards(event.Host, vPvc)
-		err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
+		err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/controllers/resources/poddisruptionbudgets/syncer.go
+++ b/pkg/controllers/resources/poddisruptionbudgets/syncer.go
@@ -53,7 +53,7 @@ func (s *pdbSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.
 
 	newPDB := s.translate(ctx, event.Virtual)
 
-	err := pro.ApplyPatchesHostObject(ctx, newPDB, event.Virtual, ctx.Config.Sync.ToHost.PodDisruptionBudgets.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newPDB, event.Virtual, ctx.Config.Sync.ToHost.PodDisruptionBudgets.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -253,7 +253,7 @@ func (s *podSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.
 		}
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pPod, event.Virtual, ctx.Config.Sync.ToHost.Pods.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pPod, event.Virtual, ctx.Config.Sync.ToHost.Pods.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -418,7 +418,7 @@ func (s *podSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncconte
 		vPod.Spec.DeprecatedServiceAccount = ""
 	}
 
-	err := pro.ApplyPatchesVirtualObject(ctx, vPod, event.Host, ctx.Config.Sync.ToHost.Pods.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vPod, event.Host, ctx.Config.Sync.ToHost.Pods.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -69,7 +69,7 @@ func (s *priorityClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 
 	newPriorityClass := s.translate(ctx, event.Virtual)
 
-	err := pro.ApplyPatchesHostObject(ctx, newPriorityClass, event.Virtual, ctx.Config.Sync.ToHost.PriorityClasses.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newPriorityClass, event.Virtual, ctx.Config.Sync.ToHost.PriorityClasses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}
@@ -135,7 +135,7 @@ func (s *priorityClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event 
 	}
 
 	newVirtualPC := s.translateFromHost(ctx, event.Host)
-	err := pro.ApplyPatchesVirtualObject(ctx, newVirtualPC, event.Host, ctx.Config.Sync.FromHost.PriorityClasses.Patches, true)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, newVirtualPC, event.Host, ctx.Config.Sync.FromHost.PriorityClasses.Patches, true)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllers/resources/runtimeclasses/syncer.go
+++ b/pkg/controllers/resources/runtimeclasses/syncer.go
@@ -61,7 +61,7 @@ func (i *runtimeClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.RuntimeClasses.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.RuntimeClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/secrets/to_host_syncer.go
+++ b/pkg/controllers/resources/secrets/to_host_syncer.go
@@ -90,7 +90,7 @@ func (s *secretSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncconte
 		newSecret.Type = corev1.SecretTypeOpaque
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, newSecret, event.Virtual, ctx.Config.Sync.ToHost.Secrets.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, newSecret, event.Virtual, ctx.Config.Sync.ToHost.Secrets.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -158,7 +158,7 @@ func (s *secretSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncco
 		return ctrl.Result{}, nil
 	}
 
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.Secrets.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.Secrets.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/serviceaccounts/syncer.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer.go
@@ -63,7 +63,7 @@ func (s *serviceAccountSyncer) SyncToHost(ctx *synccontext.SyncContext, event *s
 	pObj.AutomountServiceAccountToken = &[]bool{false}[0]
 	pObj.ImagePullSecrets = nil
 
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}
@@ -99,7 +99,7 @@ func (s *serviceAccountSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event
 	}
 
 	vObj := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host))
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -77,7 +77,7 @@ func (s *serviceSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccont
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.Services.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.Services.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -230,7 +230,7 @@ func (s *serviceSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 	}
 
 	vObj := s.translateToVirtual(ctx, event.Host)
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.Services.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.Services.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -65,7 +65,7 @@ func (s *hostStorageClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, eve
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.StorageClasses.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.StorageClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/storageclasses/syncer.go
+++ b/pkg/controllers/resources/storageclasses/syncer.go
@@ -62,7 +62,7 @@ func (s *storageClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syn
 
 	newStorageClass := translate.HostMetadata(event.Virtual, s.VirtualToHost(ctx, types.NamespacedName{Name: event.Virtual.Name}, event.Virtual), s.excludedAnnotations...)
 
-	err := pro.ApplyPatchesHostObject(ctx, newStorageClass, event.Virtual, ctx.Config.Sync.ToHost.StorageClasses.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newStorageClass, event.Virtual, ctx.Config.Sync.ToHost.StorageClasses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}

--- a/pkg/controllers/resources/volumesnapshotclasses/syncer.go
+++ b/pkg/controllers/resources/volumesnapshotclasses/syncer.go
@@ -51,7 +51,7 @@ func (s *volumeSnapshotClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)
 
 	// Apply pro patches
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.VolumeSnapshotClasses.Patches, true)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.VolumeSnapshotClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying pro patches: %w", err)
 	}

--- a/pkg/controllers/resources/volumesnapshotcontents/syncer.go
+++ b/pkg/controllers/resources/volumesnapshotcontents/syncer.go
@@ -71,7 +71,7 @@ func (s *volumeSnapshotContentSyncer) SyncToVirtual(ctx *synccontext.SyncContext
 	}
 
 	vVSC := s.translateBackwards(event.Host, vVS)
-	err = pro.ApplyPatchesVirtualObject(ctx, vVSC, event.Host, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vVSC, event.Host, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -92,7 +92,7 @@ func (s *volumeSnapshotContentSyncer) SyncToHost(ctx *synccontext.SyncContext, e
 	}
 
 	pVSC := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pVSC, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pVSC, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/volumesnapshots/syncer.go
+++ b/pkg/controllers/resources/volumesnapshots/syncer.go
@@ -76,7 +76,7 @@ func (s *volumeSnapshotSyncer) SyncToHost(ctx *synccontext.SyncContext, event *s
 		return ctrl.Result{}, err
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshots.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshots.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/patcher/patcher.go
+++ b/pkg/patcher/patcher.go
@@ -137,12 +137,12 @@ func (h *Patcher) Patch(ctx *synccontext.SyncContext, obj client.Object) error {
 	if len(h.patches) > 0 {
 		obj = obj.DeepCopyObject().(client.Object)
 		if h.direction == synccontext.SyncVirtualToHost {
-			err := pro.ApplyPatchesHostObject(ctx, obj, h.vObj, h.patches, h.reverseExpressions)
+			err := pro.ApplyPatchesHostObject(ctx, h.beforeObject, obj, h.vObj, h.patches, h.reverseExpressions)
 			if err != nil {
 				return fmt.Errorf("apply patches host object: %w", err)
 			}
 		} else if h.direction == synccontext.SyncHostToVirtual {
-			err := pro.ApplyPatchesVirtualObject(ctx, obj, h.pObj, h.patches, h.reverseExpressions)
+			err := pro.ApplyPatchesVirtualObject(ctx, h.beforeObject, obj, h.pObj, h.patches, h.reverseExpressions)
 			if err != nil {
 				return fmt.Errorf("apply patches virtual object: %w", err)
 			}

--- a/pkg/pro/patches.go
+++ b/pkg/pro/patches.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ApplyPatchesVirtualObject = func(_ *synccontext.SyncContext, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
+var ApplyPatchesVirtualObject = func(_ *synccontext.SyncContext, _, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
 	if len(patches) == 0 {
 		return nil
 	}
@@ -14,7 +14,7 @@ var ApplyPatchesVirtualObject = func(_ *synccontext.SyncContext, _, _ client.Obj
 	return NewFeatureError("translate patches")
 }
 
-var ApplyPatchesHostObject = func(_ *synccontext.SyncContext, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
+var ApplyPatchesHostObject = func(_ *synccontext.SyncContext, _, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
 	if len(patches) == 0 {
 		return nil
 	}

--- a/pkg/syncer/from_host_syncer.go
+++ b/pkg/syncer/from_host_syncer.go
@@ -117,7 +117,7 @@ func (s *genericFromHostSyncer) SyncToVirtual(ctx *synccontext.SyncContext, even
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, s.GetProPatches(ctx.Config.Config), false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, s.GetProPatches(ctx.Config.Config), false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/util/patch/patch.go
+++ b/pkg/util/patch/patch.go
@@ -56,23 +56,20 @@ func (p Patch) Clear() {
 	}
 }
 
-type translateFn func(path string, val interface{}, exists bool) (interface{}, error)
-
-func (p Patch) MustTranslate(path string, translate translateFn) {
+func (p Patch) MustTranslate(path string, translate func(path string, val interface{}) (interface{}, error)) {
 	err := p.Translate(path, translate)
 	if err != nil {
 		panic(err)
 	}
 }
 
-// Translate changes values on the given path.
-func (p Patch) Translate(path string, translate translateFn) error {
-	parsedPath, err := parsePathWithIndexing(path, true)
+// Translate changes existing (!) values on the given path. If you want to set a value, use the set function instead.
+func (p Patch) Translate(path string, translate func(path string, val interface{}) (interface{}, error)) error {
+	parsedPath, err := parsePath(path)
 	if err != nil {
 		panic(err)
-	}
-	if len(parsedPath) == 0 {
-		retVal, err := translate("", map[string]interface{}(p), true)
+	} else if len(parsedPath) == 0 {
+		retVal, err := translate("", map[string]interface{}(p))
 		if err != nil {
 			return err
 		}
@@ -98,10 +95,9 @@ func (p Patch) Translate(path string, translate translateFn) error {
 
 		switch t := cur.Value.(type) {
 		case []interface{}:
-			segment = trimBracketsPair(segment)
 			if segment == "*" {
 				for k := range t {
-					t[k], err = translate(addPathElement(cur.Path, strconv.Itoa(k)), t[k], true)
+					t[k], err = translate(addPathElement(cur.Path, strconv.Itoa(k)), t[k])
 					if err != nil {
 						return err
 					}
@@ -118,7 +114,7 @@ func (p Patch) Translate(path string, translate translateFn) error {
 				return nil
 			}
 
-			ret, err := translate(addPathElement(cur.Path, segment), t[index], true)
+			ret, err := translate(addPathElement(cur.Path, segment), t[index])
 			if err != nil {
 				return err
 			}
@@ -126,36 +122,22 @@ func (p Patch) Translate(path string, translate translateFn) error {
 			t[index] = ret
 
 		case map[string]interface{}:
-			switch {
-			case segment == "[*]":
+			if segment == "*" {
 				for k := range t {
-					t[k], err = translate(addPathElement(cur.Path, k), t[k], true)
+					t[k], err = translate(addPathElement(cur.Path, k), t[k])
 					if err != nil {
 						return err
 					}
 				}
-			case isBracketEnclosed(segment): // a.path.to.some["segment"] case
-				key := trimBracketsPair(segment)
-				if key == "" {
-					return fmt.Errorf("empty key in bracket notation in path %q", segment)
-				}
-				v, ok := t[key]
-				valueFromExpression, err := translate(cur.Path, v, ok)
-				if err != nil {
-					return fmt.Errorf("translate value for key %q in path %q: %w", key, cur.Path, err)
-				}
-				if valueFromExpression == nil {
-					p.Delete(JoinPath(cur.Path, key))
-					continue
-				}
-				t[key] = valueFromExpression
 
-			default: // a.path.to.some.segment case
-				if val, ok := t[segment]; ok {
-					t[segment], err = translate(JoinPath(cur.Path, segment), val, ok)
-					if err != nil {
-						return err
-					}
+				continue
+			}
+
+			val, ok := t[segment]
+			if ok {
+				t[segment], err = translate(JoinPath(cur.Path, segment), val)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -208,8 +190,7 @@ func (p Patch) Delete(path string) {
 
 	// delete last element, we only support maps here for now.
 	for _, cur := range curs {
-		segment := parsedPath[len(parsedPath)-1]
-		if segment == "*" {
+		if parsedPath[len(parsedPath)-1] == "*" {
 			if t, ok := cur.Value.(map[string]interface{}); ok {
 				for k := range t {
 					delete(t, k)
@@ -219,7 +200,7 @@ func (p Patch) Delete(path string) {
 		}
 
 		if t, ok := cur.Value.(map[string]interface{}); ok {
-			delete(t, segment)
+			delete(t, parsedPath[len(parsedPath)-1])
 		}
 	}
 
@@ -388,10 +369,9 @@ func nextValue(parsedPath []string, index int, cur *PathValue, create bool) ([]P
 		return []PathValue{*cur}, true
 	}
 
-	firstPath := trimBracketsPair(parsedPath[0])
 	switch val := cur.Value.(type) {
 	case map[string]interface{}:
-		if firstPath == "*" {
+		if parsedPath[0] == "*" {
 			retVals := make([]PathValue, 0, len(val))
 			for k := range val {
 				retVal, ok := nextValue(parsedPath[1:], index, &PathValue{
@@ -411,23 +391,23 @@ func nextValue(parsedPath []string, index int, cur *PathValue, create bool) ([]P
 			return retVals, true
 		}
 
-		mapValue, ok := val[firstPath]
+		mapValue, ok := val[parsedPath[0]]
 		if !ok && !create {
 			return nil, false
 		} else if create && (!ok || mapValue == nil) {
-			val[firstPath] = createValue(parsedPath[1:])
-			mapValue = val[firstPath]
+			val[parsedPath[0]] = createValue(parsedPath[1:])
+			mapValue = val[parsedPath[0]]
 		}
 
 		return nextValue(parsedPath[1:], index, &PathValue{
 			Parent: cur,
 			Value:  mapValue,
-			Key:    firstPath,
-			Path:   addPathElement(cur.Path, firstPath),
+			Key:    parsedPath[0],
+			Path:   addPathElement(cur.Path, parsedPath[0]),
 		}, create)
 	case []interface{}:
 		// try to match all
-		if firstPath == "*" {
+		if parsedPath[0] == "*" {
 			retVals := make([]PathValue, 0, len(val))
 			for i := range val {
 				retVal, ok := nextValue(parsedPath[1:], index, &PathValue{
@@ -448,7 +428,7 @@ func nextValue(parsedPath []string, index int, cur *PathValue, create bool) ([]P
 		}
 
 		// try to get index
-		indexSegment, err := strconv.Atoi(firstPath)
+		indexSegment, err := strconv.Atoi(parsedPath[0])
 		if err != nil {
 			return nil, false
 		}
@@ -474,7 +454,7 @@ func nextValue(parsedPath []string, index int, cur *PathValue, create bool) ([]P
 			Parent: cur,
 			Value:  arrVal,
 			Index:  indexSegment,
-			Path:   addPathElement(cur.Path, firstPath),
+			Path:   addPathElement(cur.Path, parsedPath[0]),
 		}, create)
 	}
 
@@ -486,8 +466,7 @@ func createValue(pathSegment []string) interface{} {
 		return map[string]interface{}{}
 	}
 
-	segment := trimBracketsPair(pathSegment[0])
-	intVal, err := strconv.Atoi(segment)
+	intVal, err := strconv.Atoi(pathSegment[0])
 	if err == nil {
 		newVal := make([]interface{}, 0, intVal+1)
 		for i := 0; i <= intVal; i++ {
@@ -517,18 +496,4 @@ func JoinPath(root, next string) string {
 		return next
 	}
 	return root + "." + next
-}
-
-func trimBracketsPair(segment string) string {
-	if isBracketEnclosed(segment) {
-		return segment[1 : len(segment)-1]
-	}
-	return segment
-}
-
-func isBracketEnclosed(segment string) bool {
-	if len(segment) < 2 {
-		return false
-	}
-	return segment[0] == '[' && segment[len(segment)-1] == ']'
 }

--- a/pkg/util/patch/patch_test.go
+++ b/pkg/util/patch/patch_test.go
@@ -35,10 +35,10 @@ func Test(t *testing.T) {
   namespace: test`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("metadata.finalizers[0]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("metadata.finalizers[0]", func(_ string, val interface{}) (interface{}, error) {
 					return val.(string) + "-translated", nil
 				})
-				p.MustTranslate("metadata.name", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("metadata.name", func(_ string, val interface{}) (interface{}, error) {
 					return val.(string) + "-translated", nil
 				})
 			},
@@ -61,7 +61,7 @@ func Test(t *testing.T) {
   namespace: test`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("metadata.finalizers[1]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("metadata.finalizers[1]", func(_ string, val interface{}) (interface{}, error) {
 					return val.(string) + "-translated", nil
 				})
 			},
@@ -116,7 +116,7 @@ metadata:
 
 			Adjust: func(p Patch) {
 				name, _ := p.String("metadata.name")
-				p.MustTranslate("metadata.namespace", func(_ string, _ interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("metadata.namespace", func(_ string, _ interface{}) (interface{}, error) {
 					return name, nil
 				})
 			},
@@ -255,7 +255,7 @@ spec:
   - host: vcluster.*.foo.com`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("spec.rules[*].host", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.rules[*].host", func(_ string, val interface{}) (interface{}, error) {
 					return "vcluster." + val.(string), nil
 				})
 			},
@@ -278,7 +278,7 @@ spec:
       host: vcluster.*.foo.com`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("spec.rules.*.host", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.rules.*.host", func(_ string, val interface{}) (interface{}, error) {
 					return "vcluster." + val.(string), nil
 				})
 			},
@@ -338,10 +338,10 @@ spec:
     - added`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("spec.rules[*][*]", func(path string, _ interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.rules[*][*]", func(path string, _ interface{}) (interface{}, error) {
 					return path, nil
 				})
-				p.MustTranslate("spec.rules[\"test.object.other\"]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.rules[\"test.object.other\"]", func(_ string, val interface{}) (interface{}, error) {
 					valArr := val.([]interface{})
 					valArr = append(valArr, "added")
 					return valArr, nil
@@ -403,7 +403,7 @@ spec:
 `,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("spec.servers[*].hosts[*]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.servers[*].hosts[*]", func(_ string, val interface{}) (interface{}, error) {
 					valString, ok := val.(string)
 					if !ok {
 						return val, nil
@@ -427,7 +427,7 @@ spec:
   rules: test`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("spec.rules", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.rules", func(_ string, val interface{}) (interface{}, error) {
 					_, ok := val.(string)
 					if !ok {
 						return "test", nil
@@ -499,11 +499,11 @@ spec:
     environment: prod-updated`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("metadata.annotations[\"app.kubernetes.io/name\"]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("metadata.annotations[\"app.kubernetes.io/name\"]", func(_ string, val interface{}) (interface{}, error) {
 					return val.(string) + "-modified", nil
 				})
 				p.Set("metadata.annotations[\"app.kubernetes.io/version\"]", "2.0")
-				p.MustTranslate("metadata.labels[\"environment\"]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("metadata.labels[\"environment\"]", func(_ string, val interface{}) (interface{}, error) {
 					return val.(string) + "-updated", nil
 				})
 			},
@@ -535,7 +535,7 @@ spec:
 
 			Adjust: func(p Patch) {
 				p.Set("config.servers[\"server.domain.com\"].port", 9090)
-				p.MustTranslate("config.databases[*].host", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("config.databases[*].host", func(_ string, val interface{}) (interface{}, error) {
 					return "new-" + val.(string), nil
 				})
 			},
@@ -564,7 +564,7 @@ spec:
           path: /v2`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("spec.ingress.rules[\"api.example.com\"].paths[*].backend", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("spec.ingress.rules[\"api.example.com\"].paths[*].backend", func(_ string, val interface{}) (interface{}, error) {
 					return "updated-" + val.(string), nil
 				})
 			},
@@ -585,11 +585,11 @@ spec:
   secret-123: encrypted-updated`,
 
 			Adjust: func(p Patch) {
-				p.MustTranslate("data[\"config.yaml\"]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("data[\"config.yaml\"]", func(_ string, val interface{}) (interface{}, error) {
 					return strings.Replace(val.(string), "value", "modified-value", 1), nil
 				})
 				p.Set("data[\"my/special@key\"]", "updated-special-value")
-				p.MustTranslate("data[\"secret-123\"]", func(_ string, val interface{}, _ bool) (interface{}, error) {
+				p.MustTranslate("data[\"secret-123\"]", func(_ string, val interface{}) (interface{}, error) {
 					return val.(string) + "-updated", nil
 				})
 			},
@@ -648,65 +648,6 @@ spec:
 					panic("unexpected nonexistent key")
 				}
 				p.Set("metadata.labels[\"verified\"]", "true")
-			},
-		},
-		{
-			Name: "Undefined vs Null Values",
-
-			Object: `metadata:
-  annotations:
-    existing-key: "value"
-    null-key: null
-  labels:
-    app: myapp`,
-
-			ExpectedObject: `metadata:
-  annotations:
-    existing-key: value-modified
-    new-key: created
-    null-key: was-null
-    undefined-key: was-undefined-value
-  labels:
-    app: myapp`,
-
-			Adjust: func(p Patch) {
-				// Modify existing key
-				p.MustTranslate("metadata.annotations[\"existing-key\"]", func(_ string, val interface{}, exists bool) (interface{}, error) {
-					if !exists {
-						panic("expected existing-key to exist")
-					}
-					return val.(string) + "-modified", nil
-				})
-
-				// Handle null value
-				p.MustTranslate("metadata.annotations[\"null-key\"]", func(_ string, val interface{}, exists bool) (interface{}, error) {
-					if !exists {
-						panic("expected null-key to exist")
-					}
-					if val == nil {
-						return "was-null", nil
-					}
-					return val, nil
-				})
-
-				// Handle undefined/non-existent key
-				p.MustTranslate("metadata.annotations[\"undefined-key\"]", func(_ string, _ interface{}, exists bool) (interface{}, error) {
-					if exists {
-						panic("unexpected undefined-key to exist")
-					}
-					return "was-undefined-value", nil
-				})
-
-				// Set a new key to show creation works
-				p.Set("metadata.annotations[\"new-key\"]", "created")
-
-				// Verify Has method behavior
-				if !p.Has("metadata.annotations[\"existing-key\"]") {
-					panic("expected existing-key")
-				}
-				if !p.Has("metadata.annotations[\"null-key\"]") {
-					panic("expected null-key to exist (even though value is null)")
-				}
 			},
 		},
 	}

--- a/pkg/util/patch/path.go
+++ b/pkg/util/patch/path.go
@@ -5,15 +5,9 @@ import (
 	"strings"
 )
 
+// parsePath parses a given json path into different segments
+// which can be used to navigate an object.
 func parsePath(path string) ([]string, error) {
-	return parsePathWithIndexing(path, false)
-}
-
-// parsePathWithIndexing parses a given json path into different segments
-// which can be used to navigate an object. If preserveIndexNotation is true,
-// it will keep the index notation (e.g. [0]) in the segments, otherwise
-// it will split the segments at the index notation and return only the key names.
-func parsePathWithIndexing(path string, preserveIndexNotation bool) ([]string, error) {
 	path = strings.TrimSpace(path)
 	retSegments := []string{}
 
@@ -48,11 +42,7 @@ func parsePathWithIndexing(path string, preserveIndexNotation bool) ([]string, e
 			}
 
 			bracketOpen = false
-			retSegment := string(curSegment)
-			if preserveIndexNotation {
-				retSegment = fmt.Sprintf("[%s]", retSegment)
-			}
-			retSegments = append(retSegments, retSegment)
+			retSegments = append(retSegments, string(curSegment))
 			curSegment = []byte{}
 		} else {
 			curSegment = append(curSegment, byte(v))


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster defining both an `expression` and `reverseExpression` on a sync patch would cause an infinite back and forth or errors.  ⚠️ Also reverts the functionality of creating non-existent keys through patch definitions.

