### PR TITLE
fix: remove dead code in podsyncer

### DIFF
--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -330,7 +330,7 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 		} else if requeue {
 			return ctrl.Result{Requeue: true}, nil
 		}
-	} else if event.Host.Spec.NodeName != "" && event.Virtual.Spec.NodeName != "" && event.Host.Spec.NodeName != event.Virtual.Spec.NodeName {
+	} else if event.Virtual.Spec.NodeName != "" && event.Host.Spec.NodeName != event.Virtual.Spec.NodeName {
 		// if physical pod nodeName is different from virtual pod nodeName, we delete the virtual one
 		return patcher.DeleteVirtualObjectWithOptions(ctx, event.Virtual, event.Host, "node name is different between the two", &client.DeleteOptions{GracePeriodSeconds: &minimumGracePeriodInSeconds})
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-10878

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix nodeName mismatch handling in `podSyncer`**
> 
> - Simplifies the conditional in `syncer.go` so that when `event.Virtual.Spec.NodeName` is set and differs from `event.Host.Spec.NodeName`, the virtual pod is deleted, even if the host pod has no `nodeName` yet.
> - Removes unreachable/dead code by dropping the redundant `event.Host.Spec.NodeName != ""` check in the mismatch branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f04c175d2baba778281c4d3651dd3d9d0848804b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->