### PR TITLE
chore: fix claude-review pipeline

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -14,13 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   id-token: write
+  actions: read # Required for Claude to read CI results on PRs
 
 jobs:
   claude-review-paths:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.repository_owner == 'loft-sh'
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Claude Review GitHub Actions workflow to grant write access, add actions:read, and set a 30-minute job timeout.
> 
> - **CI/GitHub Actions**:
>   - **Workflow `/.github/workflows/claude-review.yaml`**:
>     - Change `permissions.contents` from `read` to `write`.
>     - Add `permissions.actions: read`.
>     - Add `timeout-minutes: 30` to job `claude-review-paths`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0c7a0662392e3780b28a2abea297b63263d831a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->