### PR TITLE
Update config schema

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1030,27 +1030,9 @@
           "type": "boolean",
           "description": "Enabled defines if this resource proxy should be enabled"
         },
-        "target": {
-          "$ref": "#/$defs/CustomResourceProxyTarget",
-          "description": "CustomResourceProxyTarget is the target configuration for the custom resource proxy"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "CustomResourceProxyTarget": {
-      "properties": {
-        "name": {
+        "targetVirtualCluster": {
           "type": "string",
-          "description": "Name is the name of the virtual cluster"
-        },
-        "project": {
-          "type": "string",
-          "description": "Project is the project of the virtual cluster"
-        },
-        "serviceAccountRef": {
-          "$ref": "#/$defs/NamespacedNameArgs",
-          "description": "ServiceAccountRef is the service account to use for the proxy in target cluster"
+          "description": "TargetVirtualCluster is the target virtual cluster for the custom resource proxy"
         }
       },
       "additionalProperties": false,
@@ -1799,7 +1781,7 @@
         },
         "proxy": {
           "$ref": "#/$defs/Proxy",
-          "description": "Proxy enables vCluster-to-vCluster proxying of resources via Tailscale"
+          "description": "Proxy enables vCluster-to-vCluster proxying of resources"
         }
       },
       "additionalProperties": false,
@@ -2965,20 +2947,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "NamespacedNameArgs": {
-      "properties": {
-        "namespace": {
-          "type": "string",
-          "description": "Namespace is the namespace of the resource"
-        },
-        "name": {
-          "type": "string",
-          "description": "Name is the name of the resource"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
     "NetworkPolicy": {
       "properties": {
         "enabled": {
@@ -3587,7 +3555,7 @@
             "$ref": "#/$defs/CustomResourceProxy"
           },
           "type": "object",
-          "description": "Resources is a map of resource keys (format: \"kind.apiGroup/version\") to proxy configuration"
+          "description": "CustomResources is a map of resource keys (format: \"kind.apiGroup/version\") to proxy configuration"
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1218,9 +1218,9 @@ plugins: {}
 
 # Experimental features for vCluster. Configuration here might change, so be careful with this.
 experimental:
-  # Proxy enables vCluster-to-vCluster proxying of resources via Tailscale
+  # Proxy enables vCluster-to-vCluster proxying of resources
   proxy:
-    # Resources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
+    # CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
     customResources: {}
   
   # SyncSettings are advanced settings for the syncer controller.
@@ -1244,6 +1244,11 @@ experimental:
       manifestsTemplate: ""
       # Helm are Helm charts that should get deployed into the virtual cluster
       helm: []
+  
+  # Proxy enables vCluster-to-vCluster proxying of resources
+  proxy:
+    # CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
+    customResources: {}
 
 # Configuration related to telemetry gathered about vCluster usage.
 telemetry:

--- a/config/config.go
+++ b/config/config.go
@@ -2400,7 +2400,7 @@ type ControlPlaneHeadlessService struct {
 }
 
 type Proxy struct {
-	// Resources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
+	// CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
 	CustomResources map[string]CustomResourceProxy `json:"customResources,omitempty"`
 }
 
@@ -2408,8 +2408,8 @@ type CustomResourceProxy struct {
 	// Enabled defines if this resource proxy should be enabled
 	Enabled bool `json:"enabled,omitempty"`
 
-	// CustomResourceProxyTarget is the target configuration for the custom resource proxy
-	Target CustomResourceProxyTarget `json:"target,omitempty"`
+	// TargetVirtualCluster is the target virtual cluster for the custom resource proxy
+	TargetVirtualCluster string `json:"targetVirtualCluster,omitempty"`
 }
 
 type NamespacedNameArgs struct {
@@ -2418,17 +2418,6 @@ type NamespacedNameArgs struct {
 
 	// Name is the name of the resource
 	Name string `json:"name,omitempty"`
-}
-
-type CustomResourceProxyTarget struct {
-	// Name is the name of the virtual cluster
-	Name string `json:"name,omitempty"`
-
-	// Project is the project of the virtual cluster
-	Project string `json:"project,omitempty"`
-
-	// ServiceAccountRef is the service account to use for the proxy in target cluster
-	ServiceAccountRef NamespacedNameArgs `json:"serviceAccountRef,omitempty"`
 }
 
 type ExternalEtcdPersistence struct {
@@ -3025,7 +3014,7 @@ type Experimental struct {
 	// DenyProxyRequests denies certain requests in the vCluster proxy.
 	DenyProxyRequests []DenyRule `json:"denyProxyRequests,omitempty" product:"pro"`
 
-	// Proxy enables vCluster-to-vCluster proxying of resources via Tailscale
+	// Proxy enables vCluster-to-vCluster proxying of resources
 	Proxy Proxy `json:"proxy,omitempty"`
 }
 

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -672,6 +672,9 @@ experimental:
       manifestsTemplate: ""
       helm: []
 
+  proxy:
+    customResources: {}
+
 telemetry:
   enabled: true
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the custom resource proxy target struct with a `targetVirtualCluster` string and updates schema/docs, plus adds defaults for `experimental.proxy.customResources` and tweaks proxy descriptions.
> 
> - **Config & Schema**:
>   - Simplify `CustomResourceProxy`: replace nested `target` with `targetVirtualCluster` (string); remove `CustomResourceProxyTarget` and drop `NamespacedNameArgs` from schema.
>   - Rename descriptions to use `customResources` (not "Resources"); remove "via Tailscale" from `experimental.proxy` descriptions.
> - **Values**:
>   - Update `chart/values.yaml` comments and add `experimental.proxy.customResources` sections; unify description wording.
>   - Add defaults for `experimental.proxy.customResources` in `config/values.yaml`.
> - **Go Types**:
>   - Mirror schema change in `config/config.go`: remove `CustomResourceProxyTarget` and `Target` field; add `TargetVirtualCluster string` on `CustomResourceProxy`; adjust comments accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49d76037dd5af1bc53b2f3c4094f12e5c2b5ca46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->