### PR TITLE
fix(platform): clear platform config section instead of deleting entire config.json

### DIFF
--- a/cmd/vclusterctl/cmd/platform/destroy.go
+++ b/cmd/vclusterctl/cmd/platform/destroy.go
@@ -156,15 +156,14 @@ func (cmd *DestroyCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to destroy platform: %w", err)
 	}
 
-	cmd.Log.Infof("deleting platform config at %q", cmd.Config)
+	cmd.Log.Infof("clearing platform config at %q", cmd.Config)
 	cliConfig := cmd.LoadedConfig(cmd.Log)
-	err = cliConfig.Delete()
-	if err != nil {
+	if err = cliConfig.ClearPlatform(); err != nil {
 		if errors.Is(err, os.ErrNotExist) && cmd.IgnoreNotFound {
 			cmd.Log.Info("no platform config detected")
 			return nil
 		}
-		return fmt.Errorf("failed to delete platform config: %w", err)
+		return fmt.Errorf("failed to clear platform config: %w", err)
 	}
 
 	return nil
@@ -190,15 +189,10 @@ func (cmd *DestroyCmd) destroyDocker(ctx context.Context) error {
 		return fmt.Errorf("failed to destroy docker platform: %w", err)
 	}
 
-	cmd.Log.Infof("deleting platform config at %q", cmd.Config)
+	cmd.Log.Infof("clearing platform config at %q", cmd.Config)
 	cliConfig := cmd.LoadedConfig(cmd.Log)
-	err = cliConfig.Delete()
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) && cmd.IgnoreNotFound {
-			cmd.Log.Info("no platform config detected")
-			return nil
-		}
-		return fmt.Errorf("failed to delete platform config: %w", err)
+	if err = cliConfig.ClearPlatform(); err != nil {
+		return fmt.Errorf("failed to clear platform config: %w", err)
 	}
 
 	return nil

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,43 +55,18 @@ func (c *CLI) Save() error {
 	return Write(path, c)
 }
 
-func (c *CLI) Delete() error {
+// ClearPlatform resets the platform section of the config to its default.
+// If the driver was set to platform, it is reset to helm since the platform
+// is no longer available. Other driver settings (e.g. docker) are preserved.
+func (c *CLI) ClearPlatform() error {
 	if c == nil || c.path == "" {
 		return errors.New("nil config path")
 	}
-
-	file, err := os.Open(c.path)
-	if err != nil {
-		return fmt.Errorf("failed to load vcluster configuration file from %q : %w", c.path, err)
+	c.Platform = New().Platform
+	if c.Driver.Type == PlatformDriver {
+		c.Driver.Type = HelmDriver
 	}
-	stat, err := file.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to load vcluster configuration file from %q: %w", c.path, err)
-	}
-	if stat.IsDir() {
-		return fmt.Errorf("failed to load vcluster configuration file %q", c.path)
-	}
-	defer file.Close()
-
-	fileBytes, err := io.ReadAll(file)
-	if err != nil {
-		return fmt.Errorf("read all: %w", err)
-	}
-
-	decoder := json.NewDecoder(bytes.NewReader(fileBytes))
-	decoder.DisallowUnknownFields()
-	tryRead := &CLI{}
-	err = decoder.Decode(tryRead)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshall vcluster configuration from %q: %w", c.path, err)
-	}
-
-	// delete file at path
-	err = os.Remove(c.path)
-	if err != nil {
-		return fmt.Errorf("failed to delete configuration file at %q: %w", c.path, err)
-	}
-	return nil
+	return c.Save()
 }
 
 // Read returns the current config by trying to read it from the given config path.

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClearPlatform(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// Build a populated config and write it to disk
+	cfg := &CLI{
+		path: cfgPath,
+		Driver: Driver{
+			Type: DockerDriver,
+		},
+		TelemetryDisabled: true,
+		PreviousContext:   "my-context",
+		Platform: Platform{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Config",
+				APIVersion: "storage.loft.sh/v1",
+			},
+			Host:               "https://example.loft.host",
+			AccessKey:          "secret-key",
+			LastInstallContext: "some-context",
+			Insecure:           true,
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := cfg.ClearPlatform(); err != nil {
+		t.Fatalf("ClearPlatform: %v", err)
+	}
+
+	// Non-platform fields must be preserved
+	if cfg.Driver.Type != DockerDriver {
+		t.Errorf("Driver.Type = %q, want %q", cfg.Driver.Type, DockerDriver)
+	}
+	if !cfg.TelemetryDisabled {
+		t.Error("TelemetryDisabled should still be true")
+	}
+	if cfg.PreviousContext != "my-context" {
+		t.Errorf("PreviousContext = %q, want %q", cfg.PreviousContext, "my-context")
+	}
+
+	// Platform fields must be cleared
+	if cfg.Platform.Host != "" {
+		t.Errorf("Platform.Host = %q, want empty", cfg.Platform.Host)
+	}
+	if cfg.Platform.AccessKey != "" {
+		t.Errorf("Platform.AccessKey = %q, want empty", cfg.Platform.AccessKey)
+	}
+	if cfg.Platform.LastInstallContext != "" {
+		t.Errorf("Platform.LastInstallContext = %q, want empty", cfg.Platform.LastInstallContext)
+	}
+	if cfg.Platform.Insecure {
+		t.Error("Platform.Insecure should be false after clear")
+	}
+
+	// TypeMeta defaults must be restored
+	if cfg.Platform.Kind != "Config" {
+		t.Errorf("Platform.Kind = %q, want %q", cfg.Platform.Kind, "Config")
+	}
+	if cfg.Platform.APIVersion != "storage.loft.sh/v1" {
+		t.Errorf("Platform.APIVersion = %q, want %q", cfg.Platform.APIVersion, "storage.loft.sh/v1")
+	}
+
+	// File on disk must reflect the cleared state
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	saved := &CLI{}
+	if err := json.Unmarshal(data, saved); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if saved.Driver.Type != DockerDriver {
+		t.Errorf("saved Driver.Type = %q, want %q", saved.Driver.Type, DockerDriver)
+	}
+	if saved.Platform.Host != "" {
+		t.Errorf("saved Platform.Host = %q, want empty", saved.Platform.Host)
+	}
+}
+
+func TestClearPlatform_PlatformDriverResetToHelm(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfg := &CLI{
+		path: cfgPath,
+		Driver: Driver{
+			Type: PlatformDriver,
+		},
+		Platform: Platform{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Config",
+				APIVersion: "storage.loft.sh/v1",
+			},
+			Host:      "https://example.loft.host",
+			AccessKey: "secret-key",
+		},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := cfg.ClearPlatform(); err != nil {
+		t.Fatalf("ClearPlatform: %v", err)
+	}
+
+	// platform driver must be reset to helm to avoid "not logged in" errors
+	if cfg.Driver.Type != HelmDriver {
+		t.Errorf("Driver.Type = %q, want %q (platform driver should reset to helm after destroy)", cfg.Driver.Type, HelmDriver)
+	}
+	if cfg.Platform.Host != "" {
+		t.Errorf("Platform.Host = %q, want empty", cfg.Platform.Host)
+	}
+}

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -163,7 +163,7 @@ func (c *client) Save() error {
 }
 
 func (c *client) Delete() error {
-	return c.config.Delete()
+	return c.config.ClearPlatform()
 }
 
 func (c *client) ManagementConfig() (*rest.Config, error) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGPROV-245


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster would delete entire config.json on `vcluster platform destroy`


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
