### PR TITLE
fix(docker): remove read-only mount for vcluster.yaml

### DIFF
--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -552,7 +552,7 @@ func runControlPlaneContainer(ctx context.Context, kubernetesDir, vClusterBinary
 		args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/%s,dst=/var/lib/vcluster/bin/%s,ro", kubernetesDir, entry.Name(), entry.Name()))
 	}
 	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/vcluster,dst=/var/lib/vcluster/bin/vcluster,ro", vClusterBinaryDir))
-	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/vcluster.yaml,dst=/etc/vcluster/vcluster.yaml,ro", vClusterConfigDir))
+	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/vcluster.yaml,dst=/etc/vcluster/vcluster.yaml", vClusterConfigDir))
 	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/k8s-resolv.conf,dst=/etc/k8s-resolv.conf,ro", vClusterConfigDir))
 	args = append(args, "--mount", fmt.Sprintf("type=bind,src=%s/kubelet.env,dst=/etc/vcluster/vcluster-flags.env,ro", vClusterConfigDir))
 	args = append(args, extraArgs...)


### PR DESCRIPTION
## Summary
- Remove `,ro` from the vcluster.yaml bind mount in Docker driver container creation
- The standalone config refresh (`refreshConfig` → `updateCurrentConfig` in vcluster-pro) writes back to `/etc/vcluster/vcluster.yaml`
- With the `ro` mount, the vcluster service crash-loops: `open /etc/vcluster/vcluster.yaml: read-only file system`

## Root cause
The `ro` mount existed since the Docker driver was introduced and worked fine with 0.31 because the binary never wrote to this file. In 0.33, the platform config restructure (#3433) added `refreshConfig()` in `vcluster-pro/pkg/standalone/config/config.go` which calls `updateCurrentConfig()` → `os.WriteFile()` on the config path.

## Workaround
Until this is merged, use nsenter to rebind the config as writable after creation:
```bash
pid=$(docker inspect vcluster.cp.<name> --format '{{.State.Pid}}')
sudo nsenter -t $pid -m -- bash -c \
  "cp /etc/vcluster/vcluster.yaml /tmp/vc.yaml && \
   mount --bind /tmp/vc.yaml /etc/vcluster/vcluster.yaml"
```

## Test plan
- [ ] `vcluster use driver docker && vcluster platform start && vcluster create test --values vcluster.yaml`
- [ ] Verify vcluster service starts without crash-loop
- [ ] Verify worker node joins the cluster
- [ ] Verify `vcluster connect test` succeeds