### PR TITLE
set vClusterName globally for the translate package for use in the restore pod

### DIFF
--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -131,6 +131,9 @@ func (o *RestoreClient) Run(ctx context.Context) (retErr error) {
 	}
 	o.vConfig = vConfig
 
+	// set global vCluster name
+	translate.VClusterName = vConfig.Name
+
 	// create store
 	objectStore, err := CreateStore(ctx, &o.Snapshot)
 	if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9341


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

With this PR, we are setting the vClusterName variable for the translate package during the restore pod initialization in a similar fashion as it happens in the [regular vCluster pod](https://github.com/loft-sh/vcluster/blob/e7926d2ef67b75759196f668f9d819ae5b6731bd/pkg/setup/config/config.go#L93). This variable is utilised later when fetching the translated names.
