### PR TITLE
feat: sync containers resources inplace resize on host cluster

### DIFF
--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -40,6 +40,10 @@ rules:
     resources: ["pods/status", "pods/ephemeralcontainers"]
     verbs: ["patch", "update"]
   {{- end }}
+  {{- if ge (.Capabilities.KubeVersion.Minor|int) 35 }}
+  - apiGroups: [""]
+    resources: ["pods/resize"]
+  {{- end }}
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-11208

Sync the virtual cluster resource resizing in place to the host cluster for kubernetes version `1.35.0` and greater.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
