### PR TITLE
ci: add scheduled check for homebrew tap version drift

### DIFF
--- a/.github/scripts/brew-tap-drift.sh
+++ b/.github/scripts/brew-tap-drift.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Library for homebrew tap version drift detection.
+# Source this file to use functions, or execute directly for the compare step.
+
+# Strip v prefix for consistent version comparison.
+normalize_version() {
+  echo "${1#v}"
+}
+
+# Fetch version string from a homebrew tap formula with retry.
+fetch_formula_version() {
+  local formula="$1"
+  local version=""
+  for attempt in 1 2 3; do
+    version=$(curl -sfL --max-time 10 \
+      "https://raw.githubusercontent.com/loft-sh/homebrew-tap/main/Formula/${formula}.rb" \
+      | grep -oP 'version "\K[^"]+') && break
+    version=""
+    delay=$((1 << attempt))
+    echo "::warning::Attempt $attempt/3 to fetch ${formula} version failed, retrying in ${delay}s..." >&2
+    sleep "$delay"
+  done
+  echo "$version"
+}
+
+# Compare release tag against tap versions.
+# Sets globals: DRIFTED (true/false), DRIFT_DETAILS (human-readable summary).
+# Args: release_tag tap_vcluster [tap_experimental]
+compare_versions() {
+  local release tap_vcluster tap_experimental
+  release=$(normalize_version "$1")
+  tap_vcluster=$(normalize_version "$2")
+  tap_experimental=$(normalize_version "${3:-}")
+
+  DRIFTED="false"
+  DRIFT_DETAILS=""
+
+  if [[ "$release" != "$tap_vcluster" ]]; then
+    echo "::warning::vcluster tap drift: release=${release} tap=${tap_vcluster}"
+    DRIFTED="true"
+    DRIFT_DETAILS="vcluster: release=${release} tap=${tap_vcluster}"
+  fi
+
+  if [[ -n "$tap_experimental" && "$release" != "$tap_experimental" ]]; then
+    echo "::warning::vcluster-experimental tap drift: release=${release} tap=${tap_experimental}"
+    DRIFTED="true"
+    if [[ -n "$DRIFT_DETAILS" ]]; then
+      DRIFT_DETAILS="${DRIFT_DETAILS}\nvcluster-experimental: release=${release} tap=${tap_experimental}"
+    else
+      DRIFT_DETAILS="vcluster-experimental: release=${release} tap=${tap_experimental}"
+    fi
+  fi
+}
+
+# Main entrypoint — runs only when executed directly, not when sourced.
+# Expects env vars: RELEASE_TAG, TAP_VCLUSTER, TAP_EXPERIMENTAL, GITHUB_OUTPUT.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  compare_versions "$RELEASE_TAG" "$TAP_VCLUSTER" "${TAP_EXPERIMENTAL:-}"
+
+  if [[ "$DRIFTED" == "false" ]]; then
+    echo "No drift detected. release=$(normalize_version "$RELEASE_TAG") tap=$(normalize_version "$TAP_VCLUSTER")"
+    echo "drifted=false" >> "$GITHUB_OUTPUT"
+  else
+    echo "drifted=true" >> "$GITHUB_OUTPUT"
+    {
+      echo "details<<EOF"
+      echo -e "$DRIFT_DETAILS"
+      echo "EOF"
+    } >> "$GITHUB_OUTPUT"
+  fi
+fi

--- a/.github/tests/test-brew-tap-drift.sh
+++ b/.github/tests/test-brew-tap-drift.sh
@@ -1,55 +1,92 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Tests the version comparison logic used in check-brew-tap-drift.yaml.
-# Validates that drift is correctly detected between release tags and tap versions.
+# Tests for .github/scripts/brew-tap-drift.sh
+# Sources the library and exercises its functions directly.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../scripts/brew-tap-drift.sh"
 
 PASS=0
 FAIL=0
 
