### PR TITLE
fix: cilium, vpn & alpine issue

### DIFF
--- a/pkg/cli/start/docker.go
+++ b/pkg/cli/start/docker.go
@@ -142,7 +142,7 @@ func (l *LoftStarter) successDocker(ctx context.Context, containerID string) err
 	if !l.NoLogin {
 		err := l.login(host)
 		if err != nil {
-			return err
+			l.Log.Errorf("Error logging into platform automatically: %v", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens Docker-based vCluster creation/start with better DNS handling, config validation, mount propagation, and more resilient login.
> 
> - Adds `validateConfig` and enforces unique/non-empty node names not matching the vCluster name
> - Generates `k8s-resolv.conf` and new `kubelet.env`; mounts `kubelet.env` into control plane and worker containers instead of setting kubelet resolvConf via values
> - Ensures `mount --make-rshared /` during standalone install and worker join to avoid networking/CNI issues
> - Uses quieter `docker run -q` in probes (DNS, network reachability, privileged port) and adjusts checks
> - Optimizes vCluster image extraction by checking `.../vcluster` binary existence; minor arg/path fixes
> - Auto-login on Docker install logs errors instead of failing; CLI login retried (3x) with TLS skip and proper body handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96f9393e6e38abcffa8e14c33be94f4d2fa7bb94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->