### PR TITLE
fix cert rotation for standalone

### DIFF
--- a/cmd/vcluster/cmd/certs/rotate.go
+++ b/cmd/vcluster/cmd/certs/rotate.go
@@ -74,7 +74,10 @@ func (cmd *rotateCmd) Run(ctx context.Context, withCA bool) error {
 		}
 		vConfig = cfg
 		if os.Getenv("NAMESPACE") == "" {
-			_ = os.Setenv("NAMESPACE", "default")
+			err := os.Setenv("NAMESPACE", "default")
+			if err != nil {
+				cmd.log.Debugf("setting namespace to default failed: %s", err.Error())
+			}
 		}
 	} else {
 		cfg, err := config.ParseConfig(constants.DefaultVClusterConfigLocation, os.Getenv("VCLUSTER_NAME"), nil)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8077


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster cert rotate was failing for vCluster Standalone


**What else do we need to know?** 
Command was failing because we try to read namespace from the serviceaccount namespace file which doesn't exist for standalone. And the namespace isn't required for standalone certs, so we can set it to `default`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `NAMESPACE=default` during standalone cert rotation to prevent failures when namespace is absent.
> 
> - **Cert Rotation (standalone)**:
>   - In `cmd/vcluster/cmd/certs/rotate.go`, after parsing standalone config, sets env var `NAMESPACE` to `default` if unset, with debug log on failure.
>   - No changes to non-standalone path; continues using `config.ParseConfig` and existing rotation flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4308a682f3d7298afc7be533add875548e0345e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->