### PR TITLE
fix: check if deletion.auto is configured

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -922,6 +922,14 @@ func (c *Config) IsConfiguredForSleepMode() bool {
 	return c.Sleep != nil
 }
 
+func (c *Config) IsConfiguredForAutoDeletion() bool {
+	if c == nil || c.Deletion == nil {
+		return false
+	}
+
+	return c.Deletion.Auto != nil
+}
+
 // ValidateChanges checks for disallowed config changes.
 func ValidateChanges(oldCfg, newCfg *Config) error {
 	if err := ValidateDistroChanges(newCfg.Distro(), oldCfg.Distro()); err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-11392


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
Previously the check for auto deletion was part of the broader sleepMode check, which has been removed with the config-restructuring. This brings back the check for auto deletion (which requires an agent on the cluster) and errors out in case it has been configured w/o agent. Otherwise users might be confused because the virtual cluster can be created with `deletion.auto` w/o it working correctly.