### PR TITLE
fix(docker): remove use of mount namespace

### DIFF
--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -1132,7 +1132,7 @@ func getDockerSocketPath(ctx context.Context) (string, error) {
 	// This matches paths ending in "/docker.sock" OR "/docker.sock.real"
 	cmdStr := `netstat -xlp | awk '$NF ~ /\/docker\.sock(\.real)?$/ {print $NF}'`
 
-	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to get docker socket path: %s: %w", string(out), err)
 	}
@@ -1156,7 +1156,7 @@ func getDockerSocketPath(ctx context.Context) (string, error) {
 func getContainerdSocketPath(ctx context.Context) (string, error) {
 	// This automatically discards stderr (where the netstat warning lives)
 	// and only captures the clean stdout from awk.
-	cmd := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", `netstat -xlp | awk '$NF ~ /\/containerd\.sock$/ {print $NF}'`)
+	cmd := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-p", "-u", "-i", "-n", "sh", "-c", `netstat -xlp | awk '$NF ~ /\/containerd\.sock$/ {print $NF}'`)
 	out, err := cmd.Output()
 
 	if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #
Resolving path for containerd or docker sockes rely on having `netstat` and `awk` installed on the host system, which may not be the case. This PR removes use of the host mount namespace and it will use mentioned binaries from the alpine container that runs the resolution command.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster create with docker provider runs on a machine that doesn't have `netstat` installed.


**What else do we need to know?** 
