### PR TITLE
ENG-9490 Support canonical name lookup of default/kubernetes svc

### DIFF
--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -204,7 +204,7 @@ func TestSyncTable(t *testing.T) {
 					EnableServiceLinks:           ptr.To(false),
 					HostAliases: []corev1.HostAlias{{
 						IP:        pVclusterService.Spec.ClusterIP,
-						Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+						Hostnames: []string{"kubernetes.default.svc.cluster.local", "kubernetes", "kubernetes.default", "kubernetes.default.svc"},
 					}},
 					ServiceAccountName: "vc-workload-vcluster",
 					Hostname:           vObjectMeta.Name,
@@ -218,7 +218,7 @@ func TestSyncTable(t *testing.T) {
 					EnableServiceLinks:           ptr.To(false),
 					HostAliases: []corev1.HostAlias{{
 						IP:        pVclusterService.Spec.ClusterIP,
-						Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+						Hostnames: []string{"kubernetes.default.svc.cluster.local", "kubernetes", "kubernetes.default", "kubernetes.default.svc"},
 					}},
 					ServiceAccountName: "vc-workload-vcluster",
 					Hostname:           vObjectMeta.Name,
@@ -392,7 +392,7 @@ func TestSync(t *testing.T) {
 			EnableServiceLinks:           ptr.To(false),
 			HostAliases: []corev1.HostAlias{{
 				IP:        pVclusterService.Spec.ClusterIP,
-				Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+				Hostnames: []string{"kubernetes.default.svc.cluster.local", "kubernetes", "kubernetes.default", "kubernetes.default.svc"},
 			}},
 			ServiceAccountName: "vc-workload-vcluster",
 			Hostname:           vObjectMeta.Name,
@@ -496,7 +496,7 @@ func TestSync(t *testing.T) {
 			EnableServiceLinks:           ptr.To(false),
 			HostAliases: []corev1.HostAlias{{
 				IP:        pVclusterService.Spec.ClusterIP,
-				Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+				Hostnames: []string{"kubernetes.default.svc.cluster.local", "kubernetes", "kubernetes.default", "kubernetes.default.svc"},
 			}},
 			Hostname:           vHostPathPod.Name,
 			ServiceAccountName: "vc-workload-vcluster",
@@ -613,7 +613,7 @@ func TestSync(t *testing.T) {
 			EnableServiceLinks:           ptr.To(false),
 			HostAliases: []corev1.HostAlias{{
 				IP:        pVclusterService.Spec.ClusterIP,
-				Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+				Hostnames: []string{"kubernetes.default.svc.cluster.local", "kubernetes", "kubernetes.default", "kubernetes.default.svc"},
 			}},
 			Hostname:           vPodWithPriorityClass.Name,
 			ServiceAccountName: "vc-workload-vcluster",

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -275,9 +275,14 @@ func (t *translator) Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, s
 	serviceEnv := ServicesToEnvironmentVariables(vPod.Spec.EnableServiceLinks, services, kubeIP)
 
 	// add the required kubernetes hosts entry
+	kubernetesSvcAliases := []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"}
+	if t.clusterDomain != "" {
+		// canonical name first to mimic lookup with search domains
+		kubernetesSvcAliases = append([]string{"kubernetes.default.svc." + t.clusterDomain}, kubernetesSvcAliases...)
+	}
 	pPod.Spec.HostAliases = append(pPod.Spec.HostAliases, corev1.HostAlias{
 		IP:        kubeIP,
-		Hostnames: []string{"kubernetes", "kubernetes.default", "kubernetes.default.svc"},
+		Hostnames: kubernetesSvcAliases,
 	})
 
 	// translate the dns config


### PR DESCRIPTION
Add fqdn for svc as first entry in Pod host aliases.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9490

**Please provide a short message that should be published in the vcluster release notes**
Support look up of canonical name of default/kubernetes service.

**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepends `kubernetes.default.svc.<clusterDomain>` to pods’ `HostAliases` (when configured) and updates tests accordingly.
> 
> - **Pods translation**:
>   - Add canonical FQDN `kubernetes.default.svc.<clusterDomain>` as the first alias in `Spec.HostAliases` for the Kubernetes service when `clusterDomain` is set; retain existing aliases (`kubernetes`, `kubernetes.default`, `kubernetes.default.svc`).
> - **Tests**:
>   - Update `pkg/controllers/resources/pods/syncer_test.go` expectations to include the FQDN in `HostAliases`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c79fc0e43e8642d5be6350bf312824e7e2f96d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->