### PR TITLE
feat: add nodeMonitoring feature

### DIFF
--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -167,6 +167,11 @@ rules:
     resources: [ "referencegrants" ]
     verbs: [ "create", "delete", "patch", "update", "get", "list", "watch" ]
   {{- end }}
+  {{- if .Values.experimental.nodeMonitors }}
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["servicemonitors"]
+    verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
+  {{- end }}
   {{- include "vcluster.customResources.roleExtraRules" . | indent 2 }}
   {{- include "vcluster.plugin.roleExtraRules" . | indent 2 }}
   {{- include "vcluster.rbac.roleExtraRules" . | indent 2 }}

--- a/chart/templates/tlsroute.yaml
+++ b/chart/templates/tlsroute.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controlPlane.tlsRoute.enabled }}
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: {{ .Values.controlPlane.tlsRoute.apiVersion }}
 kind: TLSRoute
 metadata:
   {{- $annotations := merge dict .Values.controlPlane.tlsRoute.annotations .Values.controlPlane.advanced.globalMetadata.annotations }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -864,6 +864,10 @@
           "type": "boolean",
           "description": "Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to \"Passthrough\""
         },
+        "apiVersion": {
+          "type": "string",
+          "description": "APIVersion is the version of the gateway api tls route."
+        },
         "host": {
           "type": "string",
           "description": "Host is the host where vCluster will be reachable"
@@ -1791,6 +1795,13 @@
         "docker": {
           "$ref": "#/$defs/ExperimentalDocker",
           "description": "Docker allows you to configure Docker related settings when deploying a vCluster using Docker."
+        },
+        "nodeMonitors": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalNodeMonitor"
+          },
+          "type": "array",
+          "description": "NodeMonitors allows you to create a service monitor for each node."
         }
       },
       "additionalProperties": false,
@@ -2021,6 +2032,90 @@
         "name": {
           "type": "string",
           "description": "Name defines the name of the node. If not specified, a random name will be generated."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalNodeMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the monitor. It will be suffixed with the node name."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector defines the node selector for the service monitor."
+        },
+        "endpoints": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalNodeServiceMonitorEndpoint"
+          },
+          "type": "array",
+          "description": "Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name."
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra service monitor options that will be merged into the spec."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalNodeServiceMonitorEndpoint": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path."
+        },
+        "params": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object",
+          "description": "Params allows you to configure extra parameters to add to the endpoint."
+        },
+        "extraRelabelings": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name."
+        },
+        "metricsRelabelings": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint."
+        },
+        "interval": {
+          "type": "string",
+          "description": "Interval is the interval at which to scrape the endpoint."
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "description": "ScrapeTimeout is the timeout for the scrape of the endpoint."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -542,6 +542,8 @@ controlPlane:
   tlsRoute:
     # Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
     enabled: false
+    # APIVersion is the version of the gateway api tls route.
+    apiVersion: gateway.networking.k8s.io/v1
     # Host is the host where vCluster will be reachable
     host: "my-host.com"
     # ParentRefs are the parent references for the TLS route
@@ -1255,6 +1257,9 @@ experimental:
       manifestsTemplate: ""
       # Helm are Helm charts that should get deployed into the virtual cluster
       helm: []
+  
+  # NodeMonitors allows you to create a service monitor for each node.
+  nodeMonitors: []
 
 # Configuration related to telemetry gathered about vCluster usage.
 telemetry:

--- a/config/config.go
+++ b/config/config.go
@@ -1803,6 +1803,9 @@ type ControlPlaneTLSRoute struct {
 	// Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
 	Enabled bool `json:"enabled,omitempty"`
 
+	// APIVersion is the version of the gateway api tls route.
+	APIVersion string `json:"apiVersion,omitempty"`
+
 	// Host is the host where vCluster will be reachable
 	Host string `json:"host,omitempty"`
 
@@ -3135,10 +3138,49 @@ type Experimental struct {
 
 	// Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
 	Docker ExperimentalDocker `json:"docker,omitempty"`
+
+	// NodeMonitors allows you to create a service monitor for each node.
+	NodeMonitors []ExperimentalNodeMonitor `json:"nodeMonitors,omitempty"`
 }
 
 func (e Experimental) JSONSchemaExtend(base *jsonschema.Schema) {
 	addProToJSONSchema(base, reflect.TypeOf(e))
+}
+
+type ExperimentalNodeMonitor struct {
+	// Name is the name of the monitor. It will be suffixed with the node name.
+	Name string `json:"name,omitempty"`
+
+	// NodeSelector defines the node selector for the service monitor.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name.
+	Endpoints []ExperimentalNodeServiceMonitorEndpoint `json:"endpoints,omitempty"`
+
+	// Spec allows you to configure extra service monitor options that will be merged into the spec.
+	Spec map[string]interface{} `json:"spec,omitempty"`
+
+	LabelsAndAnnotations `json:",inline"`
+}
+
+type ExperimentalNodeServiceMonitorEndpoint struct {
+	// Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path.
+	Path string `json:"path,omitempty"`
+
+	// Params allows you to configure extra parameters to add to the endpoint.
+	Params map[string][]string `json:"params,omitempty"`
+
+	// ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name.
+	ExtraRelabelings []map[string]interface{} `json:"extraRelabelings,omitempty"`
+
+	// MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint.
+	MetricsRelabelings []map[string]interface{} `json:"metricsRelabelings,omitempty"`
+
+	// Interval is the interval at which to scrape the endpoint.
+	Interval string `json:"interval,omitempty"`
+
+	// ScrapeTimeout is the timeout for the scrape of the endpoint.
+	ScrapeTimeout string `json:"scrapeTimeout,omitempty"`
 }
 
 type ExperimentalSyncSettings struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -279,6 +279,7 @@ controlPlane:
 
   tlsRoute:
     enabled: false
+    apiVersion: gateway.networking.k8s.io/v1
     host: "my-host.com"
     parentRefs: []
     spec: {}
@@ -674,6 +675,8 @@ experimental:
       manifests: ""
       manifestsTemplate: ""
       helm: []
+  
+  nodeMonitors: []
 
 telemetry:
   enabled: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**Please provide a short message that should be published in the vcluster release notes**
Adds a new `experimental.nodeMonitors` feature to expose nodes via ServiceMonitors on the host cluster

