### PR TITLE
ci(lint): verify go mod tidy and vendor are in sync

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -64,6 +64,19 @@ jobs:
             exit 1
           fi
 
+      - name: Verify go mod tidy and vendor
+        run: |
+          go mod tidy
+          go mod vendor
+          if [ -n "$(git status --porcelain go.mod go.sum vendor/)" ]; then
+            echo "❌ ERROR: go.mod, go.sum, or vendor/ directory is out of sync."
+            echo "Please run 'go mod tidy && go mod vendor' and commit the changes."
+            echo ""
+            echo "Changed files:"
+            git status --porcelain go.mod go.sum vendor/
+            exit 1
+          fi
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
Closes OPS-368

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a CI check to enforce Go module and vendor consistency in the lint workflow.
> 
> - New step in `.github/workflows/lint.yaml` runs `go mod tidy` and `go mod vendor`, then fails if `go.mod`, `go.sum`, or `vendor/` differ from committed state
> - Workflow-only change; no application code modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33ac610c429a2f9ebd9cf490a41aed9aefdaed4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->