### PR TITLE
fix: flaky test for snapshot PV restore

### DIFF
--- a/test/e2e/snapshot/snapshot.go
+++ b/test/e2e/snapshot/snapshot.go
@@ -577,9 +577,6 @@ var _ = Describe("snapshot and restore", Ordered, func() {
 			// PVC has been restored in previous test specs, but without data, so it's stuck in Pending.
 			// Therefore, delete it again, so it gets restored properly.
 			deletePVC(ctx, f, controllerTestNamespaceName, pvcToRestoreName)
-			// wait a bit after deleting the PVC, so the syncer fully handles the deletion
-			time.Sleep(time.Minute)
-
 			// now restore the vCluster
 			restoreVCluster(ctx, f, snapshotPath, true, true)
 		})

--- a/test/e2e/snapshot/volumes.go
+++ b/test/e2e/snapshot/volumes.go
@@ -139,7 +139,7 @@ func deletePVC(ctx context.Context, f *framework.Framework, pvcNamespace, pvcNam
 	Expect(vClusterConfig).NotTo(BeNil())
 
 	if !vClusterConfig.PrivateNodes.Enabled {
-		hostPVCName := translate.Default.HostName(nil, pvcNamespace, pvcName)
+		hostPVCName := translate.Default.HostName(nil, pvcName, pvcNamespace)
 		Eventually(func() error {
 			hostPVC, err := f.HostClient.CoreV1().PersistentVolumeClaims(hostPVCName.Namespace).Get(ctx, hostPVCName.Name, metav1.GetOptions{})
 			if kerrors.IsNotFound(err) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-9951

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue in the flaky e2e test for vcluster PV snapshot 


**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes snapshot PV restore e2e tests by fixing host PVC name translation and removing a redundant post-delete sleep before restore.
> 
> - **Tests (e2e snapshot)**:
>   - Fix host PVC lookup by correcting `translate.Default.HostName(nil, pvcName, pvcNamespace)` argument order in `test/e2e/snapshot/volumes.go`.
>   - Remove 1-minute `time.Sleep` after PVC deletion in `test/e2e/snapshot/snapshot.go` before restore to reduce flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f0f55a1923c4649ef333c35890f33ea1c844073. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->