### PR TITLE
fix: Restore passing the "beforeObj" to revert set patches

### DIFF
--- a/pkg/controllers/resources/configmaps/to_host_syncer.go
+++ b/pkg/controllers/resources/configmaps/to_host_syncer.go
@@ -78,7 +78,7 @@ func (s *configMapSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncco
 	}
 
 	pObj := translate.HostMetadata(event.Virtual, s.VirtualToHost(ctx, types.NamespacedName{Name: event.Virtual.Name, Namespace: event.Virtual.Namespace}, event.Virtual))
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -97,7 +97,7 @@ func (s *configMapSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syn
 		return ctrl.Result{}, nil
 	}
 
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.ConfigMaps.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/csidrivers/syncer.go
+++ b/pkg/controllers/resources/csidrivers/syncer.go
@@ -50,7 +50,7 @@ func (s *csidriverSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syn
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.CSIDrivers.Patches, true)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSIDrivers.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/csinodes/syncer.go
+++ b/pkg/controllers/resources/csinodes/syncer.go
@@ -63,7 +63,7 @@ func (s *csinodeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.CSINodes.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSINodes.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/csistoragecapacities/syncer.go
+++ b/pkg/controllers/resources/csistoragecapacities/syncer.go
@@ -66,7 +66,7 @@ func (s *csistoragecapacitySyncer) SyncToVirtual(ctx *synccontext.SyncContext, e
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.CSIStorageCapacities.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.CSIStorageCapacities.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/endpoints/syncer.go
+++ b/pkg/controllers/resources/endpoints/syncer.go
@@ -92,7 +92,7 @@ func (s *endpointsSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncco
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.Endpoints.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.Endpoints.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/endpointslices/syncer.go
+++ b/pkg/controllers/resources/endpointslices/syncer.go
@@ -63,7 +63,7 @@ func (s *endpointSliceSyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.EndpointSlices.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.EndpointSlices.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/events/syncer.go
+++ b/pkg/controllers/resources/events/syncer.go
@@ -90,7 +90,7 @@ func (s *eventSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccon
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.Events.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.Events.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/ingressclasses/syncer.go
+++ b/pkg/controllers/resources/ingressclasses/syncer.go
@@ -61,7 +61,7 @@ func (i *ingressClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.IngressClasses.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.IngressClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/ingresses/syncer.go
+++ b/pkg/controllers/resources/ingresses/syncer.go
@@ -75,7 +75,7 @@ func (s *ingressSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccont
 		return ctrl.Result{}, err
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -120,7 +120,7 @@ func (s *ingressSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 	}
 
 	vIngress := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host), s.excludedAnnotations...)
-	err := pro.ApplyPatchesVirtualObject(ctx, vIngress, event.Host, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vIngress, event.Host, ctx.Config.Sync.ToHost.Ingresses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/namespaces/syncer.go
+++ b/pkg/controllers/resources/namespaces/syncer.go
@@ -81,7 +81,7 @@ func (s *namespaceSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncco
 	newNamespace := s.translateToHost(ctx, event.Virtual)
 	ctx.Log.Infof("create physical namespace %s", newNamespace.Name)
 
-	err := pro.ApplyPatchesHostObject(ctx, newNamespace, event.Virtual, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newNamespace, event.Virtual, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -132,7 +132,7 @@ func (s *namespaceSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syn
 	newNamespace := s.translateToVirtual(ctx, event.Host)
 	ctx.Log.Infof("create virtual namespace %s", newNamespace.Name)
 
-	err = pro.ApplyPatchesVirtualObject(ctx, newNamespace, event.Host, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, newNamespace, event.Host, ctx.Config.Sync.ToHost.Namespaces.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/networkpolicies/syncer.go
+++ b/pkg/controllers/resources/networkpolicies/syncer.go
@@ -52,7 +52,7 @@ func (s *networkPolicySyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.NetworkPolicies.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.NetworkPolicies.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/nodes/syncer.go
+++ b/pkg/controllers/resources/nodes/syncer.go
@@ -338,7 +338,7 @@ func (s *nodeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccont
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, virtualNode, event.Host, ctx.Config.Sync.FromHost.Nodes.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, virtualNode, event.Host, ctx.Config.Sync.FromHost.Nodes.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer.go
@@ -116,7 +116,7 @@ func (s *persistentVolumeClaimSyncer) SyncToHost(ctx *synccontext.SyncContext, e
 		}, nil
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -204,7 +204,7 @@ func (s *persistentVolumeClaimSyncer) SyncToVirtual(ctx *synccontext.SyncContext
 	}
 
 	vPvc := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host), s.excludedAnnotations...)
-	err := pro.ApplyPatchesVirtualObject(ctx, vPvc, event.Host, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vPvc, event.Host, ctx.Config.Sync.ToHost.PersistentVolumeClaims.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -120,7 +120,7 @@ func (s *persistentVolumeSyncer) SyncToHost(ctx *synccontext.SyncContext, event 
 	}
 
 	// Apply pro patches
-	err = pro.ApplyPatchesHostObject(ctx, pPv, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pPv, event.Virtual, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}
@@ -268,7 +268,7 @@ func (s *persistentVolumeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, eve
 	} else if sync {
 		// create the persistent volume
 		vObj := s.translateBackwards(event.Host, vPvc)
-		err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
+		err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.PersistentVolumes.Patches, false)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/controllers/resources/poddisruptionbudgets/syncer.go
+++ b/pkg/controllers/resources/poddisruptionbudgets/syncer.go
@@ -53,7 +53,7 @@ func (s *pdbSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.
 
 	newPDB := s.translate(ctx, event.Virtual)
 
-	err := pro.ApplyPatchesHostObject(ctx, newPDB, event.Virtual, ctx.Config.Sync.ToHost.PodDisruptionBudgets.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newPDB, event.Virtual, ctx.Config.Sync.ToHost.PodDisruptionBudgets.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -253,7 +253,7 @@ func (s *podSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.
 		}
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pPod, event.Virtual, ctx.Config.Sync.ToHost.Pods.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pPod, event.Virtual, ctx.Config.Sync.ToHost.Pods.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -418,7 +418,7 @@ func (s *podSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncconte
 		vPod.Spec.DeprecatedServiceAccount = ""
 	}
 
-	err := pro.ApplyPatchesVirtualObject(ctx, vPod, event.Host, ctx.Config.Sync.ToHost.Pods.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vPod, event.Host, ctx.Config.Sync.ToHost.Pods.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/priorityclasses/syncer.go
+++ b/pkg/controllers/resources/priorityclasses/syncer.go
@@ -69,7 +69,7 @@ func (s *priorityClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 
 	newPriorityClass := s.translate(ctx, event.Virtual)
 
-	err := pro.ApplyPatchesHostObject(ctx, newPriorityClass, event.Virtual, ctx.Config.Sync.ToHost.PriorityClasses.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newPriorityClass, event.Virtual, ctx.Config.Sync.ToHost.PriorityClasses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}
@@ -135,7 +135,7 @@ func (s *priorityClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event 
 	}
 
 	newVirtualPC := s.translateFromHost(ctx, event.Host)
-	err := pro.ApplyPatchesVirtualObject(ctx, newVirtualPC, event.Host, ctx.Config.Sync.FromHost.PriorityClasses.Patches, true)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, newVirtualPC, event.Host, ctx.Config.Sync.FromHost.PriorityClasses.Patches, true)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllers/resources/runtimeclasses/syncer.go
+++ b/pkg/controllers/resources/runtimeclasses/syncer.go
@@ -61,7 +61,7 @@ func (i *runtimeClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.RuntimeClasses.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.RuntimeClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/secrets/to_host_syncer.go
+++ b/pkg/controllers/resources/secrets/to_host_syncer.go
@@ -90,7 +90,7 @@ func (s *secretSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syncconte
 		newSecret.Type = corev1.SecretTypeOpaque
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, newSecret, event.Virtual, ctx.Config.Sync.ToHost.Secrets.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, newSecret, event.Virtual, ctx.Config.Sync.ToHost.Secrets.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -158,7 +158,7 @@ func (s *secretSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncco
 		return ctrl.Result{}, nil
 	}
 
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.Secrets.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.Secrets.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/serviceaccounts/syncer.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer.go
@@ -63,7 +63,7 @@ func (s *serviceAccountSyncer) SyncToHost(ctx *synccontext.SyncContext, event *s
 	pObj.AutomountServiceAccountToken = &[]bool{false}[0]
 	pObj.ImagePullSecrets = nil
 
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}
@@ -99,7 +99,7 @@ func (s *serviceAccountSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event
 	}
 
 	vObj := translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host))
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllers/resources/services/syncer.go
+++ b/pkg/controllers/resources/services/syncer.go
@@ -77,7 +77,7 @@ func (s *serviceSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccont
 	}
 
 	pObj := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.Services.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.Services.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -230,7 +230,7 @@ func (s *serviceSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 	}
 
 	vObj := s.translateToVirtual(ctx, event.Host)
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.ToHost.Services.Patches, false)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.ToHost.Services.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/storageclasses/host_syncer.go
+++ b/pkg/controllers/resources/storageclasses/host_syncer.go
@@ -65,7 +65,7 @@ func (s *hostStorageClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, eve
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)
 
 	// Apply pro patches
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.StorageClasses.Patches, true)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.StorageClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/storageclasses/syncer.go
+++ b/pkg/controllers/resources/storageclasses/syncer.go
@@ -62,7 +62,7 @@ func (s *storageClassSyncer) SyncToHost(ctx *synccontext.SyncContext, event *syn
 
 	newStorageClass := translate.HostMetadata(event.Virtual, s.VirtualToHost(ctx, types.NamespacedName{Name: event.Virtual.Name}, event.Virtual), s.excludedAnnotations...)
 
-	err := pro.ApplyPatchesHostObject(ctx, newStorageClass, event.Virtual, ctx.Config.Sync.ToHost.StorageClasses.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, newStorageClass, event.Virtual, ctx.Config.Sync.ToHost.StorageClasses.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("apply patches: %w", err)
 	}

--- a/pkg/controllers/resources/volumesnapshotclasses/syncer.go
+++ b/pkg/controllers/resources/volumesnapshotclasses/syncer.go
@@ -51,7 +51,7 @@ func (s *volumeSnapshotClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name}, false)
 
 	// Apply pro patches
-	err := pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, ctx.Config.Sync.FromHost.VolumeSnapshotClasses.Patches, true)
+	err := pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.VolumeSnapshotClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying pro patches: %w", err)
 	}

--- a/pkg/controllers/resources/volumesnapshotcontents/syncer.go
+++ b/pkg/controllers/resources/volumesnapshotcontents/syncer.go
@@ -71,7 +71,7 @@ func (s *volumeSnapshotContentSyncer) SyncToVirtual(ctx *synccontext.SyncContext
 	}
 
 	vVSC := s.translateBackwards(event.Host, vVS)
-	err = pro.ApplyPatchesVirtualObject(ctx, vVSC, event.Host, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vVSC, event.Host, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -92,7 +92,7 @@ func (s *volumeSnapshotContentSyncer) SyncToHost(ctx *synccontext.SyncContext, e
 	}
 
 	pVSC := s.translate(ctx, event.Virtual)
-	err := pro.ApplyPatchesHostObject(ctx, pVSC, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
+	err := pro.ApplyPatchesHostObject(ctx, nil, pVSC, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshotContents.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/resources/volumesnapshots/syncer.go
+++ b/pkg/controllers/resources/volumesnapshots/syncer.go
@@ -76,7 +76,7 @@ func (s *volumeSnapshotSyncer) SyncToHost(ctx *synccontext.SyncContext, event *s
 		return ctrl.Result{}, err
 	}
 
-	err = pro.ApplyPatchesHostObject(ctx, pObj, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshots.Patches, false)
+	err = pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.VolumeSnapshots.Patches, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/patcher/patcher.go
+++ b/pkg/patcher/patcher.go
@@ -137,12 +137,12 @@ func (h *Patcher) Patch(ctx *synccontext.SyncContext, obj client.Object) error {
 	if len(h.patches) > 0 {
 		obj = obj.DeepCopyObject().(client.Object)
 		if h.direction == synccontext.SyncVirtualToHost {
-			err := pro.ApplyPatchesHostObject(ctx, obj, h.vObj, h.patches, h.reverseExpressions)
+			err := pro.ApplyPatchesHostObject(ctx, h.beforeObject, obj, h.vObj, h.patches, h.reverseExpressions)
 			if err != nil {
 				return fmt.Errorf("apply patches host object: %w", err)
 			}
 		} else if h.direction == synccontext.SyncHostToVirtual {
-			err := pro.ApplyPatchesVirtualObject(ctx, obj, h.pObj, h.patches, h.reverseExpressions)
+			err := pro.ApplyPatchesVirtualObject(ctx, h.beforeObject, obj, h.pObj, h.patches, h.reverseExpressions)
 			if err != nil {
 				return fmt.Errorf("apply patches virtual object: %w", err)
 			}

--- a/pkg/pro/patches.go
+++ b/pkg/pro/patches.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ApplyPatchesVirtualObject = func(_ *synccontext.SyncContext, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
+var ApplyPatchesVirtualObject = func(_ *synccontext.SyncContext, _, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
 	if len(patches) == 0 {
 		return nil
 	}
@@ -14,7 +14,7 @@ var ApplyPatchesVirtualObject = func(_ *synccontext.SyncContext, _, _ client.Obj
 	return NewFeatureError("translate patches")
 }
 
-var ApplyPatchesHostObject = func(_ *synccontext.SyncContext, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
+var ApplyPatchesHostObject = func(_ *synccontext.SyncContext, _, _, _ client.Object, patches []config.TranslatePatch, _ bool) error {
 	if len(patches) == 0 {
 		return nil
 	}

--- a/pkg/syncer/from_host_syncer.go
+++ b/pkg/syncer/from_host_syncer.go
@@ -117,7 +117,7 @@ func (s *genericFromHostSyncer) SyncToVirtual(ctx *synccontext.SyncContext, even
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	err = pro.ApplyPatchesVirtualObject(ctx, vObj, event.Host, s.GetProPatches(ctx.Config.Config), false)
+	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, s.GetProPatches(ctx.Config.Config), false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

