### PR TITLE
[v0.29] Update supported etcd version to one safe for upgrading to 3.6

### DIFF
--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -39,8 +39,8 @@ var K8SVersionMap = map[string]string{
 
 // K8SEtcdVersionMap holds the supported etcd
 var K8SEtcdVersionMap = map[string]string{
-	"1.33": "registry.k8s.io/etcd:3.5.21-0",
-	"1.32": "registry.k8s.io/etcd:3.5.21-0",
+	"1.33": "registry.k8s.io/etcd:3.5.25-0",
+	"1.32": "registry.k8s.io/etcd:3.5.25-0",
 	"1.31": "registry.k8s.io/etcd:3.5.15-0",
 	"1.30": "registry.k8s.io/etcd:3.5.13-0",
 }

--- a/conformance/v1.33/vcluster-private-nodes/README.md
+++ b/conformance/v1.33/vcluster-private-nodes/README.md
@@ -32,7 +32,7 @@ controlPlane:
         enabled: true
         statefulSet:
           image:
-            tag: 3.5.21-0
+            tag: 3.5.25-0
   distro:
     k8s:
       apiServer:

--- a/conformance/v1.33/vcluster-private-nodes/values.yaml
+++ b/conformance/v1.33/vcluster-private-nodes/values.yaml
@@ -5,7 +5,7 @@ controlPlane:
         enabled: true
         statefulSet:
           image:
-            tag: 3.5.21-0
+            tag: 3.5.25-0
   distro:
     k8s:
       apiServer:

--- a/conformance/v1.33/vcluster/README.md
+++ b/conformance/v1.33/vcluster/README.md
@@ -26,7 +26,7 @@ controlPlane:
         enabled: true
         statefulSet:
           image:
-            tag: 3.5.21-0
+            tag: 3.5.25-0
   distro:
     k8s:
       apiServer:

--- a/conformance/v1.33/vcluster/values.yaml
+++ b/conformance/v1.33/vcluster/values.yaml
@@ -8,7 +8,7 @@ controlPlane:
         enabled: true
         statefulSet:
           image:
-            tag: 3.5.21-0
+            tag: 3.5.25-0
   distro:
     k8s:
       apiServer:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
part of #ENG-10664


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update etcd image from 3.5.21-0 to 3.5.25-0 for K8S 1.32/1.33 in defaults and v1.33 conformance READMEs/values.
> 
> - **Config**:
>   - Update `K8SEtcdVersionMap` for `"1.33"` and `"1.32"` to `registry.k8s.io/etcd:3.5.25-0` in `config/default_extra_values.go`.
> - **Conformance (v1.33)**:
>   - `vcluster/README.md`, `vcluster/values.yaml`, `vcluster-private-nodes/README.md`, `vcluster-private-nodes/values.yaml`:
>     - Set etcd `statefulSet.image.tag` to `3.5.25-0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db67ac415d0dcee7ad452640917bef7738bfb9de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->