### PR TITLE
Don't check if PVC should be restored when restore flag is not set

### DIFF
--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -377,7 +377,7 @@ func (o *RestoreClient) isPVCThatShouldBeRestoredInHost(key string) bool {
 	pvcName := strings.TrimPrefix(key, pvcPrefix)
 	status, ok := o.snapshotRequest.Status.VolumeSnapshots.Snapshots[pvcName]
 	if !ok {
-		klog.Infof("Snapshot not found for PVC %s", strings.TrimPrefix(key, pvcPrefix))
+		klog.V(1).Infof("Snapshot not found for PVC %s", strings.TrimPrefix(key, pvcPrefix))
 		return false
 	}
 	// skip restoring PVC if it has a snapshot, restore controller will restore it


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9645


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster restore` command was checking if the PVC should be restored on the host, even when the `--restore-volumes` flag was not set.

**What else do we need to know?** 
