### PR TITLE
feat: add docker registry proxy

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1942,12 +1942,20 @@
           "type": "array",
           "description": "Args defines extra arguments to be added to the docker run command of the container."
         },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user."
+        },
         "nodes": {
           "items": {
             "$ref": "#/$defs/ExperimentalDockerNode"
           },
           "type": "array",
           "description": "Nodes defines the nodes of the vCluster."
+        },
+        "registryProxy": {
+          "$ref": "#/$defs/ExperimentalDockerRegistryProxy",
+          "description": "Defines if docker images should be pulled from the host docker daemon."
         }
       },
       "additionalProperties": false,
@@ -1990,6 +1998,16 @@
         "name": {
           "type": "string",
           "description": "Name defines the name of the node. If not specified, a random name will be generated."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDockerRegistryProxy": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the registry proxy should be enabled."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1219,6 +1219,13 @@ plugins: {}
 
 # Experimental features for vCluster. Configuration here might change, so be careful with this.
 experimental:
+  # Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
+  docker:
+    # Defines if docker images should be pulled from the host docker daemon.
+    registryProxy:
+      # Enabled defines if the registry proxy should be enabled.
+      enabled: true
+  
   # Proxy enables vCluster-to-vCluster proxying of resources
   proxy:
     # CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration

--- a/config/config.go
+++ b/config/config.go
@@ -920,6 +920,10 @@ func (c *Config) Distro() string {
 	return K8SDistro
 }
 
+func (c *Config) IsDockerRegistryDaemonEnabled() bool {
+	return c.Experimental.Docker.Enabled && c.Experimental.Docker.RegistryProxy.Enabled
+}
+
 func (c *Config) IsVirtualSchedulerEnabled() bool {
 	return c.Distro() == K8SDistro && c.ControlPlane.Distro.K8S.Scheduler.Enabled ||
 		c.ControlPlane.Advanced.VirtualScheduler.Enabled
@@ -3151,8 +3155,19 @@ func (e ExperimentalSyncSettings) JSONSchemaExtend(base *jsonschema.Schema) {
 type ExperimentalDocker struct {
 	ExperimentalDockerContainer `json:",inline"`
 
+	// Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user.
+	Enabled bool `json:"enabled,omitempty"`
+
 	// Nodes defines the nodes of the vCluster.
 	Nodes []ExperimentalDockerNode `json:"nodes,omitempty"`
+
+	// Defines if docker images should be pulled from the host docker daemon.
+	RegistryProxy ExperimentalDockerRegistryProxy `json:"registryProxy,omitempty"`
+}
+
+type ExperimentalDockerRegistryProxy struct {
+	// Enabled defines if the registry proxy should be enabled.
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 type ExperimentalDockerNode struct {

--- a/config/default_extra_values.go
+++ b/config/default_extra_values.go
@@ -67,13 +67,22 @@ type KubernetesVersion struct {
 	Minor string
 }
 
+func GetExtraValuesNoDiff(options *ExtraValuesOptions) (*Config, error) {
+	toConfig, err := getExtraValues(options)
+	if err != nil {
+		return nil, fmt.Errorf("get extra values: %w", err)
+	}
+
+	return toConfig, nil
+}
+
 func GetExtraValues(options *ExtraValuesOptions) (string, error) {
 	fromConfig, err := NewDefaultConfig()
 	if err != nil {
 		return "", err
 	}
 
-	toConfig, err := getExtraValues(options)
+	toConfig, err := GetExtraValuesNoDiff(options)
 	if err != nil {
 		return "", fmt.Errorf("get extra values: %w", err)
 	}

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -657,6 +657,10 @@ external: {}
 plugins: {}
 
 experimental:
+  docker:
+    registryProxy:
+      enabled: true
+
   proxy:
     customResources: {}
 

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -352,6 +352,20 @@ func VClusterPlatformContextName(vClusterName string, projectName string, curren
 	return "vcluster-platform_" + vClusterName + "_" + projectName + "_" + currentContext
 }
 
+func VClusterDockerFromContext(originalContext string) (name string, context string) {
+	if !strings.HasPrefix(originalContext, "vcluster-docker_") {
+		return "", ""
+	}
+
+	splitted := strings.Split(originalContext, "_")
+	// vcluster-docker_<name>
+	if len(splitted) == 2 {
+		return splitted[1], ""
+	}
+
+	return "", ""
+}
+
 func VClusterPlatformFromContext(originalContext string) (name string, project string, context string) {
 	if !strings.HasPrefix(originalContext, "vcluster-platform_") {
 		return "", "", ""

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -236,7 +236,7 @@ func (s *Server) ServeOnListenerTLS(ctx *synccontext.ControllerContext) error {
 			},
 		)
 	}
-	if ctx.Config.ControlPlane.Advanced.Registry.Enabled {
+	if ctx.Config.ControlPlane.Advanced.Registry.Enabled || ctx.Config.IsDockerRegistryDaemonEnabled() {
 		if !ctx.Config.ControlPlane.Advanced.Registry.AnonymousPull {
 			redirectAuthNonResources = append(redirectAuthNonResources,
 				delegatingauthorizer.PathVerb{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Docker registry proxy integration and related CLI/runtime updates.
> 
> - Adds `experimental.docker.enabled` and `experimental.docker.registryProxy.enabled` (schema + defaults); new `ExperimentalDockerRegistryProxy` type and `Config.IsDockerRegistryDaemonEnabled()`
> - Docker create flow now loads/merges config, auto-enables Docker mode, disables `konnectivity` by default, and bind-mounts the host containerd socket when the Docker image store is containerd
> - Updates control-plane run to accept extra Docker args; new helpers (`isContainerdImageStore`, `getContainerdSocketPath`, `convertToMap`); exposes `GetExtraValuesNoDiff`
> - Server auth treats embedded registry as enabled when Docker registry proxy is on (authorizes `/v2*` paths)
> - vclusterctl `disconnect`: detects docker contexts (`vcluster-docker_*`) and supports non-interactive context selection when not in a TTY
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50354a94eb0d0abd5327a83f703a1efab591d08f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->