### PR TITLE
Resolve CVEs: fix alpine's internal dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENTRYPOINT ["go", "run", "-mod", "vendor", "cmd/vcluster/main.go", "start"]
 FROM alpine:3.23
 
 # install runtime dependencies
-RUN apk add --no-cache ca-certificates zstd tzdata
+RUN apk upgrade --no-cache zlib && apk add --no-cache ca-certificates zstd tzdata
 
 # Set root path as working directory
 WORKDIR /

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,7 +2,7 @@
 FROM alpine:3.23
 
 # install runtime dependencies
-RUN apk add --no-cache ca-certificates zstd tzdata
+RUN apk upgrade --no-cache zlib && apk add --no-cache ca-certificates zstd tzdata
 
 # Set root path as working directory
 WORKDIR /


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGPROV-312


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster has a CVE:
```
Critical severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE323-ZLIB-15435528
  Introduced through: zlib/zlib@1.3.1-r2, apk-tools/apk-tools@3.0.3-r1
  From: zlib/zlib@1.3.1-r2
  From: apk-tools/apk-tools@3.0.3-r1 > zlib/zlib@1.3.1-r2
  From: apk-tools/apk-tools@3.0.3-r1 > apk-tools/libapk@3.0.3-r1 > zlib/zlib@1.3.1-r2
  Fixed in: 1.3.2-r0

Package manager:   apk
Project name:      docker-image|ghcr.io/loft-sh/vcluster-oss
Docker image:      ghcr.io/loft-sh/vcluster-oss:0.33.0-rc.2
Platform:          linux/amd64
Target OS:         Alpine Linux v3.23
Licenses:          enabled
```


**What else do we need to know?** 
