### PR TITLE
feat: Ensure than spec.resources for a pod is supported on the host cluster before syncing it

### DIFF
--- a/pkg/util/testing/config.go
+++ b/pkg/util/testing/config.go
@@ -3,6 +3,9 @@ package testing
 import (
 	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/config"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
 
@@ -37,5 +40,13 @@ func NewFakeConfig() *config.VirtualClusterConfig {
 		Host:    "",
 		APIPath: "",
 	}
+
+	fakeClient := fake.NewClientset()
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major:      "1",
+		Minor:      "31",
+		GitVersion: "v1.31.0",
+	}
+	vConfig.HostClient = fakeClient
 	return vConfig
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

The MR ensure that the `spec.resources` for a pod is only synced on the host cluster when supported. It is [supported](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/#pod-level-resource-requests-and-limits) in beta starting version `1.34.0`
resolves ENG-8682


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds host-version awareness to pod translation to avoid using unsupported pod-level resources on older clusters.
> 
> - Fetches and stores host `ServerVersion` in `translator` and during `Translate` drops `pPod.Spec.Resources` when host < `v1.34.0`
> - Updates imports/structs to include `util/version` and `version.Info`
> - Adds `TestPodResourcesTranslation` covering versions above/below 1.34 and configures fake discovery client in test utilities
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2cfecf5d4449260bb82968a169fd6c2167e88ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->