### PR TITLE
fix(vind): Added values to the platform virtual cluster instance

### DIFF
--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/log/hash"
 	"github.com/loft-sh/vcluster/config"
@@ -188,7 +189,7 @@ func CreateDocker(ctx context.Context, options *CreateOptions, globalFlags *flag
 			return err
 		}
 
-		platformArgs, err := addVClusterDocker(ctx, vClusterName, vConfig, options, globalFlags, vClusterJoinToken, log)
+		platformArgs, err := addVClusterDocker(ctx, vClusterName, vConfig, options, globalFlags, vClusterJoinToken, userValues, log)
 		if err != nil {
 			return err
 		}
@@ -269,7 +270,7 @@ func writeVClusterYAML(globalFlags *flags.GlobalFlags, vClusterName string, fina
 	return filepath.Dir(vClusterYAMLPath), nil
 }
 
-func addVClusterDocker(ctx context.Context, name string, vClusterConfig *config.Config, options *CreateOptions, globalFlags *flags.GlobalFlags, joinToken string, log log.Logger) ([]string, error) {
+func addVClusterDocker(ctx context.Context, name string, vClusterConfig *config.Config, options *CreateOptions, globalFlags *flags.GlobalFlags, joinToken string, userValues string, log log.Logger) ([]string, error) {
 	platformConfig := vClusterConfig.GetPlatformConfig()
 	if platformConfig.APIKey.SecretName != "" || platformConfig.APIKey.Namespace != "" {
 		return nil, nil
@@ -307,7 +308,11 @@ func addVClusterDocker(ctx context.Context, name string, vClusterConfig *config.
 	}
 
 	// try with the regular name first
-	created, accessKey, createdName, err := platform.CreateWithName(ctx, managementClient, project, name, extraLabels)
+	created, accessKey, createdName, err := platform.CreateWithName(ctx, managementClient, project, name, extraLabels, func(vci *managementv1.VirtualClusterInstance) {
+		vci.Spec.Template.VirtualClusterCommonSpec.HelmRelease.Chart.Version = options.ChartVersion
+		vci.Spec.Template.VirtualClusterCommonSpec.HelmRelease.Values = userValues
+		vci.Spec.Standalone = true
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating platform access key: %w. If you don't want to use the platform, run this command with --add=false or run 'vcluster logout'", err)
 	} else if !created {

--- a/pkg/platform/secret.go
+++ b/pkg/platform/secret.go
@@ -293,7 +293,9 @@ func getLegacyAccessKeyHost(ctx context.Context, platformClient Client) (string,
 	return platformConfig.VirtualClusterAccessKey, nil
 }
 
-func CreateWithName(ctx context.Context, managementClient kube.Interface, project string, name string, extraLabels map[string]string) (bool, string, string, error) {
+type CreateOptionFunc func(*managementv1.VirtualClusterInstance)
+
+func CreateWithName(ctx context.Context, managementClient kube.Interface, project string, name string, extraLabels map[string]string, opts ...CreateOptionFunc) (bool, string, string, error) {
 	namespace := projectutil.ProjectNamespace(project)
 	virtualClusterInstance, err := managementClient.Loft().ManagementV1().VirtualClusterInstances(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
@@ -334,6 +336,10 @@ func CreateWithName(ctx context.Context, managementClient kube.Interface, projec
 	}
 	for k, v := range extraLabels {
 		virtualClusterInstance.Labels[k] = v
+	}
+
+	for _, opt := range opts {
+		opt(virtualClusterInstance)
 	}
 
 	// create virtual cluster instance


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
related #ENGPROV-373

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster in docker is not able to start after vcluster platform start


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
pr
```