-check_drift() {
+assert_drift() {
   local release="$1" tap="$2" expected_drifted="$3" description="$4"
 
-  # Strip v prefix for consistent comparison (mirrors workflow logic)
-  release="${release#v}"
-  tap="${tap#v}"
+  compare_versions "$release" "$tap"
 
-  if [[ "$release" != "$tap" ]]; then
-    actual_drifted="true"
-  else
-    actual_drifted="false"
-  fi
-
-  if [[ "$actual_drifted" == "$expected_drifted" ]]; then
-    printf "  PASS: %s (release=%s tap=%s drifted=%s)\n" "$description" "$release" "$tap" "$actual_drifted"
+  if [[ "$DRIFTED" == "$expected_drifted" ]]; then
+    printf "  PASS: %s (release=%s tap=%s drifted=%s)\n" \
+      "$description" "$(normalize_version "$release")" "$(normalize_version "$tap")" "$DRIFTED"
     PASS=$((PASS + 1))
   else
-    printf "  FAIL: %s (release=%s tap=%s expected_drifted=%s got=%s)\n" "$description" "$release" "$tap" "$expected_drifted" "$actual_drifted"
+    printf "  FAIL: %s (release=%s tap=%s expected=%s got=%s)\n" \
+      "$description" "$(normalize_version "$release")" "$(normalize_version "$tap")" "$expected_drifted" "$DRIFTED"
     FAIL=$((FAIL + 1))
   fi
 }
 
-printf "Testing brew tap drift detection logic\n\n"
+assert_experimental_drift() {
+  local release="$1" tap="$2" experimental="$3" expected_drifted="$4" description="$5"
+
+  compare_versions "$release" "$tap" "$experimental"
+
+  if [[ "$DRIFTED" == "$expected_drifted" ]]; then
+    printf "  PASS: %s (drifted=%s)\n" "$description" "$DRIFTED"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s (expected=%s got=%s)\n" "$description" "$expected_drifted" "$DRIFTED"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_normalize() {
+  local input="$1" expected="$2" description="$3"
+  local actual
+  actual=$(normalize_version "$input")
+
+  if [[ "$actual" == "$expected" ]]; then
+    printf "  PASS: %s (%s -> %s)\n" "$description" "$input" "$actual"
+    PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s (%s -> expected=%s got=%s)\n" "$description" "$input" "$expected" "$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+printf "=== normalize_version ===\n\n"
+assert_normalize "v0.33.0" "0.33.0" "strips v prefix"
+assert_normalize "0.33.0"  "0.33.0" "no-op without v prefix"
+assert_normalize "v1.0.0"  "1.0.0"  "strips v from major version"
+
+printf "\n=== compare_versions (single formula) ===\n\n"
 
 # matching versions — no drift
-check_drift "v0.23.0" "v0.23.0" "false" "matching versions show no drift"
-check_drift "v1.0.0"  "v1.0.0"  "false" "matching major versions show no drift"
+assert_drift "v0.23.0" "v0.23.0" "false" "matching versions show no drift"
+assert_drift "v1.0.0"  "v1.0.0"  "false" "matching major versions show no drift"
 
 # tap behind release — drift
-check_drift "v0.23.0" "v0.22.0" "true" "tap behind release is drift"
-check_drift "v0.23.1" "v0.23.0" "true" "tap behind by patch is drift"
-check_drift "v1.0.0"  "v0.23.0" "true" "tap behind by major is drift"
+assert_drift "v0.23.0" "v0.22.0" "true" "tap behind release is drift"
+assert_drift "v0.23.1" "v0.23.0" "true" "tap behind by patch is drift"
+assert_drift "v1.0.0"  "v0.23.0" "true" "tap behind by major is drift"
 
 # tap ahead of release — also drift (manual tap edit)
-check_drift "v0.22.0" "v0.23.0" "true" "tap ahead of release is drift"
+assert_drift "v0.22.0" "v0.23.0" "true" "tap ahead of release is drift"
 
 # different patch versions
-check_drift "v0.23.2" "v0.23.1" "true" "different patch versions is drift"
+assert_drift "v0.23.2" "v0.23.1" "true" "different patch versions is drift"
 
-# mixed v prefix — should still match after normalization
-check_drift "v0.33.0" "0.33.0" "false" "tag with v vs tap without v shows no drift"
-check_drift "0.33.0" "v0.33.0" "false" "tag without v vs tap with v shows no drift"
-check_drift "v0.33.0" "0.32.0" "true" "mixed prefix with version mismatch is drift"
+# mixed v prefix — should match after normalization
+assert_drift "v0.33.0" "0.33.0" "false" "tag with v vs tap without v shows no drift"
+assert_drift "0.33.0" "v0.33.0" "false" "tag without v vs tap with v shows no drift"
+assert_drift "v0.33.0" "0.32.0" "true" "mixed prefix with version mismatch is drift"
+
+printf "\n=== compare_versions (with experimental) ===\n\n"
+
+assert_experimental_drift "v0.33.0" "0.33.0" "0.33.0" "false" "all match — no drift"
+assert_experimental_drift "v0.33.0" "0.33.0" "0.32.0" "true"  "experimental behind — drift"
+assert_experimental_drift "v0.33.0" "0.32.0" "0.33.0" "true"  "vcluster behind — drift"
+assert_experimental_drift "v0.33.0" "0.33.0" ""        "false" "empty experimental — no drift"
 
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/check-brew-tap-drift.yaml
+++ b/.github/workflows/check-brew-tap-drift.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/check-brew-tap-drift.yaml
+      - .github/scripts/brew-tap-drift.sh
       - .github/tests/test-brew-tap-drift.sh
 
 permissions:
@@ -20,12 +21,13 @@ jobs:
     environment: slack-notifications
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Get latest stable release tag
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the latest stable release (goreleaser's skip_upload:auto skips pre-releases).
           TAG=$(gh release list --repo loft-sh/vcluster --limit 1 \
             --exclude-pre-releases --exclude-drafts \
             --json tagName --jq '.[0].tagName')
@@ -41,20 +43,7 @@ jobs:
       - name: Fetch tap formula versions
         id: tap
         run: |
-          fetch_formula_version() {
-            local formula="$1"
-            local version=""
-            for attempt in 1 2 3; do
-              version=$(curl -sfL --max-time 10 \
-                "https://raw.githubusercontent.com/loft-sh/homebrew-tap/main/Formula/${formula}.rb" \
-                | grep -oP 'version "\K[^"]+') && break
-              version=""
-              delay=$((1 << attempt))
-              echo "::warning::Attempt $attempt/3 to fetch ${formula} version failed, retrying in ${delay}s..."
-              sleep "$delay"
-            done
-            echo "$version"
-          }
+          source .github/scripts/brew-tap-drift.sh
 
           VCLUSTER_VERSION=$(fetch_formula_version "vcluster")
           EXPERIMENTAL_VERSION=$(fetch_formula_version "vcluster-experimental")
@@ -76,39 +65,7 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           TAP_VCLUSTER: ${{ steps.tap.outputs.vcluster }}
           TAP_EXPERIMENTAL: ${{ steps.tap.outputs.vcluster_experimental }}
-        run: |
-          # Strip v prefix for consistent comparison (tags have v, tap may not)
-          release="${RELEASE_TAG#v}"
-          tap_vcluster="${TAP_VCLUSTER#v}"
-          tap_experimental="${TAP_EXPERIMENTAL#v}"
-          drift=""
-
-          if [[ "$release" != "$tap_vcluster" ]]; then
-            echo "::warning::vcluster tap drift: release=${release} tap=${tap_vcluster}"
-            drift="vcluster: release=${release} tap=${tap_vcluster}"
-          fi
-
-          if [[ -n "$tap_experimental" && "$release" != "$tap_experimental" ]]; then
-            echo "::warning::vcluster-experimental tap drift: release=${release} tap=${tap_experimental}"
-            if [[ -n "$drift" ]]; then
-              drift="${drift}\nvcluster-experimental: release=${release} tap=${tap_experimental}"
-            else
-              drift="vcluster-experimental: release=${release} tap=${tap_experimental}"
-            fi
-          fi
-
-          if [[ -z "$drift" ]]; then
-            echo "No drift detected. release=${release} tap=${tap_vcluster}"
-            echo "drifted=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "drifted=true" >> "$GITHUB_OUTPUT"
-            # Use a heredoc to preserve newlines in the output
-            {
-              echo "details<<EOF"
-              echo -e "$drift"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-          fi
+        run: bash .github/scripts/brew-tap-drift.sh
 
       - name: Notify eng-releases
         if: steps.compare.outputs.drifted == 'true'
@@ -116,13 +73,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "⚠️ Homebrew tap version drift detected",
+              "text": "Homebrew tap version drift detected",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "⚠️ Homebrew Tap Version Drift"
+                    "text": "Homebrew Tap Version Drift"
                   }
                 },
                 {


### PR DESCRIPTION
## Summary

- Adds a daily GitHub Action that detects homebrew tap version drift for vCluster
- Checks both `vcluster` and `vcluster-experimental` formulas against the latest stable release
- Sends Slack alert to `#eng-releases` when versions diverge

## Why

PR #3613 added retry + fail-hard logic to guard against tap downgrades during releases, but drift can also happen outside the release pipeline (manual tap edits, goreleaser bugs). This scheduled check catches those cases.

## Details

- **Schedule**: Daily at 08:00 UTC (+ manual `workflow_dispatch`)
- **Release version**: Uses `gh release list` to find the latest *stable* release (skips pre-releases, matching goreleaser's `skip_upload: auto`)
- **Tap fetch**: Curl with retry + exponential backoff (same pattern as release.yaml)
- **Slack**: Uses `slackapi/slack-github-action@v2.1.1` with `SLACK_WEBHOOK_URL_ENG_RELEASES` secret
- **Org guard**: Only runs when `repository_owner == 'loft-sh'`

## New secret required

`SLACK_WEBHOOK_URL_ENG_RELEASES` — incoming webhook URL for the `#eng-releases` Slack channel.

## Test plan

- [x] `.github/tests/test-brew-tap-drift.sh` — all 7 assertions pass (version comparison logic)
- [x] Verified formula version extraction against live URLs:
  - `curl` on `loft-sh/homebrew-tap/main/Formula/vcluster.rb` → `0.33.0`
  - `curl` on `loft-sh/homebrew-tap/main/Formula/vcluster-experimental.rb` → `0.33.0`
- [x] Verified release tag fetch: `gh release list --repo loft-sh/vcluster` → `v0.33.0` (latest stable)
- [x] Confirmed versions match (`v0.33.0` == `v0.33.0`) — no false drift on current state
- [ ] End-to-end: trigger via `workflow_dispatch` after `SLACK_WEBHOOK_URL_ENG_RELEASES` secret is added

Closes DEVOPS-654