### PR TITLE
feat: allow PodDisruptionBudget configuration for vcluster control plane

### DIFF
--- a/chart/templates/pod-disruption-budget.yaml
+++ b/chart/templates/pod-disruption-budget.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.controlPlane.advanced.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+spec:
+{{- with .Values.controlPlane.advanced.podDisruptionBudget }}
+  {{- if .minAvailable }}
+  minAvailable: {{ .minAvailable }}
+  {{- else if .maxUnavailable }}
+  maxUnavailable: {{ .maxUnavailable }}
+  {{- end }}
+  {{- if .unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .unhealthyPodEvictionPolicy }}
+  {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: vcluster
+      release: {{ .Release.Name }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -461,6 +461,10 @@
         "kubeVip": {
           "$ref": "#/$defs/KubeVip",
           "description": "KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2."
+        },
+        "podDisruptionBudget": {
+          "$ref": "#/$defs/PodDisruptionBudget",
+          "description": "PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once\nto ensure availability during maintenance or scaling operations."
         }
       },
       "additionalProperties": false,
@@ -3361,6 +3365,26 @@
       "additionalProperties": false,
       "type": "object",
       "description": "PodDNSConfigOption defines DNS resolver options of a pod."
+    },
+    "PodDisruptionBudget": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the pod disruption budget should be enabled."
+        },
+        "minAvailable": {
+          "description": "MinAvailable describes the minimal number or percentage of available pods."
+        },
+        "maxUnavailable": {
+          "description": "MaxUnavailable describes the minimal number or percentage of unavailable pods."
+        },
+        "unhealthyPodEvictionPolicy": {
+          "type": "string",
+          "description": "UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.\nCurrently supported values are:\n* IfHealthyBudget - pods that are in the Running phase but not yet healthy are considered disrupted\n\tand may be evicted even if the PodDisruptionBudget criteria are not met.\n* AlwaysAllow - pods that are in the Running phase but not yet healthy are considered disrupted\n\tand can be evicted regardless of whether the criteria in a PDB is met."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "Policies": {
       "properties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -800,6 +800,11 @@ controlPlane:
     # GlobalMetadata is metadata that will be added to all resources deployed by Helm.
     globalMetadata:
       annotations: {}
+    # PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
+    # to ensure availability during maintenance or scaling operations.
+    podDisruptionBudget:
+      # Enabled defines if the pod disruption budget should be enabled.
+      enabled: false
 
 # PrivateNodes holds configuration for vCluster private nodes mode.
 privateNodes:

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/invopop/jsonschema"
 	yamlv3 "gopkg.in/yaml.v3"
+	policyv1 "k8s.io/api/policy/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2373,6 +2374,10 @@ type ControlPlaneAdvanced struct {
 
 	// KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
 	KubeVip KubeVip `json:"kubeVip,omitempty"`
+
+	// PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
+	// to ensure availability during maintenance or scaling operations.
+	PodDisruptionBudget PodDisruptionBudget `json:"podDisruptionBudget,omitempty"`
 }
 
 type Registry struct {
@@ -2622,6 +2627,22 @@ type ControlPlaneSecurity struct {
 type ControlPlaneGlobalMetadata struct {
 	// Annotations are extra annotations for this resource.
 	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type PodDisruptionBudget struct {
+	// Enabled defines if the pod disruption budget should be enabled.
+	Enabled bool `json:"enabled,omitempty"`
+	// MinAvailable describes the minimal number or percentage of available pods.
+	MinAvailable interface{} `json:"minAvailable,omitempty"`
+	// MaxUnavailable describes the minimal number or percentage of unavailable pods.
+	MaxUnavailable interface{} `json:"maxUnavailable,omitempty"`
+	// UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.
+	// Currently supported values are:
+	// * IfHealthyBudget - pods that are in the Running phase but not yet healthy are considered disrupted
+	//	and may be evicted even if the PodDisruptionBudget criteria are not met.
+	// * AlwaysAllow - pods that are in the Running phase but not yet healthy are considered disrupted
+	//	and can be evicted regardless of whether the criteria in a PDB is met.
+	UnhealthyPodEvictionPolicy *policyv1.UnhealthyPodEvictionPolicyType `json:"unhealthyPodEvictionPolicy,omitempty"`
 }
 
 type LabelsAndAnnotations struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -439,6 +439,9 @@ controlPlane:
     globalMetadata:
       annotations: {}
 
+    podDisruptionBudget:
+      enabled: false
+
 privateNodes:
   enabled: false
   kubelet:

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -181,6 +181,11 @@ func ValidateConfigAndSetDefaults(vConfig *VirtualClusterConfig) error {
 		vConfig.ControlPlane.Advanced.WorkloadServiceAccount.Name = "vc-workload-" + vConfig.Name
 	}
 
+	err = validateAdvancedControlPlaneConfig(vConfig.ControlPlane.Advanced)
+	if err != nil {
+		return err
+	}
+
 	// check config for exporting kubeconfig Secrets
 	err = validateExportKubeConfig(vConfig.ExportKubeConfig)
 	if err != nil {
@@ -871,6 +876,16 @@ func validateRequirements(requirements []config.Requirement) error {
 				return fmt.Errorf("value or values is required for operator %s", requirement.Operator)
 			}
 		}
+	}
+
+	return nil
+}
+
+func validateAdvancedControlPlaneConfig(controlPlaneAdvanced config.ControlPlaneAdvanced) error {
+	if controlPlaneAdvanced.PodDisruptionBudget.Enabled &&
+		controlPlaneAdvanced.PodDisruptionBudget.MaxUnavailable != nil &&
+		controlPlaneAdvanced.PodDisruptionBudget.MinAvailable != nil {
+		return fmt.Errorf("minAvailable and maxUnavailable cannot be used together in a podDisruptionBudget")
 	}
 
 	return nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9790

**Please provide a short message that should be published in the vcluster release notes**
Allow to configure PodDisruptionBudget for vcluster

**What else do we need to know?** 
With configuration:
```
controlPlane:
  advanced:
    podDisruptionBudget:
      minAvailable: 1
      unhealthyPodEvictionPolicy: IfHealthyBudget
```

The following object will be created:

```yaml
nmm@pc:~/Workspace/vcluster$ k get pdb -nvcluster vcluster 
NAME       MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
vcluster   1               N/A               0                     2m50s
nmm@pc:~/Workspace/vcluster$ k get pdb -nvcluster vcluster  -oyaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  annotations:
    meta.helm.sh/release-name: vcluster
    meta.helm.sh/release-namespace: vcluster
  creationTimestamp: "2025-11-04T12:16:26Z"
  generation: 2
  labels:
    app.kubernetes.io/managed-by: Helm
  name: vcluster
  namespace: vcluster
  resourceVersion: "12425"
  uid: 578c9c9c-49a6-47d8-baa1-da895ca480f5
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app: vcluster
      release: vcluster
  unhealthyPodEvictionPolicy: IfHealthyBudget
status:
  conditions:
  - lastTransitionTime: "2025-11-04T12:16:26Z"
    message: ""
    observedGeneration: 2
    reason: InsufficientPods
    status: "False"
    type: DisruptionAllowed
  currentHealthy: 1
  desiredHealthy: 1
  disruptionsAllowed: 0
  expectedPods: 2
  observedGeneration: 2

```
