### PR TITLE
feat: add vCluster docker driver

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1786,6 +1786,10 @@
         "proxy": {
           "$ref": "#/$defs/Proxy",
           "description": "Proxy enables vCluster-to-vCluster proxying of resources"
+        },
+        "docker": {
+          "$ref": "#/$defs/ExperimentalDocker",
+          "description": "Docker allows you to configure Docker related settings when deploying a vCluster using Docker."
         }
       },
       "additionalProperties": false,
@@ -1899,6 +1903,93 @@
           },
           "type": "array",
           "description": "Helm are Helm charts that should get deployed into the virtual cluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDocker": {
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container."
+        },
+        "ports": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Ports defines extra port mappings to be added to the container."
+        },
+        "volumes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Volumes defines extra volumes to be added to the container."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Env defines extra environment variables to be added to the container. Use key=value."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args defines extra arguments to be added to the docker run command of the container."
+        },
+        "nodes": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalDockerNode"
+          },
+          "type": "array",
+          "description": "Nodes defines the nodes of the vCluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDockerNode": {
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container."
+        },
+        "ports": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Ports defines extra port mappings to be added to the container."
+        },
+        "volumes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Volumes defines extra volumes to be added to the container."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Env defines extra environment variables to be added to the container. Use key=value."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args defines extra arguments to be added to the docker run command of the container."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name defines the name of the node. If not specified, a random name will be generated."
         }
       },
       "additionalProperties": false,

--- a/cmd/vclusterctl/cmd/connect.go
+++ b/cmd/vclusterctl/cmd/connect.go
@@ -112,6 +112,10 @@ func (cmd *ConnectCmd) Run(ctx context.Context, args []string) error {
 		cmd.Log.Fatalf("Following platform flags have been set, which won't have any effect when using driver type %s: %s", config.HelmDriver, strings.Join(fs, ", "))
 	}
 
+	if driverType == config.DockerDriver {
+		return cli.ConnectDocker(ctx, &cmd.ConnectOptions, cmd.GlobalFlags, vClusterName, args[1:], cmd.Log)
+	}
+
 	return cli.ConnectHelm(ctx, &cmd.ConnectOptions, cmd.GlobalFlags, vClusterName, args[1:], cmd.Log)
 }
 

--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -110,7 +110,12 @@ func (cmd *CreateCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	if len(fs) > 0 {
-		cmd.log.Fatalf("Following platform flags have been set, which won't have any effect when using driver type %s: %s", config.HelmDriver, strings.Join(fs, ", "))
+		cmd.log.Fatalf("Following platform flags have been set, which won't have any effect when using driver type %s: %s", driver, strings.Join(fs, ", "))
+	}
+
+	// check if we should create a docker vCluster
+	if driver == config.DockerDriver {
+		return cli.CreateDocker(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log)
 	}
 
 	return cli.CreateHelm(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log)

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -92,7 +92,11 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	if len(fs) > 0 {
-		cmd.log.Fatalf("Following platform flags have been set, which won't have any effect when using driver type %s: %s", config.HelmDriver, strings.Join(fs, ", "))
+		cmd.log.Fatalf("Following platform flags have been set, which won't have any effect when using driver type %s: %s", driverType, strings.Join(fs, ", "))
+	}
+
+	if driverType == config.DockerDriver {
+		return cli.DeleteDocker(ctx, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
 	}
 
 	return cli.DeleteHelm(ctx, platformClient, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)

--- a/cmd/vclusterctl/cmd/describe.go
+++ b/cmd/vclusterctl/cmd/describe.go
@@ -83,6 +83,9 @@ func (cmd *DescribeCmd) Run(cobraCmd *cobra.Command, driver, name string) error 
 	if driverType == config.PlatformDriver {
 		return cli.DescribePlatform(cobraCmd.Context(), cmd.GlobalFlags, os.Stdout, cmd.log, name, cmd.project, cmd.configOnly, cmd.output)
 	}
+	if driverType == config.DockerDriver {
+		return cli.DescribeDocker(cobraCmd.Context(), cmd.GlobalFlags, os.Stdout, cmd.log, name, cmd.configOnly, cmd.output)
+	}
 
 	return cli.DescribeHelm(cobraCmd.Context(), cmd.GlobalFlags, os.Stdout, cmd.log, name, cmd.configOnly, cmd.output)
 }

--- a/cmd/vclusterctl/cmd/list.go
+++ b/cmd/vclusterctl/cmd/list.go
@@ -65,6 +65,9 @@ func (cmd *ListCmd) Run(cobraCmd *cobra.Command) error {
 	if driverType == config.PlatformDriver {
 		return cli.ListPlatform(cobraCmd.Context(), &cmd.ListOptions, cmd.GlobalFlags, cmd.log, "", false)
 	}
+	if driverType == config.DockerDriver {
+		return cli.ListDocker(cobraCmd.Context(), &cmd.ListOptions, cmd.GlobalFlags, cmd.log)
+	}
 
 	return cli.ListHelm(cobraCmd.Context(), &cmd.ListOptions, cmd.GlobalFlags, cmd.log)
 }

--- a/cmd/vclusterctl/cmd/pause.go
+++ b/cmd/vclusterctl/cmd/pause.go
@@ -80,5 +80,9 @@ func (cmd *PauseCmd) Run(ctx context.Context, args []string) error {
 		return cli.PausePlatform(ctx, &cmd.PauseOptions, cfg, args[0], cmd.Log)
 	}
 
+	if driverType == config.DockerDriver {
+		return cli.PauseDocker(ctx, cmd.GlobalFlags, args[0], cmd.Log)
+	}
+
 	return cli.PauseHelm(ctx, cmd.GlobalFlags, args[0], cmd.Log)
 }

--- a/cmd/vclusterctl/cmd/resume.go
+++ b/cmd/vclusterctl/cmd/resume.go
@@ -74,6 +74,10 @@ func (cmd *ResumeCmd) Run(ctx context.Context, args []string) error {
 		return cli.ResumePlatform(ctx, &cmd.ResumeOptions, cfg, args[0], cmd.Log)
 	}
 
