### PR TITLE
ENG-10923 | Update jsonschema regex for targetVirtualCluster and make it required

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1032,6 +1032,8 @@
         },
         "targetVirtualCluster": {
           "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
           "description": "TargetVirtualCluster is the target virtual cluster for the custom resource proxy"
         },
         "accessResources": {
@@ -1040,7 +1042,10 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "required": [
+        "targetVirtualCluster"
+      ]
     },
     "Database": {
       "properties": {

--- a/config/config.go
+++ b/config/config.go
@@ -2417,7 +2417,7 @@ type CustomResourceProxy struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// TargetVirtualCluster is the target virtual cluster for the custom resource proxy
-	TargetVirtualCluster string `json:"targetVirtualCluster,omitempty"`
+	TargetVirtualCluster string `json:"targetVirtualCluster" jsonschema:"required,minLength=1,pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"`
 
 	// AccessResources defines which resources should be accessible in the proxy.
 	AccessResources AccessResourcesMode `json:"accessResources,omitempty"`


### PR DESCRIPTION
/kind bugfix

resolves ENG-10923

```bash
➜ helm upgrade --install my-vcluster  chart/  \                                 
      --values test-fail.yaml  \
      --namespace team-x --create-namespace 
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
vcluster:
- at '/experimental/proxy/customResources/workflows.alpha.sh~1v1': validation failed
  - at '/experimental/proxy/customResources/workflows.alpha.sh~1v1/targetVirtualCluster': minLength: got 0, want 1
  - at '/experimental/proxy/customResources/workflows.alpha.sh~1v1/targetVirtualCluster': '' does not match pattern '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
```