### PR TITLE
fix: add --docker to vcluster platform destroy

### DIFF
--- a/cmd/vclusterctl/cmd/platform/start.go
+++ b/cmd/vclusterctl/cmd/platform/start.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/survey"
 	"github.com/loft-sh/log/terminal"
+	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/email"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
@@ -86,6 +87,13 @@ before running this command:
 }
 
 func (cmd *StartCmd) Run(ctx context.Context) error {
+	// automatically use docker mode if the driver is set to docker
+	cfg := cmd.LoadedConfig(cmd.Log)
+	if cfg.Driver.Type == config.DockerDriver && !cmd.Docker {
+		cmd.Log.Info("Automatically using --docker flag because driver is set to 'docker'")
+		cmd.Docker = true
+	}
+
 	// get the version to deploy
 	if cmd.Version == "latest" || cmd.Version == "" {
 		cmd.Version = platform.MinimumVersionTag

--- a/pkg/cli/destroy/destroy_docker.go
+++ b/pkg/cli/destroy/destroy_docker.go
@@ -1,0 +1,130 @@
+package destroy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/loft-sh/log"
+)
+
+const (
+	// PlatformContainerName is the name of the docker container for vCluster platform
+	PlatformContainerName = "vcluster-platform"
+	// PlatformVolumeName is the name of the docker volume for vCluster platform
+	PlatformVolumeName = "vcluster-platform"
+)
+
+// ErrDockerPlatformNotFound is returned when no docker platform installation is found
+var ErrDockerPlatformNotFound = fmt.Errorf("no vCluster platform docker installation found (no container or volume)")
+
+// DestroyDocker stops and removes the vCluster platform docker container and volume.
+// If ignoreNotFound is false and no container or volume is found, it returns ErrDockerPlatformNotFound.
+func DestroyDocker(ctx context.Context, ignoreNotFound bool, log log.Logger) error {
+	// check if docker is available
+	_, err := exec.LookPath("docker")
+	if err != nil {
+		return fmt.Errorf("docker is not installed or not available in PATH: %w", err)
+	}
+
+	// check if docker daemon is running
+	output, err := exec.CommandContext(ctx, "docker", "ps").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker daemon is not running or not accessible: %s", string(output))
+	}
+
+	// track if we found anything to destroy
+	foundContainer := false
+	foundVolume := false
+
+	// check if container exists
+	containerID, err := findContainer(ctx, PlatformContainerName)
+	if err != nil {
+		return fmt.Errorf("failed to find container: %w", err)
+	}
+
+	if containerID != "" {
+		foundContainer = true
+		// stop the container
+		log.Infof("Stopping vCluster platform container %s...", PlatformContainerName)
+		out, err := exec.CommandContext(ctx, "docker", "stop", containerID).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to stop container: %w: %s", err, string(out))
+		}
+
+		// remove the container
+		log.Infof("Removing vCluster platform container %s...", PlatformContainerName)
+		out, err = exec.CommandContext(ctx, "docker", "rm", containerID).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to remove container: %w: %s", err, string(out))
+		}
+	}
+
+	// check if volume exists and remove it
+	hasVolume, err := volumeExists(ctx, PlatformVolumeName)
+	if err != nil {
+		return fmt.Errorf("failed to check if volume exists: %w", err)
+	}
+
+	if hasVolume {
+		foundVolume = true
+		log.Infof("Removing vCluster platform volume %s...", PlatformVolumeName)
+		out, err := exec.CommandContext(ctx, "docker", "volume", "rm", PlatformVolumeName).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to remove volume: %w: %s", err, string(out))
+		}
+	}
+
+	// check if anything was found
+	if !foundContainer && !foundVolume {
+		if ignoreNotFound {
+			log.Info("No vCluster platform docker installation found")
+			return nil
+		}
+		return ErrDockerPlatformNotFound
+	}
+
+	log.Info("Successfully destroyed vCluster platform docker installation")
+	return nil
+}
+
+// findContainer finds a container by name and returns its ID
+func findContainer(ctx context.Context, name string) (string, error) {
+	out, err := exec.CommandContext(ctx, "docker", "ps", "-q", "-a", "-f", "name=^"+name+"$").CombinedOutput()
+	if err != nil {
+		return "", wrapCommandError(out, err)
+	}
+
+	containerID := strings.TrimSpace(string(out))
+	return containerID, nil
+}
+
+// volumeExists checks if a docker volume exists
+func volumeExists(ctx context.Context, name string) (bool, error) {
+	out, err := exec.CommandContext(ctx, "docker", "volume", "ls", "-q", "-f", "name=^"+name+"$").CombinedOutput()
+	if err != nil {
+		return false, wrapCommandError(out, err)
+	}
+
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func wrapCommandError(stdout []byte, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	message := ""
+	if len(stdout) > 0 {
+		message += string(stdout) + "\n"
+	}
+
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError != nil && len(exitError.Stderr) > 0 {
+		message += string(exitError.Stderr) + "\n"
+	}
+
+	return fmt.Errorf("%s%w", message, err)
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Docker-based uninstall for vCluster Platform and auto-selects Docker mode based on config.
> 
> - New `--docker` flag in `vcluster platform destroy` with confirmation prompt; updates help text to include Docker cleanup
> - Implements `DestroyDocker` to stop/remove `vcluster-platform` container and volume with daemon/availability checks and not-found handling
> - Auto-enables Docker mode in both `start` and `destroy` when config driver type is `docker`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c007fca347cfc1b081a2103cccdede105daa8695. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->