### PR TITLE
test: Enable network policies by default in e2e tests

### DIFF
--- a/test/commonValues.yaml
+++ b/test/commonValues.yaml
@@ -47,3 +47,7 @@ networking:
 experimental:
   syncSettings:
     setOwner: true
+
+policies:
+  networkPolicy:
+    enabled: true

--- a/test/values_ha.yaml
+++ b/test/values_ha.yaml
@@ -20,3 +20,10 @@ controlPlane:
   coredns:
     deployment:
       replicas: 3
+
+# Disable network policies due to known issue related to kindnet, network policies and multiple coredns replicas.
+# - https://linear.app/loft/document/design-doc-custom-network-policy-inboundingress-rules-during-vcluster-2ea800d0072d#slow-dns-queries-409ada74
+# - https://bugzilla.netfilter.org/show_bug.cgi?id=1766
+policies:
+  networkPolicy:
+    enabled: false


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG-9904


**Please provide a short message that should be published in the vcluster release notes**
Default ingress/egress network policies are enabled in the vcluster e2e tests.

**What else do we need to know?** 
Network policies are disabled in the e2e HA tests due to slow DNS queries known issue related to kindnet CNI, network policies and multiple coredns instances. https://bugzilla.netfilter.org/show_bug.cgi?id=1766 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable network policies by default in e2e tests, but disable them for the HA profile due to known DNS/kindnet issues.
> 
> - **Test configuration**:
>   - Enable `policies.networkPolicy.enabled: true` in `test/commonValues.yaml`.
>   - In HA profile (`test/values_ha.yaml`), set `policies.networkPolicy.enabled: false` with notes about known DNS/kindnet issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56b032ec5a9e941f1484eeee52861c6117e55de0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->