### PR TITLE
ci(justfile): migrate local dev targets from kind to vind

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -27,16 +27,18 @@ build-snapshot:
   cp Dockerfile.release {{DIST_FOLDER}}/Dockerfile
   cd {{DIST_FOLDER}} && docker buildx build --load . -t ghcr.io/loft-sh/vcluster:dev-next
 
-# --- Kind ---
+# --- vind ---
 
-# Create a local kind cluster
-create-kind:
-  kind delete cluster -n vcluster
-  kind create cluster -n vcluster
+# Create a local vind cluster
+create-vind:
+  vcluster delete vcluster --driver docker 2>/dev/null || true
+  vcluster use driver docker
+  vcluster create vcluster --connect=false
+  vcluster connect vcluster --update-current
 
-# Delete the local kind cluster
-delete-kind:
-  kind delete cluster -n vcluster
+# Delete the local vind cluster
+delete-vind:
+  vcluster delete vcluster --driver docker
 
 # --- Build ---
 
@@ -105,15 +107,13 @@ setup-csi-volume-snapshots:
   kubectl wait --for=condition=Available -n kube-system deploy/snapshot-controller --timeout=60s
 
 # Run e2e tests
-e2e distribution="k8s" path="./test/e2e" multinamespace="false": create-kind setup-csi-volume-snapshots && delete-kind
+e2e distribution="k8s" path="./test/e2e" multinamespace="false": create-vind setup-csi-volume-snapshots && delete-vind
   echo "Execute test suites ({{ distribution }}, {{ path }}, {{ multinamespace }})"
 
   TELEMETRY_PRIVATE_KEY="" goreleaser build --snapshot --clean
   cp dist/vcluster_linux_$(go env GOARCH | sed s/amd64/amd64_v1/g | sed s/arm64/arm64_v8.0/g)/vcluster ./vcluster
   docker build -t vcluster:e2e-latest -f Dockerfile.release --build-arg TARGETARCH=$(uname -m | sed s/x86_64/amd64/g) --build-arg TARGETOS=linux .
   rm ./vcluster
-
-  kind load docker-image vcluster:e2e-latest -n vcluster
 
   cp test/commonValues.yaml dist/commonValues.yaml
 
@@ -122,7 +122,7 @@ e2e distribution="k8s" path="./test/e2e" multinamespace="false": create-kind set
   yq eval -i '.controlPlane.distro.{{distribution}}.enabled = true' dist/commonValues.yaml
   rm dist/commonValues.yaml.bak
 
-  sed -i.bak "s|kind-control-plane|vcluster-control-plane|g" dist/commonValues.yaml
+  sed -i.bak "s|kind-control-plane|vcluster|g" dist/commonValues.yaml
   rm dist/commonValues.yaml.bak
 
   kubectl create namespace from-host-sync-test
@@ -145,7 +145,7 @@ e2e distribution="k8s" path="./test/e2e" multinamespace="false": create-kind set
     VCLUSTER_NAMESPACE=vcluster \
     MULTINAMESPACE_MODE={{ multinamespace }} \
     VCLUSTER_BACKGROUND_PROXY_IMAGE=vcluster:e2e-latest \
-    KIND_NAME=vcluster \
+    HOST_NODE_NAME=vcluster \
     go test -v -ginkgo.v -ginkgo.skip='.*NetworkPolicy.*' -ginkgo.fail-fast
 
 


### PR DESCRIPTION
## Summary

Migrates the Justfile local development targets from KinD to vind (vCluster Docker driver). Companion to #3614 (CI workflow migration).

- Rename `create-kind`/`delete-kind` targets to `create-vind`/`delete-vind` using `vcluster` CLI with Docker driver
- Remove `kind load docker-image` step — vind shares Docker images natively
- Update node hostname sed replacement to match vind convention (cluster name, not `<name>-control-plane`)
- Replace `KIND_NAME` env var with `HOST_NODE_NAME` to match updated test code

## Test plan

- [ ] Run `just create-vind` to verify cluster creation via Docker driver
- [ ] Run `just delete-vind` to verify cluster teardown
- [ ] Confirm `just e2e` target invokes the new vind targets

References DEVOPS-579