### PR TITLE
add a fallback command for checking helm binary version (v4.x)

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -139,6 +139,8 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 
 	output, err := exec.Command(helmBinaryPath, "version", "--client", "--template", "{{.Version}}").Output()
 	if err != nil {
+		log.Debugf("error getting helm version: '%v'. Attempting again with commandline flags compatible with Helm v4.x..", err)
+
 		// Helm v4.x does not support the --client flag
 		output, err = exec.Command(helmBinaryPath, "version", "--template", "{{.Version}}").Output()
 		if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-10292


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster CLI would not work with Helm v4


**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add fallback Helm version check without --client to ensure compatibility with Helm v4.
> 
> - **CLI**:
>   - Update Helm version detection in `pkg/cli/create_helm.go` to retry without `--client` when the initial `helm version --client` call fails, adding debug logging for the fallback (supports Helm v4).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f32f065a88f68a91a38d4fbf2498675612a5711. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->