### PR TITLE
fix(ci): use github token instead of oidc for claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,9 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -35,7 +34,8 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_LOFT_GH_APP_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

- Use explicit `github_token` instead of OIDC token exchange with Claude GitHub App
- The OIDC flow was failing with "Invalid OIDC token" error
- Changed `pull-requests` permission from `read` to `write` so Claude can post review comments
- Switched to standard `ANTHROPIC_API_KEY` secret name

## Why

The Claude GitHub App OIDC token exchange requires completing an onboarding flow on claude.ai that appears to be broken (page spins forever). Using explicit GitHub token bypasses this entirely.