### PR TITLE
fix(ci): allow lint workflow to pass for fork PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,8 +18,11 @@ concurrency:
 jobs:
   golangci:
     name: lint
-    if: github.repository_owner == 'loft-sh' # do not run on forks
     runs-on: ubuntu-latest
+    env:
+      # Use vendored dependencies so fork PRs (which lack access to
+      # GH_ACCESS_TOKEN) can still compile against private modules.
+      GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,6 +33,7 @@ jobs:
           cache: false
 
       - name: Configure git
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: git config --global url.https://"$GH_ACCESS_TOKEN"@github.com/.insteadOf https://github.com/
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -55,6 +59,7 @@ jobs:
           fi
 
       - name: Verify go mod tidy and vendor
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           go mod tidy
           go mod vendor
@@ -73,6 +78,8 @@ jobs:
             echo "   Run 'git status --ignored' locally to see ignored files."
             exit 1
           fi
+        env:
+          GOFLAGS: ""
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9


### PR DESCRIPTION
## Summary

- Fix broken fork PR detection in lint workflow — `github.repository_owner == 'loft-sh'` always evaluates to true for pull_request events, so the intended fork skip never worked
- Set `GOFLAGS=-mod=vendor` at job level so all Go commands (generate, schema check, golangci-lint) use committed vendor directory instead of resolving modules over the network
- Skip `Configure git` and `Verify go mod tidy and vendor` steps for fork PRs since they require `GH_ACCESS_TOKEN` (unavailable to forks per GitHub security model)
- Internal PRs retain the full `go mod tidy` + `go mod vendor` verification with `GOFLAGS` reset to empty

## Context

PR #3387 added a dependency on private repo `loft-sh/e2e-framework`. Since fork PRs don't receive repository secrets, `go mod tidy` fails with `fatal: could not read Password for 'https://github.com'`. The dependency is vendored, so using `-mod=vendor` sidesteps the network resolution entirely.

Closes DEVOPS-652

## Security

- **Secret guard**: `GH_ACCESS_TOKEN` only used when `head.repo.full_name == github.repository` (correct fork detection). The previous `repository_owner` check was always true and provided zero protection.
- **`-mod=vendor` is security-positive**: forces Go to use committed vendor directory instead of fetching from the network, eliminating dependency confusion during CI.
- **Skipped mod-tidy for forks**: fork PRs bypass `go mod tidy` consistency check. Acceptable trade-off — forks can't access secrets (GitHub security model), and code review catches vendor/ diffs before merge.
- **No new code execution surface**: `pull_request` trigger (not `pull_request_target`) means fork PRs run with read-only token and no secret access.

## Test plan

- [ ] Internal PR: all lint steps run (including mod tidy verification)
- [ ] Fork PR: lint, schema check, and golangci-lint run; git config and mod tidy steps are skipped