### PR TITLE
Update etcd version to make it safe to upgrade to 3.6

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -377,7 +377,7 @@ controlPlane:
             # Repository is the repository of the container image, e.g. my-repo/my-image
             repository: "etcd"
             # Tag is the tag of the container image, and is the default version.
-            tag: "3.5.21-0"
+            tag: "3.5.25-0"
           # ImagePullPolicy is the pull policy for the external etcd image
           imagePullPolicy: ""
           # ExtraArgs are appended to the etcd command.

--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -39,8 +39,8 @@ var K8SVersionMap = map[string]string{
 
 // K8SEtcdVersionMap holds the supported etcd
 var K8SEtcdVersionMap = map[string]string{
-	"1.33": "registry.k8s.io/etcd:3.5.21-0",
-	"1.32": "registry.k8s.io/etcd:3.5.21-0",
+	"1.33": "registry.k8s.io/etcd:3.5.25-0",
+	"1.32": "registry.k8s.io/etcd:3.5.25-0",
 	"1.31": "registry.k8s.io/etcd:3.5.15-0",
 	"1.30": "registry.k8s.io/etcd:3.5.13-0",
 }

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -181,7 +181,7 @@ controlPlane:
           image:
             registry: "registry.k8s.io"
             repository: "etcd"
-            tag: "3.5.21-0"
+            tag: "3.5.25-0"
           imagePullPolicy: ""
           extraArgs: []
           env: []

--- a/conformance/v1.33/vcluster-private-nodes/values.yaml
+++ b/conformance/v1.33/vcluster-private-nodes/values.yaml
@@ -5,7 +5,7 @@ controlPlane:
         enabled: true
         statefulSet:
           image:
-            tag: 3.5.21-0
+            tag: 3.5.25-0
   distro:
     k8s:
       apiServer:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of #ENG-10665

## This just bumps the etcd version 

See: https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps the etcd image to 3.5.25-0 across Helm values and updates the K8S etcd version map for 1.32/1.33.
> 
> - **Etcd version bump**:
>   - Update `etcd` image tag to `3.5.25-0` in `chart/values.yaml`, `config/values.yaml`, and `conformance/v1.33/vcluster-private-nodes/values.yaml`.
>   - Update `K8SEtcdVersionMap` for `1.32` and `1.33` to `registry.k8s.io/etcd:3.5.25-0` in `config/default_extra_values.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c61dae1ccadd005abdb759b028a0045c7a2ecff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->