### PR TITLE
fix: pro feature enabled check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1078,7 +1078,8 @@ func (c *Config) IsProFeatureEnabled() bool {
 		return true
 	}
 
-	if c.PrivateNodes.Enabled {
+	// private nodes is allowed in standalone mode
+	if c.PrivateNodes.Enabled && !c.ControlPlane.Standalone.Enabled {
 		return true
 	}
 


### PR DESCRIPTION
In standalone, private nodes are enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines pro feature detection logic.
> 
> - Updates `IsProFeatureEnabled` in `config.go` to return pro only if `privateNodes.enabled` is set and `controlPlane.standalone.enabled` is false, allowing private nodes in standalone without triggering pro mode
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d047576d44191a1e49fb2b44b4a84c18d11b0e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->