### PR TITLE
feat: Add hostAliases to the controlPlane statefulSet pod configuration

### DIFF
--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -56,6 +56,10 @@ spec:
 {{ toYaml .Values.controlPlane.statefulSet.pods.labels | indent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.controlPlane.statefulSet.hostAliases }}
+      hostAliases:
+      {{- toYaml .Values.controlPlane.statefulSet.hostAliases | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.controlPlane.statefulSet.scheduling.priorityClassName }}
       priorityClassName: {{ .Values.controlPlane.statefulSet.scheduling.priorityClassName }}

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -728,6 +728,38 @@ tests:
           path: spec.template.spec.dnsConfig.options[0].value
           value: "2"
 
+  - it: sets host aliases
+    set:
+      controlPlane:
+        statefulSet:
+          hostAliases:
+            - ip: "127.0.0.1"
+              hostnames:
+                - "myadded.examplehostname.com"
+            - ip: "10.0.1.5"
+              hostnames:
+                - "custom-db.internal"
+                - "db-alias"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.hostAliases
+          count: 2
+      - equal:
+          path: spec.template.spec.hostAliases[0].ip
+          value: "127.0.0.1"
+      - equal:
+          path: spec.template.spec.hostAliases[0].hostnames[0]
+          value: "myadded.examplehostname.com"
+      - equal:
+          path: spec.template.spec.hostAliases[1].ip
+          value: "10.0.1.5"
+      - equal:
+          path: spec.template.spec.hostAliases[1].hostnames[0]
+          value: "custom-db.internal"
+      - equal:
+          path: spec.template.spec.hostAliases[1].hostnames[1]
+          value: "db-alias"
+
   - it: must use StatefulSet for embedded etcd
     set:
       controlPlane:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -862,6 +862,13 @@
           "items": true,
           "type": "array",
           "description": "SidecarContainers are additional sidecar containers for the statefulSet."
+        },
+        "hostAliases": {
+          "items": {
+            "$ref": "#/$defs/HostAlias"
+          },
+          "type": "array",
+          "description": "HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created."
         }
       },
       "additionalProperties": false,
@@ -2207,6 +2214,21 @@
           },
           "type": "object",
           "description": "ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.\nThere are several wildcards supported:\n1. To match all objects in host namespace and sync them to different namespace in vCluster:\nbyName:\n  \"foo/*\": \"foo-in-virtual/*\"\n2. To match specific object in the host namespace and sync it to the same namespace with the same name:\nbyName:\n  \"foo/my-object\": \"foo/my-object\"\n3. To match specific object in the host namespace and sync it to the same namespace with different name:\nbyName:\n  \"foo/my-object\": \"foo/my-virtual-object\"\n4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:\nbyName:\n  \"\": \"my-virtual-namespace/*\"\n5. To match specific objects in the vCluster host namespace and sync them to a different namespace in vCluster:\nbyName:\n  \"/my-object\": \"my-virtual-namespace/my-object\""
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HostAlias": {
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "hostnames": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -711,6 +711,8 @@ controlPlane:
     initContainers: []
     # SidecarContainers are additional sidecar containers for the statefulSet.
     sidecarContainers: []
+    # HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
+    hostAliases: []
   
   # ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
   serviceMonitor:

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/invopop/jsonschema"
 	yamlv3 "gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1859,6 +1860,9 @@ type ControlPlaneStatefulSet struct {
 
 	// SidecarContainers are additional sidecar containers for the statefulSet.
 	SidecarContainers []interface{} `json:"sidecarContainers,omitempty"`
+
+	// HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 }
 
 type Distro struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -382,6 +382,8 @@ controlPlane:
     initContainers: []
     sidecarContainers: []
 
+    hostAliases: []
+
   serviceMonitor:
     enabled: false
     labels: {}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature 

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-8076
resolves #2500

**Please provide a short message that should be published in the vcluster release notes**
- Add support for configuring `hostAliases` in the control plane StatefulSet


**What else do we need to know?** 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables configuring custom `/etc/hosts` entries for control plane pods.
> 
> - Template: renders `spec.hostAliases` when `controlPlane.statefulSet.hostAliases` is set in `statefulset.yaml`
> - Values/Schema: adds `controlPlane.statefulSet.hostAliases` (array of `HostAlias`) with default `[]` and defines `$defs.HostAlias`
> - Go config: adds `HostAliases []corev1.HostAlias` to `ControlPlaneStatefulSet`
> - Tests: adds unit test to validate `hostAliases` rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf51de4a6de515796329636aff1b81a5f70bc9d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->