### PR TITLE
feat(ci): cleanup backport branches

### DIFF
--- a/.github/workflows/cleanup-backport-branches.yaml
+++ b/.github/workflows/cleanup-backport-branches.yaml
@@ -1,0 +1,31 @@
+name: Cleanup backport branches
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run mode'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  cleanup:
+    name: Delete stale backport branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v2.4.0
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          dry-run: ${{ github.event.inputs.dry_run || 'false' }}
+          restrict-branches-regex: '^backport/'
+          days-before-branch-stale: 7
+          days-before-branch-delete: 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a scheduled GitHub Actions workflow to prune stale `backport/` branches with an optional dry-run.
> 
> - **CI/CD**:
>   - **New workflow** `/.github/workflows/cleanup-backport-branches.yaml`:
>     - Runs weekly (Sunday 02:00 UTC) and via `workflow_dispatch` with `dry_run` input.
>     - Uses `fpicalausa/remove-stale-branches@v2.4.0` with `secrets.GH_ACCESS_TOKEN`.
>     - Targets branches matching `^backport/`, marks stale after 7 days, deletes immediately (`days-before-branch-delete: 0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4f660cb0b9d2496648c8df47852c5092c6b4dfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



References OPS-373