### PR TITLE
chore: scope devops codeowners to production release pipelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 * @loft-sh/eng-dev-vcluster-platform
 
 /.github/workflows/ @loft-sh/devops-team
-/.github/workflows/backport.yaml @Piotr1215
+/.github/workflows/backport.yaml @loft-sh/devops-team
 /.github/workflows/e2e*.yaml @loft-sh/eng-qa @loft-sh/cto-office
 /.github/workflows/release.yaml @loft-sh/devops-team @loft-sh/cto-office
 /.github/CODEOWNERS @loft-sh/cto-office


### PR DESCRIPTION
## Summary

- Reorder CODEOWNERS workflow rules so the blanket `/.github/workflows/ @loft-sh/devops-team` comes **first** (as default), with specific overrides **after** (last-match-wins)
- `e2e*.yaml` now owned by `@loft-sh/eng-qa @loft-sh/cto-office` — no longer requires DevOps approval
- `release.yaml` stays with `@loft-sh/cto-office`, `backport.yaml` stays with `@Piotr1215`
- Matches the pattern already used in `loft-enterprise`

## Why

The blanket rule on line 9 came after specific rules (lines 5-8), overriding them all due to CODEOWNERS last-match-wins semantics. This meant DevOps approval was required for QA e2e workflow changes, blocking the QA team unnecessarily.

## Related

- Companion PR: https://github.com/loft-sh/vcluster-pro/pull/1598
- `loft-enterprise` already has this pattern — no change needed

## Test plan

- [ ] Verify with `gh api repos/loft-sh/vcluster/contents/.github/CODEOWNERS` after merge
- [ ] Confirm e2e workflow PRs no longer request DevOps review