### PR TITLE
Allow control plane ingress from vcluster rancher operator agent install pods

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -151,6 +151,12 @@ spec:
             matchLabels:
               app: vcluster-snapshot
 
+    # Allow ingress from vcluster rancher operator agent install pods.
+    - from:
+        - podSelector:
+            matchLabels:
+              app: rancher-agent-install
+
     # Allow ingress from vcluster platform.
     - from:
         - podSelector:

--- a/chart/tests/networkpolicy_test.yaml
+++ b/chart/tests/networkpolicy_test.yaml
@@ -57,7 +57,7 @@ tests:
           value: vc-cp-my-release
         lengthEqual:
           path: spec.ingress
-          count: 4
+          count: 5
       - documentSelector:
           path: metadata.name
           value: vc-kube-dns-my-release
@@ -163,5 +163,5 @@ tests:
           path: metadata.name
           value: vc-cp-my-release
         equal:
-          path: spec.ingress[4].ports[0].port
+          path: spec.ingress[5].ports[0].port
           value: 12340


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
related #ENG-10941
related #ENG-10779

**Please provide a short message that should be published in the vcluster release notes**
Allow vcluster rancher operator agent install job pods to connect to the virtual cluster control plane when network policies are enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables rancher operator agent install pods to reach the virtual cluster control plane when NetworkPolicies are enabled.
> 
> - Adds a new `from` rule in `vc-cp-<release>` NetworkPolicy matching `app: rancher-agent-install` in `networkpolicy.yaml`
> - Updates tests in `networkpolicy_test.yaml`: increases expected control plane ingress rule count and shifts indices for extra ingress assertions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36cf255a99d9c1fba5fc35c270659283f2602c21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->