### PR TITLE
ENG-10934 | Check against using the same resource for both sync and proxy

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -305,6 +305,15 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 		return err
 	}
 
+	err = pkgconfig.ValidateCustomResourceSyncProxyConflicts(
+		vClusterConfig.Sync.ToHost.CustomResources,
+		vClusterConfig.Sync.FromHost.CustomResources,
+		vClusterConfig.Experimental.Proxy.CustomResources,
+	)
+	if err != nil {
+		return err
+	}
+
 	err = pkgconfig.ValidateExperimentalProxyCustomResourcesConfig(vClusterConfig.Experimental.Proxy.CustomResources)
 	if err != nil {
 		return err


### PR DESCRIPTION
resolves ENG-10934

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens configuration validation around custom resources and experimental proxying.
> 
> - New `ValidateCustomResourceSyncProxyConflicts` enforces exclusivity between `sync.toHost.customResources`, `sync.fromHost.customResources`, and `experimental.proxy.customResources` (only considers entries with `enabled: true`)
> - New `ValidateExperimentalProxyCustomResourcesConfig` validates proxy CR entries: resource path format (`resource.group/version`), required `targetVirtualCluster.name`, and `accessResources` values (`owned|all`)
> - Invoked during `ValidateConfigAndSetDefaults` and from `pkg/cli/create_helm.go` prior to install/upgrade
> - Adds comprehensive unit tests for both validations
> - Minor: imports `lo` for set operations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 877b45dbef33037083b0801f676045f2b18ff122. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->