### PR TITLE
fix: handle --restore flag in platform driver create path

### DIFF
--- a/pkg/cli/create_platform.go
+++ b/pkg/cli/create_platform.go
@@ -18,6 +18,8 @@ import (
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/kube"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
 	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
 	"github.com/loft-sh/vcluster/pkg/projectutil"
 	"github.com/loft-sh/vcluster/pkg/strvals"
@@ -141,6 +143,15 @@ func CreatePlatform(ctx context.Context, options *CreateOptions, globalFlags *fl
 		return err
 	}
 	log.Donef("Successfully created the virtual cluster %s in project %s", virtualClusterName, options.Project)
+
+	// restore from snapshot if requested
+	if options.Restore != "" {
+		log.Infof("Restore vCluster %s...", virtualClusterName)
+		err = Restore(ctx, []string{virtualClusterName, options.Restore}, globalFlags, &snapshot.Options{}, &pod.Options{}, false, false, log)
+		if err != nil {
+			return fmt.Errorf("restore vCluster %s: %w", virtualClusterName, err)
+		}
+	}
 
 	// check if we should connect to the vcluster or print the kubeconfig
 	if options.Connect || options.Print {

--- a/pkg/cli/create_platform_test.go
+++ b/pkg/cli/create_platform_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// Regression test for ENGPROV-118: --restore flag must not be silently ignored
+// when using the platform driver. This test verifies that CreatePlatform
+// references options.Restore and calls the Restore function.
+func TestCreatePlatform_RestoreNotIgnored_ENGPROV118(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "create_platform.go", nil, 0)
+	assert.NilError(t, err)
+
+	// Find the CreatePlatform function
+	var createPlatformFunc *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "CreatePlatform" {
+			createPlatformFunc = fn
+			break
+		}
+	}
+	assert.Assert(t, createPlatformFunc != nil, "CreatePlatform function not found")
+
+	// Verify that CreatePlatform references options.Restore
+	foundRestoreCheck := false
+	// Verify that CreatePlatform calls the Restore function
+	foundRestoreCall := false
+
+	ast.Inspect(createPlatformFunc, func(n ast.Node) bool {
+		// Check for options.Restore selector
+		sel, ok := n.(*ast.SelectorExpr)
+		if ok && sel.Sel.Name == "Restore" {
+			if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "options" {
+				foundRestoreCheck = true
+			}
+		}
+
+		// Check for a call to Restore()
+		call, ok := n.(*ast.CallExpr)
+		if ok {
+			if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "Restore" {
+				foundRestoreCall = true
+			}
+		}
+
+		return true
+	})
+
+	assert.Assert(t, foundRestoreCheck,
+		"CreatePlatform must check options.Restore (ENGPROV-118: --restore flag was silently ignored with platform driver)")
+	assert.Assert(t, foundRestoreCall,
+		"CreatePlatform must call Restore() when options.Restore is set (ENGPROV-118: --restore flag was silently ignored with platform driver)")
+}


### PR DESCRIPTION
## Summary
The `--restore` flag was silently ignored when creating a vCluster with `--driver platform`. This adds restore handling to the platform driver create path, matching the helm driver behavior.

## Root Cause
`CreatePlatform()` in `pkg/cli/create_platform.go` never checked `options.Restore` and never called `Restore()`, while the helm driver path did.

## Fix
Added a check for `options.Restore` after vCluster creation in `CreatePlatform()`. When set, it calls `Restore()` with the snapshot path, matching the helm driver behavior.

## Testing
- Added regression test `TestCreatePlatform_RestoreNotIgnored_ENGPROV118` that verifies `CreatePlatform` handles the restore flag
- All existing `./pkg/cli/...` tests pass

## Reproduction
See reproduction steps in ENGPROV-118

## Linear
Fixes ENGPROV-118