### PR TITLE
feat: add load balancer support & refactor

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1965,8 +1965,26 @@
           "description": "Nodes defines the nodes of the vCluster."
         },
         "registryProxy": {
-          "$ref": "#/$defs/ExperimentalDockerRegistryProxy",
-          "description": "Defines if docker images should be pulled from the host docker daemon."
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to\nuse purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd"
+        },
+        "loadBalancer": {
+          "$ref": "#/$defs/ExperimentalDockerLoadBalancer",
+          "description": "Defines if vCluster should configure load balancer services inside the vCluster. This might require\nsudo access on the host cluster for docker desktop or rancher desktop on macos."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDockerLoadBalancer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "forwardPorts": {
+          "type": "boolean",
+          "description": "ForwardPorts defines if the load balancer ips should be made available locally\nvia port forwarding. This will be only done if necessary for example on macos when using docker desktop."
         }
       },
       "additionalProperties": false,
@@ -2009,16 +2027,6 @@
         "name": {
           "type": "string",
           "description": "Name defines the name of the node. If not specified, a random name will be generated."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ExperimentalDockerRegistryProxy": {
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enabled defines if the registry proxy should be enabled."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1223,9 +1223,17 @@ plugins: {}
 experimental:
   # Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
   docker:
-    # Defines if docker images should be pulled from the host docker daemon.
+    # Defines if vCluster should configure load balancer services inside the vCluster. This might require
+    # sudo access on the host cluster for docker desktop or rancher desktop on macos.
+    loadBalancer:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+      # ForwardPorts defines if the load balancer ips should be made available locally
+      # via port forwarding. This will be only done if necessary for example on macos when using docker desktop.
+      forwardPorts: true
+    # Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
+    # use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
     registryProxy:
-      # Enabled defines if the registry proxy should be enabled.
       enabled: true
   
   # Proxy enables vCluster-to-vCluster proxying of resources

--- a/cmd/vclusterctl/cmd/delete.go
+++ b/cmd/vclusterctl/cmd/delete.go
@@ -96,7 +96,7 @@ func (cmd *DeleteCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	}
 
 	if driverType == config.DockerDriver {
-		return cli.DeleteDocker(ctx, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
+		return cli.DeleteDocker(ctx, platformClient, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)
 	}
 
 	return cli.DeleteHelm(ctx, platformClient, &cmd.DeleteOptions, cmd.GlobalFlags, args[0], cmd.log)

--- a/config/config.go
+++ b/config/config.go
@@ -3168,13 +3168,21 @@ type ExperimentalDocker struct {
 	// Nodes defines the nodes of the vCluster.
 	Nodes []ExperimentalDockerNode `json:"nodes,omitempty"`
 
-	// Defines if docker images should be pulled from the host docker daemon.
-	RegistryProxy ExperimentalDockerRegistryProxy `json:"registryProxy,omitempty"`
+	// Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
+	// use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
+	RegistryProxy EnableSwitch `json:"registryProxy,omitempty"`
+
+	// Defines if vCluster should configure load balancer services inside the vCluster. This might require
+	// sudo access on the host cluster for docker desktop or rancher desktop on macos.
+	LoadBalancer ExperimentalDockerLoadBalancer `json:"loadBalancer,omitempty"`
 }
 
-type ExperimentalDockerRegistryProxy struct {
-	// Enabled defines if the registry proxy should be enabled.
-	Enabled bool `json:"enabled,omitempty"`
+type ExperimentalDockerLoadBalancer struct {
+	EnableSwitch `json:",inline"`
+
+	// ForwardPorts defines if the load balancer ips should be made available locally
+	// via port forwarding. This will be only done if necessary for example on macos when using docker desktop.
+	ForwardPorts bool `json:"forwardPorts,omitempty"`
 }
 
 type ExperimentalDockerNode struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -660,6 +660,9 @@ plugins: {}
 
 experimental:
   docker:
+    loadBalancer:
+      enabled: true
+      forwardPorts: true
     registryProxy:
       enabled: true
 

--- a/pkg/cli/start/docker.go
+++ b/pkg/cli/start/docker.go
@@ -139,6 +139,13 @@ func (l *LoftStarter) successDocker(ctx context.Context, containerID string) err
 		return fmt.Errorf(product.Replace("error waiting for loft: %v%w"), err)
 	}
 
+	if !l.NoLogin {
+		err := l.login(host)
+		if err != nil {
+			return err
+		}
+	}
+
 	// print success message
 	PrintSuccessMessageDockerInstall(host, l.Password, l.Log)
 	return nil

--- a/pkg/constants/cli.go
+++ b/pkg/constants/cli.go
@@ -13,6 +13,15 @@ const (
 	NodeTypeWorker       = "worker"
 )
 
+const (
+	DockerContainerdSocketPath = "/var/run/docker/containerd/containerd.sock"
+	DockerSocketPath           = "/var/run/docker/docker.sock"
+	DockerControlPlanePrefix   = "vcluster.cp."
+	DockerNodePrefix           = "vcluster.node."
+	DockerLoadBalancerPrefix   = "vcluster.lb."
+	DockerNetworkPrefix        = "vcluster."
+)
+
 func DefaultBackgroundProxyImage(version string) string {
 	envProxyImage := os.Getenv("VCLUSTER_BACKGROUND_PROXY_IMAGE")
 	if envProxyImage != "" {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

Adds support for load balancer services inside the vCluster

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds experimental Docker load balancer support and refactors Docker driver workflows, networking, and naming.
> 
> - Introduces `experimental.docker.loadBalancer` (with `enabled` and `forwardPorts`) in schema/config; defaults enabled in `values.yaml`
> - Replaces `ExperimentalDockerRegistryProxy` with `EnableSwitch`; updates docs and mounting of containerd socket when available
> - Refactors Docker create flow: split config loading (`loadUserValues`/`convertConfig`), network setup (`configureNetwork`), and LB setup (`configureLoadBalancer`); adds reachability/privileged-port checks, loopback IP aliasing on macOS, mounts Docker/containerd sockets
> - Standardizes Docker resource names via constants (`Docker*Prefix`, socket paths); adds `--network-alias` for control plane and workers; network creation now probes a free subnet
> - Extends CLI commands to handle new prefixes and LB containers: `list`, `pause`, `resume`, `delete`; `delete` now also removes matching platform instances via hashed join-token label and requires `platformClient`
> - Misc: improved resolv.conf handling with logging, start flow logs in post-install unless `NoLogin`, minor logging/error improvements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e741b87acdbf775a4b566b6d2ff581dce7d4919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->