### PR TITLE
fix(ci): prevent version check from breaking alpha release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
           echo "MinimumVersionTag=$MINIMUM_VERSION_TAG is a stable version"
 
   publish:
+    if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [check_minimum_version_tag]
     name: Publish vcluster
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

- Move alpha/pre-release condition from job-level `if` to step-level `if` on `check_minimum_version_tag` job
- Remove workaround condition on `publish` job that checked for `skipped` result
- Fixes GitHub Actions implicit `success()` breaking the release pipeline for alpha tags

## Why

GitHub Actions' implicit `success()` evaluates the entire transitive `needs` chain. When `check_minimum_version_tag` was skipped via job-level `if` (for alpha/pre-release tags containing `-`), all downstream jobs also evaluated as not-successful, breaking the release pipeline.

Same fix as loft-sh/loft-enterprise#6265.

Closes DEVOPS-635

## Test plan

- [ ] Create an alpha release (e.g. `v0.x.x-alpha.1`) and verify the pipeline runs to completion
- [ ] Create a stable release and verify `check_minimum_version_tag` still validates `MinimumVersionTag`