### PR TITLE
bugfix: do not rely on the kubeconfig for getting SharedSecrets

### DIFF
--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -59,6 +59,8 @@ const LoftRouterDomainSecret = "loft-router-domain"
 
 const DefaultPlatformNamespace = "vcluster-platform"
 
+const LegacyPlatformNamespace = "loft"
+
 const DefaultPlatformServiceName = "loft"
 
 const defaultTimeout = 10 * time.Minute


### PR DESCRIPTION
; instead look in the --namespace, vcluster-platform and loft namespaces

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9635


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster was relying on the kubeconfig for getting SharedSecrets to determine platform namespace


**What else do we need to know?** 
