### PR TITLE
[v0.26] Update etcd version to make it safe to upgrade to 3.6

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -370,7 +370,7 @@ controlPlane:
             # Repository is the repository of the container image, e.g. my-repo/my-image
             repository: "etcd"
             # Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
-            tag: "3.5.21-0"
+            tag: "3.5.25-0"
           # ImagePullPolicy is the pull policy for the external etcd image
           imagePullPolicy: ""
           # ExtraArgs are appended to the etcd command.

--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -37,7 +37,7 @@ var K8SVersionMap = map[string]string{
 
 // K8SEtcdVersionMap holds the supported etcd
 var K8SEtcdVersionMap = map[string]string{
-	"1.32": "registry.k8s.io/etcd:3.5.21-0",
+	"1.32": "registry.k8s.io/etcd:3.5.25-0",
 	"1.31": "registry.k8s.io/etcd:3.5.15-0",
 	"1.30": "registry.k8s.io/etcd:3.5.13-0",
 }

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -178,7 +178,7 @@ controlPlane:
           image:
             registry: "registry.k8s.io"
             repository: "etcd"
-            tag: "3.5.21-0"
+            tag: "3.5.25-0"
           imagePullPolicy: ""
           extraArgs: []
           env: []


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of #ENG-10667

## This just bumps the etcd version 

See: https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates etcd image to 3.5.25-0 across Helm chart values and the 1.32 K8S etcd version map.
> 
> - **Storage / etcd**
>   - Update external etcd image tag to `3.5.25-0` in `chart/values.yaml` (`controlPlane.backingStore.etcd.deploy.statefulSet.image.tag`).
>   - Update default etcd image tag to `3.5.25-0` in `config/values.yaml` (`controlPlane.backingStore.etcd.deploy.statefulSet.image.tag`).
>   - Update `K8SEtcdVersionMap` for `"1.32"` to `"registry.k8s.io/etcd:3.5.25-0"` in `config/default_extra_values.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 418f96b197256553363fe97787539492b5f5359b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->