### PR TITLE
restore vCluster config from snapshot

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -1,15 +1,10 @@
 package cli
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -924,48 +919,13 @@ func (cmd *createHelm) getVClusterConfigFromSnapshot(ctx context.Context) (strin
 		return "", fmt.Errorf("parse snapshot: %w", err)
 	}
 
-	objectStore, err := snapshot.CreateStore(ctx, snapshotOptions)
-	if err != nil {
-		return "", fmt.Errorf("create snapshot store: %w", err)
-	}
-
-	reader, err := objectStore.GetObject(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get snapshot object: %w", err)
-	}
-
-	// read the first tar entry
-	gzipReader, err := gzip.NewReader(reader)
-	if err != nil {
-		return "", fmt.Errorf("create gzip reader: %w", err)
-	}
-	defer gzipReader.Close()
-
-	// create a new tar reader
-	tarReader := tar.NewReader(gzipReader)
-
-	// read the vCluster config
-	header, err := tarReader.Next()
-	if err != nil {
+	release, err := snapshot.GetVClusterReleaseFromSnapshot(ctx, snapshotOptions)
+	if err != nil && !errors.Is(err, snapshot.ErrVClusterReleaseNotFound) {
 		return "", err
 	}
 
-	buf := &bytes.Buffer{}
-	_, err = io.Copy(buf, tarReader)
-	if err != nil {
-		return "", err
-	}
-
-	// no vCluster config in the snapshot
-	if header.Name != snapshot.SnapshotReleaseKey {
+	if release == nil {
 		return "", nil
-	}
-
-	// unmarshal the release
-	release := &snapshot.HelmRelease{}
-	err = json.Unmarshal(buf.Bytes(), release)
-	if err != nil {
-		return "", fmt.Errorf("unmarshal vCluster release: %w", err)
 	}
 
 	// set chart version


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) <br>/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) <br>resolves [ENGCP-487](https://linear.app/loft/issue/ENGCP-487/bug-vcluster-restore-fails-when-vcluster-is-in-crashloopbackoff)

**Please provide a short message that should be published in the vcluster release notes**<br>vCluster will now automatically restore the cluster.yaml configuration while restoring from a snapshot

**What else do we need to know?**

---

> \[!NOTE\]<br>Load Helm release values from snapshot, merge with defaults, use for restore/config parsing, and write to `vc-config-*` Secret; CLI consumes snapshot values/versions during `--restore`.
>
> * **Restore pipeline**:
>   * Add `snapshot.GetVClusterReleaseFromSnapshot` to extract `HelmRelease` from snapshot.
>   * Merge release values with defaults (`mergeWithDefaults`) and parse config via `config.ParseConfigBytes`.
>   * Initialize clients (`InitClients`) and use merged config for restore validation.
>   * Persist merged values to `Secret` `vc-config-<name>` (`config.yaml`).
>   * Refactor `createRestoreRequest` to use internal `o.vConfig`.
> * **CLI (**`pkg/cli/create_helm.go`):
>   * Use `snapshot.GetVClusterReleaseFromSnapshot` to fetch config on `--restore`.
>   * Auto-set `cmd.ChartVersion` from snapshot release and temp-write values for install/upgrade.
>
> Written by [Cursor Bugbot](<https://cursor.com/dashboard?tab=bugbot>) for commit 4d888da6cf4fd10778383162001d147b8f1f23e7. This will update automatically on new commits. Configure [here](<https://cursor.com/dashboard?tab=bugbot>).