### PR TITLE
fix(ci): skip homebrew upload for non-latest stable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,22 +87,32 @@ jobs:
           # Only check stable releases. Pre-releases are handled by
           # goreleaser's skip_upload: auto in .goreleaser.yaml.
           if [[ "$CURRENT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            # Fetch the current version from the homebrew tap formula.
-            # Only skip if this release would downgrade what's in the tap.
-            TAP_VERSION=$(curl -sfL --max-time 10 \
-              "https://raw.githubusercontent.com/loft-sh/homebrew-tap/main/Formula/vcluster.rb" \
-              | grep -oP 'version "\K[^"]+' || echo "")
-            if [ -n "$TAP_VERSION" ]; then
-              CURRENT_VERSION="${CURRENT_TAG#v}"
-              if [ "$(printf '%s\n' "$CURRENT_VERSION" "$TAP_VERSION" | sort -V | tail -1)" != "$CURRENT_VERSION" ]; then
-                echo "skip_homebrew=true" >> "$GITHUB_OUTPUT"
-                echo "::notice::Skipping Homebrew upload: $CURRENT_TAG would downgrade tap from v$TAP_VERSION"
-              else
-                echo "skip_homebrew=false" >> "$GITHUB_OUTPUT"
-              fi
+            # Fetch the current version from the homebrew tap formula with
+            # retry + exponential backoff. If we can't verify the tap version
+            # we must fail — otherwise an older release could silently overwrite
+            # the latest version in the tap.
+            TAP_VERSION=""
+            for attempt in 1 2 3; do
+              TAP_VERSION=$(curl -sfL --max-time 10 \
+                "https://raw.githubusercontent.com/loft-sh/homebrew-tap/main/Formula/vcluster.rb" \
+                | grep -oP 'version "\K[^"]+') && break
+              TAP_VERSION=""
+              delay=$((1 << attempt))  # 2, 4, 8 seconds
+              echo "::warning::Attempt $attempt/3 to fetch tap version failed, retrying in ${delay}s..."
+              sleep "$delay"
+            done
+
+            if [ -z "$TAP_VERSION" ]; then
+              echo "::error::Failed to fetch homebrew tap version after 3 attempts. Failing to prevent potential tap downgrade."
+              exit 1
+            fi
+
+            CURRENT_VERSION="${CURRENT_TAG#v}"
+            if [ "$(printf '%s\n' "$CURRENT_VERSION" "$TAP_VERSION" | sort -V | tail -1)" != "$CURRENT_VERSION" ]; then
+              echo "skip_homebrew=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping Homebrew upload: $CURRENT_TAG would downgrade tap from v$TAP_VERSION"
             else
               echo "skip_homebrew=false" >> "$GITHUB_OUTPUT"
-              echo "::warning::Could not determine current tap version, allowing upload"
             fi
           else
             echo "skip_homebrew=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Prevents older maintenance releases (e.g. v0.31.1) from overwriting newer stable versions (v0.32.0) in the `loft-sh/homebrew-tap` formulas.

## What changed

Added a step to the release workflow that fetches the current version from `loft-sh/homebrew-tap/Formula/vcluster.rb` before running GoReleaser. If the release would downgrade the tap, `--skip=homebrew` is passed to GoReleaser. All other release assets (Docker images, binaries, chart) are still published normally.

Fallback: if the tap can't be reached, the upload proceeds (safe default). Pre-releases are unaffected — goreleaser's existing `skip_upload: auto` handles them.

## Test plan

- [ ] Release a maintenance patch while tap has a newer version — homebrew upload skipped
- [ ] Release the latest stable version — homebrew upload proceeds
- [ ] Release a pre-release — handled by goreleaser's `skip_upload: auto`
- [ ] Network failure fetching tap — falls back to allowing upload

Closes DEVOPS-630