### PR TITLE
[ENG-8736] Fix: quote .Release.Name in Helm label values to prevent YAML int coercion

### DIFF
--- a/chart/templates/etcd-service.yaml
+++ b/chart/templates/etcd-service.yaml
@@ -28,6 +28,6 @@ spec:
       protocol: TCP
   selector:
     app: vcluster-etcd
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
 {{- end }}
 {{- end }}

--- a/chart/templates/etcd-statefulset.yaml
+++ b/chart/templates/etcd-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
   selector:
     matchLabels:
       app: vcluster-etcd
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
   {{- if $externalEtcd.persistence.volumeClaimTemplates }}
   volumeClaimTemplates:
 {{ toYaml $externalEtcd.persistence.volumeClaimTemplates | indent 4 }}
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       labels:
         app: vcluster-etcd
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
         {{- range $k, $v := $externalEtcd.pods.labels }}
         {{ $k }}: {{ $v | quote }}
         {{- end }}
@@ -82,7 +82,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ .Release.Name | quote }}
               topologyKey: "kubernetes.io/hostname"
           # if possible avoid scheduling pod onto node that is in the same zone as one or more vcluster pods are running
           - weight: 50
@@ -96,7 +96,7 @@ spec:
                 - key: release
                   operator: In
                   values:
-                  - {{ .Release.Name }}
+                  - {{ .Release.Name | quote }}
               topologyKey: topology.kubernetes.io/zone
       {{- end }}
       {{- if $externalEtcd.scheduling.topologySpreadConstraints }}

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
   policyTypes:
     - Egress
     - Ingress
@@ -32,13 +32,13 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
 
     # Allow egress to other vcluster workloads, including coredns when not embedded.
     - to:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
 
 {{- if .Values.policies.networkPolicy.workload.publicEgress.enabled }}
     # Allow public egress.
@@ -57,13 +57,13 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
 
     # Allow ingress from other vcluster workloads.
     - from:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
 
 {{- if .Values.policies.networkPolicy.workload.ingress }}
 {{ toYaml .Values.policies.networkPolicy.workload.ingress | indent 4 }}
@@ -79,7 +79,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
   policyTypes:
     - Egress
     - Ingress
@@ -106,13 +106,13 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
 
     # Allow egress connections to vcluster workloads.
     - to:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
 
     # Allow egress to vcluster platform.
     - to:
@@ -130,7 +130,7 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
 
     # Allow ingress for vcluster workloads.
     - ports:
@@ -143,7 +143,7 @@ spec:
       from:
         - podSelector:
             matchLabels:
-              vcluster.loft.sh/managed-by: {{ .Release.Name }}
+              vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
 
     # Allow ingress from vcluster snapshot.
     - from:
@@ -174,7 +174,7 @@ spec:
   podSelector:
     matchLabels:
       k8s-app: vcluster-kube-dns
-      vcluster.loft.sh/managed-by: {{ .Release.Name }}
+      vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
   policyTypes:
     - Egress
     - Ingress
@@ -195,7 +195,7 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
 
   ingress:
     # Allow ingress from vcluster workloads.
@@ -207,7 +207,7 @@ spec:
       from:
        - podSelector:
            matchLabels:
-             vcluster.loft.sh/managed-by: {{ .Release.Name }}
+             vcluster.loft.sh/managed-by: {{ .Release.Name | quote }}
 {{- end }}
 
 ---
@@ -229,7 +229,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              release: {{ .Release.Name }}
+              release: {{ .Release.Name | quote }}
 
     # Allow egress to host kube-dns.
     - to:

--- a/chart/templates/pod-disruption-budget.yaml
+++ b/chart/templates/pod-disruption-budget.yaml
@@ -17,5 +17,5 @@ spec:
   selector:
     matchLabels:
       app: vcluster
-      release: {{ .Release.Name }}
+      release: {{ .Release.Name | quote }}
 {{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -47,6 +47,6 @@ spec:
   {{- if not .Values.controlPlane.service.spec.selector }}
   selector:
     app: vcluster
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
   {{- end }}
 {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: vcluster
     chart: "{{ include "vcluster.version.label"  $ }}"
-    release: {{ .Release.Name }}
+    release: {{ .Release.Name | quote }}
     heritage: "{{ .Release.Service }}"
   {{- if .Values.controlPlane.statefulSet.labels }}
 {{ toYaml .Values.controlPlane.statefulSet.labels | indent 4 }}
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       labels:
         app: vcluster
-        release: {{ .Release.Name }}
+        release: {{ .Release.Name | quote }}
         {{- if .Values.controlPlane.statefulSet.pods.labels }}
 {{ toYaml .Values.controlPlane.statefulSet.pods.labels | indent 8 }}
         {{- end }}


### PR DESCRIPTION
## Summary

- Adds `| quote` pipeline to all standalone `.Release.Name` usages in `release:` and `vcluster.loft.sh/managed-by:` label values across 6 Helm template files
- Prevents YAML parsers from interpreting a numeric release name as an integer

## Problem

When the Helm release name is a purely numeric string (e.g. `1`), YAML parsers interpret unquoted label values as integers rather than strings. The vCluster binary calls `yaml.UnmarshalStrict` on the rendered `config.yaml` and fails with a type-mismatch error, causing the pod to crash-loop.

## Changes

Added `| quote` to `release: {{ .Release.Name }}` and `vcluster.loft.sh/managed-by: {{ .Release.Name }}` label values in:
- `chart/templates/statefulset.yaml` (2 occurrences)
- `chart/templates/service.yaml` (1 occurrence)
- `chart/templates/networkpolicy.yaml` (7 `release:` + 6 `managed-by:` = 13 occurrences)
- `chart/templates/etcd-statefulset.yaml` (2 occurrences)
- `chart/templates/etcd-service.yaml` (1 occurrence)
- `chart/templates/pod-disruption-budget.yaml` (1 occurrence)

`name:` fields and embedded forms like `vc-config-{{ .Release.Name }}` are intentionally unchanged (they are already strings by context or embedding).

## Related

- Linear: https://linear.app/loft/issue/ENG-8736
- loft-enterprise validation PR (companion): https://github.com/loft-sh/loft-enterprise/pull/6167

## Test plan

- [x] `go build -mod vendor ./cmd/vclusterctl/` passes
- [x] `helm lint chart` passes (1 chart linted, 0 failed)

Generated by pascal.breuninger (🤖) (VibePod). Review carefully before merging.