### PR TITLE
Implement DeleteAllOf in blockingcacheclient and pluginhookclient

### DIFF
--- a/pkg/util/blockingcacheclient/client.go
+++ b/pkg/util/blockingcacheclient/client.go
@@ -263,7 +263,9 @@ func (c *CacheClient) blockApply(ctx context.Context, obj runtime.ApplyConfigura
 	})
 }
 
-// TODO: implement DeleteAllOf
+func (c *CacheClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return c.Client.DeleteAllOf(ctx, obj, opts...)
+}
 
 func (c *CacheClient) Status() client.StatusWriter {
 	return &CacheStatusClient{

--- a/pkg/util/pluginhookclient/client.go
+++ b/pkg/util/pluginhookclient/client.go
@@ -193,7 +193,9 @@ func (c *Client) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts
 	return c.Client.Apply(ctx, obj, opts...)
 }
 
-// TODO: implement DeleteAllOf
+func (c *Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return c.Client.DeleteAllOf(ctx, obj, opts...)
+}
 
 func (c *Client) Status() client.StatusWriter {
 	return &StatusClient{


### PR DESCRIPTION
## What does this PR do?

Implements `DeleteAllOf` explicitly on the wrapper clients so the previously unimplemented method is no longer a TODO.

## Changes

- **pkg/util/blockingcacheclient/client.go**: Add `DeleteAllOf` that delegates to the embedded `client.Client`. Removes the `// TODO: implement DeleteAllOf` comment.
- **pkg/util/pluginhookclient/client.go**: Add `DeleteAllOf` that delegates to the embedded `client.Client`. Removes the `// TODO: implement DeleteAllOf` comment.

## Behavior

No behavior change. Both wrappers already exposed the embedded client’s `DeleteAllOf` via struct embedding. This makes that behavior explicit and resolves the TODOs.