### PR TITLE
fix: skip error event on resourceversion conflict in pod syncer

### DIFF
--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -384,6 +384,10 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 
 	defer func() {
 		if err := patch.Patch(ctx, event.Host, event.Virtual); err != nil {
+			if kerrors.IsConflict(err) {
+				retErr = utilerrors.NewAggregate([]error{retErr, err})
+				return
+			}
 			retErr = utilerrors.NewAggregate([]error{retErr, err})
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #<issue_number> 

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster pod syncer would record unnecessary SyncError events for transient resource version conflicts during patch operations, which could mislead users into thinking the operation failed when it would actually succeed on retry.

**What else do we need to know?**

## Summary

This PR fixes the handling of conflict errors in the pod syncer's patch operation. When a resource version conflict occurs during patching (e.g., due to concurrent updates from webhooks or other controllers), controller-runtime will automatically retry the reconcile operation and eventually maintain data consistency. However, the previous implementation would record a SyncError event for these transient conflicts, which could mislead users into thinking the operation had failed when it would actually succeed on retry.

## Problem

When a resource version conflict causes a patch operation to fail:
- Controller-runtime automatically retries the reconcile operation
- The operation eventually succeeds and data consistency is maintained
- However, recording a SyncError event for these transient conflicts creates a false impression of failure to users

## Changes

- Added conflict error detection in `pkg/controllers/resources/pods/syncer.go`
- When a conflict error is detected during patch operation, the error is aggregated but not recorded as a SyncError event
- This prevents misleading error events while still allowing controller-runtime to handle retries automatically

## Technical Details

The fix adds a check for `kerrors.IsConflict(err)` before recording the error. When a resource version conflict is detected:
1. The error is aggregated with any existing errors
2. The function returns early without recording a SyncError event
3. Controller-runtime's retry mechanism will automatically retry the reconcile operation
4. The operation will eventually succeed and maintain data consistency

This prevents unnecessary and misleading error events from being recorded in the virtual cluster for transient conflicts that are expected to be resolved on retry.


## Related Issues

<img width="2272" height="157" alt="image" src="https://github.com/user-attachments/assets/86682262-0d0a-4a29-99fa-6e193f3ef37a" />

