### PR TITLE
chore(backport): create prs with conflict markers for visibility

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,8 @@
   "repoOwner": "loft-sh",
   "repoName": "vcluster",
   "targetBranchChoices": ["v0.19", "v0.20", "v0.21", "v0.22", "v0.23", "v0.24"],
-    "prDescription": "Backport from `{{sourceBranch}}` to `{{targetBranch}}`\n\nOriginal PR Nr.: #{{sourcePullRequest.number}}\n\n### Backported Commits:\n{{#each commits}}\n- {{shortSha this.sourceCommit.sha}} {{this.sourceCommit.message}}\n{{/each}}",
+  "commitConflicts": true,
+  "prDescription": "Backport from `{{sourceBranch}}` to `{{targetBranch}}`\n\nOriginal PR Nr.: #{{sourcePullRequest.number}}\n\n### Backported Commits:\n{{#each commits}}\n- {{shortSha this.sourceCommit.sha}} {{this.sourceCommit.message}}\n{{/each}}",
   "branchLabelMapping": {
     "^backport-to-(.+)$": "$1"
   }


### PR DESCRIPTION
References OPS-461

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables visibility into merge conflicts during backports.
> 
> - Adds `commitConflicts: true` to `.backportrc.json` so backport PRs include conflict markers
> - Retains existing `prDescription` template and branch mapping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52f44b564e42989722001247b307152ae0eab1c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->