### PR TITLE
fix: claude-review

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -13,14 +13,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
 jobs:
   claude-review-paths:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'loft-sh'
-    permissions:
-      contents: read
-      pull-requests: read
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -30,6 +31,7 @@ jobs:
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Claude review GitHub Actions workflow to set top-level permissions (including PR write) and pass GITHUB_TOKEN to the action.
> 
> - **CI/GitHub Actions**:
>   - **Workflow permissions**: Add top-level `permissions` (`contents: read`, `pull-requests: write`, `id-token: write`) and remove job-level permissions.
>   - **Claude Code Review step**: Provide `github_token: ${{ secrets.GITHUB_TOKEN }}` to `anthropics/claude-code-action@v1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b826202ac653df66ae0e795f7bd19ebbd76703a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->