### PR TITLE
[ENGPROV-120] Move vCluster spec validation into Create call

### DIFF
--- a/pkg/cli/create_platform.go
+++ b/pkg/cli/create_platform.go
@@ -169,6 +169,14 @@ func createWithoutTemplate(ctx context.Context, platformClient platform.Client, 
 		return nil, err
 	}
 
+	// validate helm values against vcluster config schema
+	if helmValues != "" {
+		cfg := &vclusterconfig.Config{}
+		if err := cfg.UnmarshalYAMLStrict([]byte(helmValues)); err != nil {
+			return nil, fmt.Errorf("invalid vcluster.yaml: %w", err)
+		}
+	}
+
 	// create virtual cluster instance
 	zone, offset := time.Now().Zone()
 	virtualClusterInstance := &managementv1.VirtualClusterInstance{
@@ -266,6 +274,14 @@ func upgradeWithoutTemplate(ctx context.Context, platformClient platform.Client,
 	helmValues, err := mergeValues(platformClient, options)
 	if err != nil {
 		return nil, err
+	}
+
+	// validate helm values against vcluster config schema
+	if helmValues != "" {
+		cfg := &vclusterconfig.Config{}
+		if err := cfg.UnmarshalYAMLStrict([]byte(helmValues)); err != nil {
+			return nil, fmt.Errorf("invalid vcluster.yaml: %w", err)
+		}
 	}
 
 	// update virtual cluster instance

--- a/pkg/platform/helper.go
+++ b/pkg/platform/helper.go
@@ -262,6 +262,13 @@ func SelectSpaceInstance(ctx context.Context, client Client, spaceName, projectN
 
 func SelectProjectOrCluster(ctx context.Context, client Client, clusterName, projectName string, allowClusterOnly bool, log log.Logger) (cluster string, project string, err error) {
 	if projectName != "" {
+		if clusterName != "" {
+			// Validate the cluster is available in the project
+			_, err := findProjectCluster(ctx, client, projectName, clusterName)
+			if err != nil {
+				return "", "", fmt.Errorf("cluster %q is not available in project %q: %w", clusterName, projectName, err)
+			}
+		}
 		return clusterName, projectName, nil
 	} else if allowClusterOnly && clusterName != "" {
 		return clusterName, "", nil


### PR DESCRIPTION
## Linear Ticket

https://linear.app/loft/issue/ENGPROV-120

## Summary

Implemented two validation fixes for the vCluster platform Create flow:

1. **vcluster.yaml schema validation**: Added `UnmarshalYAMLStrict` validation in both `createWithoutTemplate` and `upgradeWithoutTemplate` functions in `pkg/cli/create_platform.go`. This mirrors the existing pattern in the non-platform `parseVClusterYAML` function in `create_helm.go`. Invalid vcluster.yaml fields are now rejected at create time with a clear error message.

2. **Cluster reference validation**: Modified `SelectProjectOrCluster` in `pkg/platform/helper.go` to call the existing `findProjectCluster` helper when both `clusterName` and `projectName` are specified. Previously this early-return path skipped validation entirely, allowing creation with a cluster that doesn't exist in the project.

## Changes

- `pkg/cli/create_platform.go`: Added `UnmarshalYAMLStrict` validation in `createWithoutTemplate` and `upgradeWithoutTemplate`
- `pkg/platform/helper.go`: Added cluster membership validation in `SelectProjectOrCluster`

## Test Results

- Build: PASSED
- Unit tests (`pkg/cli/...`, `config/...`): PASSED
- E2E (local vCluster Platform on kind):
  - Invalid vcluster.yaml → rejected at create time ✅
  - Nonexistent cluster in project → rejected with clear error ✅
  - Valid settings → passes validation ✅

---
Generated by pascal.breuninger (🤖) (VibePod). Review carefully before merging.