### PR TITLE
Fix checking if PVC is restored on the host

### DIFF
--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -375,7 +375,11 @@ func (o *RestoreClient) isPVCThatShouldBeRestoredInHost(key string) bool {
 	}
 
 	pvcName := strings.TrimPrefix(key, pvcPrefix)
-	status, ok := o.snapshotRequest.Status.VolumeSnapshots.Snapshots[pvcName]
+	translatedPVCName := getTranslatedPVCName(pvcName)
+	if translatedPVCName == "" {
+		return true
+	}
+	status, ok := o.snapshotRequest.Status.VolumeSnapshots.Snapshots[translatedPVCName]
 	if !ok {
 		klog.V(1).Infof("Snapshot not found for PVC %s", strings.TrimPrefix(key, pvcPrefix))
 		return false


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster restore was not removing the incorrect volume name for a PVC that is being restored from a snapshot.