+	if driverType == config.DockerDriver {
+		return cli.ResumeDocker(ctx, cmd.GlobalFlags, args[0], cmd.Log)
+	}
+
 	if err := cli.ResumeHelm(ctx, cmd.GlobalFlags, args[0], cmd.Log); err != nil {
 		// If they specified a driver, don't fall back to the platform automatically.
 		if cmd.Driver == "" && errors.Is(err, cli.ErrPlatformDriverRequired) {

--- a/config/config.go
+++ b/config/config.go
@@ -3124,6 +3124,9 @@ type Experimental struct {
 
 	// Proxy enables vCluster-to-vCluster proxying of resources
 	Proxy Proxy `json:"proxy,omitempty"`
+
+	// Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
+	Docker ExperimentalDocker `json:"docker,omitempty"`
 }
 
 func (e Experimental) JSONSchemaExtend(base *jsonschema.Schema) {
@@ -3143,6 +3146,37 @@ type ExperimentalSyncSettings struct {
 
 func (e ExperimentalSyncSettings) JSONSchemaExtend(base *jsonschema.Schema) {
 	addProToJSONSchema(base, reflect.TypeOf(e))
+}
+
+type ExperimentalDocker struct {
+	ExperimentalDockerContainer `json:",inline"`
+
+	// Nodes defines the nodes of the vCluster.
+	Nodes []ExperimentalDockerNode `json:"nodes,omitempty"`
+}
+
+type ExperimentalDockerNode struct {
+	ExperimentalDockerContainer `json:",inline"`
+
+	// Name defines the name of the node. If not specified, a random name will be generated.
+	Name string `json:"name,omitempty"`
+}
+
+type ExperimentalDockerContainer struct {
+	// Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container.
+	Image string `json:"image,omitempty"`
+
+	// Ports defines extra port mappings to be added to the container.
+	Ports []string `json:"ports,omitempty"`
+
+	// Volumes defines extra volumes to be added to the container.
+	Volumes []string `json:"volumes,omitempty"`
+
+	// Env defines extra environment variables to be added to the container. Use key=value.
+	Env []string `json:"env,omitempty"`
+
+	// Args defines extra arguments to be added to the docker run command of the container.
+	Args []string `json:"args,omitempty"`
 }
 
 type ExperimentalDeploy struct {

--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -52,9 +52,8 @@ var K8SEtcdVersionMap = map[string]string{
 type ExtraValuesOptions struct {
 	Distro string
 
-	Expose            bool
-	NodePort          bool
-	KubernetesVersion KubernetesVersion
+	Expose   bool
+	NodePort bool
 
 	DisableTelemetry    bool
 	InstanceCreatorType string

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -20,6 +20,7 @@ const (
 
 	HelmDriver     DriverType = "helm"
 	PlatformDriver DriverType = "platform"
+	DockerDriver   DriverType = "docker"
 )
 
 var singleConfig *CLI
@@ -137,12 +138,14 @@ func PrintDriverInfo(verb string, driver DriverType, log log.Logger) {
 	// only print this to stderr
 	log = log.ErrorStreamOnly()
 
-	if driver == HelmDriver {
+	switch driver {
+	case HelmDriver:
 		log.Infof("Using vCluster driver 'helm' to %s your virtual clusters, which means the vCluster CLI is running helm commands directly", verb)
 		log.Info("If you prefer to use the vCluster platform API instead, use the flag '--driver platform' or run 'vcluster use driver platform' to change the default")
-	} else {
+	case PlatformDriver:
 		log.Infof("Using vCluster driver 'platform' to %s your virtual clusters, which means the CLI is using the vCluster platform API instead of helm", verb)
 		log.Info("If you prefer to use helm instead, use the flag '--driver helm' or run 'vcluster use driver helm' to change the default")
+	case DockerDriver:
 	}
 }
 
@@ -152,8 +155,10 @@ func ParseDriverType(driver string) (DriverType, error) {
 		return HelmDriver, nil
 	case "platform":
 		return PlatformDriver, nil
+	case "docker":
+		return DockerDriver, nil
 	default:
-		return "", fmt.Errorf("invalid driver type: %q, only \"helm\" or \"platform\" are valid", driver)
+		return "", fmt.Errorf("invalid driver type: %q, only \"helm\", \"platform\" or \"docker\" are valid", driver)
 	}
 }
 

--- a/pkg/cli/connect_docker.go
+++ b/pkg/cli/connect_docker.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// dockerContainerDetails represents relevant info from docker inspect
+type dockerContainerDetails struct {
+	ID              string                 `json:"Id,omitempty"`
+	State           dockerContainerState   `json:"State,omitempty"`
+	NetworkSettings dockerContainerNetwork `json:"NetworkSettings,omitempty"`
+	Config          dockerContainerConfig  `json:"Config,omitempty"`
+}
+
+type dockerContainerState struct {
+	Status    string `json:"Status,omitempty"`
+	Running   bool   `json:"Running,omitempty"`
+	StartedAt string `json:"StartedAt,omitempty"`
+}
+
+type dockerContainerNetwork struct {
+	Ports map[string][]dockerContainerPort `json:"Ports,omitempty"`
+}
+
+type dockerContainerPort struct {
+	HostIP   string `json:"HostIp,omitempty"`
+	HostPort string `json:"HostPort,omitempty"`
+}
+
+type dockerContainerConfig struct {
+	Env []string `json:"Env,omitempty"`
+}
+
+type connectDocker struct {
+	*flags.GlobalFlags
+	*ConnectOptions
+
+	log log.Logger
+}
+
+func ConnectDocker(ctx context.Context, options *ConnectOptions, globalFlags *flags.GlobalFlags, vClusterName string, command []string, log log.Logger) error {
+	cmd := &connectDocker{
+		GlobalFlags:    globalFlags,
+		ConnectOptions: options,
+		log:            log,
+	}
+
+	return cmd.connect(ctx, vClusterName, command)
+}
+
+func (cmd *connectDocker) connect(ctx context.Context, vClusterName string, command []string) error {
+	containerName := getControlPlaneContainerName(vClusterName)
+
+	// find the docker container
+	cmd.log.Infof("Finding docker container %s...", containerName)
+	containerDetails, err := cmd.inspectDockerContainer(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to find vcluster container %s: %w", containerName, err)
+	}
+
+	// check if container is running
+	if !containerDetails.State.Running {
+		return fmt.Errorf("vcluster container %s is not running (status: %s)", containerName, containerDetails.State.Status)
+	}
+
+	// get the exposed port for 8443
+	hostPort, err := cmd.getExposedPort(containerDetails, "8443/tcp")
+	if err != nil {
+		return fmt.Errorf("failed to get exposed port: %w", err)
+	}
+	cmd.log.Debugf("Found exposed port %s for vcluster container %s", hostPort, containerName)
+
+	// get the kubeconfig from the container
+	kubeConfig, err := getDockerVClusterKubeConfig(ctx, containerName, hostPort, cmd.log)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	// set context name
+	if cmd.KubeConfigContextName == "" {
+		cmd.KubeConfigContextName = "vcluster-docker_" + vClusterName
+	}
+
+	// exchange context name
+	err = cmd.exchangeContextName(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	// wait for vCluster to become ready (unless just printing)
+	if !cmd.ConnectOptions.Print {
+		err = cmd.waitForVCluster(ctx, *kubeConfig)
+		if err != nil {
+			return fmt.Errorf("failed connecting to vcluster: %w", err)
+		}
+	}
+
+	// check if we should execute command
+	if len(command) > 0 {
+		return executeCommand(*kubeConfig, command, nil, cmd.log)
+	}
+
+	// write kube config
+	return writeKubeConfig(kubeConfig, vClusterName, cmd.ConnectOptions, cmd.GlobalFlags, false, cmd.log)
+}
+
+func (cmd *connectDocker) inspectDockerContainer(ctx context.Context, containerName string) (*dockerContainerDetails, error) {
+	args := []string{"inspect", "--type", "container", containerName}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect failed: %w", err)
+	}
+
+	var containerDetails []dockerContainerDetails
+	err = json.Unmarshal(out, &containerDetails)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse docker inspect output: %w", err)
+	}
+	if len(containerDetails) == 0 {
+		return nil, fmt.Errorf("container %s not found", containerName)
+	}
+
+	return &containerDetails[0], nil
+}
+
+func (cmd *connectDocker) getExposedPort(containerDetails *dockerContainerDetails, containerPort string) (string, error) {
+	ports, ok := containerDetails.NetworkSettings.Ports[containerPort]
+	if !ok || len(ports) == 0 {
+		return "", fmt.Errorf("port %s is not exposed", containerPort)
+	}
+
+	hostPort := ports[0].HostPort
+	if hostPort == "" {
+		return "", fmt.Errorf("port %s has no host port mapping", containerPort)
+	}
+
+	return hostPort, nil
+}
+
+func getDockerVClusterKubeConfig(ctx context.Context, containerName, hostPort string, log log.Logger) (*clientcmdapi.Config, error) {
+	// The kubeconfig in standalone mode is written to /data/kubeconfig.yaml
+	// We retrieve it from the container
+	args := []string{"exec", containerName, "cat", "/var/lib/vcluster/kubeconfig.yaml"}
+
+	var kubeConfigBytes []byte
+	var err error
+
+	// Poll until the kubeconfig is available (vcluster might still be starting up)
+	log.Infof("Waiting for vCluster kubeconfig to be available...")
+	waitErr := wait.PollUntilContextTimeout(ctx, time.Second*2, time.Minute*5, true, func(ctx context.Context) (bool, error) {
+		kubeConfigBytes, err = exec.CommandContext(ctx, "docker", args...).Output()
+		if err != nil {
+			log.Debugf("Kubeconfig not yet available: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if waitErr != nil {
+		return nil, fmt.Errorf("timeout waiting for kubeconfig: %w (last error: %w)", waitErr, err)
+	}
+
+	// parse the kubeconfig
+	kubeConfig, err := clientcmd.Load(kubeConfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+
+	// update the server address to point to localhost:hostPort
+	for _, cluster := range kubeConfig.Clusters {
+		if cluster != nil {
+			cluster.Server = "https://localhost:" + hostPort
+			cluster.CertificateAuthorityData = nil
+			cluster.InsecureSkipTLSVerify = true
+		}
+	}
+
+	return kubeConfig, nil
+}
+
+// exchangeContextName updates the kubeconfig to use the configured context name
+func (cmd *connectDocker) exchangeContextName(kubeConfig *clientcmdapi.Config) error {
+	if kubeConfig == nil {
+		return fmt.Errorf("nil kubeConfig")
+	}
+	if kubeConfig.Clusters == nil || kubeConfig.Contexts == nil || kubeConfig.AuthInfos == nil {
+		return fmt.Errorf("kubeconfig is missing required fields")
+	}
+
+	// update cluster name
+	for k, cluster := range kubeConfig.Clusters {
+		kubeConfig.Clusters[cmd.KubeConfigContextName] = cluster
+		if k != cmd.KubeConfigContextName {
+			delete(kubeConfig.Clusters, k)
+		}
+		break
+	}
+
+	// update context
+	for k, ctx := range kubeConfig.Contexts {
+		if ctx == nil {
+			continue
+		}
+		ctx.Cluster = cmd.KubeConfigContextName
+		ctx.AuthInfo = cmd.KubeConfigContextName
+		kubeConfig.Contexts[cmd.KubeConfigContextName] = ctx
+		if k != cmd.KubeConfigContextName {
+			delete(kubeConfig.Contexts, k)
+		}
+		break
+	}
+
+	// update authinfo
+	for k, authInfo := range kubeConfig.AuthInfos {
+		if authInfo == nil {
+			continue
+		}
+		kubeConfig.AuthInfos[cmd.KubeConfigContextName] = authInfo
+		if k != cmd.KubeConfigContextName {
+			delete(kubeConfig.AuthInfos, k)
+		}
+		break
+	}
+
+	kubeConfig.CurrentContext = cmd.KubeConfigContextName
+	return nil
+}
+
+func (cmd *connectDocker) waitForVCluster(ctx context.Context, kubeConfig clientcmdapi.Config) error {
+	cmd.log.Infof("Waiting for vCluster to become ready...")
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(kubeConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to create rest config: %w", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Minute*3, true, func(ctx context.Context) (bool, error) {
+		// check if we can reach the API server by getting the default service account
+		_, err := kubeClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+		if err != nil {
+			cmd.log.Debugf("vCluster not ready yet: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timeout waiting for vcluster to become ready: %w", err)
+	}
+
+	cmd.log.Donef("vCluster is ready")
+	return nil
+}

--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -1,0 +1,667 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/loft-sh/vcluster/pkg/cli/oci"
+	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/random"
+	"github.com/loft-sh/vcluster/pkg/telemetry"
+	"github.com/loft-sh/vcluster/pkg/upgrade"
+	"github.com/loft-sh/vcluster/pkg/util/clihelper"
+	"github.com/samber/lo"
+	"golang.org/x/mod/semver"
+)
+
+var containerVolumes = map[string]string{
+	"var":     "/var",
+	"etc":     "/etc",
+	"bin":     "/usr/local/bin",
+	"cni-bin": "/opt/cni/bin",
+}
+
+func CreateDocker(ctx context.Context, options *CreateOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	// make sure we deploy the correct version
+	vClusterVersion := strings.TrimPrefix(options.ChartVersion, "v")
+	if vClusterVersion == upgrade.DevelopmentVersion {
+		return fmt.Errorf("please specify a vCluster version via --chart-version")
+	}
+
+	// if the vCluster version is older than 0.31.0-alpha.0 return an error
+	if semver.Compare("v"+vClusterVersion, "v0.31.0-alpha.0") == -1 {
+		return fmt.Errorf("please use a newer version of vCluster, the minimum version is v0.31.0-alpha.0")
+	}
+
+	// check if container exists
+	exists, err := containerExists(ctx, getControlPlaneContainerName(vClusterName))
+	if err != nil {
+		return fmt.Errorf("failed to check if container exists: %w", err)
+	} else if exists {
+		if !options.Upgrade {
+			return fmt.Errorf("vCluster %s already exists, use --upgrade to upgrade it", vClusterName)
+		}
+
+		log.Infof("vCluster container %s already exists, recreating it...", vClusterName)
+
+		// stop and delete the container
+		err = stopContainer(ctx, getControlPlaneContainerName(vClusterName))
+		if err != nil {
+			return fmt.Errorf("failed to stop container: %w", err)
+		}
+	}
+
+	// build extra values
+	filesToRemove, err := buildExtraValues(ctx, options, log)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, file := range filesToRemove {
+			os.Remove(file)
+		}
+	}()
+
+	dockerOptions, err := toDockerOptions(globalFlags, log)
+	if err != nil {
+		return err
+	}
+	extraValues, err := config.GetExtraValues(dockerOptions)
+	if err != nil {
+		return err
+	}
+
+	// parse vCluster config
+	finalValues, err := mergeAllValues(options.SetValues, options.Values, extraValues)
+	if err != nil {
+		return fmt.Errorf("merge values: %w", err)
+	}
+
+	// parse config
+	vConfig := &config.Config{}
+	if err := vConfig.UnmarshalYAMLStrict([]byte(finalValues)); err != nil {
+		return fmt.Errorf("unmarshal vcluster config: %w", err)
+	}
+
+	// pull the kubernetes image and folder structure looks roughly like this:
+	// - etcd
+	// - etcdctl
+	// - helm
+	// - kine
+	// - konnectivity-server
+	// - kube-apiserver
+	// - kube-controller-manager
+	// - kube-scheduler
+	// - kubernetes-v1.34.0-amd64.tar.gz
+	// - kubernetes-v1.34.0-arm64.tar.gz
+	kubernetesDir, kubernetesVersion, err := pullKubernetesImage(ctx, vConfig, globalFlags, log)
+	if err != nil {
+		return err
+	}
+
+	// pull the vcluster image and folder structure looks roughly like this:
+	// - vcluster
+	vClusterDir, err := pullVClusterImage(ctx, vClusterVersion, globalFlags, log)
+	if err != nil {
+		return err
+	}
+
+	// add the platform credentials to the docker container
+	extraArgs := []string{
+		"--vcluster-name", vClusterName,
+	}
+	if options.Add && !exists {
+		err := vclusterconfig.ValidatePlatformProject(ctx, vConfig, globalFlags.LoadedConfig(log))
+		if err != nil {
+			return err
+		}
+
+		platformArgs, err := addVClusterDocker(ctx, vClusterName, vConfig, options, globalFlags, log)
+		if err != nil {
+			return err
+		}
+
+		extraArgs = append(extraArgs, platformArgs...)
+	}
+
+	// write the vcluster.yaml
+	vClusterYAMLPath, err := writeVClusterYAML(globalFlags, vClusterName, finalValues)
+	if err != nil {
+		return err
+	}
+
+	// now remove the container if it exists
+	if exists {
+		err = removeContainer(ctx, getControlPlaneContainerName(vClusterName))
+		if err != nil {
+			return fmt.Errorf("failed to remove container: %w", err)
+		}
+	}
+
+	// create the docker network
+	if !exists {
+		err = createNetwork(ctx, vClusterName, log)
+		if err != nil {
+			return fmt.Errorf("failed to create network: %w", err)
+		}
+	}
+
+	// ensure the join token
+	vClusterJoinToken, err := ensureVClusterJoinToken(globalFlags, vClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to ensure join token: %w", err)
+	}
+	extraArgs = append(extraArgs, "--join-token", vClusterJoinToken)
+
+	// run the docker container
+	err = runControlPlaneContainer(ctx, kubernetesDir, vClusterDir, vClusterYAMLPath, vClusterName, vConfig, log)
+	if err != nil {
+		return err
+	}
+
+	// install vCluster standalone
+	if !exists {
+		err = installVClusterStandalone(ctx, vClusterName, vClusterVersion, extraArgs, log)
+		if err != nil {
+			return err
+		}
+	}
+
+	// ensure the nodes
+	err = ensureVClusterNodes(ctx, kubernetesDir, vClusterName, vClusterJoinToken, kubernetesVersion, vConfig, log)
+	if err != nil {
+		return fmt.Errorf("failed to ensure vCluster nodes: %w", err)
+	}
+
+	// check if we should connect to the vcluster or print the kubeconfig
+	if options.Connect || options.Print {
+		log.Donef("Successfully created virtual cluster %s", vClusterName)
+		return ConnectDocker(ctx, &ConnectOptions{
+			UpdateCurrent: true,
+			Print:         options.Print,
+		}, globalFlags, vClusterName, nil, log)
+	}
+
+	if !exists {
+		log.Donef(
+			"Successfully created virtual cluster %s. \n"+
+				"- Use 'vcluster connect %s' to access the virtual cluster\n"+
+				"- Use `vcluster connect %s -- kubectl get ns` to run a command directly within the vcluster",
+			vClusterName, vClusterName, vClusterName,
+		)
+	} else {
+		log.Donef(
+			"Successfully upgraded virtual cluster %s. \n"+
+				"- Use 'vcluster connect %s' to access the virtual cluster\n"+
+				"- Use `vcluster connect %s -- kubectl get ns` to run a command directly within the vcluster",
+			vClusterName, vClusterName, vClusterName,
+		)
+	}
+	return nil
+}
+
+func writeVClusterYAML(globalFlags *flags.GlobalFlags, vClusterName string, finalValues string) (string, error) {
+	vClusterYAMLPath := filepath.Join(filepath.Dir(globalFlags.Config), "docker", "vclusters", vClusterName, "vcluster.yaml")
+	err := os.MkdirAll(filepath.Dir(vClusterYAMLPath), 0755)
+	if err != nil {
+		return "", fmt.Errorf("create directory: %w", err)
+	}
+
+	err = os.WriteFile(vClusterYAMLPath, []byte(finalValues), 0644)
+	if err != nil {
+		return "", fmt.Errorf("write file: %w", err)
+	}
+
+	return vClusterYAMLPath, nil
+}
+
+func addVClusterDocker(ctx context.Context, name string, vClusterConfig *config.Config, options *CreateOptions, globalFlags *flags.GlobalFlags, log log.Logger) ([]string, error) {
+	platformConfig, err := vClusterConfig.GetPlatformConfig()
+	if err != nil {
+		return nil, fmt.Errorf("get platform config: %w", err)
+	} else if platformConfig.APIKey.SecretName != "" || platformConfig.APIKey.Namespace != "" {
+		return nil, nil
+	}
+
+	platformClient, err := platform.InitClientFromConfig(ctx, globalFlags.LoadedConfig(log))
+	if err != nil {
+		if vClusterConfig.IsProFeatureEnabled() {
+			return nil, fmt.Errorf("you have vCluster pro features enabled, but seems like you are not logged in (%w). Please make sure to log into vCluster Platform to use vCluster pro features or run this command with --add=false", err)
+		}
+
+		log.Debugf("create platform client: %v", err)
+		return nil, nil
+	}
+
+	// set host
+	host := strings.TrimPrefix(platformClient.Config().Platform.Host, "https://")
+	project := options.Project
+	if project == "" {
+		project = platformConfig.Project
+	}
+	if project == "" {
+		project = "default"
+	}
+
+	// get management client
+	managementClient, err := platformClient.Management()
+	if err != nil {
+		return nil, fmt.Errorf("error getting management client: %w", err)
+	}
+
+	// try with the regular name first
+	created, accessKey, createdName, err := platform.CreateWithName(ctx, managementClient, project, name)
+	if err != nil {
+		return nil, fmt.Errorf("error creating platform secret: %w", err)
+	} else if !created {
+		return nil, fmt.Errorf("couldn't create virtual cluster instance, name %s already exists", name)
+	}
+
+	// build the extra args
+	retArgs := []string{
+		"--platform-access-key", accessKey,
+		"--platform-host", host,
+		"--platform-insecure",
+		"--platform-project", project,
+		"--platform-instance-name", createdName,
+	}
+
+	return retArgs, nil
+}
+
+func installVClusterStandalone(ctx context.Context, vClusterName, vClusterVersion string, extraArgs []string, log log.Logger) error {
+	log.Infof("Starting vCluster standalone %s", vClusterName)
+	joinedArgs := strings.Join(extraArgs, " ")
+	args := []string{
+		"exec", getControlPlaneContainerName(vClusterName),
+		"bash", "-c", fmt.Sprintf(`set -e -o pipefail; curl -sfLk "https://github.com/loft-sh/vcluster/releases/download/v%s/install-standalone.sh" | sh -s -- --skip-download --skip-wait %s`, vClusterVersion, joinedArgs),
+	}
+
+	log.Debugf("Running command: docker %s", strings.Join(args, " "))
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start vCluster standalone: %w: %s", err, string(out))
+	}
+
+	log.Debugf("Output: %s", string(out))
+	return nil
+}
+
+func runControlPlaneContainer(ctx context.Context, kubernetesDir, vClusterDir, vClusterYAMLPath, vClusterName string, config *config.Config, log log.Logger) error {
+	args := []string{
+		"run",
+		"-d",
+		"-h", vClusterName,
+		"--tmpfs", "/run",
+		"--tmpfs", "/tmp",
+		"--privileged",
+		"--network", getNetworkName(vClusterName),
+		"-e", "VCLUSTER_NAME=" + vClusterName,
+		"-p", fmt.Sprintf("%d:8443", clihelper.RandomPort()),
+		"--name", getControlPlaneContainerName(vClusterName),
+	}
+	for volumeName, volumePath := range containerVolumes {
+		args = append(args, "-v", getControlPlaneVolumeName(vClusterName, volumeName)+":"+volumePath)
+	}
+	args = append(args, config.Experimental.Docker.Args...)
+
+	// add the ports and volumes
+	for _, port := range config.Experimental.Docker.Ports {
+		args = append(args, "-p", port)
+	}
+	for _, volume := range config.Experimental.Docker.Volumes {
+		args = append(args, "-v", volume)
+	}
+	for _, env := range config.Experimental.Docker.Env {
+		args = append(args, "-e", env)
+	}
+
+	// create a bind mount for every file in the kubernetes and vcluster directories
+	entries, err := os.ReadDir(kubernetesDir)
+	if err != nil {
+		return fmt.Errorf("read kubernetes directory: %w", err)
+	}
+	for _, entry := range entries {
+		args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/%s,dst=/var/lib/vcluster/bin/%s,ro", kubernetesDir, entry.Name(), entry.Name()))
+	}
+	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/vcluster,dst=/var/lib/vcluster/bin/vcluster,ro", vClusterDir))
+	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s,dst=/etc/vcluster/vcluster.yaml,ro", vClusterYAMLPath))
+
+	// add the image to start
+	image := "ghcr.io/loft-sh/vm-container"
+	if config.Experimental.Docker.Image != "" {
+		image = config.Experimental.Docker.Image
+	}
+	args = append(args, image)
+
+	// start the docker container
+	log.Debugf("Running command: docker %s", strings.Join(args, " "))
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start docker container: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+func ensureVClusterJoinToken(globalFlags *flags.GlobalFlags, vClusterName string) (string, error) {
+	tokenPath := filepath.Join(filepath.Dir(globalFlags.Config), "docker", "vclusters", vClusterName, "token.txt")
+	_, err := os.Stat(tokenPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("ensure token file: %w", err)
+		}
+
+		token := random.String(64)
+		err = os.WriteFile(tokenPath, []byte(token), 0644)
+		if err != nil {
+			return "", fmt.Errorf("write token file: %w", err)
+		}
+		return token, nil
+	}
+
+	token, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("read token file: %w", err)
+	}
+
+	return string(token), nil
+}
+
+func runWorkerContainer(ctx context.Context, kubernetesDir, vClusterName string, workerConfig *config.ExperimentalDockerNode, log log.Logger) error {
+	args := []string{
+		"run",
+		"-d",
+		"-h", workerConfig.Name,
+		"--tmpfs", "/run",
+		"--tmpfs", "/tmp",
+		"--privileged",
+		"--network", getNetworkName(vClusterName),
+		"--name", getWorkerContainerName(vClusterName, workerConfig.Name),
+	}
+	for volumeName, volumePath := range containerVolumes {
+		args = append(args, "-v", getWorkerVolumeName(vClusterName, workerConfig.Name, volumeName)+":"+volumePath)
+	}
+	args = append(args, workerConfig.Args...)
+
+	// add the ports and volumes
+	for _, port := range workerConfig.Ports {
+		args = append(args, "-p", port)
+	}
+	for _, volume := range workerConfig.Volumes {
+		args = append(args, "-v", volume)
+	}
+	for _, env := range workerConfig.Env {
+		args = append(args, "-e", env)
+	}
+
+	// create a bind mount for every file in the kubernetes and vcluster directories
+	entries, err := os.ReadDir(kubernetesDir)
+	if err != nil {
+		return fmt.Errorf("read kubernetes directory: %w", err)
+	}
+	for _, entry := range entries {
+		args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/%s,dst=/var/lib/vcluster/bin/%s,ro", kubernetesDir, entry.Name(), entry.Name()))
+	}
+
+	// add the image to start
+	image := "ghcr.io/loft-sh/vm-container"
+	if workerConfig.Image != "" {
+		image = workerConfig.Image
+	}
+	args = append(args, image)
+
+	// start the docker container
+	log.Debugf("Running command: docker %s", strings.Join(args, " "))
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start docker container: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+func joinVClusterNodeContainer(ctx context.Context, vClusterName, workerName, vClusterJoinToken, kubernetesVersion string, log log.Logger) error {
+	log.Infof("Joining node %s to vCluster %s...", workerName, vClusterName)
+
+	// Define retry logic: try every 2 seconds until a 200 OK is received.
+	// --retry-all-errors is used for curl versions that support it,
+	// but a manual 'until' loop is more portable across container OS versions.
+	joinScript := fmt.Sprintf(`
+until curl -fsSLk -o /tmp/join.sh "https://%s:8443/node/join?token=%s&type=worker"; do
+  echo "Waiting for vCluster API to be ready..."
+  sleep 2
+done
+sh /tmp/join.sh --bundle-path /var/lib/vcluster/bin/kubernetes-%s-%s.tar.gz --force-join
+`, vClusterName, url.QueryEscape(vClusterJoinToken), kubernetesVersion, runtime.GOARCH)
+	args := []string{"exec", getWorkerContainerName(vClusterName, workerName), "bash", "-c", joinScript}
+
+	log.Debugf("Running command: docker %s", strings.Join(args, " "))
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start vCluster standalone: %w: %s", err, string(out))
+	}
+
+	log.Debugf("Output: %s", string(out))
+	return nil
+}
+
+func ensureVClusterNodes(ctx context.Context, kubernetesDir, vClusterName, vClusterJoinToken, kubernetesVersion string, vClusterConfig *config.Config, log log.Logger) error {
+	nodes, err := findDockerVClusterNodes(ctx, vClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to find vCluster nodes: %w", err)
+	}
+
+	// remove the nodes that are not in the config
+	for _, node := range nodes {
+		_, found := lo.Find(vClusterConfig.Experimental.Docker.Nodes, func(n config.ExperimentalDockerNode) bool {
+			return node.Name == n.Name
+		})
+		if !found {
+			log.Infof("Removing node %s from vCluster %s", node.Name, vClusterName)
+			err = stopContainer(ctx, getWorkerContainerName(vClusterName, node.Name))
+			if err != nil {
+				return fmt.Errorf("failed to stop vCluster node: %w", err)
+			}
+			err = removeContainer(ctx, getWorkerContainerName(vClusterName, node.Name))
+			if err != nil {
+				return fmt.Errorf("failed to remove vCluster node: %w", err)
+			}
+			for volumeName := range containerVolumes {
+				err = removeVolume(ctx, getWorkerVolumeName(vClusterName, node.Name, volumeName))
+				if err != nil {
+					return fmt.Errorf("failed to remove vCluster node volume: %w", err)
+				}
+			}
+		}
+	}
+
+	// if there are no nodes to add, return
+	if len(vClusterConfig.Experimental.Docker.Nodes) == 0 {
+		return nil
+	}
+
+	// add the nodes that are not in the config
+	for _, node := range vClusterConfig.Experimental.Docker.Nodes {
+		_, found := lo.Find(nodes, func(n dockerVCluster) bool {
+			return node.Name == n.Name
+		})
+		if !found {
+			if node.Name == "" {
+				return fmt.Errorf("node name is required")
+			}
+
+			log.Infof("Adding node %s to vCluster %s", node.Name, vClusterName)
+			err = runWorkerContainer(ctx, kubernetesDir, vClusterName, &node, log)
+			if err != nil {
+				return fmt.Errorf("failed to run vCluster node: %w", err)
+			}
+			err = joinVClusterNodeContainer(ctx, vClusterName, node.Name, vClusterJoinToken, kubernetesVersion, log)
+			if err != nil {
+				return fmt.Errorf("failed to join vCluster node: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func pullVClusterImage(ctx context.Context, vClusterVersion string, globalFlags *flags.GlobalFlags, log log.Logger) (string, error) {
+	fullImage := "ghcr.io/loft-sh/vcluster-pro:" + vClusterVersion
+
+	// get the target directory
+	targetDir := filepath.Join(filepath.Dir(globalFlags.Config), "docker", "vcluster", vClusterVersion)
+	_, err := os.Stat(targetDir)
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat target directory: %w", err)
+	} else if err == nil {
+		return targetDir, nil
+	}
+
+	// create the target directory
+	err = os.MkdirAll(targetDir, 0755)
+	if err != nil {
+		return "", fmt.Errorf("create target directory: %w", err)
+	}
+
+	// create a temp directory
+	tempDir, err := os.MkdirTemp("", "vcluster-upgrade-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// pull the image
+	log.Infof("Pulling image %s to %s...", fullImage, tempDir)
+	err = oci.PullImage(ctx, fullImage, tempDir, nil)
+	if err != nil {
+		return "", fmt.Errorf("pull image: %w", err)
+	}
+
+	// extract the image
+	log.Infof("Extracting vcluster binary from %s to %s...", fullImage, targetDir)
+	err = oci.ExtractFile(tempDir, "/vcluster", filepath.Join(targetDir, "vcluster"))
+	if err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", fmt.Errorf("extract image: %w", err)
+	}
+
+	return targetDir, nil
+}
+
+func pullKubernetesImage(ctx context.Context, vConfig *config.Config, globalFlags *flags.GlobalFlags, log log.Logger) (string, string, error) {
+	// get the kubernetes version
+	kubernetesVersion := ""
+	if vConfig.ControlPlane.Distro.K8S.Version != "" {
+		kubernetesVersion = vConfig.ControlPlane.Distro.K8S.Version
+	} else {
+		kubernetesVersion = vConfig.ControlPlane.Distro.K8S.Image.Tag
+	}
+	if kubernetesVersion == "" {
+		defaultConfig, err := config.NewDefaultConfig()
+		if err != nil {
+			return "", "", err
+		}
+		kubernetesVersion = defaultConfig.ControlPlane.Distro.K8S.Image.Tag
+	}
+
+	fullImage := "ghcr.io/loft-sh/kubernetes:" + kubernetesVersion + "-full"
+
+	// get the target directory
+	targetDir := filepath.Join(filepath.Dir(globalFlags.Config), "docker", "kubernetes", kubernetesVersion)
+	_, err := os.Stat(targetDir)
+	if err != nil && !os.IsNotExist(err) {
+		return "", "", fmt.Errorf("stat target directory: %w", err)
+	} else if err == nil {
+		return targetDir, kubernetesVersion, nil
+	}
+
+	// create a temp directory
+	tempDir, err := os.MkdirTemp("", "vcluster-docker-kubernetes-")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// create the target directory
+	err = os.MkdirAll(targetDir, 0755)
+	if err != nil {
+		return "", "", fmt.Errorf("create target directory: %w", err)
+	}
+
+	// pull the image
+	log.Infof("Pulling image %s to %s...", fullImage, tempDir)
+	err = oci.PullImage(ctx, fullImage, tempDir, nil)
+	if err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", "", fmt.Errorf("pull image: %w", err)
+	}
+
+	// extract the image
+	log.Infof("Extracting image %s to %s...", fullImage, targetDir)
+	err = oci.Extract(tempDir, "/kubernetes", targetDir)
+	if err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", "", fmt.Errorf("extract image: %w", err)
+	}
+
+	return targetDir, kubernetesVersion, nil
+}
+
+func toDockerOptions(globalFlags *flags.GlobalFlags, log log.Logger) (*config.ExtraValuesOptions, error) {
+	cfg := globalFlags.LoadedConfig(log)
+	return &config.ExtraValuesOptions{
+		DisableTelemetry:    cfg.TelemetryDisabled,
+		InstanceCreatorType: "vclusterctl",
+		MachineID:           telemetry.GetMachineID(cfg),
+	}, nil
+}
+
+func createNetwork(ctx context.Context, vClusterName string, log log.Logger) error {
+	log.Infof("Creating network %s...", getNetworkName(vClusterName))
+	args := []string{"network", "create", getNetworkName(vClusterName)}
+	log.Debugf("Running command: docker %s", strings.Join(args, " "))
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil && !strings.HasSuffix(strings.TrimSpace(string(out)), "already exists") {
+		return fmt.Errorf("failed to create network: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+func deleteNetwork(ctx context.Context, vClusterName string, log log.Logger) error {
+	args := []string{"network", "rm", getNetworkName(vClusterName)}
+	log.Debugf("Running command: docker %s", strings.Join(args, " "))
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to delete network: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+func getNetworkName(vClusterName string) string {
+	return "vcluster-" + vClusterName
+}
+
+func getControlPlaneContainerName(vClusterName string) string {
+	return "vcluster-docker." + vClusterName
+}
+
+func getControlPlaneVolumeName(vClusterName, volumeName string) string {
+	return "vcluster-docker." + vClusterName + "." + volumeName
+}
+
+func getWorkerContainerName(vClusterName, workerName string) string {
+	return "vcluster-docker-worker." + vClusterName + "." + workerName
+}
+
+func getWorkerVolumeName(vClusterName, workerName, volumeName string) string {
+	return "vcluster-docker-worker." + vClusterName + "." + workerName + "." + volumeName
+}

--- a/pkg/cli/create_platform.go
+++ b/pkg/cli/create_platform.go
@@ -652,8 +652,6 @@ func toChartOptions(platformClient platform.Client, options *CreateOptions) (*vc
 		return nil, fmt.Errorf("unsupported distro %s, please select one of: %s", options.Distro, strings.Join(AllowedDistros, ", "))
 	}
 
-	kubernetesVersion := vclusterconfig.KubernetesVersion{}
-
 	// use default version if its development
 	if options.ChartVersion == upgrade.DevelopmentVersion {
 		options.ChartVersion = ""
@@ -663,7 +661,6 @@ func toChartOptions(platformClient platform.Client, options *CreateOptions) (*vc
 	return &vclusterconfig.ExtraValuesOptions{
 		Distro:              options.Distro,
 		Expose:              options.Expose,
-		KubernetesVersion:   kubernetesVersion,
 		DisableTelemetry:    cfg.TelemetryDisabled,
 		InstanceCreatorType: "vclusterctl",
 		PlatformInstanceID:  telemetry.GetPlatformInstanceID(cfg, platformClient.Self()),

--- a/pkg/cli/delete_docker.go
+++ b/pkg/cli/delete_docker.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type deleteDocker struct {
+	*flags.GlobalFlags
+	*DeleteOptions
+
+	log log.Logger
+}
+
+func DeleteDocker(ctx context.Context, options *DeleteOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	cmd := &deleteDocker{
+		GlobalFlags:   globalFlags,
+		DeleteOptions: options,
+		log:           log,
+	}
+
+	return cmd.delete(ctx, vClusterName)
+}
+
+func (cmd *deleteDocker) delete(ctx context.Context, vClusterName string) error {
+	containerName := getControlPlaneContainerName(vClusterName)
+
+	// check if container exists
+	exists, err := containerExists(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to check if container exists: %w", err)
+	}
+
+	if !exists {
+		if cmd.IgnoreNotFound {
+			cmd.log.Infof("vCluster container %s not found, nothing to delete", containerName)
+			return nil
+		}
+		return fmt.Errorf("vCluster container %s not found", containerName)
+	}
+
+	// stop & delete the container
+	cmd.log.Infof("Removing vCluster container %s...", containerName)
+	err = stopContainer(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to stop container: %w", err)
+	}
+	err = removeContainer(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to remove container: %w", err)
+	}
+	for volumeName := range containerVolumes {
+		err = removeVolume(ctx, getControlPlaneVolumeName(vClusterName, volumeName))
+		if err != nil {
+			cmd.log.Warnf("Failed to delete volume %s: %v", getControlPlaneVolumeName(vClusterName, volumeName), err)
+		}
+	}
+
+	// delete the nodes
+	nodes, err := findDockerVClusterNodes(ctx, vClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to find vCluster nodes: %w", err)
+	}
+	for _, node := range nodes {
+		cmd.log.Infof("Removing vCluster node %s...", node.Name)
+		err = stopContainer(ctx, getWorkerContainerName(vClusterName, node.Name))
+		if err != nil {
+			return fmt.Errorf("failed to stop vCluster node: %w", err)
+		}
+		err = removeContainer(ctx, getWorkerContainerName(vClusterName, node.Name))
+		if err != nil {
+			return fmt.Errorf("failed to remove vCluster node: %w", err)
+		}
+		for volumeName := range containerVolumes {
+			err = removeVolume(ctx, getWorkerVolumeName(vClusterName, node.Name, volumeName))
+			if err != nil {
+				cmd.log.Warnf("Failed to delete volume %s: %v", getWorkerVolumeName(vClusterName, node.Name, volumeName), err)
+			}
+		}
+	}
+
+	// delete the network
+	err = deleteNetwork(ctx, vClusterName, cmd.log)
+	if err != nil {
+		cmd.log.Warnf("Failed to delete network: %v", err)
+	}
+
+	// delete context from kubeconfig if requested
+	if cmd.DeleteContext {
+		err = cmd.deleteKubeContext(vClusterName)
+		if err != nil {
+			cmd.log.Warnf("Failed to delete kube context: %v", err)
+		}
+	}
+
+	// delete the vCluster directory
+	err = os.RemoveAll(filepath.Join(filepath.Dir(cmd.GlobalFlags.Config), "docker", "vclusters", vClusterName))
+	if err != nil {
+		cmd.log.Warnf("Failed to delete vCluster directory: %v", err)
+	}
+
+	cmd.log.Donef("Successfully deleted virtual cluster %s", vClusterName)
+	return nil
+}
+
+func containerExists(ctx context.Context, containerName string) (bool, error) {
+	args := []string{"inspect", "--type", "container", containerName}
+	err := exec.CommandContext(ctx, "docker", args...).Run()
+	if err != nil {
+		// container doesn't exist or docker command failed
+		return false, nil
+	}
+	return true, nil
+}
+
+func stopContainer(ctx context.Context, containerName string) error {
+	args := []string{"stop", "--timeout=1", containerName}
+	output, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker stop failed: %w, output: %s", err, string(output))
+	}
+	return nil
+}
+
+func removeVolume(ctx context.Context, volumeName string) error {
+	args := []string{"volume", "rm", volumeName}
+	output, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker volume rm failed: %w, output: %s", err, string(output))
+	}
+	return nil
+}
+
+func removeContainer(ctx context.Context, containerName string) error {
+	args := []string{"rm", containerName}
+	output, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker rm failed: %w, output: %s", err, string(output))
+	}
+	return nil
+}
+
+func (cmd *deleteDocker) deleteKubeContext(vClusterName string) error {
+	// The context name follows the pattern from connect_docker.go
+	kubeContextName := "vcluster-docker_" + vClusterName
+
+	// Load the kubeconfig
+	kubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).RawConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	// Check if context exists
+	if _, ok := kubeConfig.Contexts[kubeContextName]; !ok {
+		cmd.log.Debugf("Kube context %s not found, nothing to delete", kubeContextName)
+		return nil
+	}
+
+	// Delete context using the shared deleteContext function
+	err = deleteContext(&kubeConfig, kubeContextName, "")
+	if err != nil {
+		return fmt.Errorf("failed to delete context: %w", err)
+	}
+
+	cmd.log.Infof("Deleted kube context %s", kubeContextName)
+	return nil
+}

--- a/pkg/cli/describe_docker.go
+++ b/pkg/cli/describe_docker.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"text/tabwriter"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubectl/pkg/describe"
+)
+
+// DockerDescribeOutput holds information about a docker-based vCluster
+type DockerDescribeOutput struct {
+	Name           string      `json:"name,omitempty"`
+	ContainerID    string      `json:"containerId,omitempty"`
+	Status         string      `json:"status,omitempty"`
+	Created        metav1.Time `json:"created,omitempty"`
+	Image          string      `json:"image,omitempty"`
+	Ports          string      `json:"ports,omitempty"`
+	UserConfigYaml *string     `json:"userConfigYaml,omitempty"`
+}
+
+func (do *DockerDescribeOutput) String() string {
+	out := &tabwriter.Writer{}
+	buf := &bytes.Buffer{}
+	out.Init(buf, 0, 8, 2, ' ', 0)
+
+	w := describe.NewPrefixWriter(out)
+	w.Write(describe.LEVEL_0, "Name:\t%s\n", do.Name)
+	w.Write(describe.LEVEL_0, "Container ID:\t%s\n", do.ContainerID)
+	w.Write(describe.LEVEL_0, "Status:\t%s\n", do.Status)
+	if !do.Created.IsZero() {
+		w.Write(describe.LEVEL_0, "Created:\t%s\n", do.Created.Time.Format(time.RFC1123Z))
+	}
+	w.Write(describe.LEVEL_0, "Image:\t%s\n", do.Image)
+	if do.Ports != "" {
+		w.Write(describe.LEVEL_0, "Ports:\t%s\n", do.Ports)
+	}
+
+	if do.UserConfigYaml != nil {
+		userConfigYaml, isTruncated := truncateString(*do.UserConfigYaml, "\n", 50)
+		w.Write(describe.LEVEL_0, "\n------------------- vcluster.yaml -------------------\n")
+		w.Write(describe.LEVEL_0, "%s\n", userConfigYaml)
+		if isTruncated {
+			w.Write(describe.LEVEL_0, "... (truncated)\n")
+		}
+		w.Write(describe.LEVEL_0, "-----------------------------------------------------\n")
+		if isTruncated {
+			w.Write(describe.LEVEL_0, "Use --config-only to retrieve the full vcluster.yaml only\n")
+		} else {
+			w.Write(describe.LEVEL_0, "Use --config-only to retrieve just the vcluster.yaml\n")
+		}
+	}
+
+	out.Flush()
+	return buf.String()
+}
+
+// dockerInspectDetails represents detailed docker inspect output
+type dockerInspectDetails struct {
+	ID      string `json:"Id,omitempty"`
+	Name    string `json:"Name,omitempty"`
+	Created string `json:"Created,omitempty"`
+	State   struct {
+		Status  string `json:"Status,omitempty"`
+		Running bool   `json:"Running,omitempty"`
+	} `json:"State,omitempty"`
+	Config struct {
+		Image string `json:"Image,omitempty"`
+	} `json:"Config,omitempty"`
+	NetworkSettings struct {
+		Ports map[string][]struct {
+			HostIP   string `json:"HostIp,omitempty"`
+			HostPort string `json:"HostPort,omitempty"`
+		} `json:"Ports,omitempty"`
+	} `json:"NetworkSettings,omitempty"`
+}
+
+func DescribeDocker(ctx context.Context, flags *flags.GlobalFlags, output io.Writer, l log.Logger, name string, configOnly bool, format string) error {
+	containerName := getControlPlaneContainerName(name)
+
+	// inspect the container
+	details, err := inspectDockerContainerDetails(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to find vcluster container %s: %w", containerName, err)
+	}
+
+	// get vcluster.yaml from the container if it's running
+	var userConfigYaml *string
+	if details.State.Running {
+		configBytes, err := getVClusterConfigFromContainer(ctx, containerName)
+		if err != nil {
+			l.Debugf("Failed to get vcluster config: %v", err)
+		} else if len(configBytes) > 0 {
+			configStr := string(configBytes)
+			userConfigYaml = &configStr
+		}
+	}
+
+	// Return only the user supplied vcluster.yaml, if configOnly is set
+	if configOnly {
+		if userConfigYaml == nil {
+			return fmt.Errorf("failed to load vcluster config (container may not be running)")
+		}
+
+		if _, err := output.Write([]byte(*userConfigYaml)); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// parse created time
+	created := metav1.Time{}
+	if details.Created != "" {
+		t, err := time.Parse(time.RFC3339, details.Created)
+		if err == nil {
+			created = metav1.Time{Time: t}
+		}
+	}
+
+	// format ports
+	ports := formatPorts(details)
+
+	describeOutput := &DockerDescribeOutput{
+		Name:           name,
+		ContainerID:    details.ID,
+		Status:         details.State.Status,
+		Created:        created,
+		Image:          details.Config.Image,
+		Ports:          ports,
+		UserConfigYaml: userConfigYaml,
+	}
+
+	return writeDockerDescribeWithFormat(output, format, describeOutput)
+}
+
+func inspectDockerContainerDetails(ctx context.Context, containerName string) (*dockerInspectDetails, error) {
+	args := []string{"inspect", "--type", "container", containerName}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect failed: %w", err)
+	}
+
+	var results []dockerInspectDetails
+	err = json.Unmarshal(out, &results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse docker inspect output: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("container %s not found", containerName)
+	}
+
+	return &results[0], nil
+}
+
+func getVClusterConfigFromContainer(ctx context.Context, containerName string) ([]byte, error) {
+	// The vcluster.yaml is written to /etc/vcluster/vcluster.yaml in create_docker.go
+	args := []string{"exec", containerName, "cat", "/etc/vcluster/vcluster.yaml"}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vcluster config: %w", err)
+	}
+	return out, nil
+}
+
+func formatPorts(details *dockerInspectDetails) string {
+	if details.NetworkSettings.Ports == nil {
+		return ""
+	}
+
+	var ports []string
+	for containerPort, hostPorts := range details.NetworkSettings.Ports {
+		for _, hp := range hostPorts {
+			if hp.HostPort != "" {
+				ports = append(ports, fmt.Sprintf("%s:%s->%s", hp.HostIP, hp.HostPort, containerPort))
+			}
+		}
+	}
+
+	if len(ports) == 0 {
+		return ""
+	}
+
+	result := ""
+	for i, p := range ports {
+		if i > 0 {
+			result += ", "
+		}
+		result += p
+	}
+	return result
+}
+
+func writeDockerDescribeWithFormat(writer io.Writer, format string, o *DockerDescribeOutput) error {
+	var outputBytes []byte
+	var err error
+
+	switch format {
+	case "json":
+		outputBytes, err = json.MarshalIndent(o, "", "  ")
+	case "yaml":
+		outputBytes, err = yaml.Marshal(o)
+	case "":
+		outputBytes = []byte(o.String())
+	default:
+		return fmt.Errorf("unknown format %s", format)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(outputBytes)
+	return err
+}

--- a/pkg/cli/list_docker.go
+++ b/pkg/cli/list_docker.go
@@ -1,0 +1,234 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/log/scanner"
+	"github.com/loft-sh/log/table"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// dockerVCluster holds information about a docker-based vCluster
+type dockerVCluster struct {
+	Name      string
+	Status    string
+	Created   time.Time
+	Connected bool
+}
+
+func ListDocker(ctx context.Context, options *ListOptions, globalFlags *flags.GlobalFlags, log log.Logger) error {
+	// find all vcluster containers
+	vClusters, err := findDockerVClusters(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list docker vclusters: %w", err)
+	}
+
+	// get current context to check if connected
+	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).RawConfig()
+	if err != nil {
+		log.Debugf("Failed to load kubeconfig: %v", err)
+	}
+	currentContext := rawConfig.CurrentContext
+
+	// mark connected vclusters
+	for i := range vClusters {
+		expectedContext := "vcluster-docker_" + vClusters[i].Name
+		vClusters[i].Connected = currentContext == expectedContext
+	}
+
+	// print output
+	if options.Output == "json" {
+		// convert to ListVCluster format for consistent JSON output
+		output := make([]ListVCluster, len(vClusters))
+		for i, vc := range vClusters {
+			output[i] = ListVCluster{
+				Name:       vc.Name,
+				Namespace:  "docker", // use "docker" as namespace placeholder
+				Status:     vc.Status,
+				Created:    vc.Created,
+				AgeSeconds: int(time.Since(vc.Created).Round(time.Second).Seconds()),
+				Connected:  vc.Connected,
+			}
+		}
+
+		bytes, err := json.MarshalIndent(output, "", "    ")
+		if err != nil {
+			return fmt.Errorf("json marshal vClusters: %w", err)
+		}
+		log.WriteString(logrus.InfoLevel, string(bytes)+"\n")
+	} else {
+		header := []string{"NAME", "STATUS", "CONNECTED", "AGE"}
+		values := dockerVClustersToValues(vClusters)
+		table.PrintTable(log, header, values)
+	}
+
+	return nil
+}
+
+func findDockerVClusters(ctx context.Context) ([]dockerVCluster, error) {
+	// list all containers with name starting with "vcluster-docker."
+	args := []string{"ps", "-a", "--filter", "name=^vcluster-docker.", "--format", "{{.ID}}"}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker ps failed: %w", err)
+	}
+
+	// parse container IDs
+	var containerIDs []string
+	scan := scanner.NewScanner(bytes.NewReader(out))
+	for scan.Scan() {
+		id := strings.TrimSpace(scan.Text())
+		if id != "" {
+			containerIDs = append(containerIDs, id)
+		}
+	}
+
+	if len(containerIDs) == 0 {
+		return nil, nil
+	}
+
+	// inspect each container to get details
+	var vClusters []dockerVCluster
+	for _, containerID := range containerIDs {
+		details, err := inspectDockerContainerForList(ctx, containerID)
+		if err != nil {
+			continue // skip containers we can't inspect
+		}
+
+		// extract vcluster name from container name (remove "vcluster-docker." prefix)
+		name := strings.TrimPrefix(details.Name, "/vcluster-docker.")
+		if name == details.Name {
+			// doesn't have the prefix, skip
+			continue
+		}
+
+		// parse created time
+		created, err := time.Parse(time.RFC3339, details.Created)
+		if err != nil {
+			created = time.Time{}
+		}
+
+		vClusters = append(vClusters, dockerVCluster{
+			Name:    name,
+			Status:  details.State.Status,
+			Created: created,
+		})
+	}
+
+	return vClusters, nil
+}
+
+func findDockerVClusterNodes(ctx context.Context, vClusterName string) ([]dockerVCluster, error) {
+	// list all containers with name starting with "vcluster-docker-worker."
+	args := []string{"ps", "-a", "--filter", "name=^vcluster-docker-worker." + vClusterName + ".", "--format", "{{.ID}}"}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker ps failed: %w", err)
+	}
+
+	// parse container IDs
+	var containerIDs []string
+	scan := scanner.NewScanner(bytes.NewReader(out))
+	for scan.Scan() {
+		id := strings.TrimSpace(scan.Text())
+		if id != "" {
+			containerIDs = append(containerIDs, id)
+		}
+	}
+
+	if len(containerIDs) == 0 {
+		return nil, nil
+	}
+
+	// inspect each container to get details
+	var vClusterNodes []dockerVCluster
+	for _, containerID := range containerIDs {
+		details, err := inspectDockerContainerForList(ctx, containerID)
+		if err != nil {
+			continue // skip containers we can't inspect
+		}
+
+		// extract vcluster name from container name (remove "vcluster-docker-worker."+vClusterName+"." prefix)
+		name := strings.TrimPrefix(details.Name, "/vcluster-docker-worker."+vClusterName+".")
+		if name == details.Name {
+			// doesn't have the prefix, skip
+			continue
+		}
+
+		// parse created time
+		created, err := time.Parse(time.RFC3339, details.Created)
+		if err != nil {
+			created = time.Time{}
+		}
+
+		vClusterNodes = append(vClusterNodes, dockerVCluster{
+			Name:    name,
+			Status:  details.State.Status,
+			Created: created,
+		})
+	}
+
+	return vClusterNodes, nil
+}
+
+// dockerInspectResult represents the result of docker inspect
+type dockerInspectResult struct {
+	Name    string               `json:"Name,omitempty"`
+	Created string               `json:"Created,omitempty"`
+	State   dockerContainerState `json:"State,omitempty"`
+}
+
+func inspectDockerContainerForList(ctx context.Context, containerID string) (*dockerInspectResult, error) {
+	args := []string{"inspect", "--type", "container", containerID}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker inspect failed: %w", err)
+	}
+
+	var results []dockerInspectResult
+	err = json.Unmarshal(out, &results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse docker inspect output: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("container %s not found", containerID)
+	}
+
+	return &results[0], nil
+}
+
+func dockerVClustersToValues(vClusters []dockerVCluster) [][]string {
+	var values [][]string
+	for _, vc := range vClusters {
+		isConnected := ""
+		if vc.Connected {
+			isConnected = "True"
+		}
+
+		age := ""
+		if !vc.Created.IsZero() {
+			age = duration.HumanDuration(time.Since(vc.Created))
+		}
+
+		values = append(values, []string{
+			vc.Name,
+			vc.Status,
+			isConnected,
+			age,
+		})
+	}
+	return values
+}

--- a/pkg/cli/oci/extract.go
+++ b/pkg/cli/oci/extract.go
@@ -1,0 +1,303 @@
+package oci
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func Extract(archive, prefix, outDir string) error {
+	lp := layout.Path(archive)
+	idx, err := lp.ImageIndex()
+	if err != nil {
+		return fmt.Errorf("layout.ImageIndex: %w", err)
+	}
+	img, err := selectImageForRef(idx)
+	if err != nil {
+		return fmt.Errorf("select image: %w", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("get layers: %w", err)
+	}
+
+	// Normalize prefix like "/kubernetes" -> "kubernetes/"
+	wantPrefix := strings.TrimPrefix(prefix, "/")
+	if wantPrefix != "" && !strings.HasSuffix(wantPrefix, "/") {
+		wantPrefix += "/"
+	}
+
+	// Process layers from TOP to BASE so newer wins, track whiteouts & seen paths.
+	seen := map[string]bool{}
+	var blockedPrefixes []string      // from .wh..wh..opq or dir deletes
+	deletedExact := map[string]bool{} // from .wh.<name>
+
+	shouldBlock := func(p string) bool {
+		// exact deletions and directory-prefix blocks
+		if _, ok := deletedExact[p]; ok {
+			return true
+		}
+		for _, pre := range blockedPrefixes {
+			if strings.HasPrefix(p, pre) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create out dir: %w", err)
+	}
+
+	for i := len(layers) - 1; i >= 0; i-- {
+		rc, err := layers[i].Uncompressed()
+		if err != nil {
+			return fmt.Errorf("get uncompressed layer: %w", err)
+		}
+		tr := tar.NewReader(rc)
+
+		for {
+			h, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				rc.Close()
+				return fmt.Errorf("next: %w", err)
+			}
+			name := path.Clean(h.Name) // tar paths use forward slashes
+			if strings.HasPrefix(path.Base(name), ".wh.") {
+				base := path.Base(name)
+				dir := path.Dir(name)
+				if base == ".wh..wh..opq" {
+					// block everything under this directory in lower layers
+					prefix := strings.TrimSuffix(dir, "/")
+					if prefix != "" {
+						prefix += "/"
+					}
+					blockedPrefixes = append(blockedPrefixes, prefix)
+				} else {
+					target := path.Join(dir, strings.TrimPrefix(base, ".wh."))
+					// block the exact path and anything under it (if it's a dir in lower layers)
+					deletedExact[target] = true
+					dirPrefix := strings.TrimSuffix(target, "/")
+					if dirPrefix != "" {
+						dirPrefix += "/"
+						blockedPrefixes = append(blockedPrefixes, dirPrefix)
+					}
+				}
+				continue
+			}
+
+			// We only care about entries under desired prefix.
+			if wantPrefix != "" && !(name == strings.TrimSuffix(wantPrefix, "/") || strings.HasPrefix(name, wantPrefix)) {
+				continue
+			}
+
+			// Normalize to absolute-ish for tracking, but keep tar-style
+			key := "/" + name
+			if _, ok := seen[key]; ok {
+				continue // newer layer already materialized this path
+			}
+			if shouldBlock(name) {
+				continue
+			}
+
+			switch h.Typeflag {
+			case tar.TypeDir:
+				// No need to create dirs unless we later place a file; mark as seen to avoid lower layers overriding perms.
+				seen[key] = true
+			case tar.TypeReg:
+				rel := strings.TrimPrefix(name, strings.TrimSuffix(wantPrefix, "/"))
+				rel = strings.TrimPrefix(rel, "/")
+				dest := filepath.Join(outDir, rel)
+				if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+					rc.Close()
+					return fmt.Errorf("ensure dir: %w", err)
+				}
+				out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(h.Mode))
+				if err != nil {
+					rc.Close()
+					return fmt.Errorf("open file: %w", err)
+				}
+				if _, err := io.Copy(out, tr); err != nil {
+					out.Close()
+					rc.Close()
+					return fmt.Errorf("copy file: %w", err)
+				}
+				out.Close()
+				seen[key] = true
+			case tar.TypeSymlink:
+				// Skip symlinks for "binaries" by default. If you want them, handle here.
+				seen[key] = true
+			default:
+				seen[key] = true
+			}
+		}
+		rc.Close()
+	}
+
+	return nil
+}
+
+// ExtractFile finds a single regular file at `filePath` inside the image and writes it
+// to `outDir/<basename(filePath)>`. Whiteouts/opaque dirs are honored across layers.
+// Returns os.ErrNotExist if the file does not exist (after considering deletions).
+func ExtractFile(archive, filePath, outPath string) error {
+	lp := layout.Path(archive)
+	idx, err := lp.ImageIndex()
+	if err != nil {
+		return fmt.Errorf("layout.ImageIndex: %w", err)
+	}
+	img, err := selectImageForRef(idx)
+	if err != nil {
+		return fmt.Errorf("select image: %w", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return fmt.Errorf("get layers: %w", err)
+	}
+
+	// Normalize wanted path like "/kubernetes/bin/kubelet" -> "kubernetes/bin/kubelet"
+	want := strings.TrimPrefix(filePath, "/")
+	want = path.Clean(want)
+	if want == "." || want == "" {
+		return fmt.Errorf("invalid file path")
+	}
+
+	// Process layers from TOP to BASE so newer wins.
+	// Track whether higher layers delete/occlude our target so we can stop early.
+	for i := len(layers) - 1; i >= 0; i-- {
+		rc, err := layers[i].Uncompressed()
+		if err != nil {
+			return fmt.Errorf("get uncompressed layer: %w", err)
+		}
+		tr := tar.NewReader(rc)
+
+		var deletedBelow bool // exact whiteout for the wanted path
+		var blockedBelow bool // ancestor opq or dir deletion blocking lower layers
+
+		for {
+			h, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				rc.Close()
+				return fmt.Errorf("next: %w", err)
+			}
+
+			name := path.Clean(h.Name) // tar paths use forward slashes
+
+			// Handle whiteouts that affect ONLY lower layers.
+			if strings.HasPrefix(path.Base(name), ".wh.") {
+				base := path.Base(name)
+				dir := path.Dir(name)
+
+				if base == ".wh..wh..opq" {
+					// This blocks all entries under `dir` in lower layers.
+					prefix := strings.TrimPrefix(strings.TrimSuffix(dir, "/"), "/")
+					if prefix != "" {
+						prefix += "/"
+					}
+					if strings.HasPrefix(want, prefix) || want == strings.TrimSuffix(prefix, "/") {
+						blockedBelow = true
+					}
+				} else {
+					target := path.Join(dir, strings.TrimPrefix(base, ".wh."))
+					target = strings.TrimPrefix(target, "/")
+
+					// Exact deletion
+					if target == want {
+						deletedBelow = true
+					}
+					// If a whole directory was whiteouted, that blocks our wanted file in lower layers.
+					dirPrefix := strings.TrimSuffix(target, "/")
+					if dirPrefix != "" {
+						dirPrefix += "/"
+						if strings.HasPrefix(want, dirPrefix) {
+							blockedBelow = true
+						}
+					}
+				}
+				continue
+			}
+
+			// If this layer contains the file as a regular file, extract and return immediately.
+			if h.Typeflag == tar.TypeReg && name == want {
+				// remove first to avoid still in use errors
+				_ = os.Remove(outPath)
+				out, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(h.Mode))
+				if err != nil {
+					rc.Close()
+					return fmt.Errorf("open file: %w", err)
+				}
+				if _, err := io.Copy(out, tr); err != nil {
+					out.Close()
+					rc.Close()
+					return fmt.Errorf("copy file: %w", err)
+				}
+				out.Close()
+				rc.Close()
+				return nil
+			}
+
+			// We ignore other entry types (dirs/symlinks/etc.) for a single-file extract.
+		}
+
+		rc.Close()
+
+		// If a higher (newer) layer indicated our path/ancestor is deleted/opaque and
+		// this layer didn't provide the file, lower layers can't provide it either.
+		if deletedBelow || blockedBelow {
+			return os.ErrNotExist
+		}
+	}
+
+	// Never found it in any layer.
+	return os.ErrNotExist
+}
+
+// pick the image for a given tag and prefer linux/amd64 if multi-platform
+func selectImageForRef(idx v1.ImageIndex) (v1.Image, error) {
+	im, err := idx.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(im.Manifests) == 0 {
+		return nil, fmt.Errorf("no manifests in index")
+	}
+
+	desc := im.Manifests[0]
+	if desc.Size == 0 {
+		return nil, fmt.Errorf("no manifests in index")
+	}
+
+	switch desc.MediaType {
+	case types.OCIImageIndex, types.DockerManifestList:
+		child, err := idx.ImageIndex(desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+		// recurse once: choose linux/amd64 child image
+		cim, err := child.IndexManifest()
+		if err != nil {
+			return nil, err
+		}
+		desc2 := cim.Manifests[0]
+		return child.Image(desc2.Digest)
+	default: // image manifest
+		return idx.Image(desc.Digest)
+	}
+}

--- a/pkg/cli/oci/pull.go
+++ b/pkg/cli/oci/pull.go
@@ -1,0 +1,73 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/loft-sh/image/copy"
+	"github.com/loft-sh/image/transports/alltransports"
+	"github.com/loft-sh/image/types"
+	"github.com/loft-sh/vcluster/config"
+)
+
+func PullImage(ctx context.Context, image, destination string, dockerAuthConfig *types.DockerAuthConfig) error {
+	srcContext := &types.SystemContext{
+		OSChoice:                    "linux",
+		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+		DockerAuthConfig:            dockerAuthConfig,
+	}
+	destContext := &types.SystemContext{
+		OSChoice:                    "linux",
+		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+	}
+
+	// get the source reference
+	srcRef, err := alltransports.ParseImageName("docker://" + image)
+	if err != nil {
+		return fmt.Errorf("invalid source name %s: %w", image, err)
+	}
+
+	// check if the image is a digest
+	srcContext.ArchitectureChoice = runtime.GOARCH
+	destContext.ArchitectureChoice = runtime.GOARCH
+
+	// this is always an oci-archive for now
+	destRef, err := alltransports.ParseImageName(fmt.Sprintf("oci:%s", destination))
+	if err != nil {
+		return fmt.Errorf("invalid destination name %s: %w", destination, err)
+	}
+
+	// copy the image
+	buffer := &bytes.Buffer{}
+	_, err = copy.Image(ctx, destRef, srcRef, &copy.Options{
+		SourceCtx:      srcContext,
+		DestinationCtx: destContext,
+
+		RemoveSignatures: true,
+		ReportWriter:     buffer,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to copy image: %s - %w", buffer.String(), err)
+	}
+
+	return nil
+}
+
+func GetDockerAuthConfig(containerdConfig config.ContainerdJoin, registry string) *types.DockerAuthConfig {
+	if containerdConfig.Registry.Auth != nil {
+		registryParts := strings.Split(registry, "/")
+		registryAuth := containerdConfig.Registry.Auth[registryParts[0]]
+		if registryAuth.Username != "" {
+			return &types.DockerAuthConfig{
+				Username:      registryAuth.Username,
+				Password:      registryAuth.Password,
+				IdentityToken: registryAuth.IdentityToken,
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/pause_docker.go
+++ b/pkg/cli/pause_docker.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+)
+
+func PauseDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	containerName := getControlPlaneContainerName(vClusterName)
+
+	// check if container exists
+	exists, running, err := checkDockerContainerState(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to check container state: %w", err)
+	}
+
+	if !exists {
+		return fmt.Errorf("vCluster container %s not found", containerName)
+	}
+
+	if !running {
+		log.Infof("vCluster %s is already paused (container stopped)", vClusterName)
+		return nil
+	}
+
+	// stop the container
+	log.Infof("Pausing vCluster %s...", vClusterName)
+	err = stopDockerContainer(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to pause vCluster: %w", err)
+	}
+
+	// stop the nodes
+	nodes, err := findDockerVClusterNodes(ctx, vClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to find vCluster nodes: %w", err)
+	}
+	for _, node := range nodes {
+		log.Infof("Stopping node %s from vCluster %s...", node.Name, vClusterName)
+		err = stopDockerContainer(ctx, getWorkerContainerName(vClusterName, node.Name))
+		if err != nil {
+			return fmt.Errorf("failed to stop vCluster node: %w", err)
+		}
+	}
+
+	log.Donef("Successfully paused vCluster %s", vClusterName)
+	return nil
+}
+
+func checkDockerContainerState(ctx context.Context, containerName string) (exists bool, running bool, err error) {
+	args := []string{"inspect", "--type", "container", "--format", "{{.State.Running}}", containerName}
+	out, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		// container doesn't exist
+		return false, false, nil
+	}
+
+	// check if running
+	stateStr := string(out)
+	if stateStr == "true\n" || stateStr == "true" {
+		return true, true, nil
+	}
+
+	return true, false, nil
+}
+
+func stopDockerContainer(ctx context.Context, containerName string) error {
+	args := []string{"stop", containerName}
+	output, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker stop failed: %w, output: %s", err, string(output))
+	}
+	return nil
+}

--- a/pkg/cli/resume_docker.go
+++ b/pkg/cli/resume_docker.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+)
+
+func ResumeDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	containerName := getControlPlaneContainerName(vClusterName)
+
+	// check if container exists
+	exists, running, err := checkDockerContainerState(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to check container state: %w", err)
+	}
+
+	if !exists {
+		return fmt.Errorf("vCluster container %s not found", containerName)
+	}
+
+	if running {
+		log.Infof("vCluster %s is already running", vClusterName)
+		return nil
+	}
+
+	// start the container
+	log.Infof("Resuming vCluster %s...", vClusterName)
+	err = startDockerContainerByName(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to resume vCluster: %w", err)
+	}
+
+	// start the nodes
+	nodes, err := findDockerVClusterNodes(ctx, vClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to find vCluster nodes: %w", err)
+	}
+	for _, node := range nodes {
+		log.Infof("Starting node %s from vCluster %s...", node.Name, vClusterName)
+		err = startDockerContainerByName(ctx, getWorkerContainerName(vClusterName, node.Name))
+		if err != nil {
+			return fmt.Errorf("failed to start vCluster node: %w", err)
+		}
+	}
+
+	log.Donef("Successfully resumed vCluster %s", vClusterName)
+	return nil
+}
+
+func startDockerContainerByName(ctx context.Context, containerName string) error {
+	args := []string{"start", containerName}
+	output, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker start failed: %w, output: %s", err, string(output))
+	}
+	return nil
+}

--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -209,7 +209,7 @@ func getAccessKey(ctx context.Context, kubeClient kubernetes.Interface, platform
 	}
 
 	// try with the regular name first
-	created, accessKey, createdName, err := createWithName(ctx, managementClient, project, vName)
+	created, accessKey, createdName, err := CreateWithName(ctx, managementClient, project, vName)
 	if err != nil {
 		return "", "", fmt.Errorf("error creating platform secret %s/%s: %w", namespace, DefaultPlatformSecretName, err)
 	} else if created {
@@ -220,7 +220,7 @@ func getAccessKey(ctx context.Context, kubeClient kubernetes.Interface, platform
 
 	// try with random name
 	vName += "-" + random.String(5)
-	created, accessKey, createdName, err = createWithName(ctx, managementClient, project, vName)
+	created, accessKey, createdName, err = CreateWithName(ctx, managementClient, project, vName)
 	if err != nil {
 		return "", "", fmt.Errorf("error creating platform secret %s/%s: %w", namespace, DefaultPlatformSecretName, err)
 	} else if !created {
@@ -293,7 +293,7 @@ func getLegacyAccessKeyHost(ctx context.Context, platformClient Client) (string,
 	return platformConfig.VirtualClusterAccessKey, nil
 }
 
-func createWithName(ctx context.Context, managementClient kube.Interface, project string, name string) (bool, string, string, error) {
+func CreateWithName(ctx context.Context, managementClient kube.Interface, project string, name string) (bool, string, string, error) {
 	namespace := projectutil.ProjectNamespace(project)
 	virtualClusterInstance, err := managementClient.Loft().ManagementV1().VirtualClusterInstances(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/README.md
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/README.md
@@ -1,0 +1,5 @@
+# `layout`
+
+[![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout)
+
+The `layout` package implements support for interacting with an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/master/image-layout.md).

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/blob.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/blob.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"io"
+	"os"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Blob returns a blob with the given hash from the Path.
+func (l Path) Blob(h v1.Hash) (io.ReadCloser, error) {
+	return os.Open(l.blobPath(h))
+}
+
+// Bytes is a convenience function to return a blob from the Path as
+// a byte slice.
+func (l Path) Bytes(h v1.Hash) ([]byte, error) {
+	return os.ReadFile(l.blobPath(h))
+}
+
+func (l Path) blobPath(h v1.Hash) string {
+	return l.path("blobs", h.Algorithm, h.Hex)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/doc.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package layout provides facilities for reading/writing artifacts from/to
+// an OCI image layout on disk, see:
+//
+// https://github.com/opencontainers/image-spec/blob/master/image-layout.md
+package layout

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/gc.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/gc.go
@@ -1,0 +1,137 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is an EXPERIMENTAL package, and may change in arbitrary ways without notice.
+package layout
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// GarbageCollect removes unreferenced blobs from the oci-layout
+//
+//	This is an experimental api, and not subject to any stability guarantees
+//	We may abandon it at any time, without prior notice.
+//	Deprecated: Use it at your own risk!
+func (l Path) GarbageCollect() ([]v1.Hash, error) {
+	idx, err := l.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+	blobsToKeep := map[string]bool{}
+	if err := l.garbageCollectImageIndex(idx, blobsToKeep); err != nil {
+		return nil, err
+	}
+	blobsDir := l.path("blobs")
+	removedBlobs := []v1.Hash{}
+
+	err = filepath.WalkDir(blobsDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(blobsDir, path)
+		if err != nil {
+			return err
+		}
+		hashString := strings.Replace(rel, "/", ":", 1)
+		if present := blobsToKeep[hashString]; !present {
+			h, err := v1.NewHash(hashString)
+			if err != nil {
+				return err
+			}
+			removedBlobs = append(removedBlobs, h)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return removedBlobs, nil
+}
+
+func (l Path) garbageCollectImageIndex(index v1.ImageIndex, blobsToKeep map[string]bool) error {
+	idxm, err := index.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	h, err := index.Digest()
+	if err != nil {
+		return err
+	}
+
+	blobsToKeep[h.String()] = true
+
+	for _, descriptor := range idxm.Manifests {
+		if descriptor.MediaType.IsImage() {
+			img, err := index.Image(descriptor.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.garbageCollectImage(img, blobsToKeep); err != nil {
+				return err
+			}
+		} else if descriptor.MediaType.IsIndex() {
+			idx, err := index.ImageIndex(descriptor.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.garbageCollectImageIndex(idx, blobsToKeep); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("gc: unknown media type: %s", descriptor.MediaType)
+		}
+	}
+	return nil
+}
+
+func (l Path) garbageCollectImage(image v1.Image, blobsToKeep map[string]bool) error {
+	h, err := image.Digest()
+	if err != nil {
+		return err
+	}
+	blobsToKeep[h.String()] = true
+
+	h, err = image.ConfigName()
+	if err != nil {
+		return err
+	}
+	blobsToKeep[h.String()] = true
+
+	ls, err := image.Layers()
+	if err != nil {
+		return err
+	}
+	for _, l := range ls {
+		h, err := l.Digest()
+		if err != nil {
+			return err
+		}
+		blobsToKeep[h.String()] = true
+	}
+	return nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/image.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type layoutImage struct {
+	path         Path
+	desc         v1.Descriptor
+	manifestLock sync.Mutex // Protects rawManifest
+	rawManifest  []byte
+}
+
+var _ partial.CompressedImageCore = (*layoutImage)(nil)
+
+// Image reads a v1.Image with digest h from the Path.
+func (l Path) Image(h v1.Hash) (v1.Image, error) {
+	ii, err := l.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	return ii.Image(h)
+}
+
+func (li *layoutImage) MediaType() (types.MediaType, error) {
+	return li.desc.MediaType, nil
+}
+
+// Implements WithManifest for partial.Blobset.
+func (li *layoutImage) Manifest() (*v1.Manifest, error) {
+	return partial.Manifest(li)
+}
+
+func (li *layoutImage) RawManifest() ([]byte, error) {
+	li.manifestLock.Lock()
+	defer li.manifestLock.Unlock()
+	if li.rawManifest != nil {
+		return li.rawManifest, nil
+	}
+
+	b, err := li.path.Bytes(li.desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	li.rawManifest = b
+	return li.rawManifest, nil
+}
+
+func (li *layoutImage) RawConfigFile() ([]byte, error) {
+	manifest, err := li.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	return li.path.Bytes(manifest.Config.Digest)
+}
+
+func (li *layoutImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
+	manifest, err := li.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	if h == manifest.Config.Digest {
+		return &compressedBlob{
+			path: li.path,
+			desc: manifest.Config,
+		}, nil
+	}
+
+	for _, desc := range manifest.Layers {
+		if h == desc.Digest {
+			return &compressedBlob{
+				path: li.path,
+				desc: desc,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find layer in image: %s", h)
+}
+
+type compressedBlob struct {
+	path Path
+	desc v1.Descriptor
+}
+
+func (b *compressedBlob) Digest() (v1.Hash, error) {
+	return b.desc.Digest, nil
+}
+
+func (b *compressedBlob) Compressed() (io.ReadCloser, error) {
+	return b.path.Blob(b.desc.Digest)
+}
+
+func (b *compressedBlob) Size() (int64, error) {
+	return b.desc.Size, nil
+}
+
+func (b *compressedBlob) MediaType() (types.MediaType, error) {
+	return b.desc.MediaType, nil
+}
+
+// Descriptor implements partial.withDescriptor.
+func (b *compressedBlob) Descriptor() (*v1.Descriptor, error) {
+	return &b.desc, nil
+}
+
+// See partial.Exists.
+func (b *compressedBlob) Exists() (bool, error) {
+	_, err := os.Stat(b.path.blobPath(b.desc.Digest))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/index.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/index.go
@@ -1,0 +1,161 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+var _ v1.ImageIndex = (*layoutIndex)(nil)
+
+type layoutIndex struct {
+	mediaType types.MediaType
+	path      Path
+	rawIndex  []byte
+}
+
+// ImageIndexFromPath is a convenience function which constructs a Path and returns its v1.ImageIndex.
+func ImageIndexFromPath(path string) (v1.ImageIndex, error) {
+	lp, err := FromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return lp.ImageIndex()
+}
+
+// ImageIndex returns a v1.ImageIndex for the Path.
+func (l Path) ImageIndex() (v1.ImageIndex, error) {
+	rawIndex, err := os.ReadFile(l.path("index.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	idx := &layoutIndex{
+		mediaType: types.OCIImageIndex,
+		path:      l,
+		rawIndex:  rawIndex,
+	}
+
+	return idx, nil
+}
+
+func (i *layoutIndex) MediaType() (types.MediaType, error) {
+	return i.mediaType, nil
+}
+
+func (i *layoutIndex) Digest() (v1.Hash, error) {
+	return partial.Digest(i)
+}
+
+func (i *layoutIndex) Size() (int64, error) {
+	return partial.Size(i)
+}
+
+func (i *layoutIndex) IndexManifest() (*v1.IndexManifest, error) {
+	var index v1.IndexManifest
+	err := json.Unmarshal(i.rawIndex, &index)
+	return &index, err
+}
+
+func (i *layoutIndex) RawManifest() ([]byte, error) {
+	return i.rawIndex, nil
+}
+
+func (i *layoutIndex) Image(h v1.Hash) (v1.Image, error) {
+	// Look up the digest in our manifest first to return a better error.
+	desc, err := i.findDescriptor(h)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isExpectedMediaType(desc.MediaType, types.OCIManifestSchema1, types.DockerManifestSchema2) {
+		return nil, fmt.Errorf("unexpected media type for %v: %s", h, desc.MediaType)
+	}
+
+	img := &layoutImage{
+		path: i.path,
+		desc: *desc,
+	}
+	return partial.CompressedToImage(img)
+}
+
+func (i *layoutIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	// Look up the digest in our manifest first to return a better error.
+	desc, err := i.findDescriptor(h)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isExpectedMediaType(desc.MediaType, types.OCIImageIndex, types.DockerManifestList) {
+		return nil, fmt.Errorf("unexpected media type for %v: %s", h, desc.MediaType)
+	}
+
+	rawIndex, err := i.path.Bytes(h)
+	if err != nil {
+		return nil, err
+	}
+
+	return &layoutIndex{
+		mediaType: desc.MediaType,
+		path:      i.path,
+		rawIndex:  rawIndex,
+	}, nil
+}
+
+func (i *layoutIndex) Blob(h v1.Hash) (io.ReadCloser, error) {
+	return i.path.Blob(h)
+}
+
+func (i *layoutIndex) findDescriptor(h v1.Hash) (*v1.Descriptor, error) {
+	im, err := i.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	if h == (v1.Hash{}) {
+		if len(im.Manifests) != 1 {
+			return nil, errors.New("oci layout must contain only a single image to be used with layout.Image")
+		}
+		return &(im.Manifests)[0], nil
+	}
+
+	for _, desc := range im.Manifests {
+		if desc.Digest == h {
+			return &desc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find descriptor in index: %s", h)
+}
+
+// TODO: Pull this out into methods on types.MediaType? e.g. instead, have:
+// * mt.IsIndex()
+// * mt.IsImage()
+func isExpectedMediaType(mt types.MediaType, expected ...types.MediaType) bool {
+	for _, allowed := range expected {
+		if mt == allowed {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/layoutpath.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/layoutpath.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The original author or authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import "path/filepath"
+
+// Path represents an OCI image layout rooted in a file system path
+type Path string
+
+func (l Path) path(elem ...string) string {
+	complete := []string{string(l)}
+	return filepath.Join(append(complete, elem...)...)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/options.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/options.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import v1 "github.com/google/go-containerregistry/pkg/v1"
+
+// Option is a functional option for Layout.
+type Option func(*options)
+
+type options struct {
+	descOpts []descriptorOption
+}
+
+func makeOptions(opts ...Option) *options {
+	o := &options{
+		descOpts: []descriptorOption{},
+	}
+	for _, apply := range opts {
+		apply(o)
+	}
+	return o
+}
+
+type descriptorOption func(*v1.Descriptor)
+
+// WithAnnotations adds annotations to the artifact descriptor.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(o *options) {
+		o.descOpts = append(o.descOpts, func(desc *v1.Descriptor) {
+			if desc.Annotations == nil {
+				desc.Annotations = make(map[string]string)
+			}
+			for k, v := range annotations {
+				desc.Annotations[k] = v
+			}
+		})
+	}
+}
+
+// WithURLs adds urls to the artifact descriptor.
+func WithURLs(urls []string) Option {
+	return func(o *options) {
+		o.descOpts = append(o.descOpts, func(desc *v1.Descriptor) {
+			if desc.URLs == nil {
+				desc.URLs = []string{}
+			}
+			desc.URLs = append(desc.URLs, urls...)
+		})
+	}
+}
+
+// WithPlatform sets the platform of the artifact descriptor.
+func WithPlatform(platform v1.Platform) Option {
+	return func(o *options) {
+		o.descOpts = append(o.descOpts, func(desc *v1.Descriptor) {
+			desc.Platform = &platform
+		})
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/read.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/read.go
@@ -1,0 +1,32 @@
+// Copyright 2019 The original author or authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FromPath reads an OCI image layout at path and constructs a layout.Path.
+func FromPath(path string) (Path, error) {
+	// TODO: check oci-layout exists
+
+	_, err := os.Stat(filepath.Join(path, "index.json"))
+	if err != nil {
+		return "", err
+	}
+
+	return Path(path), nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/write.go
@@ -1,0 +1,492 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"golang.org/x/sync/errgroup"
+)
+
+var layoutFile = `{
+    "imageLayoutVersion": "1.0.0"
+}`
+
+// renameMutex guards os.Rename calls in AppendImage on Windows only.
+var renameMutex sync.Mutex
+
+// AppendImage writes a v1.Image to the Path and updates
+// the index.json to reference it.
+func (l Path) AppendImage(img v1.Image, options ...Option) error {
+	if err := l.WriteImage(img); err != nil {
+		return err
+	}
+
+	desc, err := partial.Descriptor(img)
+	if err != nil {
+		return err
+	}
+
+	o := makeOptions(options...)
+	for _, opt := range o.descOpts {
+		opt(desc)
+	}
+
+	return l.AppendDescriptor(*desc)
+}
+
+// AppendIndex writes a v1.ImageIndex to the Path and updates
+// the index.json to reference it.
+func (l Path) AppendIndex(ii v1.ImageIndex, options ...Option) error {
+	if err := l.WriteIndex(ii); err != nil {
+		return err
+	}
+
+	desc, err := partial.Descriptor(ii)
+	if err != nil {
+		return err
+	}
+
+	o := makeOptions(options...)
+	for _, opt := range o.descOpts {
+		opt(desc)
+	}
+
+	return l.AppendDescriptor(*desc)
+}
+
+// AppendDescriptor adds a descriptor to the index.json of the Path.
+func (l Path) AppendDescriptor(desc v1.Descriptor) error {
+	ii, err := l.ImageIndex()
+	if err != nil {
+		return err
+	}
+
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	index.Manifests = append(index.Manifests, desc)
+
+	rawIndex, err := json.MarshalIndent(index, "", "   ")
+	if err != nil {
+		return err
+	}
+
+	return l.WriteFile("index.json", rawIndex, os.ModePerm)
+}
+
+// ReplaceImage writes a v1.Image to the Path and updates
+// the index.json to reference it, replacing any existing one that matches matcher, if found.
+func (l Path) ReplaceImage(img v1.Image, matcher match.Matcher, options ...Option) error {
+	if err := l.WriteImage(img); err != nil {
+		return err
+	}
+
+	return l.replaceDescriptor(img, matcher, options...)
+}
+
+// ReplaceIndex writes a v1.ImageIndex to the Path and updates
+// the index.json to reference it, replacing any existing one that matches matcher, if found.
+func (l Path) ReplaceIndex(ii v1.ImageIndex, matcher match.Matcher, options ...Option) error {
+	if err := l.WriteIndex(ii); err != nil {
+		return err
+	}
+
+	return l.replaceDescriptor(ii, matcher, options...)
+}
+
+// replaceDescriptor adds a descriptor to the index.json of the Path, replacing
+// any one matching matcher, if found.
+func (l Path) replaceDescriptor(append mutate.Appendable, matcher match.Matcher, options ...Option) error {
+	ii, err := l.ImageIndex()
+	if err != nil {
+		return err
+	}
+
+	desc, err := partial.Descriptor(append)
+	if err != nil {
+		return err
+	}
+
+	o := makeOptions(options...)
+	for _, opt := range o.descOpts {
+		opt(desc)
+	}
+
+	add := mutate.IndexAddendum{
+		Add:        append,
+		Descriptor: *desc,
+	}
+	ii = mutate.AppendManifests(mutate.RemoveManifests(ii, matcher), add)
+
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	rawIndex, err := json.MarshalIndent(index, "", "   ")
+	if err != nil {
+		return err
+	}
+
+	return l.WriteFile("index.json", rawIndex, os.ModePerm)
+}
+
+// RemoveDescriptors removes any descriptors that match the match.Matcher from the index.json of the Path.
+func (l Path) RemoveDescriptors(matcher match.Matcher) error {
+	ii, err := l.ImageIndex()
+	if err != nil {
+		return err
+	}
+	ii = mutate.RemoveManifests(ii, matcher)
+
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	rawIndex, err := json.MarshalIndent(index, "", "   ")
+	if err != nil {
+		return err
+	}
+
+	return l.WriteFile("index.json", rawIndex, os.ModePerm)
+}
+
+// WriteFile write a file with arbitrary data at an arbitrary location in a v1
+// layout. Used mostly internally to write files like "oci-layout" and
+// "index.json", also can be used to write other arbitrary files. Do *not* use
+// this to write blobs. Use only WriteBlob() for that.
+func (l Path) WriteFile(name string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(l.path(), os.ModePerm); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	return os.WriteFile(l.path(name), data, perm)
+}
+
+// WriteBlob copies a file to the blobs/ directory in the Path from the given ReadCloser at
+// blobs/{hash.Algorithm}/{hash.Hex}.
+func (l Path) WriteBlob(hash v1.Hash, r io.ReadCloser) error {
+	return l.writeBlob(hash, -1, r, nil)
+}
+
+func (l Path) writeBlob(hash v1.Hash, size int64, rc io.ReadCloser, renamer func() (v1.Hash, error)) error {
+	defer rc.Close()
+	if hash.Hex == "" && renamer == nil {
+		panic("writeBlob called an invalid hash and no renamer")
+	}
+
+	dir := l.path("blobs", hash.Algorithm)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Check if blob already exists and is the correct size
+	file := filepath.Join(dir, hash.Hex)
+	if s, err := os.Stat(file); err == nil && !s.IsDir() && (s.Size() == size || size == -1) {
+		return nil
+	}
+
+	// If a renamer func was provided write to a temporary file
+	open := func() (*os.File, error) { return os.Create(file) }
+	if renamer != nil {
+		open = func() (*os.File, error) { return os.CreateTemp(dir, hash.Hex) }
+	}
+	w, err := open()
+	if err != nil {
+		return err
+	}
+	if renamer != nil {
+		// Delete temp file if an error is encountered before renaming
+		defer func() {
+			if err := os.Remove(w.Name()); err != nil && !errors.Is(err, os.ErrNotExist) {
+				logs.Warn.Printf("error removing temporary file after encountering an error while writing blob: %v", err)
+			}
+		}()
+	}
+	defer w.Close()
+
+	// Write to file and exit if not renaming
+	if n, err := io.Copy(w, rc); err != nil || renamer == nil {
+		return err
+	} else if size != -1 && n != size {
+		return fmt.Errorf("expected blob size %d, but only wrote %d", size, n)
+	}
+
+	// Always close reader before renaming, since Close computes the digest in
+	// the case of streaming layers. If Close is not called explicitly, it will
+	// occur in a goroutine that is not guaranteed to succeed before renamer is
+	// called. When renamer is the layer's Digest method, it can return
+	// ErrNotComputed.
+	if err := rc.Close(); err != nil {
+		return err
+	}
+
+	// Always close file before renaming
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	// Rename file based on the final hash
+	finalHash, err := renamer()
+	if err != nil {
+		return fmt.Errorf("error getting final digest of layer: %w", err)
+	}
+
+	renamePath := l.path("blobs", finalHash.Algorithm, finalHash.Hex)
+
+	if runtime.GOOS == "windows" {
+		renameMutex.Lock()
+		defer renameMutex.Unlock()
+	}
+	return os.Rename(w.Name(), renamePath)
+}
+
+// writeLayer writes the compressed layer to a blob. Unlike WriteBlob it will
+// write to a temporary file (suffixed with .tmp) within the layout until the
+// compressed reader is fully consumed and written to disk. Also unlike
+// WriteBlob, it will not skip writing and exit without error when a blob file
+// exists, but does not have the correct size. (The blob hash is not
+// considered, because it may be expensive to compute.)
+func (l Path) writeLayer(layer v1.Layer) error {
+	d, err := layer.Digest()
+	if errors.Is(err, stream.ErrNotComputed) {
+		// Allow digest errors, since streams may not have calculated the hash
+		// yet. Instead, use an empty value, which will be transformed into a
+		// random file name with `os.CreateTemp` and the final digest will be
+		// calculated after writing to a temp file and before renaming to the
+		// final path.
+		d = v1.Hash{Algorithm: "sha256", Hex: ""}
+	} else if err != nil {
+		return err
+	}
+
+	s, err := layer.Size()
+	if errors.Is(err, stream.ErrNotComputed) {
+		// Allow size errors, since streams may not have calculated the size
+		// yet. Instead, use zero as a sentinel value meaning that no size
+		// comparison can be done and any sized blob file should be considered
+		// valid and not overwritten.
+		//
+		// TODO: Provide an option to always overwrite blobs.
+		s = -1
+	} else if err != nil {
+		return err
+	}
+
+	r, err := layer.Compressed()
+	if err != nil {
+		return err
+	}
+
+	if err := l.writeBlob(d, s, r, layer.Digest); err != nil {
+		return fmt.Errorf("error writing layer: %w", err)
+	}
+	return nil
+}
+
+// RemoveBlob removes a file from the blobs directory in the Path
+// at blobs/{hash.Algorithm}/{hash.Hex}
+// It does *not* remove any reference to it from other manifests or indexes, or
+// from the root index.json.
+func (l Path) RemoveBlob(hash v1.Hash) error {
+	dir := l.path("blobs", hash.Algorithm)
+	err := os.Remove(filepath.Join(dir, hash.Hex))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// WriteImage writes an image, including its manifest, config and all of its
+// layers, to the blobs directory. If any blob already exists, as determined by
+// the hash filename, does not write it.
+// This function does *not* update the `index.json` file. If you want to write the
+// image and also update the `index.json`, call AppendImage(), which wraps this
+// and also updates the `index.json`.
+func (l Path) WriteImage(img v1.Image) error {
+	layers, err := img.Layers()
+	if err != nil {
+		return err
+	}
+
+	// Write the layers concurrently.
+	var g errgroup.Group
+	for _, layer := range layers {
+		layer := layer
+		g.Go(func() error {
+			return l.writeLayer(layer)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Write the config.
+	cfgName, err := img.ConfigName()
+	if err != nil {
+		return err
+	}
+	cfgBlob, err := img.RawConfigFile()
+	if err != nil {
+		return err
+	}
+	if err := l.WriteBlob(cfgName, io.NopCloser(bytes.NewReader(cfgBlob))); err != nil {
+		return err
+	}
+
+	// Write the img manifest.
+	d, err := img.Digest()
+	if err != nil {
+		return err
+	}
+	manifest, err := img.RawManifest()
+	if err != nil {
+		return err
+	}
+
+	return l.WriteBlob(d, io.NopCloser(bytes.NewReader(manifest)))
+}
+
+type withLayer interface {
+	Layer(v1.Hash) (v1.Layer, error)
+}
+
+type withBlob interface {
+	Blob(v1.Hash) (io.ReadCloser, error)
+}
+
+func (l Path) writeIndexToFile(indexFile string, ii v1.ImageIndex) error {
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	// Walk the descriptors and write any v1.Image or v1.ImageIndex that we find.
+	// If we come across something we don't expect, just write it as a blob.
+	for _, desc := range index.Manifests {
+		switch desc.MediaType {
+		case types.OCIImageIndex, types.DockerManifestList:
+			ii, err := ii.ImageIndex(desc.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.WriteIndex(ii); err != nil {
+				return err
+			}
+		case types.OCIManifestSchema1, types.DockerManifestSchema2:
+			img, err := ii.Image(desc.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.WriteImage(img); err != nil {
+				return err
+			}
+		default:
+			// TODO: The layout could reference arbitrary things, which we should
+			// probably just pass through.
+
+			var blob io.ReadCloser
+			// Workaround for #819.
+			if wl, ok := ii.(withLayer); ok {
+				layer, lerr := wl.Layer(desc.Digest)
+				if lerr != nil {
+					return lerr
+				}
+				blob, err = layer.Compressed()
+			} else if wb, ok := ii.(withBlob); ok {
+				blob, err = wb.Blob(desc.Digest)
+			}
+			if err != nil {
+				return err
+			}
+			if err := l.WriteBlob(desc.Digest, blob); err != nil {
+				return err
+			}
+		}
+	}
+
+	rawIndex, err := ii.RawManifest()
+	if err != nil {
+		return err
+	}
+
+	return l.WriteFile(indexFile, rawIndex, os.ModePerm)
+}
+
+// WriteIndex writes an index to the blobs directory. Walks down the children,
+// including its children manifests and/or indexes, and down the tree until all of
+// config and all layers, have been written. If any blob already exists, as determined by
+// the hash filename, does not write it.
+// This function does *not* update the `index.json` file. If you want to write the
+// index and also update the `index.json`, call AppendIndex(), which wraps this
+// and also updates the `index.json`.
+func (l Path) WriteIndex(ii v1.ImageIndex) error {
+	// Always just write oci-layout file, since it's small.
+	if err := l.WriteFile("oci-layout", []byte(layoutFile), os.ModePerm); err != nil {
+		return err
+	}
+
+	h, err := ii.Digest()
+	if err != nil {
+		return err
+	}
+
+	indexFile := filepath.Join("blobs", h.Algorithm, h.Hex)
+	return l.writeIndexToFile(indexFile, ii)
+}
+
+// Write constructs a Path at path from an ImageIndex.
+//
+// The contents are written in the following format:
+// At the top level, there is:
+//
+//	One oci-layout file containing the version of this image-layout.
+//	One index.json file listing descriptors for the contained images.
+//
+// Under blobs/, there is, for each image:
+//
+//	One file for each layer, named after the layer's SHA.
+//	One file for each config blob, named after its SHA.
+//	One file for each manifest blob, named after its SHA.
+func Write(path string, ii v1.ImageIndex) (Path, error) {
+	lp := Path(path)
+	// Always just write oci-layout file, since it's small.
+	if err := lp.WriteFile("oci-layout", []byte(layoutFile), os.ModePerm); err != nil {
+		return "", err
+	}
+
+	// TODO create blobs/ in case there is a blobs file which would prevent the directory from being created
+
+	return lp, lp.writeIndexToFile("index.json", ii)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -477,6 +477,7 @@ github.com/google/go-containerregistry/pkg/logs
 github.com/google/go-containerregistry/pkg/name
 github.com/google/go-containerregistry/pkg/v1
 github.com/google/go-containerregistry/pkg/v1/empty
+github.com/google/go-containerregistry/pkg/v1/layout
 github.com/google/go-containerregistry/pkg/v1/match
 github.com/google/go-containerregistry/pkg/v1/mutate
 github.com/google/go-containerregistry/pkg/v1/partial


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-10954


**Please provide a short message that should be published in the vcluster release notes**
This adds the capability to the vcluster cli to create vClusters purely in docker similar to KinD:
```
vcluster create test --driver docker
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Docker driver and end-to-end Docker workflow for vclusterctl, plus experimental Docker config and OCI helpers.
> 
> - **Docker driver support across CLI**: `create`, `connect`, `delete`, `list`, `describe`, `pause`, `resume` now route to Docker-specific implementations when `--driver docker` is set
> - **Experimental config/schema**: new `experimental.docker` with container/node fields (`image`, `ports`, `volumes`, `env`, `args`, `nodes[*]`); corresponding Go types added
> - **Docker runtime implementation**: manage containers, networks, and volumes; extract kubeconfig from container; wait-for-ready; node join/ensure logic; join token persistence
> - **OCI image utilities**: new `pkg/cli/oci` to pull images and extract files; vendored `go-containerregistry` layout package
> - **Config/driver plumbing**: driver parsing updated to include `docker`; driver info/log messages adjusted; minor refactors in Helm path (value building/parsing) and platform API helper export
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cff601444d376cf6c8f33130891fc573148d51f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->