### PR TITLE
fix(snapshot): add timeout and socket cleanup to restore kine startup

### DIFF
--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -562,7 +562,8 @@ func setLatestRevisionSQLite(ctx context.Context, file string, revision int64) e
 	defer timeoutTimer.Stop()
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	for {
+	var fileCreated bool
+	for !fileCreated {
 		select {
 		case err := <-doneChan:
 			// kine exited before creating the file
@@ -572,15 +573,15 @@ func setLatestRevisionSQLite(ctx context.Context, file string, revision int64) e
 			return fmt.Errorf("kine exited before creating database")
 		case <-timeoutTimer.C:
 			cancel()
+			// drain doneChan to prevent goroutine leak from unbuffered channel send
+			<-doneChan
 			return fmt.Errorf("timed out waiting for kine to create database after %s", kineStartTimeout)
 		case <-ticker.C:
 			if _, err := os.Stat(file); err == nil {
-				// file created, proceed
-				goto fileCreated
+				fileCreated = true
 			}
 		}
 	}
-fileCreated:
 
 	// stop kine
 	cancel()


### PR DESCRIPTION
## Summary

- Remove stale `/data/kine.sock` before starting kine in `setLatestRevisionSQLite` to prevent "address already in use" errors
- Replace infinite `os.Stat` polling loop with a `select` that watches the kine `doneChan` (early exit on failure), a 30-second timeout, and the file creation ticker
- The infinite loop was the root cause of all 4 e2e timeout failures (e2e_node, e2e, e2e_isolation_mode, e2e_scheduler) in PR #3614 — kine failed to start due to stale socket, loop spun forever, go test killed it after 40 minutes

## Root cause

During snapshot restore, `setLatestRevisionSQLite()` starts kine to create a fresh SQLite database. The old code had:

```go
for {
    time.Sleep(1 * time.Second)
    _, err := os.Stat(file)
    if err == nil {
        break
    }
}
```

Two bugs:
1. If kine fails to start (exits immediately), the loop never breaks — `doneChan` is never read
2. If a stale `kine.sock` exists from the previous vcluster process, kine fails with "address already in use"

In the restore pod (which mounts the same `data-vcluster-0` PVC), the stale socket from the original vcluster StatefulSet pod is present, triggering both bugs simultaneously.

## Test plan

- [ ] Existing e2e snapshot/restore tests pass (these were the tests timing out)
- [ ] No unit tests in `pkg/snapshot/` — function spawns real kine binary, only testable at e2e level

Closes DEVOPS-641