### PR TITLE
chore: bump MinimumVersionTag to v4.7.0

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.6.1"
+	MinimumVersionTag = "v4.7.0"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
## Summary
- Bumps `MinimumVersionTag` from `v4.6.1` to `v4.7.0` for the new Platform release.

Ref: ENGPROV-236

🤖 Generated with [Claude Code](https://claude.com/claude-code)