### PR TITLE
Fix race condition in restore volumes e2e test

### DIFF
--- a/test/e2e/snapshot/snapshot.go
+++ b/test/e2e/snapshot/snapshot.go
@@ -578,7 +578,7 @@ var _ = Describe("snapshot and restore", Ordered, func() {
 			// Therefore, delete it again, so it gets restored properly.
 			deletePVC(ctx, f, controllerTestNamespaceName, pvcToRestoreName)
 			// wait a bit after deleting the PVC, so the syncer fully handles the deletion
-			time.Sleep(15 * time.Second)
+			time.Sleep(time.Minute)
 
 			// now restore the vCluster
 			restoreVCluster(ctx, f, snapshotPath, true, true)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What else do we need to know?** 
There is a race condition bug that sometimes happens, which makes the test to fail. The restore happens too quickly after the PVC has been deleted, so the PVC syncer probably doesn't have to fully handle the PVC deletion.