### PR TITLE
Disable CoreDNS reload plugin in embedded mode

### DIFF
--- a/pkg/coredns/template.go
+++ b/pkg/coredns/template.go
@@ -52,7 +52,9 @@ const corednsCorefile = `{{- if .Values.controlPlane.coredns.overwriteConfig }}
     {{- end }}
     cache 30
     loop
+    {{- if not .Values.controlPlane.coredns.embedded }}
     reload
+    {{- end }}
     loadbalance
 }
 

--- a/pkg/coredns/template_test.go
+++ b/pkg/coredns/template_test.go
@@ -1009,7 +1009,6 @@ func TestProcessCorefile(t *testing.T) {
     forward . /etc/resolv.conf
     cache 30
     loop
-    reload
     loadbalance
 }
 


### PR DESCRIPTION
It breaks DNS and isn't necessary since the config doesn't change

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
ENG-9524

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster logs errors from the reload plugin in embedded mode.

**What else do we need to know?** 
