### PR TITLE
Deprecate ingress nginx

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1126,7 +1126,7 @@
         },
         "ingressNginx": {
           "$ref": "#/$defs/IngressNginx",
-          "description": "IngressNginx holds dedicated ingress-nginx configuration."
+          "description": "IngressNginx holds dedicated ingress-nginx configuration.\nDeprecated: We do not deploy ingress nginx and the project is being deprecated."
         },
         "metricsServer": {
           "$ref": "#/$defs/DeployMetricsServer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -548,9 +548,9 @@ controlPlane:
     pathType: ImplementationSpecific
     labels: {}
     annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/backend-protocol: HTTPS # ingress-nginx has been deprecated
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true" # ingress-nginx has been deprecated
+      nginx.ingress.kubernetes.io/ssl-redirect: "true" # ingress-nginx has been deprecated
     # Spec allows you to configure extra ingress options.
     spec:
       tls: []
@@ -890,6 +890,7 @@ deploy:
       l2Advertisement: true
   
   # IngressNginx holds dedicated ingress-nginx configuration.
+  # Deprecated: We do not deploy ingress nginx and the project is being deprecated.
   ingressNginx:
     # Enabled defines if ingress-nginx should be enabled.
     enabled: false

--- a/config/config.go
+++ b/config/config.go
@@ -296,6 +296,7 @@ type Deploy struct {
 	LocalPathProvisioner LocalPathProvisioner `json:"localPathProvisioner,omitempty"`
 
 	// IngressNginx holds dedicated ingress-nginx configuration.
+	// Deprecated: We do not deploy ingress nginx and the project is being deprecated.
 	IngressNginx IngressNginx `json:"ingressNginx,omitempty"`
 
 	// MetricsServer holds dedicated metrics server configuration.

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -283,9 +283,9 @@ controlPlane:
     pathType: ImplementationSpecific
     labels: {}
     annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/backend-protocol: HTTPS # ingress-nginx has been deprecated
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true" # ingress-nginx has been deprecated
+      nginx.ingress.kubernetes.io/ssl-redirect: "true" # ingress-nginx has been deprecated
     spec:
       tls: []
 

--- a/pkg/platform/clihelper/clihelper.go
+++ b/pkg/platform/clihelper/clihelper.go
@@ -624,8 +624,8 @@ func EnsureIngressController(ctx context.Context, kubeClient kubernetes.Interfac
 	)
 
 	answer, err := log.Question(&survey.QuestionOptions{
-		Question:     "Ingress controller required. Should the nginx-ingress controller be installed?",
-		DefaultValue: YesOption,
+		Question:     "[DEPRECATED]: Ingress controller required. Should the nginx-ingress controller be installed?",
+		DefaultValue: NoOption,
 		Options: []string{
 			YesOption,
 			NoOption,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENG10314


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks ingress-nginx as deprecated across config/schema and switches the CLI install prompt to a deprecated message with a No default.
> 
> - **Config/Schema**:
>   - Mark `deploy.ingressNginx` as deprecated in `chart/values.schema.json` and `config/config.go`.
>   - Add deprecation comments around `deploy.ingressNginx` and ingress annotations in `chart/values.yaml` and `config/values.yaml`.
> - **CLI**:
>   - Update ingress controller install question to `[DEPRECATED]` and change default from `Yes` to `No` in `pkg/platform/clihelper/clihelper.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5597a691e574fffe3bc66bf41414122063e7997f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->