### PR TITLE
test: Cleanup restored PVC in the volume restore e2e test

### DIFF
--- a/test/e2e/snapshot/snapshot.go
+++ b/test/e2e/snapshot/snapshot.go
@@ -734,7 +734,7 @@ var _ = Describe("snapshot and restore", Ordered, func() {
 				}
 			}).WithContext(ctx).
 				WithPolling(framework.PollInterval).
-				WithTimeout(framework.PollTimeoutLong).
+				WithTimeout(5 * time.Minute).
 				Should(Succeed())
 		})
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
towards ENG-9706
closes ENG-9959
closes ENG-9952

**What else do we need to know?** 
Cleanup restored PVC which sometimes causes the next test to fail. Also increase test timeout because volume snapshot creation can really take longer sometimes.