### PR TITLE
fix: resolve merge conflict markers in linear-sync

### DIFF
--- a/hack/linear-sync/linear_test.go
+++ b/hack/linear-sync/linear_test.go
@@ -54,9 +54,9 @@ func TestMoveIssueLogic(t *testing.T) {
 
 // MockLinearClient is a mock implementation of the LinearClient interface for testing
 type MockLinearClient struct {
-	mockIssueStates       map[string]string
-	mockIssueStateNames   map[string]string
-	mockWorkflowIDs       map[string]string
+	mockIssueStates     map[string]string
+	mockIssueStateNames map[string]string
+	mockWorkflowIDs     map[string]string
 }
 
 func NewMockLinearClient() *MockLinearClient {
@@ -109,25 +109,25 @@ func (m *MockLinearClient) MoveIssueToState(ctx context.Context, dryRun bool, is
 	if strings.HasPrefix(strings.ToLower(issueID), "cve") {
 		return nil
 	}
-	
+
 	currentStateID, currentStateName, _ := m.IssueStateDetails(ctx, issueID)
-	
+
 	// Already in released state
 	if currentStateID == releasedStateID {
 		return nil
 	}
-	
+
 	// Skip if not in ready for release state
 	if currentStateName != readyForReleaseStateName {
 		return fmt.Errorf("issue %s not in ready for release state", issueID)
 	}
-	
+
 	// Only ENG-1234 is expected to be moved successfully
 	// Explicitly return errors for other issues to ensure the test only counts ENG-1234
 	if issueID != "ENG-1234" {
 		return fmt.Errorf("would not move issue %s for test purposes", issueID)
 	}
-	
+
 	return nil
 }
 
@@ -136,8 +136,8 @@ func TestIsIssueInState(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := []struct {
-		IssueID     string
-		StateID     string
+		IssueID        string
+		StateID        string
 		ExpectedResult bool
 	}{
 		{"ENG-1234", "ready-state-id", true},
@@ -164,10 +164,10 @@ func TestMoveIssueStateFiltering(t *testing.T) {
 	// Create a custom mock client for this test
 	mockClient := &MockLinearClient{
 		mockIssueStates: map[string]string{
-			"ENG-1234": "ready-state-id",  // Ready for release
-			"ENG-5678": "in-progress-id",  // In progress 
-			"ENG-9012": "released-id",     // Already released
-			"CVE-1234": "ready-state-id",  // Ready but should be skipped as CVE
+			"ENG-1234": "ready-state-id", // Ready for release
+			"ENG-5678": "in-progress-id", // In progress
+			"ENG-9012": "released-id",    // Already released
+			"CVE-1234": "ready-state-id", // Ready but should be skipped as CVE
 		},
 		mockIssueStateNames: map[string]string{
 			"ENG-1234": "Ready for Release",
@@ -181,7 +181,7 @@ func TestMoveIssueStateFiltering(t *testing.T) {
 			"In Progress":       "in-progress-id",
 		},
 	}
-	
+
 	ctx := context.Background()
 
 	// Test cases for the overall filtering logic
@@ -198,19 +198,19 @@ func TestMoveIssueStateFiltering(t *testing.T) {
 		if strings.HasPrefix(strings.ToLower(issueID), "cve") {
 			continue
 		}
-		
+
 		currentStateID, currentStateName, _ := mockClient.IssueStateDetails(ctx, issueID)
-		
+
 		// Skip if already in released state
 		if currentStateID == releasedStateID {
 			continue
 		}
-		
+
 		// Skip if not in ready for release state
 		if currentStateName != readyForReleaseStateName {
 			continue
 		}
-		
+
 		// This issue would be moved
 		actualMoved = append(actualMoved, issueID)
 	}
@@ -230,7 +230,7 @@ func TestMoveIssueStateFiltering(t *testing.T) {
 				break
 			}
 		}
-		
+
 		if !found {
 			t.Errorf("Expected issue %s to be moved, but it wasn't in the result set", expectedID)
 		}
@@ -243,17 +243,12 @@ func TestIssueIDsExtraction(t *testing.T) {
 	defer func() {
 		issuesInBodyREs = originalRegex
 	}()
-<<<<<<< HEAD
-	
-	// For testing, use a regex that matches any 3-letter prefix format
-=======
 
 	// For testing, use a regex that matches team keys of 2-10 chars and issue numbers 1-5 digits
->>>>>>> 3aa6f7157 (fix(linear-sync): support variable-length team keys in issue regex (#3469))
 	issuesInBodyREs = []*regexp.Regexp{
 		regexp.MustCompile(`(?P<issue>\w{2,10}-\d{1,5})`),
 	}
-	
+
 	testCases := []struct {
 		name        string
 		body        string
@@ -321,7 +316,7 @@ func TestIssueIDsExtraction(t *testing.T) {
 			expected:    []string{"eng-12345"},
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := LinearPullRequest{
@@ -330,15 +325,15 @@ func TestIssueIDsExtraction(t *testing.T) {
 					HeadRefName: tc.headRefName,
 				},
 			}
-			
+
 			result := pr.IssueIDs()
-			
+
 			if len(result) != len(tc.expected) {
 				t.Errorf("Expected %d issues, got %d", len(tc.expected), len(result))
 				t.Errorf("Expected: %v, Got: %v", tc.expected, result)
 				return
 			}
-			
+
 			// Check all expected IDs are found (ignoring order)
 			for _, expectedID := range tc.expected {
 				found := false


### PR DESCRIPTION
Conflict markers were accidentally merged into v0.28.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
