### PR TITLE
fix(e2e-next): re-render YAML templates after flag parsing

### DIFF
--- a/e2e-next/clusters/clusters.go
+++ b/e2e-next/clusters/clusters.go
@@ -2,13 +2,15 @@ package clusters
 
 import (
 	_ "embed"
-
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/loft-sh/e2e-framework/pkg/provider/kind"
 	providervcluster "github.com/loft-sh/e2e-framework/pkg/provider/vcluster"
+	"github.com/loft-sh/e2e-framework/pkg/setup"
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/e2e-framework/pkg/setup/suite"
 	"github.com/loft-sh/e2e-framework/pkg/setup/vcluster"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
 	"github.com/loft-sh/vcluster/e2e-next/setup/template"
@@ -23,114 +25,135 @@ var (
 	)
 )
 
-var (
-	//go:embed vcluster-default.yaml
-	DefaultVClusterYAMLTemplate string
-	DefaultVClusterVars         map[string]interface{} = map[string]interface{}{
+// vclusterEntry tracks a vCluster definition together with its YAML template
+// metadata so that re-rendering, cleanup, and setup can be driven from a
+// single registry instead of manual enumeration in e2e_suite_test.go.
+type vclusterEntry struct {
+	definition suite.Dependency
+	tmplText   string // Go template source (embedded)
+	filePath   string // rendered temp file path
+	cleanup    func() error
+}
+
+// registry is the single list of all vCluster definitions.
+var registry []*vclusterEntry
+
+// register creates a vCluster definition, renders its YAML template to a temp
+// file, records it in the registry, and returns the suite.Dependency.
+//
+// Templates are rendered at init time with default vars so that
+// vcluster.WithVClusterYAML receives a valid file path. PrepareAndDeferCleanup
+// re-renders them after flag parsing with the correct --vcluster-image values.
+func register(name string, tmplText string, extraOpts ...vcluster.Options) suite.Dependency {
+	// Initial render with default vars — gives us a file path for WithVClusterYAML.
+	// Content will be overwritten by PrepareAndDeferCleanup after flag parsing.
+	filePath, cleanup := template.MustRender(tmplText, map[string]interface{}{
+		"Repository": constants.GetRepository(),
+		"Tag":        constants.GetTag(),
+	})
+
+	opts := append([]vcluster.Options{
+		vcluster.WithName(name),
+		vcluster.WithVClusterYAML(filePath),
+		vcluster.WithOptions(DefaultVClusterOptions...),
+		vcluster.WithDependencies(HostCluster),
+	}, extraOpts...)
+
+	entry := &vclusterEntry{
+		definition: vcluster.Define(opts...),
+		tmplText:   tmplText,
+		filePath:   filePath,
+		cleanup:    cleanup,
+	}
+	registry = append(registry, entry)
+	return entry.definition
+}
+
+// PrepareAndDeferCleanup re-renders all vCluster YAML templates with the
+// current flag values (--vcluster-image) and registers temp-file cleanup.
+// Call once in SynchronizedBeforeSuite after flag parsing.
+func PrepareAndDeferCleanup(deferCleanup func(args ...interface{})) error {
+	vars := map[string]interface{}{
 		"Repository": constants.GetRepository(),
 		"Tag":        constants.GetTag(),
 	}
+	for _, e := range registry {
+		if err := template.RenderToFile(e.filePath, e.tmplText, vars); err != nil {
+			return fmt.Errorf("re-render %s: %w", e.filePath, err)
+		}
+		deferCleanup(e.cleanup)
+	}
+	return nil
+}
 
-	DefaultVClusterYAML, DefaultVClusterYAMLCleanup = template.MustRender(DefaultVClusterYAMLTemplate, DefaultVClusterVars)
-	DefaultVClusterOptions                          = []support.ClusterOpts{
+// SetupFuncs returns the Setup function for every registered vCluster,
+// suitable for passing to setup.AllConcurrent.
+func SetupFuncs() []setup.Func {
+	fns := make([]setup.Func, len(registry))
+	for i, e := range registry {
+		fns[i] = e.definition.Setup
+	}
+	return fns
+}
+
+// --- Shared defaults ---
+
+var (
+	DefaultVClusterOptions = []support.ClusterOpts{
 		providervcluster.WithPath(filepath.Join(os.Getenv("GOBIN"), "vcluster")),
 		providervcluster.WithLocalChartDir("../chart"),
 		providervcluster.WithUpgrade(true),
 		providervcluster.WithBackgroundProxyImage(constants.GetVClusterImage()),
 	}
 )
+
+// --- Embedded YAML templates ---
+
+var (
+	//go:embed vcluster-default.yaml
+	DefaultVClusterYAMLTemplate string
+
+	//go:embed vcluster-test-helm.yaml
+	HelmChartsVClusterYAMLTemplate string
+
+	//go:embed vcluster-init-manifest.yaml
+	InitManifestsVClusterTemplate string
+
+	//go:embed vcluster-servicesync.yaml
+	ServiceSyncVClusterYAMLTemplate string
+
+	//go:embed vcluster-fromhost-configmaps.yaml
+	FromHostConfigMapsVClusterYAMLTemplate string
+)
+
+// --- vCluster definitions ---
+
 var (
 	K8sDefaultEndpointVClusterName = "k8s-default-endpoint-test"
-	K8sDefaultEndpointVCluster     = vcluster.Define(
-		vcluster.WithName(K8sDefaultEndpointVClusterName),
-		vcluster.WithVClusterYAML(DefaultVClusterYAML),
-		vcluster.WithOptions(
-			DefaultVClusterOptions...,
-		),
-		vcluster.WithDependencies(HostCluster),
-	)
+	K8sDefaultEndpointVCluster     = register(K8sDefaultEndpointVClusterName, DefaultVClusterYAMLTemplate)
 )
 
 var (
 	NodesVClusterName = "nodes-test-vcluster"
-	NodesVCluster     = vcluster.Define(
-		vcluster.WithName(NodesVClusterName),
-		vcluster.WithVClusterYAML(DefaultVClusterYAML),
-		vcluster.WithOptions(
-			DefaultVClusterOptions...,
-		),
-		vcluster.WithDependencies(HostCluster),
-	)
+	NodesVCluster     = register(NodesVClusterName, DefaultVClusterYAMLTemplate)
 )
 
 var (
-	//go:embed vcluster-test-helm.yaml
-	HelmChartsVClusterYAMLTemplate                        string
-	HelmChartsVClusterYAML, HelmChartsVClusterYAMLCleanup = template.MustRender(
-		HelmChartsVClusterYAMLTemplate,
-		DefaultVClusterVars,
-	)
 	HelmChartsVClusterName = "helm-charts-test-vcluster"
-	HelmChartsVCluster     = vcluster.Define(
-		vcluster.WithName(HelmChartsVClusterName),
-		vcluster.WithVClusterYAML(HelmChartsVClusterYAML),
-		vcluster.WithOptions(
-			DefaultVClusterOptions...,
-		),
-		vcluster.WithDependencies(HostCluster),
-	)
+	HelmChartsVCluster     = register(HelmChartsVClusterName, HelmChartsVClusterYAMLTemplate)
 )
 
 var (
-	//go:embed vcluster-init-manifest.yaml
-	InitManifestsVClusterTemplate                               string
-	InitManifestsVClusterName                                   = "init-manifests-test-vcluster"
-	InitManifestsVClusterYAML, InitManifestsVClusterYAMLCleanup = template.MustRender(
-		InitManifestsVClusterTemplate,
-		DefaultVClusterVars,
-	)
-	InitManifestsVCluster = vcluster.Define(
-		vcluster.WithName(InitManifestsVClusterName),
-		vcluster.WithVClusterYAML(InitManifestsVClusterYAML),
-		vcluster.WithOptions(
-			DefaultVClusterOptions...,
-		),
-		vcluster.WithDependencies(HostCluster),
-	)
+	InitManifestsVClusterName = "init-manifests-test-vcluster"
+	InitManifestsVCluster     = register(InitManifestsVClusterName, InitManifestsVClusterTemplate)
 )
 
 var (
-	//go:embed vcluster-servicesync.yaml
-	ServiceSyncVClusterYAMLTemplate                         string
-	ServiceSyncVClusterName                                 = "service-sync-vcluster"
-	ServiceSyncVClusterYAML, ServiceSyncVClusterYAMLCleanup = template.MustRender(
-		ServiceSyncVClusterYAMLTemplate,
-		DefaultVClusterVars,
-	)
-	ServiceSyncVCluster = vcluster.Define(
-		vcluster.WithName(ServiceSyncVClusterName),
-		vcluster.WithVClusterYAML(ServiceSyncVClusterYAML),
-		vcluster.WithOptions(
-			DefaultVClusterOptions...,
-		),
-		vcluster.WithDependencies(HostCluster),
-	)
+	ServiceSyncVClusterName = "service-sync-vcluster"
+	ServiceSyncVCluster     = register(ServiceSyncVClusterName, ServiceSyncVClusterYAMLTemplate)
 )
 
 var (
-	//go:embed vcluster-fromhost-configmaps.yaml
-	FromHostConfigMapsVClusterYAMLTemplate                                string
-	FromHostConfigMapsVClusterName                                        = "fromhost-configmaps-vcluster"
-	FromHostConfigMapsVClusterYAML, FromHostConfigMapsVClusterYAMLCleanup = template.MustRender(
-		FromHostConfigMapsVClusterYAMLTemplate,
-		DefaultVClusterVars,
-	)
-	FromHostConfigMapsVCluster = vcluster.Define(
-		vcluster.WithName(FromHostConfigMapsVClusterName),
-		vcluster.WithVClusterYAML(FromHostConfigMapsVClusterYAML),
-		vcluster.WithOptions(
-			DefaultVClusterOptions...,
-		),
-		vcluster.WithDependencies(HostCluster),
-	)
+	FromHostConfigMapsVClusterName = "fromhost-configmaps-vcluster"
+	FromHostConfigMapsVCluster     = register(FromHostConfigMapsVClusterName, FromHostConfigMapsVClusterYAMLTemplate)
 )

--- a/e2e-next/e2e_suite_test.go
+++ b/e2e-next/e2e_suite_test.go
@@ -83,16 +83,16 @@ var _ = SynchronizedBeforeSuite(
 	func(ctx context.Context) (context.Context, []byte) {
 		var err error
 
-		// Clean up vcluster yaml
-		DeferCleanup(clusters.DefaultVClusterYAMLCleanup)
-		DeferCleanup(clusters.HelmChartsVClusterYAMLCleanup)
-		DeferCleanup(clusters.InitManifestsVClusterYAMLCleanup)
-		DeferCleanup(clusters.ServiceSyncVClusterYAMLCleanup)
-		DeferCleanup(clusters.FromHostConfigMapsVClusterYAMLCleanup)
+		// Re-render YAML templates with current flag values (--vcluster-image)
+		// and register temp-file cleanup for each one.
+		Expect(clusters.PrepareAndDeferCleanup(DeferCleanup)).To(Succeed())
 
 		ctx, err = setup.All(
 			clusters.HostCluster.Setup,
 			func(ctx context.Context) (context.Context, error) {
+				if cluster.From(ctx, clusterName) == nil {
+					return ctx, nil
+				}
 				var err error
 				By("Loading image to kind cluster...", func() {
 					ctx, err = cluster.LoadImage(clusterName, vclusterImage)(ctx)
@@ -103,14 +103,7 @@ var _ = SynchronizedBeforeSuite(
 			func(ctx context.Context) (context.Context, error) {
 				var err error
 				By("Creating all virtual clusters...", func() {
-					ctx, err = setup.AllConcurrent(
-						clusters.K8sDefaultEndpointVCluster.Setup,
-						clusters.NodesVCluster.Setup,
-						clusters.HelmChartsVCluster.Setup,
-						clusters.InitManifestsVCluster.Setup,
-						clusters.ServiceSyncVCluster.Setup,
-						clusters.FromHostConfigMapsVCluster.Setup,
-					)(ctx)
+					ctx, err = setup.AllConcurrent(clusters.SetupFuncs()...)(ctx)
 					Expect(err).NotTo(HaveOccurred())
 				})
 				return ctx, err

--- a/e2e-next/setup/template/template.go
+++ b/e2e-next/setup/template/template.go
@@ -35,3 +35,20 @@ func Render(template string, data interface{}) (string, func() error, error) {
 		return os.Remove(tmpFile.Name())
 	}, nil
 }
+
+// RenderToFile re-renders a template with new data to an existing file path.
+// This is useful for updating previously rendered templates after flag parsing.
+func RenderToFile(path string, tmpl string, data interface{}) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	parsed, err := gotemplate.New("template").Parse(tmpl)
+	if err != nil {
+		return err
+	}
+
+	return parsed.Execute(f, data)
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
