### PR TITLE
fix(ci): duplicate comments prevented via issue id deduplication

### DIFF
--- a/hack/linear-sync/main.go
+++ b/hack/linear-sync/main.go
@@ -166,6 +166,10 @@ func run(
 		}
 	}
 
+	// Deduplicate issue IDs - same issue can appear in both PR body and branch name,
+	// or across multiple PRs referencing the same issue
+	releasedIssues = deduplicateIssueIDs(releasedIssues)
+
 	logger.Info("Found issues in pull requests", "count", len(releasedIssues))
 
 	linearClient := NewLinearClient(ctx, *linearToken)
@@ -201,4 +205,17 @@ func run(
 	logger.Info("Linear sync completed", "processed", len(releasedIssues), "released", releasedCount, "skipped", skippedCount)
 
 	return nil
+}
+
+// deduplicateIssueIDs removes duplicate issue IDs from the slice while preserving order
+func deduplicateIssueIDs(issueIDs []string) []string {
+	seen := make(map[string]bool)
+	result := make([]string, 0, len(issueIDs))
+	for _, id := range issueIDs {
+		if !seen[id] {
+			seen[id] = true
+			result = append(result, id)
+		}
+	}
+	return result
 }

--- a/hack/linear-sync/main_test.go
+++ b/hack/linear-sync/main_test.go
@@ -269,6 +269,62 @@ func TestRunFunction_FlagValidation(t *testing.T) {
 	}
 }
 
+func TestDeduplicateIssueIDs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "no duplicates",
+			input:    []string{"eng-1234", "eng-5678", "eng-9012"},
+			expected: []string{"eng-1234", "eng-5678", "eng-9012"},
+		},
+		{
+			name:     "with duplicates within single PR (body + branch)",
+			input:    []string{"eng-8061", "eng-8061"},
+			expected: []string{"eng-8061"},
+		},
+		{
+			name:     "with duplicates across multiple PRs",
+			input:    []string{"eng-1234", "eng-5678", "eng-1234", "eng-9012", "eng-5678"},
+			expected: []string{"eng-1234", "eng-5678", "eng-9012"},
+		},
+		{
+			name:     "empty list",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "all duplicates",
+			input:    []string{"eng-1234", "eng-1234", "eng-1234"},
+			expected: []string{"eng-1234"},
+		},
+		{
+			name:     "preserves order",
+			input:    []string{"eng-3333", "eng-1111", "eng-2222", "eng-1111"},
+			expected: []string{"eng-3333", "eng-1111", "eng-2222"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := deduplicateIssueIDs(tc.input)
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("expected %d items, got %d", len(tc.expected), len(result))
+				return
+			}
+
+			for i, v := range result {
+				if v != tc.expected[i] {
+					t.Errorf("at index %d: expected %q, got %q", i, tc.expected[i], v)
+				}
+			}
+		})
+	}
+}
+
 func TestFlagDescriptions(t *testing.T) {
 	// Test that all flags have proper descriptions
 	flagset := flag.NewFlagSet("test", flag.ContinueOnError)


### PR DESCRIPTION
Closes OPS-460

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents duplicate Linear updates by deduplicating issue IDs extracted from PRs before state transitions.
> 
> - Adds `deduplicateIssueIDs` and applies it to collected `releasedIssues` prior to syncing
> - New tests in `main_test.go` validate deduplication (duplicates across PRs/body+branch, order preservation, empty/all-dup cases)
> - Logging now reports counts post-deduplication
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a300b16650016b5bd819e90a2fa918699ddcd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->