### PR TITLE
refactor: rename and export patchSecret func

### DIFF
--- a/pkg/certs/rotate.go
+++ b/pkg/certs/rotate.go
@@ -238,7 +238,7 @@ func SyncSecret(ctx context.Context, secretNamespace, secretName, pkiPath string
 		d, err := os.ReadFile(filepath.Join(pkiPath, k))
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("reading file %s: %w", k, err)
+				return fmt.Errorf("reading file %s: %w", filepath.Join(pkiPath, k), err)
 			}
 			// If the cert/key referenced in certMap does not exist in the PKI directory, don't add it to the secret.
 			continue


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Part of ENG-10034


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
In order for vcluster-pro to have a way to sync the updated certs to the certs secret.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces patchSecret with exported SyncSecret that syncs the certs secret from the PKI directory, skipping non-existent files and improving error handling.
> 
> - **certs**:
>   - **Rotation flow**: `Rotate` now calls `SyncSecret` to update `cert` secret after regenerating PKI assets.
>   - **New exported `SyncSecret`**:
>     - Syncs secret data from PKI directory (PKI is source of truth); updates/creates entries and skips missing files instead of erroring.
>     - Adds detailed file path in read errors; uses merge patch to update secret.
>   - Imports `errors` and updates comments/docs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 804d9b70dad611cb6003fece14d603b6a47cd1ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->