### PR TITLE
fix: fall back to login flow if config access key is invalid

### DIFF
--- a/cmd/vclusterctl/cmd/platform/login.go
+++ b/cmd/vclusterctl/cmd/platform/login.go
@@ -119,14 +119,21 @@ func (cmd *LoginCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// log into platform
+	var err error
 	loginClient := platform.NewLoginClientFromConfig(cfg)
 	url = strings.TrimSuffix(url, "/")
-	var err error
 	if cmd.AccessKey != "" {
 		err = loginClient.LoginWithAccessKey(url, cmd.AccessKey, cmd.Insecure)
 	} else if cfg.Platform.AccessKey != "" && cfg.Platform.Host == url {
 		// check if user was already logged in i.e. config contains the access key for the same host
-		err = loginClient.LoginWithAccessKey(url, cfg.Platform.AccessKey, cmd.Insecure)
+		if loginErr := loginClient.LoginWithAccessKey(url, cfg.Platform.AccessKey, cmd.Insecure); loginErr != nil {
+			if errors.Is(loginErr, platform.ErrInvalidAccessKey) {
+				cmd.Log.Warnf("Invalid access key, attempting to login again...")
+				err = loginClient.Login(url, cmd.Insecure, cmd.Log)
+			} else {
+				err = loginErr
+			}
+		}
 	} else {
 		err = loginClient.Login(url, cmd.Insecure, cmd.Log)
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-9984 


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster commands would repeatedly prompt a user to login when their access key is expired without replacing it with an valid key.


**What else do we need to know?** 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Falls back to browser login when the stored access key is invalid and provides clearer TLS/self-signed certificate errors during login.
> 
> - **Platform Login Flow**:
>   - When config has an access key for the same host, validate it via `LoginWithAccessKey`; on `ErrInvalidAccessKey`, warn and fall back to interactive `Login`.
>   - `LoginWithAccessKey` now always validates by calling `mgmtLogin` even if key matches config.
> - **Error Handling & Messages**:
>   - Introduce `platform.ErrInvalidAccessKey`; propagate when `Selves().Create` fails to signal invalid keys.
>   - Improve TLS error detection using `tls.CertificateVerificationError` and `x509.UnknownAuthorityError`, with guidance to retry using `--insecure` and HTTPS enforcement messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 525ef0688b4cf606f8eca50b9797ecd0edc92bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->