### PR TITLE
bugfix(cli): use the helm version fallback command in the delete subcommand as well

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -137,7 +137,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 		return err
 	}
 
-	output, err := exec.Command(helmBinaryPath, "version", "--client", "--template", "{{.Version}}").Output()
+	output, err := exec.Command(helmBinaryPath, "version", "--template", "{{.Version}}").Output()
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/delete_helm.go
+++ b/pkg/cli/delete_helm.go
@@ -100,7 +100,7 @@ func DeleteHelm(ctx context.Context, platformClient platform.Client, options *De
 		return err
 	}
 
-	output, err := exec.Command(helmBinaryPath, "version", "--client", "--template", "{{.Version}}").Output()
+	output, err := exec.Command(helmBinaryPath, "version", "--template", "{{.Version}}").Output()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-10647


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vCluster CLI would fail with a fatal error when deleting a virtual cluster


**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `helm version --template "{{.Version}}"` (no `--client`) for version checks in both create and delete commands, removing fallback logic.
> 
> - **CLI**
>   - **Helm version detection**:
>     - Use `helm version --template "{{.Version}}"` in `pkg/cli/create_helm.go` and `pkg/cli/delete_helm.go`.
>     - Remove deprecated `--client` flag usage and associated fallback/retry logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db334e21c7ddc120693e5720a6d6b254b1472d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->