### PR TITLE
fix(linear-sync): support variable-length team keys in issue regex

### DIFF
--- a/hack/linear-sync/linear_test.go
+++ b/hack/linear-sync/linear_test.go
@@ -244,9 +244,9 @@ func TestIssueIDsExtraction(t *testing.T) {
 		issuesInBodyREs = originalRegex
 	}()
 
-	// For testing, use a regex that matches any 3-letter prefix format
+	// For testing, use a regex that matches team keys of 2-10 chars and issue numbers 1-5 digits
 	issuesInBodyREs = []*regexp.Regexp{
-		regexp.MustCompile(`(?P<issue>\w{3}-\d{4})`),
+		regexp.MustCompile(`(?P<issue>\w{2,10}-\d{1,5})`),
 	}
 
 	testCases := []struct {
@@ -284,6 +284,36 @@ func TestIssueIDsExtraction(t *testing.T) {
 			body:        "This PR fixes CVE-1234",
 			headRefName: "security/fix",
 			expected:    []string{},
+		},
+		{
+			name:        "Long team key (DEVOPS)",
+			body:        "This PR fixes DEVOPS-471",
+			headRefName: "feature/infra-update",
+			expected:    []string{"devops-471"},
+		},
+		{
+			name:        "Short team key (QA)",
+			body:        "This PR fixes QA-42",
+			headRefName: "feature/test-fix",
+			expected:    []string{"qa-42"},
+		},
+		{
+			name:        "Mixed team keys",
+			body:        "This PR fixes ENG-1234 and DEVOPS-471",
+			headRefName: "feature/QA-99-cross-team",
+			expected:    []string{"eng-1234", "devops-471", "qa-99"},
+		},
+		{
+			name:        "Issue with short number",
+			body:        "This PR fixes ENG-1",
+			headRefName: "feature/quick-fix",
+			expected:    []string{"eng-1"},
+		},
+		{
+			name:        "Issue with long number",
+			body:        "This PR fixes ENG-12345",
+			headRefName: "feature/big-project",
+			expected:    []string{"eng-12345"},
 		},
 	}
 

--- a/hack/linear-sync/pr.go
+++ b/hack/linear-sync/pr.go
@@ -8,7 +8,7 @@ import (
 )
 
 var issuesInBodyREs = []*regexp.Regexp{
-	regexp.MustCompile(`(?P<issue>\w{3}-\d{4})`),
+	regexp.MustCompile(`(?i)(?P<issue>[A-Z]{2,10}-\d{1,5})`),
 }
 
 const PageSize = 100


### PR DESCRIPTION
Fixes DEVOPS-471

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broadens Linear issue detection and strengthens tests.
> 
> - Updates `issuesInBodyREs` to `\w{2,10}-\d{1,5}` (from `\w{3}-\d{4}`) to support variable-length team keys and issue numbers while still skipping `CVE-*`
> - Expands tests in `linear_test.go` to cover long/short team keys (e.g., `DEVOPS-471`, `QA-42`), mixed sources (body and branch), and short/long numbers (1–5 digits)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d25646026c42aaa8fa5ae8ef9dd0e0c19c5a37cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->