### PR TITLE
Workload sleep/wake from the cli

### DIFF
--- a/pkg/cli/list_platform.go
+++ b/pkg/cli/list_platform.go
@@ -40,7 +40,7 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 		return err
 	}
 
-	err = printProVClusters(ctx, options, proToVClusters(ctx, platformClient, proVClusters, currentContext), globalFlags, logger)
+	err = printProVClusters(ctx, options, proToVClusters(ctx, platformClient, proVClusters, currentContext, logger), globalFlags, logger)
 	if err != nil {
 		return err
 	}
@@ -48,10 +48,14 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 	return nil
 }
 
-func proToVClusters(ctx context.Context, platformClient platform.Client, vClusters []*platform.VirtualClusterInstanceProject, currentContext string) []ListProVCluster {
-	var output []ListProVCluster
-	for _, vCluster := range vClusters {
-		status := platformVClusterListStatus(ctx, platformClient, vCluster)
+func proToVClusters(ctx context.Context, platformClient platform.Client, vClusters []*platform.VirtualClusterInstanceProject, currentContext string, logger log.Logger) []ListProVCluster {
+	if len(vClusters) == 0 {
+		return nil
+	}
+
+	output := make([]ListProVCluster, len(vClusters))
+	for i, vCluster := range vClusters {
+		status := platformVClusterListStatus(ctx, platformClient, logger, vCluster)
 
 		version := ""
 		if vCluster.VirtualCluster.Status.VirtualCluster != nil && vCluster.VirtualCluster.Status.VirtualCluster.HelmRelease.Chart.Version != "" {
@@ -66,7 +70,7 @@ func proToVClusters(ctx context.Context, platformClient platform.Client, vCluste
 		}
 
 		connected := strings.HasPrefix(currentContext, "vcluster-platform_"+vCluster.VirtualCluster.Name+"_"+vCluster.Project.Name)
-		vClusterOutput := ListProVCluster{
+		output[i] = ListProVCluster{
 			ListVCluster{
 				Name:       name,
 				Namespace:  vCluster.VirtualCluster.Spec.ClusterRef.Namespace,
@@ -78,12 +82,12 @@ func proToVClusters(ctx context.Context, platformClient platform.Client, vCluste
 			},
 			vCluster.Project.Name,
 		}
-		output = append(output, vClusterOutput)
 	}
+
 	return output
 }
 
-func platformVClusterListStatus(ctx context.Context, platformClient platform.Client, vCluster *platform.VirtualClusterInstanceProject) string {
+func platformVClusterListStatus(ctx context.Context, platformClient platform.Client, logger log.Logger, vCluster *platform.VirtualClusterInstanceProject) string {
 	if vCluster == nil || vCluster.VirtualCluster == nil {
 		return "Pending"
 	}
@@ -97,7 +101,9 @@ func platformVClusterListStatus(ctx context.Context, platformClient platform.Cli
 	}
 
 	workloadSleeping, err := isPlatformVClusterWorkloadSleeping(ctx, platformClient, vCluster)
-	if err == nil && workloadSleeping {
+	if err != nil {
+		logger.Debugf("failed to determine workload sleep state for platform vCluster %s in project %s: %v", vCluster.VirtualCluster.Name, vCluster.Project.Name, err)
+	} else if workloadSleeping {
 		return string(find.StatusWorkloadSleeping)
 	}
 

--- a/pkg/cli/list_platform.go
+++ b/pkg/cli/list_platform.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
 	"github.com/sirupsen/logrus"
 
 	"github.com/loft-sh/log"
@@ -39,7 +40,7 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 		return err
 	}
 
-	err = printProVClusters(ctx, options, proToVClusters(proVClusters, currentContext), globalFlags, logger)
+	err = printProVClusters(ctx, options, proToVClusters(ctx, platformClient, proVClusters, currentContext), globalFlags, logger)
 	if err != nil {
 		return err
 	}
@@ -47,15 +48,10 @@ func ListPlatform(ctx context.Context, options *ListOptions, globalFlags *flags.
 	return nil
 }
 
-func proToVClusters(vClusters []*platform.VirtualClusterInstanceProject, currentContext string) []ListProVCluster {
+func proToVClusters(ctx context.Context, platformClient platform.Client, vClusters []*platform.VirtualClusterInstanceProject, currentContext string) []ListProVCluster {
 	var output []ListProVCluster
 	for _, vCluster := range vClusters {
-		status := string(vCluster.VirtualCluster.Status.Phase)
-		if vCluster.VirtualCluster.DeletionTimestamp != nil {
-			status = "Terminating"
-		} else if status == "" {
-			status = "Pending"
-		}
+		status := platformVClusterListStatus(ctx, platformClient, vCluster)
 
 		version := ""
 		if vCluster.VirtualCluster.Status.VirtualCluster != nil && vCluster.VirtualCluster.Status.VirtualCluster.HelmRelease.Chart.Version != "" {
@@ -85,6 +81,39 @@ func proToVClusters(vClusters []*platform.VirtualClusterInstanceProject, current
 		output = append(output, vClusterOutput)
 	}
 	return output
+}
+
+func platformVClusterListStatus(ctx context.Context, platformClient platform.Client, vCluster *platform.VirtualClusterInstanceProject) string {
+	if vCluster == nil || vCluster.VirtualCluster == nil {
+		return "Pending"
+	}
+
+	status := string(vCluster.VirtualCluster.Status.Phase)
+	if vCluster.VirtualCluster.DeletionTimestamp != nil {
+		return "Terminating"
+	}
+	if status == string(storagev1.InstanceSleeping) {
+		return status
+	}
+
+	workloadSleeping, err := isPlatformVClusterWorkloadSleeping(ctx, platformClient, vCluster)
+	if err == nil && workloadSleeping {
+		return string(find.StatusWorkloadSleeping)
+	}
+
+	if status == "" {
+		return "Pending"
+	}
+
+	return status
+}
+
+func isPlatformVClusterWorkloadSleeping(ctx context.Context, platformClient platform.Client, vCluster *platform.VirtualClusterInstanceProject) (bool, error) {
+	target, err := getPlatformWorkloadSleepSecret(ctx, platformClient, vCluster.Project.Name, vCluster.VirtualCluster, "")
+	if err != nil {
+		return false, err
+	}
+	return isWorkloadSleepSecretSleeping(target.secret), nil
 }
 
 func printProVClusters(ctx context.Context, options *ListOptions, output []ListProVCluster, globalFlags *flags.GlobalFlags, logger log.Logger) error {

--- a/pkg/cli/list_platform_test.go
+++ b/pkg/cli/list_platform_test.go
@@ -10,6 +10,7 @@ import (
 	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
+	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
@@ -44,7 +45,7 @@ func TestProToVClustersDisplaysHostWorkloadSleep(t *testing.T) {
 	output := proToVClusters(ctx, &fakePlatformClient{clusterClient: clusterClient}, []*platform.VirtualClusterInstanceProject{{
 		VirtualCluster: virtualClusterInstance,
 		Project:        &managementv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "test-project"}},
-	}}, "")
+	}}, "", log.Discard)
 
 	assert.Equal(t, len(output), 1)
 	assert.Equal(t, output[0].Status, string(find.StatusWorkloadSleeping))
@@ -91,7 +92,7 @@ func TestProToVClustersDisplaysStandaloneWorkloadSleep(t *testing.T) {
 	output := proToVClusters(ctx, &fakePlatformClient{restConfig: &rest.Config{Host: server.URL}}, []*platform.VirtualClusterInstanceProject{{
 		VirtualCluster: virtualClusterInstance,
 		Project:        &managementv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "test-project"}},
-	}}, "")
+	}}, "", log.Discard)
 
 	assert.Equal(t, len(output), 1)
 	assert.Equal(t, output[0].Status, string(find.StatusWorkloadSleeping))

--- a/pkg/cli/list_platform_test.go
+++ b/pkg/cli/list_platform_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
+	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestProToVClustersDisplaysHostWorkloadSleep(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clusterClient := &fakePlatformKubeClient{Interface: k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-release",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation: clusterv1.SleepTypeForced,
+			},
+		},
+	})}
+
+	virtualClusterInstance := &managementv1.VirtualClusterInstance{}
+	virtualClusterInstance.Name = "instance-name"
+	virtualClusterInstance.Spec.ClusterRef.Cluster = "host-cluster"
+	virtualClusterInstance.Spec.ClusterRef.Namespace = "test-ns"
+	virtualClusterInstance.Spec.ClusterRef.VirtualCluster = "release"
+	virtualClusterInstance.Status.Phase = storagev1.InstanceReady
+
+	output := proToVClusters(ctx, &fakePlatformClient{clusterClient: clusterClient}, []*platform.VirtualClusterInstanceProject{{
+		VirtualCluster: virtualClusterInstance,
+		Project:        &managementv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "test-project"}},
+	}}, "")
+
+	assert.Equal(t, len(output), 1)
+	assert.Equal(t, output[0].Status, string(find.StatusWorkloadSleeping))
+}
+
+func TestProToVClustersDisplaysStandaloneWorkloadSleep(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	gotSleepModeIgnoreHeader := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/namespaces/default/secrets/"+sleepmode.StandaloneSleepSecretName {
+			http.NotFound(w, r)
+			return
+		}
+		gotSleepModeIgnoreHeader = r.Header.Get("X-Sleep-Mode-Ignore")
+		if gotSleepModeIgnoreHeader != "true" {
+			http.Error(w, "missing sleep mode ignore header", http.StatusForbidden)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sleepmode.StandaloneSleepSecretName,
+				Namespace: "default",
+				Annotations: map[string]string{
+					clusterv1.SleepModeSleepTypeAnnotation: clusterv1.SleepTypeForced,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	virtualClusterInstance := &managementv1.VirtualClusterInstance{}
+	virtualClusterInstance.Name = "standalone-name"
+	virtualClusterInstance.Spec.Standalone = true
+	virtualClusterInstance.Status.Phase = storagev1.InstanceReady
+
+	output := proToVClusters(ctx, &fakePlatformClient{restConfig: &rest.Config{Host: server.URL}}, []*platform.VirtualClusterInstanceProject{{
+		VirtualCluster: virtualClusterInstance,
+		Project:        &managementv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "test-project"}},
+	}}, "")
+
+	assert.Equal(t, len(output), 1)
+	assert.Equal(t, output[0].Status, string(find.StatusWorkloadSleeping))
+	assert.Equal(t, gotSleepModeIgnoreHeader, "true")
+}

--- a/pkg/cli/pause_helm.go
+++ b/pkg/cli/pause_helm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -13,8 +14,11 @@ import (
 	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
+
+var errWorkloadSleep = errors.New("failed to sleep")
 
 type PauseOptions struct {
 	Driver string
@@ -60,7 +64,7 @@ func PauseVCluster(
 	}
 
 	// Check if workload sleep mode is configured and apply it instead of scaling down.
-	if used, err := pauseWorkloadSleepModeIfConfigured(ctx, kubeClient, vCluster, log); err != nil {
+	if used, err := workloadSleep(ctx, kubeClient, vCluster, log); err != nil {
 		return err
 	} else if used {
 		return nil
@@ -84,10 +88,10 @@ func PauseVCluster(
 	return nil
 }
 
-// pauseWorkloadSleepModeIfConfigured detects whether workload sleep mode is configured and, if so,
-// updates the appropriate secret with the sleep type and sleeping-since annotations instead of
-// scaling down the control plane. Returns true if workload sleep mode was applied.
-func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster, log log.Logger) (bool, error) {
+// workloadSleep checks if whether workload sleep mode is configured and
+// sets the appropriate secret with the sleep type and sleeping-since annotations
+// Returns true if workload sleep mode was applied.
+func workloadSleep(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster, log log.Logger) (applied bool, retErr error) {
 	configSecret, vClusterConfig, configured, err := hostVClusterSleepModeConfig(ctx, kubeClient, vCluster.Namespace, vCluster.Name)
 	if err != nil {
 		return false, err
@@ -96,32 +100,53 @@ func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient kubernet
 		return false, nil
 	}
 
+	defer func() {
+		if retErr != nil {
+			log.Error(retErr, "Please try again.  If the problem persists, please contact support.")
+		}
+	}()
+
 	log.Infof("vCluster %s/%s is configured for workload sleep mode, sleeping workloads only (control plane stays running)", vCluster.Namespace, vCluster.Name)
 
 	sleepingSince := strconv.FormatInt(time.Now().Unix(), 10)
 
 	if vClusterConfig.ControlPlane.Standalone.Enabled {
-		// Annotate the host config secret so find.go can detect StatusWorkloadSleeping,
-		// then also write to the virtual cluster's standalone sleep secret for the
-		// in-cluster sleep state controller.
-		if err := patchSecretWithSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret, sleepingSince, nil); err != nil {
+		virtualKubeClient, err := standaloneKubeClient(vCluster)
+		if err != nil {
 			return false, err
 		}
-		return true, pauseStandaloneWorkloadSleep(ctx, vCluster, sleepingSince)
+
+		return true, sleepStandaloneWorkloadSleepOrRollback(ctx, kubeClient, virtualKubeClient, vCluster.Namespace, configSecret, sleepingSince)
 	}
 
 	return true, patchSecretWithSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret, sleepingSince, nil)
 }
 
-// pauseStandaloneWorkloadSleep updates the vc-standalone-sleep-state secret in the virtual
-// cluster's default namespace. For standalone vClusters the sleep state controller watches
-// this secret inside the virtual cluster rather than the vc-config secret on a host cluster.
-func pauseStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster, sleepingSince string) error {
-	virtualKubeClient, err := standaloneSleepKubeClient(vCluster)
-	if err != nil {
-		return err
+func sleepStandaloneWorkloadSleepOrRollback(ctx context.Context, hostKubeClient, virtualKubeClient kubernetes.Interface, namespace string, configSecret *corev1.Secret, sleepingSince string) error {
+	// Update the in-cluster sleep state first.
+	if err := sleepStandaloneWorkload(ctx, virtualKubeClient, sleepingSince); err != nil {
+		return errWorkloadSleep
 	}
 
+	// If the host config patch fails, try to rollback
+	if err := patchSecretWithSleepAnnotations(ctx, hostKubeClient, namespace, configSecret, sleepingSince, nil); err != nil {
+		if rollbackErr := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+			if err := wakeStandalone(ctx, virtualKubeClient); err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		}); rollbackErr != nil {
+			return errWorkloadSleep
+		}
+
+		return errWorkloadSleep
+	}
+
+	return nil
+}
+
+func sleepStandaloneWorkload(ctx context.Context, virtualKubeClient kubernetes.Interface, sleepingSince string) error {
 	return mutateSleepSecret(ctx, virtualKubeClient, defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName,
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: defaultSleepModeNamespace}},
 		func(s *corev1.Secret) {

--- a/pkg/cli/pause_helm.go
+++ b/pkg/cli/pause_helm.go
@@ -122,8 +122,8 @@ func pauseStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster, 
 		return err
 	}
 
-	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName,
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: "default"}},
+	return mutateSleepSecret(ctx, virtualKubeClient, defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: defaultSleepModeNamespace}},
 		func(s *corev1.Secret) {
 			applySleepAnnotations(s, sleepingSince, nil)
 		},

--- a/pkg/cli/pause_helm.go
+++ b/pkg/cli/pause_helm.go
@@ -3,12 +3,18 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/lifecycle"
+	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type PauseOptions struct {
@@ -49,6 +55,17 @@ func PauseVCluster(
 		log.Infof("vcluster %s/%s is already sleeping", vCluster.Namespace, vCluster.Name)
 		return nil
 	}
+	if vCluster.Status == find.StatusWorkloadSleeping {
+		log.Infof("vcluster %s/%s is already in workload sleep mode", vCluster.Namespace, vCluster.Name)
+		return nil
+	}
+
+	// Check if workload sleep mode is configured and apply it instead of scaling down.
+	if used, err := pauseWorkloadSleepModeIfConfigured(ctx, kubeClient, vCluster, log); err != nil {
+		return err
+	} else if used {
+		return nil
+	}
 
 	err := lifecycle.PauseVCluster(ctx, kubeClient, vCluster.Name, vCluster.Namespace, false, log)
 	if err != nil {
@@ -66,6 +83,68 @@ func PauseVCluster(
 	}
 
 	return nil
+}
+
+// pauseWorkloadSleepModeIfConfigured detects whether workload sleep mode is configured and, if so,
+// updates the appropriate secret with the sleep type and sleeping-since annotations instead of
+// scaling down the control plane. Returns true if workload sleep mode was applied.
+func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient *kubernetes.Clientset, vCluster *find.VCluster, log log.Logger) (bool, error) {
+	configSecret, vClusterConfig, configured, err := hostVClusterSleepModeConfig(ctx, kubeClient, vCluster.Namespace, vCluster.Name)
+	if err != nil {
+		return false, err
+	}
+	if !configured {
+		return false, nil
+	}
+
+	log.Infof("vCluster %s/%s is configured for workload sleep mode, sleeping workloads only (control plane stays running)", vCluster.Namespace, vCluster.Name)
+
+	sleepingSince := strconv.FormatInt(time.Now().Unix(), 10)
+
+	if vClusterConfig.ControlPlane.Standalone.Enabled {
+		return true, pauseStandaloneWorkloadSleep(ctx, vCluster, sleepingSince)
+	}
+
+	return true, patchSecretWithSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret, sleepingSince, nil)
+}
+
+// pauseStandaloneWorkloadSleep updates the vc-standalone-sleep-state secret in the virtual
+// cluster's default namespace. For standalone vClusters the sleep state controller watches
+// this secret inside the virtual cluster rather than the vc-config secret on a host cluster.
+func pauseStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster, sleepingSince string) error {
+	vClusterCtxName := find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context)
+
+	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), nil,
+	).RawConfig()
+	if err != nil {
+		return fmt.Errorf("load kubeconfig: %w", err)
+	}
+
+	if _, ok := rawConfig.Contexts[vClusterCtxName]; !ok {
+		return fmt.Errorf("cannot pause standalone vCluster %s/%s: context %q not found in kubeconfig, please run 'vcluster connect %s -n %s' first",
+			vCluster.Namespace, vCluster.Name, vClusterCtxName, vCluster.Name, vCluster.Namespace)
+	}
+
+	virtualRestConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{CurrentContext: vClusterCtxName},
+	).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("create virtual cluster client config: %w", err)
+	}
+
+	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(virtualRestConfig))
+	if err != nil {
+		return fmt.Errorf("create virtual cluster client: %w", err)
+	}
+
+	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: "default"}},
+		func(s *corev1.Secret) {
+			applySleepAnnotations(s, sleepingSince, nil)
+		},
+	)
 }
 
 func preparePause(vCluster *find.VCluster, globalFlags *flags.GlobalFlags) (*kubernetes.Clientset, error) {

--- a/pkg/cli/pause_helm.go
+++ b/pkg/cli/pause_helm.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type PauseOptions struct {
@@ -88,7 +87,7 @@ func PauseVCluster(
 // pauseWorkloadSleepModeIfConfigured detects whether workload sleep mode is configured and, if so,
 // updates the appropriate secret with the sleep type and sleeping-since annotations instead of
 // scaling down the control plane. Returns true if workload sleep mode was applied.
-func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient *kubernetes.Clientset, vCluster *find.VCluster, log log.Logger) (bool, error) {
+func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster, log log.Logger) (bool, error) {
 	configSecret, vClusterConfig, configured, err := hostVClusterSleepModeConfig(ctx, kubeClient, vCluster.Namespace, vCluster.Name)
 	if err != nil {
 		return false, err
@@ -102,6 +101,12 @@ func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient *kuberne
 	sleepingSince := strconv.FormatInt(time.Now().Unix(), 10)
 
 	if vClusterConfig.ControlPlane.Standalone.Enabled {
+		// Annotate the host config secret so find.go can detect StatusWorkloadSleeping,
+		// then also write to the virtual cluster's standalone sleep secret for the
+		// in-cluster sleep state controller.
+		if err := patchSecretWithSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret, sleepingSince, nil); err != nil {
+			return false, err
+		}
 		return true, pauseStandaloneWorkloadSleep(ctx, vCluster, sleepingSince)
 	}
 
@@ -112,31 +117,9 @@ func pauseWorkloadSleepModeIfConfigured(ctx context.Context, kubeClient *kuberne
 // cluster's default namespace. For standalone vClusters the sleep state controller watches
 // this secret inside the virtual cluster rather than the vc-config secret on a host cluster.
 func pauseStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster, sleepingSince string) error {
-	vClusterCtxName := find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context)
-
-	rawConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(), nil,
-	).RawConfig()
+	virtualKubeClient, err := standaloneSleepKubeClient(vCluster)
 	if err != nil {
-		return fmt.Errorf("load kubeconfig: %w", err)
-	}
-
-	if _, ok := rawConfig.Contexts[vClusterCtxName]; !ok {
-		return fmt.Errorf("cannot pause standalone vCluster %s/%s: context %q not found in kubeconfig, please run 'vcluster connect %s -n %s' first",
-			vCluster.Namespace, vCluster.Name, vClusterCtxName, vCluster.Name, vCluster.Namespace)
-	}
-
-	virtualRestConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{CurrentContext: vClusterCtxName},
-	).ClientConfig()
-	if err != nil {
-		return fmt.Errorf("create virtual cluster client config: %w", err)
-	}
-
-	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(virtualRestConfig))
-	if err != nil {
-		return fmt.Errorf("create virtual cluster client: %w", err)
+		return err
 	}
 
 	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName,

--- a/pkg/cli/pause_helm_test.go
+++ b/pkg/cli/pause_helm_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestPauseStandaloneWorkloadSleepWithHostStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	hostClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+		},
+	})
+	virtualClient := k8sfake.NewClientset()
+
+	configSecret, err := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	err = sleepStandaloneWorkloadSleepOrRollback(ctx, hostClient, virtualClient, "test-ns", configSecret, "123")
+	assert.NilError(t, err)
+
+	hostSecret, err := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, hostSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], clusterv1.SleepTypeForced)
+	assert.Equal(t, hostSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation], "123")
+
+	virtualSecret, err := virtualClient.CoreV1().Secrets(defaultSleepModeNamespace).Get(ctx, "vc-standalone-sleep-state", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], clusterv1.SleepTypeForced)
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation], "123")
+}
+
+func TestPauseStandaloneWorkloadSleepWithHostStatusRollsBackStandaloneSecretOnHostPatchFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	hostClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+		},
+	})
+	hostClient.PrependReactor("patch", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("host patch failed")
+	})
+
+	virtualClient := k8sfake.NewClientset()
+
+	configSecret, err := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	err = sleepStandaloneWorkloadSleepOrRollback(ctx, hostClient, virtualClient, "test-ns", configSecret, "123")
+	assert.ErrorIs(t, err, errWorkloadSleep, "expected error to be %s", errWorkloadSleep.Error())
+
+	hostSecret, getErr := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, getErr)
+	_, hasSleepType := hostSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	assert.Assert(t, !hasSleepType)
+	_, hasSleepingSince := hostSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation]
+	assert.Assert(t, !hasSleepingSince)
+
+	virtualSecret, getErr := virtualClient.CoreV1().Secrets(defaultSleepModeNamespace).Get(ctx, "vc-standalone-sleep-state", metav1.GetOptions{})
+	if kerrors.IsNotFound(getErr) {
+		return
+	}
+	assert.NilError(t, getErr)
+
+	_, hasSleepType = virtualSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	assert.Assert(t, !hasSleepType)
+	_, hasSleepingSince = virtualSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation]
+	assert.Assert(t, !hasSleepingSince)
+	assert.Assert(t, virtualSecret.Annotations[clusterv1.SleepModeLastActivityAnnotation] != "")
+}
+
+func TestPauseStandaloneWorkloadSleepWithHostStatusRetriesRollbackUntilSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	hostClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+		},
+	})
+	hostClient.PrependReactor("patch", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("host patch failed")
+	})
+
+	virtualClient := k8sfake.NewClientset()
+	virtualPatchAttempts := 0
+	virtualClient.PrependReactor("patch", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		virtualPatchAttempts++
+		if virtualPatchAttempts == 1 {
+			return true, nil, errors.New("transient rollback failure")
+		}
+
+		return false, nil, nil
+	})
+
+	configSecret, err := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	err = sleepStandaloneWorkloadSleepOrRollback(ctx, hostClient, virtualClient, "test-ns", configSecret, "123")
+	assert.ErrorIs(t, err, errWorkloadSleep, "expected error to be %s", errWorkloadSleep.Error())
+	assert.Assert(t, virtualPatchAttempts >= 2)
+
+	virtualSecret, getErr := virtualClient.CoreV1().Secrets(defaultSleepModeNamespace).Get(ctx, "vc-standalone-sleep-state", metav1.GetOptions{})
+	if kerrors.IsNotFound(getErr) {
+		return
+	}
+	assert.NilError(t, getErr)
+
+	_, hasSleepType := virtualSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	assert.Assert(t, !hasSleepType)
+	_, hasSleepingSince := virtualSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation]
+	assert.Assert(t, !hasSleepingSince)
+	assert.Assert(t, virtualSecret.Annotations[clusterv1.SleepModeLastActivityAnnotation] != "")
+}

--- a/pkg/cli/pause_platform.go
+++ b/pkg/cli/pause_platform.go
@@ -10,13 +10,17 @@ import (
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
 	"github.com/loft-sh/log"
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	cliconfig "github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/clihelper"
+	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 func PausePlatform(ctx context.Context, options *PauseOptions, cfg *cliconfig.CLI, vClusterName string, log log.Logger) error {
@@ -30,10 +34,18 @@ func PausePlatform(ctx context.Context, options *PauseOptions, cfg *cliconfig.CL
 		return err
 	}
 
+	projectName := vCluster.Project.Name
 	log.Infof("Putting virtual cluster %s in project %s to sleep", vCluster.VirtualCluster.Name, vCluster.Project.Name)
 	virtualClusterInstance := vCluster.VirtualCluster
 	if virtualClusterInstance.Annotations[clusterv1.SleepScopeAnnotation] == "workloads-only" {
 		return workloadSleepOnly(ctx, platformClient, options, log, vClusterName, virtualClusterInstance)
+	}
+
+	// Check if the vCluster config enables workload sleep mode natively (no agent).
+	if used, err := pausePlatformWorkloadSleepModeIfConfigured(ctx, platformClient, projectName, options.ForceDuration, log, vClusterName, virtualClusterInstance); err != nil {
+		return err
+	} else if used {
+		return nil
 	}
 
 	if vCluster.IsInstanceSleeping() {
@@ -95,24 +107,88 @@ func workloadSleepOnly(ctx context.Context, platformClient platform.Client, opti
 		return fmt.Errorf("failed to load the vcluster config: %w", err)
 	}
 
-	orig := configSecret.DeepCopy()
-	if configSecret.Annotations == nil {
-		configSecret.Annotations = map[string]string{}
+	sleepingSince := strconv.FormatInt(time.Now().Unix(), 10)
+	return patchSecretWithSleepAnnotations(ctx, kClient, vcNamespace, configSecret, sleepingSince, forceDurationPtr(options.ForceDuration))
+}
+
+// pausePlatformWorkloadSleepModeIfConfigured detects whether workload sleep mode is configured
+// from the vCluster config (not the SleepScopeAnnotation) and applies it without scaling down
+// the control plane. Returns true if workload sleep mode was applied.
+func pausePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, forceDuration int64, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
+
+	// Standalone vClusters have no clusterRef — they run without a host cluster.
+	// Parse the config from the instance's Helm values directly.
+	if clusterName == "" {
+		return pausePlatformStandaloneIfConfigured(ctx, platformClient, projectName, forceDuration, log, vClusterName, virtualClusterInstance)
 	}
 
-	configSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation] = clusterv1.SleepTypeForced
-	if options.ForceDuration >= 0 {
-		configSecret.Annotations[clusterv1.SleepModeForceDurationAnnotation] = strconv.FormatInt(options.ForceDuration, 10)
-	}
-	patch := client.MergeFrom(orig)
-	patchBytes, err := patch.Data(configSecret)
+	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
+
+	kClient, err := platformClient.Cluster(clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to create patch for secret %s: %w", configSecretName, err)
+		return false, fmt.Errorf("create host cluster client: %w", err)
 	}
 
-	if _, err := kClient.CoreV1().Secrets(vcNamespace).Patch(ctx, configSecretName, patch.Type(), patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("failed to sleep vCluster: %w", err)
+	configSecret, _, configured, err := hostVClusterSleepModeConfig(ctx, kClient, vcNamespace, vClusterName)
+	if err != nil {
+		return false, err
+	}
+	if !configured {
+		return false, nil
 	}
 
-	return nil
+	log.Infof("vCluster %s/%s is configured for workload sleep mode, sleeping workloads only (control plane stays running)", vcNamespace, vClusterName)
+
+	sleepingSince := strconv.FormatInt(time.Now().Unix(), 10)
+	return true, patchSecretWithSleepAnnotations(ctx, kClient, vcNamespace, configSecret, sleepingSince, forceDurationPtr(forceDuration))
+}
+
+// pausePlatformStandaloneIfConfigured handles workload sleep mode for standalone vClusters
+// (those with no clusterRef). It prefers rendered Helm values from status and falls back to
+// the template values if status is unavailable, then updates the vc-standalone-sleep-state
+// secret via the platform proxy.
+func pausePlatformStandaloneIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, forceDuration int64, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+	valuesYAML := platformVClusterValuesYAML(virtualClusterInstance)
+	if valuesYAML == "" {
+		return false, nil
+	}
+
+	var vClusterConfig vclusterconfig.Config
+	if err := yaml.Unmarshal([]byte(valuesYAML), &vClusterConfig); err != nil {
+		return false, nil
+	}
+
+	if !vClusterConfig.IsConfiguredForSleepMode() {
+		return false, nil
+	}
+
+	log.Infof("vCluster %s is configured for workload sleep mode (standalone), sleeping workloads only (control plane stays running)", vClusterName)
+
+	sleepingSince := strconv.FormatInt(time.Now().Unix(), 10)
+	return true, pausePlatformStandaloneWorkloadSleep(ctx, platformClient, projectName, vClusterName, sleepingSince, forceDuration)
+}
+
+// pausePlatformStandaloneWorkloadSleep updates the vc-standalone-sleep-state secret inside the
+// virtual cluster's default namespace via the platform proxy.
+func pausePlatformStandaloneWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName, vClusterName, sleepingSince string, forceDuration int64) error {
+	if projectName == "" {
+		projectName = "default"
+	}
+	restConfig, err := platformClient.RestConfig("/kubernetes/project/" + projectName + "/virtualcluster/" + vClusterName)
+	if err != nil {
+		return fmt.Errorf("create virtual cluster rest config: %w", err)
+	}
+
+	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(restConfig))
+	if err != nil {
+		return fmt.Errorf("create virtual cluster client: %w", err)
+	}
+
+	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: "default"}},
+		func(s *corev1.Secret) {
+			applySleepAnnotations(s, sleepingSince, forceDurationPtr(forceDuration))
+		},
+	)
 }

--- a/pkg/cli/pause_platform.go
+++ b/pkg/cli/pause_platform.go
@@ -100,9 +100,9 @@ func workloadSleepOnly(ctx context.Context, platformClient platform.Client, opti
 
 	kClient, err := platformClient.Cluster(clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to create client for host cluster %s: %w", clusterName, err)
+		return fmt.Errorf("create host cluster client for %s: %w", clusterName, err)
 	}
-	configSecretName := "vc-config-" + vClusterName
+	configSecretName := vClusterConfigSecretName(vClusterName)
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
 	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, configSecretName, metav1.GetOptions{})
 	if err != nil {
@@ -125,7 +125,7 @@ func pausePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformCli
 		return pausePlatformStandaloneIfConfigured(ctx, platformClient, projectName, forceDuration, log, vClusterName, virtualClusterInstance)
 	}
 	if clusterName == "" {
-		return false, fmt.Errorf("create host cluster client: virtual cluster instance has no cluster ref")
+		return false, nil
 	}
 
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
@@ -182,8 +182,8 @@ func pausePlatformStandaloneWorkloadSleep(ctx context.Context, platformClient pl
 		return err
 	}
 
-	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName,
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: "default"}},
+	return mutateSleepSecret(ctx, virtualKubeClient, defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: defaultSleepModeNamespace}},
 		func(s *corev1.Secret) {
 			applySleepAnnotations(s, sleepingSince, forceDurationPtr(forceDuration))
 		},

--- a/pkg/cli/pause_platform.go
+++ b/pkg/cli/pause_platform.go
@@ -41,7 +41,7 @@ func PausePlatform(ctx context.Context, options *PauseOptions, cfg *cliconfig.CL
 	}
 
 	// Check if the vCluster config enables workload sleep mode natively (no agent).
-	if used, err := pausePlatformWorkloadSleepModeIfConfigured(ctx, platformClient, projectName, options.ForceDuration, log, vClusterName, virtualClusterInstance); err != nil {
+	if used, err := sleepPlatformWorkloadSleep(ctx, platformClient, projectName, options.ForceDuration, log, vClusterName, virtualClusterInstance); err != nil {
 		return err
 	} else if used {
 		return nil
@@ -113,10 +113,10 @@ func workloadSleepOnly(ctx context.Context, platformClient platform.Client, opti
 	return patchSecretWithSleepAnnotations(ctx, kClient, vcNamespace, configSecret, sleepingSince, forceDurationPtr(options.ForceDuration))
 }
 
-// pausePlatformWorkloadSleepModeIfConfigured detects whether workload sleep mode is configured
+// sleepPlatformWorkloadSleep detects whether workload sleep mode is configured
 // from the vCluster config (not the SleepScopeAnnotation) and applies it without scaling down
 // the control plane. Returns true if workload sleep mode was applied.
-func pausePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, forceDuration int64, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+func sleepPlatformWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName string, forceDuration int64, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
 
 	// Standalone vClusters run without a host cluster. Parse the config from the
@@ -177,7 +177,7 @@ func pausePlatformStandaloneIfConfigured(ctx context.Context, platformClient pla
 // pausePlatformStandaloneWorkloadSleep updates the vc-standalone-sleep-state secret inside the
 // virtual cluster's default namespace via the platform proxy.
 func pausePlatformStandaloneWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName, vClusterName, sleepingSince string, forceDuration int64) error {
-	virtualKubeClient, err := standalonePlatformSleepKubeClient(platformClient, projectName, vClusterName)
+	virtualKubeClient, err := standalonePlatformKubeClient(platformClient, projectName, vClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/pause_platform.go
+++ b/pkg/cli/pause_platform.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 )
 
@@ -92,6 +91,9 @@ func PausePlatform(ctx context.Context, options *PauseOptions, cfg *cliconfig.CL
 func workloadSleepOnly(ctx context.Context, platformClient platform.Client, options *PauseOptions, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) error {
 	log.Infof("This vCluster is configured to pause only workloads, control plane will be left running")
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
+	if virtualClusterInstance.Spec.Standalone {
+		return fmt.Errorf("cannot pause workload-scope vcluster: virtual cluster instance is standalone and has no host cluster")
+	}
 	if clusterName == "" {
 		return fmt.Errorf("cannot pause workload-scope vcluster: virtual cluster instance has no cluster ref (host cluster unknown)")
 	}
@@ -117,10 +119,13 @@ func workloadSleepOnly(ctx context.Context, platformClient platform.Client, opti
 func pausePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, forceDuration int64, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
 
-	// Standalone vClusters have no clusterRef — they run without a host cluster.
-	// Parse the config from the instance's Helm values directly.
-	if clusterName == "" {
+	// Standalone vClusters run without a host cluster. Parse the config from the
+	// instance's Helm values directly.
+	if virtualClusterInstance.Spec.Standalone {
 		return pausePlatformStandaloneIfConfigured(ctx, platformClient, projectName, forceDuration, log, vClusterName, virtualClusterInstance)
+	}
+	if clusterName == "" {
+		return false, fmt.Errorf("create host cluster client: virtual cluster instance has no cluster ref")
 	}
 
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
@@ -156,7 +161,7 @@ func pausePlatformStandaloneIfConfigured(ctx context.Context, platformClient pla
 
 	var vClusterConfig vclusterconfig.Config
 	if err := yaml.Unmarshal([]byte(valuesYAML), &vClusterConfig); err != nil {
-		return false, nil
+		return false, fmt.Errorf("unmarshal vcluster helm values: %w", err)
 	}
 
 	if !vClusterConfig.IsConfiguredForSleepMode() {
@@ -172,17 +177,9 @@ func pausePlatformStandaloneIfConfigured(ctx context.Context, platformClient pla
 // pausePlatformStandaloneWorkloadSleep updates the vc-standalone-sleep-state secret inside the
 // virtual cluster's default namespace via the platform proxy.
 func pausePlatformStandaloneWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName, vClusterName, sleepingSince string, forceDuration int64) error {
-	if projectName == "" {
-		projectName = "default"
-	}
-	restConfig, err := platformClient.RestConfig("/kubernetes/project/" + projectName + "/virtualcluster/" + vClusterName)
+	virtualKubeClient, err := standalonePlatformSleepKubeClient(platformClient, projectName, vClusterName)
 	if err != nil {
-		return fmt.Errorf("create virtual cluster rest config: %w", err)
-	}
-
-	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(restConfig))
-	if err != nil {
-		return fmt.Errorf("create virtual cluster client: %w", err)
+		return err
 	}
 
 	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName,

--- a/pkg/cli/resume_helm.go
+++ b/pkg/cli/resume_helm.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
@@ -12,6 +14,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -21,7 +24,10 @@ type ResumeOptions struct {
 	Project string
 }
 
-var ErrPlatformDriverRequired = errors.New("cannot resume a virtual cluster that is paused by the platform, please run 'vcluster use driver platform' or use the '--driver platform' flag")
+var (
+	ErrPlatformDriverRequired = errors.New("cannot resume a virtual cluster that is paused by the platform, please run 'vcluster use driver platform' or use the '--driver platform' flag")
+	errWorkloadWake           = errors.New("failed to wake")
+)
 
 func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	vCluster, err := find.GetVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
@@ -39,7 +45,7 @@ func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterNam
 	}
 
 	if vCluster.Status == find.StatusWorkloadSleeping {
-		if err := wakeWorkloadSleepHelm(ctx, kubeClient, vCluster); err != nil {
+		if err := workloadWake(ctx, kubeClient, vCluster); err != nil {
 			return err
 		}
 		log.Donef("Successfully woke vcluster %s in namespace %s", vClusterName, globalFlags.Namespace)
@@ -55,10 +61,10 @@ func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterNam
 	return nil
 }
 
-// wakeWorkloadSleepHelm clears the sleep annotations from the vc-config secret, waking the
+// workloadWake clears the sleep annotations from the vc-config secret, waking the
 // vCluster's workloads. For standalone vClusters it also clears the sleep secret inside the
 // virtual cluster that the in-cluster sleep state controller watches.
-func wakeWorkloadSleepHelm(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster) error {
+func workloadWake(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster) (retErr error) {
 	configSecret, err := kubeClient.CoreV1().Secrets(vCluster.Namespace).Get(ctx, vClusterConfigSecretName(vCluster.Name), metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get config secret: %w", err)
@@ -69,21 +75,67 @@ func wakeWorkloadSleepHelm(ctx context.Context, kubeClient kubernetes.Interface,
 		return err
 	}
 	if hasConfig && vClusterConfig.ControlPlane.Standalone.Enabled {
-		if err := wakeStandaloneWorkloadSleep(ctx, vCluster); err != nil {
+		virtualKubeClient, err := standaloneKubeClient(vCluster)
+		if err != nil {
 			return err
 		}
+
+		return wakeStandaloneWorkloadSleepOrRollback(ctx, kubeClient, virtualKubeClient, vCluster.Namespace, configSecret)
 	}
 
 	return clearSecretSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret)
 }
 
-// wakeStandaloneWorkloadSleep clears sleep annotations from the vc-standalone-sleep-state
-// secret inside the virtual cluster's default namespace. Mirrors pauseStandaloneWorkloadSleep.
-func wakeStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster) error {
-	virtualKubeClient, err := standaloneSleepKubeClient(vCluster)
-	if err != nil {
-		return err
+func wakeStandaloneWorkloadSleepOrRollback(ctx context.Context, hostKubeClient, virtualKubeClient kubernetes.Interface, namespace string, configSecret *corev1.Secret) error {
+	if err := wakeStandalone(ctx, virtualKubeClient); err != nil {
+		return errWorkloadWake
 	}
+
+	originalConfigSecret := configSecret.DeepCopy()
+	if err := clearSecretSleepAnnotations(ctx, hostKubeClient, namespace, configSecret.DeepCopy()); err != nil {
+		if rollbackErr := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+			if err := restoreStandaloneWorkloadSleep(ctx, virtualKubeClient, originalConfigSecret); err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		}); rollbackErr != nil {
+			return errWorkloadWake
+		}
+
+		return errWorkloadWake
+	}
+
+	return nil
+}
+
+func restoreStandaloneWorkloadSleep(ctx context.Context, virtualKubeClient kubernetes.Interface, configSecret *corev1.Secret) error {
+	sleepType, hasSleepType := configSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	sleepingSince, hasSleepingSince := configSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation]
+	if !hasSleepType || sleepType == "" || !hasSleepingSince {
+		return nil
+	}
+
+	forceDuration, hasForceDuration := configSecret.Annotations[clusterv1.SleepModeForceDurationAnnotation]
+	return mutateSleepSecret(ctx, virtualKubeClient, defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: sleepmode.StandaloneSleepSecretName, Namespace: defaultSleepModeNamespace}},
+		func(s *corev1.Secret) {
+			s.Annotations[clusterv1.SleepModeSleepTypeAnnotation] = sleepType
+			s.Annotations[clusterv1.SleepModeSleepingSinceAnnotation] = sleepingSince
+			if hasForceDuration {
+				s.Annotations[clusterv1.SleepModeForceDurationAnnotation] = forceDuration
+			} else {
+				delete(s.Annotations, clusterv1.SleepModeForceDurationAnnotation)
+			}
+			delete(s.Annotations, clusterv1.SleepModeForceAnnotation)
+			delete(s.Annotations, clusterv1.SleepModeLastActivityAnnotation)
+		},
+	)
+}
+
+// wakeStandalone clears sleep annotations from the vc-standalone-sleep-state
+// secret inside the virtual cluster's default namespace. Mirrors sleepStandaloneWorkload.
+func wakeStandalone(ctx context.Context, virtualKubeClient kubernetes.Interface) error {
 	// nil initial: if the secret doesn't exist there is nothing to wake.
 	return mutateSleepSecret(ctx, virtualKubeClient, defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName, nil, func(s *corev1.Secret) {
 		clearSleepAnnotations(s)

--- a/pkg/cli/resume_helm.go
+++ b/pkg/cli/resume_helm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/lifecycle"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -35,6 +36,14 @@ func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterNam
 		return err
 	}
 
+	if vCluster.Status == find.StatusWorkloadSleeping {
+		if err := wakeWorkloadSleepHelm(ctx, kubeClient, vCluster); err != nil {
+			return err
+		}
+		log.Donef("Successfully woke vcluster %s in namespace %s", vClusterName, globalFlags.Namespace)
+		return nil
+	}
+
 	err = lifecycle.ResumeVCluster(ctx, kubeClient, vClusterName, globalFlags.Namespace, false, log)
 	if err != nil {
 		return err
@@ -42,6 +51,17 @@ func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterNam
 
 	log.Donef("Successfully resumed vcluster %s in namespace %s", vClusterName, globalFlags.Namespace)
 	return nil
+}
+
+// wakeWorkloadSleepHelm clears the sleep annotations from the vc-config secret, waking the
+// vCluster's workloads. StatusWorkloadSleeping is always detected via the host-cluster config
+// secret (standalone vClusters are not found via the helm path).
+func wakeWorkloadSleepHelm(ctx context.Context, kubeClient *kubernetes.Clientset, vCluster *find.VCluster) error {
+	configSecret, err := kubeClient.CoreV1().Secrets(vCluster.Namespace).Get(ctx, "vc-config-"+vCluster.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get config secret: %w", err)
+	}
+	return clearSecretSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret)
 }
 
 func prepareResume(vCluster *find.VCluster, globalFlags *flags.GlobalFlags) (*kubernetes.Clientset, error) {

--- a/pkg/cli/resume_helm.go
+++ b/pkg/cli/resume_helm.go
@@ -59,7 +59,7 @@ func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterNam
 // vCluster's workloads. For standalone vClusters it also clears the sleep secret inside the
 // virtual cluster that the in-cluster sleep state controller watches.
 func wakeWorkloadSleepHelm(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster) error {
-	configSecret, err := kubeClient.CoreV1().Secrets(vCluster.Namespace).Get(ctx, "vc-config-"+vCluster.Name, metav1.GetOptions{})
+	configSecret, err := kubeClient.CoreV1().Secrets(vCluster.Namespace).Get(ctx, vClusterConfigSecretName(vCluster.Name), metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get config secret: %w", err)
 	}
@@ -85,7 +85,7 @@ func wakeStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster) e
 		return err
 	}
 	// nil initial: if the secret doesn't exist there is nothing to wake.
-	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName, nil, func(s *corev1.Secret) {
+	return mutateSleepSecret(ctx, virtualKubeClient, defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName, nil, func(s *corev1.Secret) {
 		clearSleepAnnotations(s)
 	})
 }

--- a/pkg/cli/resume_helm.go
+++ b/pkg/cli/resume_helm.go
@@ -9,6 +9,8 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/lifecycle"
+	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -54,14 +56,38 @@ func ResumeHelm(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterNam
 }
 
 // wakeWorkloadSleepHelm clears the sleep annotations from the vc-config secret, waking the
-// vCluster's workloads. StatusWorkloadSleeping is always detected via the host-cluster config
-// secret (standalone vClusters are not found via the helm path).
-func wakeWorkloadSleepHelm(ctx context.Context, kubeClient *kubernetes.Clientset, vCluster *find.VCluster) error {
+// vCluster's workloads. For standalone vClusters it also clears the sleep secret inside the
+// virtual cluster that the in-cluster sleep state controller watches.
+func wakeWorkloadSleepHelm(ctx context.Context, kubeClient kubernetes.Interface, vCluster *find.VCluster) error {
 	configSecret, err := kubeClient.CoreV1().Secrets(vCluster.Namespace).Get(ctx, "vc-config-"+vCluster.Name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("get config secret: %w", err)
 	}
+
+	vClusterConfig, hasConfig, err := secretVClusterConfig(configSecret)
+	if err != nil {
+		return err
+	}
+	if hasConfig && vClusterConfig.ControlPlane.Standalone.Enabled {
+		if err := wakeStandaloneWorkloadSleep(ctx, vCluster); err != nil {
+			return err
+		}
+	}
+
 	return clearSecretSleepAnnotations(ctx, kubeClient, vCluster.Namespace, configSecret)
+}
+
+// wakeStandaloneWorkloadSleep clears sleep annotations from the vc-standalone-sleep-state
+// secret inside the virtual cluster's default namespace. Mirrors pauseStandaloneWorkloadSleep.
+func wakeStandaloneWorkloadSleep(ctx context.Context, vCluster *find.VCluster) error {
+	virtualKubeClient, err := standaloneSleepKubeClient(vCluster)
+	if err != nil {
+		return err
+	}
+	// nil initial: if the secret doesn't exist there is nothing to wake.
+	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName, nil, func(s *corev1.Secret) {
+		clearSleepAnnotations(s)
+	})
 }
 
 func prepareResume(vCluster *find.VCluster, globalFlags *flags.GlobalFlags) (*kubernetes.Clientset, error) {

--- a/pkg/cli/resume_helm_test.go
+++ b/pkg/cli/resume_helm_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestWakeWorkloadSleepHelm_NonStandalone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	kubeClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				clusterv1.SleepModeForceAnnotation:         "true",
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+				clusterv1.SleepModeForceDurationAnnotation: "600",
+			},
+		},
+		Data: map[string][]byte{
+			"config.yaml": []byte("sleep:\n  auto:\n    afterInactivity: 1h\n"),
+		},
+	})
+
+	vCluster := &find.VCluster{
+		Name:      "test",
+		Namespace: "test-ns",
+	}
+
+	err := wakeWorkloadSleepHelm(ctx, kubeClient, vCluster)
+	assert.NilError(t, err)
+
+	secret, err := kubeClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	_, hasForce := secret.Annotations[clusterv1.SleepModeForceAnnotation]
+	assert.Assert(t, !hasForce)
+	_, hasSleepType := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	assert.Assert(t, !hasSleepType)
+	_, hasSleepingSince := secret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation]
+	assert.Assert(t, !hasSleepingSince)
+	_, hasForceDuration := secret.Annotations[clusterv1.SleepModeForceDurationAnnotation]
+	assert.Assert(t, !hasForceDuration)
+	assert.Assert(t, secret.Annotations[clusterv1.SleepModeLastActivityAnnotation] != "")
+}
+
+func TestWakeWorkloadSleepHelm_NoConfigYAML(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	kubeClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+			},
+		},
+		// No config.yaml — treat as non-standalone, host secret cleared successfully.
+	})
+
+	vCluster := &find.VCluster{
+		Name:      "test",
+		Namespace: "test-ns",
+	}
+
+	err := wakeWorkloadSleepHelm(ctx, kubeClient, vCluster)
+	assert.NilError(t, err)
+
+	secret, err := kubeClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+	_, hasSleepType := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	assert.Assert(t, !hasSleepType)
+}

--- a/pkg/cli/resume_helm_test.go
+++ b/pkg/cli/resume_helm_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
@@ -9,7 +10,9 @@ import (
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestWakeWorkloadSleepHelm_NonStandalone(t *testing.T) {
@@ -37,7 +40,7 @@ func TestWakeWorkloadSleepHelm_NonStandalone(t *testing.T) {
 		Namespace: "test-ns",
 	}
 
-	err := wakeWorkloadSleepHelm(ctx, kubeClient, vCluster)
+	err := workloadWake(ctx, kubeClient, vCluster)
 	assert.NilError(t, err)
 
 	secret, err := kubeClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
@@ -75,11 +78,110 @@ func TestWakeWorkloadSleepHelm_NoConfigYAML(t *testing.T) {
 		Namespace: "test-ns",
 	}
 
-	err := wakeWorkloadSleepHelm(ctx, kubeClient, vCluster)
+	err := workloadWake(ctx, kubeClient, vCluster)
 	assert.NilError(t, err)
 
 	secret, err := kubeClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
 	assert.NilError(t, err)
 	_, hasSleepType := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
 	assert.Assert(t, !hasSleepType)
+}
+
+func TestWakeStandaloneWorkloadSleepOrRollbackRollsBackStandaloneSecretOnHostPatchFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	hostClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+				clusterv1.SleepModeForceDurationAnnotation: "600",
+			},
+		},
+	})
+	hostClient.PrependReactor("patch", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("host patch failed")
+	})
+
+	virtualClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-standalone-sleep-state",
+			Namespace: defaultSleepModeNamespace,
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+				clusterv1.SleepModeForceDurationAnnotation: "600",
+			},
+		},
+	})
+
+	configSecret, err := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	err = wakeStandaloneWorkloadSleepOrRollback(ctx, hostClient, virtualClient, "test-ns", configSecret)
+	assert.ErrorIs(t, err, errWorkloadWake)
+
+	virtualSecret, getErr := virtualClient.CoreV1().Secrets(defaultSleepModeNamespace).Get(ctx, "vc-standalone-sleep-state", metav1.GetOptions{})
+	assert.NilError(t, getErr)
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], clusterv1.SleepTypeForced)
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation], "123")
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeForceDurationAnnotation], "600")
+	_, hasLastActivity := virtualSecret.Annotations[clusterv1.SleepModeLastActivityAnnotation]
+	assert.Assert(t, !hasLastActivity)
+}
+
+func TestWakeStandaloneWorkloadSleepOrRollbackRetriesRollbackUntilSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	hostClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+			},
+		},
+	})
+	hostClient.PrependReactor("patch", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("host patch failed")
+	})
+
+	virtualClient := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-standalone-sleep-state",
+			Namespace: defaultSleepModeNamespace,
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+			},
+		},
+	})
+	virtualPatchAttempts := 0
+	virtualClient.PrependReactor("patch", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		virtualPatchAttempts++
+		if virtualPatchAttempts == 2 {
+			return true, nil, errors.New("transient rollback failure")
+		}
+
+		return false, nil, nil
+	})
+
+	configSecret, err := hostClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	err = wakeStandaloneWorkloadSleepOrRollback(ctx, hostClient, virtualClient, "test-ns", configSecret)
+	assert.ErrorIs(t, err, errWorkloadWake)
+	assert.Assert(t, virtualPatchAttempts >= 3)
+
+	virtualSecret, getErr := virtualClient.CoreV1().Secrets(defaultSleepModeNamespace).Get(ctx, "vc-standalone-sleep-state", metav1.GetOptions{})
+	assert.NilError(t, getErr)
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], clusterv1.SleepTypeForced)
+	assert.Equal(t, virtualSecret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation], "123")
+	_, hasLastActivity := virtualSecret.Annotations[clusterv1.SleepModeLastActivityAnnotation]
+	assert.Assert(t, !hasLastActivity)
 }

--- a/pkg/cli/resume_platform.go
+++ b/pkg/cli/resume_platform.go
@@ -35,7 +35,7 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 	}
 
 	if virtualClusterInstance.Annotations[clusterv1.SleepScopeAnnotation] == "workloads-only" {
-		return workloadWakeOnly(ctx, platformClient, log, vClusterName, virtualClusterInstance)
+		return workloadWakeOnly(ctx, platformClient, vClusterName, virtualClusterInstance)
 	}
 
 	if !vCluster.IsInstanceSleeping() {
@@ -61,7 +61,7 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 	return nil
 }
 
-func workloadWakeOnly(ctx context.Context, platformClient platform.Client, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) error {
+func workloadWakeOnly(ctx context.Context, platformClient platform.Client, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) error {
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
 	if clusterName == "" {
 		return fmt.Errorf("cannot wake workload-scope vcluster: virtual cluster instance has no cluster ref (host cluster unknown)")

--- a/pkg/cli/resume_platform.go
+++ b/pkg/cli/resume_platform.go
@@ -3,17 +3,20 @@ package cli
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"time"
 
 	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	"github.com/loft-sh/log"
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/platform"
+	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
 )
 
 func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.CLI, vClusterName string, log log.Logger) error {
@@ -26,9 +29,17 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 		return err
 	}
 
+	projectName := vCluster.Project.Name
 	virtualClusterInstance := vCluster.VirtualCluster
 	if virtualClusterInstance.Annotations[clusterv1.SleepScopeAnnotation] == "workloads-only" {
 		return workloadWakeOnly(ctx, platformClient, log, vClusterName, virtualClusterInstance)
+	}
+
+	// Check if the vCluster is in native workload sleep mode and wake it.
+	if used, err := resumePlatformWorkloadSleepModeIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance); err != nil {
+		return err
+	} else if used {
+		return nil
 	}
 
 	if !vCluster.IsInstanceSleeping() {
@@ -57,38 +68,101 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 func workloadWakeOnly(ctx context.Context, platformClient platform.Client, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) error {
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
 	if clusterName == "" {
-		return fmt.Errorf("cannot pause workload-scope vcluster: virtual cluster instance has no cluster ref (host cluster unknown)")
+		return fmt.Errorf("cannot wake workload-scope vcluster: virtual cluster instance has no cluster ref (host cluster unknown)")
 	}
 
 	kClient, err := platformClient.Cluster(clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to create client for host cluster %s: %w", clusterName, err)
+		return fmt.Errorf("create client for host cluster %s: %w", clusterName, err)
 	}
-	configSecretName := "vc-config-" + vClusterName
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
-	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, configSecretName, metav1.GetOptions{})
+	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, "vc-config-"+vClusterName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to load the vcluster config: %w", err)
+		return fmt.Errorf("load vcluster config secret: %w", err)
 	}
 
-	orig := configSecret.DeepCopy()
-	if configSecret.Annotations == nil {
-		configSecret.Annotations = map[string]string{}
+	return clearSecretSleepAnnotations(ctx, kClient, vcNamespace, configSecret)
+}
+
+// resumePlatformWorkloadSleepModeIfConfigured detects whether the vCluster is in native workload
+// sleep mode and clears the sleep annotations to wake it. Mirrors pausePlatformWorkloadSleepModeIfConfigured.
+func resumePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
+
+	// Standalone vClusters have no clusterRef — wake via platform proxy.
+	if clusterName == "" {
+		return resumePlatformStandaloneIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance)
 	}
 
-	delete(configSecret.Annotations, clusterv1.SleepModeForceAnnotation)
-	delete(configSecret.Annotations, clusterv1.SleepModeSleepTypeAnnotation)
-	delete(configSecret.Annotations, clusterv1.SleepModeForceDurationAnnotation)
-	configSecret.Annotations[clusterv1.SleepModeLastActivityAnnotation] = strconv.FormatInt(time.Now().Unix(), 10)
-	patch := client.MergeFrom(orig)
-	patchBytes, err := patch.Data(configSecret)
+	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
+
+	kClient, err := platformClient.Cluster(clusterName)
 	if err != nil {
-		return fmt.Errorf("failed to create patch for secret %s: %w", configSecretName, err)
+		return false, fmt.Errorf("create host cluster client: %w", err)
 	}
 
-	if _, err := kClient.CoreV1().Secrets(vcNamespace).Patch(ctx, configSecretName, patch.Type(), patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("failed to wake vCluster: %w", err)
+	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, "vc-config-"+vClusterName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get config secret: %w", err)
 	}
 
-	return nil
+	// If the agent is managing this vCluster, defer to it.
+	if _, agentInstalled := configSecret.Annotations[sleepmode.AnnotationAgentInstalled]; agentInstalled {
+		return false, nil
+	}
+
+	// Only act if the secret is currently marked as sleeping by native workload sleep mode.
+	if _, sleeping := configSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]; !sleeping {
+		return false, nil
+	}
+
+	log.Infof("Waking vCluster %s/%s workloads", vcNamespace, vClusterName)
+	return true, clearSecretSleepAnnotations(ctx, kClient, vcNamespace, configSecret)
+}
+
+// resumePlatformStandaloneIfConfigured wakes a standalone vCluster by reading rendered Helm
+// values from status when available and clearing sleep annotations from the
+// vc-standalone-sleep-state secret via the platform proxy.
+func resumePlatformStandaloneIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+	valuesYAML := platformVClusterValuesYAML(virtualClusterInstance)
+	if valuesYAML == "" {
+		return false, nil
+	}
+
+	var vClusterConfig vclusterconfig.Config
+	if err := yaml.Unmarshal([]byte(valuesYAML), &vClusterConfig); err != nil {
+		return false, nil
+	}
+
+	if !vClusterConfig.IsConfiguredForSleepMode() {
+		return false, nil
+	}
+
+	log.Infof("Waking standalone vCluster %s workloads (clearing workload sleep mode)", vClusterName)
+	return true, resumePlatformStandaloneWorkloadSleep(ctx, platformClient, projectName, vClusterName)
+}
+
+// resumePlatformStandaloneWorkloadSleep clears sleep annotations from the vc-standalone-sleep-state
+// secret inside the virtual cluster's default namespace via the platform proxy.
+func resumePlatformStandaloneWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName, vClusterName string) error {
+	if projectName == "" {
+		projectName = "default"
+	}
+	restConfig, err := platformClient.RestConfig("/kubernetes/project/" + projectName + "/virtualcluster/" + vClusterName)
+	if err != nil {
+		return fmt.Errorf("create virtual cluster rest config: %w", err)
+	}
+
+	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(restConfig))
+	if err != nil {
+		return fmt.Errorf("create virtual cluster client: %w", err)
+	}
+
+	// nil initial: if the secret doesn't exist there is nothing to wake.
+	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName, nil, func(s *corev1.Secret) {
+		clearSleepAnnotations(s)
+	})
 }

--- a/pkg/cli/resume_platform.go
+++ b/pkg/cli/resume_platform.go
@@ -69,10 +69,10 @@ func workloadWakeOnly(ctx context.Context, platformClient platform.Client, vClus
 
 	kClient, err := platformClient.Cluster(clusterName)
 	if err != nil {
-		return fmt.Errorf("create client for host cluster %s: %w", clusterName, err)
+		return fmt.Errorf("create host cluster client for %s: %w", clusterName, err)
 	}
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
-	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, "vc-config-"+vClusterName, metav1.GetOptions{})
+	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, vClusterConfigSecretName(vClusterName), metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("load vcluster config secret: %w", err)
 	}
@@ -90,7 +90,7 @@ func resumePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformCl
 		return resumePlatformStandaloneIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance)
 	}
 	if clusterName == "" {
-		return false, fmt.Errorf("create host cluster client: virtual cluster instance has no cluster ref")
+		return false, nil
 	}
 
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace

--- a/pkg/cli/resume_platform.go
+++ b/pkg/cli/resume_platform.go
@@ -28,7 +28,7 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 	projectName := vCluster.Project.Name
 	virtualClusterInstance := vCluster.VirtualCluster
 	// Check if the vCluster is in native workload sleep mode and wake it.
-	if used, err := resumePlatformWorkloadSleepModeIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance); err != nil {
+	if used, err := wakePlatformWorkloadSleep(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance); err != nil {
 		return err
 	} else if used {
 		return nil
@@ -80,14 +80,14 @@ func workloadWakeOnly(ctx context.Context, platformClient platform.Client, vClus
 	return clearSecretSleepAnnotations(ctx, kClient, vcNamespace, configSecret)
 }
 
-// resumePlatformWorkloadSleepModeIfConfigured detects whether the vCluster is in native workload
-// sleep mode and clears the sleep annotations to wake it. Mirrors pausePlatformWorkloadSleepModeIfConfigured.
-func resumePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+// wakePlatformWorkloadSleep detects whether the vCluster is in native workload
+// sleep mode and clears the sleep annotations to wake it. Mirrors sleepPlatformWorkloadSleep.
+func wakePlatformWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
 
 	// Standalone vClusters wake via the virtual cluster proxy.
 	if virtualClusterInstance.Spec.Standalone {
-		return resumePlatformStandaloneIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance)
+		return wakePlatformStandalone(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance)
 	}
 	if clusterName == "" {
 		return false, nil
@@ -117,10 +117,10 @@ func resumePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformCl
 	return true, clearSecretSleepAnnotations(ctx, target.kubeClient, target.namespace, target.secret)
 }
 
-// resumePlatformStandaloneIfConfigured wakes a standalone vCluster by reading rendered Helm
+// wakePlatformStandalone wakes a standalone vCluster by reading rendered Helm
 // values from status when available and clearing sleep annotations from the
 // vc-standalone-sleep-state secret via the platform proxy.
-func resumePlatformStandaloneIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
+func wakePlatformStandalone(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
 	valuesYAML := platformVClusterValuesYAML(virtualClusterInstance)
 	if valuesYAML == "" {
 		return false, nil
@@ -135,13 +135,18 @@ func resumePlatformStandaloneIfConfigured(ctx context.Context, platformClient pl
 		return false, nil
 	}
 
-	log.Infof("Waking standalone vCluster %s workloads (clearing workload sleep mode)", vClusterName)
 	target, err := getPlatformWorkloadSleepSecret(ctx, platformClient, projectName, virtualClusterInstance, vClusterName)
 	if err != nil {
 		return true, err
 	}
+	return wakePlatformStandaloneTarget(ctx, log, vClusterName, target)
+}
+
+func wakePlatformStandaloneTarget(ctx context.Context, log log.Logger, vClusterName string, target *platformWorkloadSleepSecretTarget) (bool, error) {
 	if target == nil || target.secret == nil {
-		return true, nil
+		return false, nil
 	}
+
+	log.Infof("Waking standalone vCluster %s workloads (clearing workload sleep mode)", vClusterName)
 	return true, clearSecretSleepAnnotations(ctx, target.kubeClient, target.namespace, target.secret)
 }

--- a/pkg/cli/resume_platform.go
+++ b/pkg/cli/resume_platform.go
@@ -11,11 +11,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/platform"
-	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
-	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 )
 
@@ -31,15 +27,15 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 
 	projectName := vCluster.Project.Name
 	virtualClusterInstance := vCluster.VirtualCluster
-	if virtualClusterInstance.Annotations[clusterv1.SleepScopeAnnotation] == "workloads-only" {
-		return workloadWakeOnly(ctx, platformClient, log, vClusterName, virtualClusterInstance)
-	}
-
 	// Check if the vCluster is in native workload sleep mode and wake it.
 	if used, err := resumePlatformWorkloadSleepModeIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance); err != nil {
 		return err
 	} else if used {
 		return nil
+	}
+
+	if virtualClusterInstance.Annotations[clusterv1.SleepScopeAnnotation] == "workloads-only" {
+		return workloadWakeOnly(ctx, platformClient, log, vClusterName, virtualClusterInstance)
 	}
 
 	if !vCluster.IsInstanceSleeping() {
@@ -89,38 +85,36 @@ func workloadWakeOnly(ctx context.Context, platformClient platform.Client, log l
 func resumePlatformWorkloadSleepModeIfConfigured(ctx context.Context, platformClient platform.Client, projectName string, log log.Logger, vClusterName string, virtualClusterInstance *managementv1.VirtualClusterInstance) (bool, error) {
 	clusterName := virtualClusterInstance.Spec.ClusterRef.Cluster
 
-	// Standalone vClusters have no clusterRef — wake via platform proxy.
-	if clusterName == "" {
+	// Standalone vClusters wake via the virtual cluster proxy.
+	if virtualClusterInstance.Spec.Standalone {
 		return resumePlatformStandaloneIfConfigured(ctx, platformClient, projectName, log, vClusterName, virtualClusterInstance)
+	}
+	if clusterName == "" {
+		return false, fmt.Errorf("create host cluster client: virtual cluster instance has no cluster ref")
 	}
 
 	vcNamespace := virtualClusterInstance.Spec.ClusterRef.Namespace
 
-	kClient, err := platformClient.Cluster(clusterName)
+	target, err := getPlatformWorkloadSleepSecret(ctx, platformClient, projectName, virtualClusterInstance, vClusterName)
 	if err != nil {
-		return false, fmt.Errorf("create host cluster client: %w", err)
+		return false, err
 	}
-
-	configSecret, err := kClient.CoreV1().Secrets(vcNamespace).Get(ctx, "vc-config-"+vClusterName, metav1.GetOptions{})
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("get config secret: %w", err)
+	if target == nil || target.secret == nil {
+		return false, nil
 	}
 
 	// If the agent is managing this vCluster, defer to it.
-	if _, agentInstalled := configSecret.Annotations[sleepmode.AnnotationAgentInstalled]; agentInstalled {
+	if isWorkloadSleepSecretAgentManaged(target.secret) {
 		return false, nil
 	}
 
 	// Only act if the secret is currently marked as sleeping by native workload sleep mode.
-	if _, sleeping := configSecret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]; !sleeping {
+	if !isWorkloadSleepSecretSleeping(target.secret) {
 		return false, nil
 	}
 
 	log.Infof("Waking vCluster %s/%s workloads", vcNamespace, vClusterName)
-	return true, clearSecretSleepAnnotations(ctx, kClient, vcNamespace, configSecret)
+	return true, clearSecretSleepAnnotations(ctx, target.kubeClient, target.namespace, target.secret)
 }
 
 // resumePlatformStandaloneIfConfigured wakes a standalone vCluster by reading rendered Helm
@@ -134,7 +128,7 @@ func resumePlatformStandaloneIfConfigured(ctx context.Context, platformClient pl
 
 	var vClusterConfig vclusterconfig.Config
 	if err := yaml.Unmarshal([]byte(valuesYAML), &vClusterConfig); err != nil {
-		return false, nil
+		return false, fmt.Errorf("unmarshal vcluster helm values: %w", err)
 	}
 
 	if !vClusterConfig.IsConfiguredForSleepMode() {
@@ -142,27 +136,12 @@ func resumePlatformStandaloneIfConfigured(ctx context.Context, platformClient pl
 	}
 
 	log.Infof("Waking standalone vCluster %s workloads (clearing workload sleep mode)", vClusterName)
-	return true, resumePlatformStandaloneWorkloadSleep(ctx, platformClient, projectName, vClusterName)
-}
-
-// resumePlatformStandaloneWorkloadSleep clears sleep annotations from the vc-standalone-sleep-state
-// secret inside the virtual cluster's default namespace via the platform proxy.
-func resumePlatformStandaloneWorkloadSleep(ctx context.Context, platformClient platform.Client, projectName, vClusterName string) error {
-	if projectName == "" {
-		projectName = "default"
-	}
-	restConfig, err := platformClient.RestConfig("/kubernetes/project/" + projectName + "/virtualcluster/" + vClusterName)
+	target, err := getPlatformWorkloadSleepSecret(ctx, platformClient, projectName, virtualClusterInstance, vClusterName)
 	if err != nil {
-		return fmt.Errorf("create virtual cluster rest config: %w", err)
+		return true, err
 	}
-
-	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(restConfig))
-	if err != nil {
-		return fmt.Errorf("create virtual cluster client: %w", err)
+	if target == nil || target.secret == nil {
+		return true, nil
 	}
-
-	// nil initial: if the secret doesn't exist there is nothing to wake.
-	return mutateSleepSecret(ctx, virtualKubeClient, "default", sleepmode.StandaloneSleepSecretName, nil, func(s *corev1.Secret) {
-		clearSleepAnnotations(s)
-	})
+	return true, clearSecretSleepAnnotations(ctx, target.kubeClient, target.namespace, target.secret)
 }

--- a/pkg/cli/sleepmode_helpers.go
+++ b/pkg/cli/sleepmode_helpers.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
 	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"github.com/loft-sh/vcluster/pkg/platform"
 	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -86,6 +90,153 @@ func clearSleepAnnotations(secret *corev1.Secret) {
 	secret.Annotations[clusterv1.SleepModeLastActivityAnnotation] = strconv.FormatInt(time.Now().Unix(), 10)
 }
 
+func standaloneSleepKubeClient(vCluster *find.VCluster) (kubernetes.Interface, error) {
+	if vCluster.ClientFactory == nil {
+		return nil, fmt.Errorf("cannot access standalone vCluster %s/%s: kubeconfig is not available", vCluster.Namespace, vCluster.Name)
+	}
+
+	rawConfig, err := vCluster.ClientFactory.RawConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load kubeconfig: %w", err)
+	}
+
+	vClusterCtxName := find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context)
+	if _, ok := rawConfig.Contexts[vClusterCtxName]; !ok {
+		return nil, fmt.Errorf("cannot access standalone vCluster %s/%s: context %q not found in kubeconfig, please run 'vcluster connect %s -n %s' first",
+			vCluster.Namespace, vCluster.Name, vClusterCtxName, vCluster.Name, vCluster.Namespace)
+	}
+
+	virtualRestConfig, err := clientcmd.NewDefaultClientConfig(rawConfig, &clientcmd.ConfigOverrides{CurrentContext: vClusterCtxName}).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("create virtual cluster client config: %w", err)
+	}
+
+	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(virtualRestConfig))
+	if err != nil {
+		return nil, fmt.Errorf("create virtual cluster client: %w", err)
+	}
+
+	return virtualKubeClient, nil
+}
+
+func standalonePlatformSleepKubeClient(platformClient platform.Client, projectName, vClusterName string) (kubernetes.Interface, error) {
+	if projectName == "" {
+		projectName = "default"
+	}
+
+	restConfig, err := platformClient.RestConfig("/kubernetes/project/" + url.PathEscape(projectName) + "/virtualcluster/" + url.PathEscape(vClusterName))
+	if err != nil {
+		return nil, fmt.Errorf("create virtual cluster rest config: %w", err)
+	}
+
+	virtualKubeClient, err := kubernetes.NewForConfig(withSleepModeIgnore(restConfig))
+	if err != nil {
+		return nil, fmt.Errorf("create virtual cluster client: %w", err)
+	}
+
+	return virtualKubeClient, nil
+}
+
+type platformWorkloadSleepSecretTarget struct {
+	kubeClient kubernetes.Interface
+	namespace  string
+	secret     *corev1.Secret
+}
+
+func getPlatformWorkloadSleepSecret(ctx context.Context, platformClient platform.Client, projectName string, virtualClusterInstance *managementv1.VirtualClusterInstance, fallbackVClusterName string) (*platformWorkloadSleepSecretTarget, error) {
+	if virtualClusterInstance == nil {
+		return nil, nil
+	}
+
+	if virtualClusterInstance.Spec.Standalone {
+		virtualClusterName := virtualClusterInstance.Name
+		if virtualClusterName == "" {
+			virtualClusterName = fallbackVClusterName
+		}
+
+		virtualKubeClient, err := standalonePlatformSleepKubeClient(platformClient, projectName, virtualClusterName)
+		if err != nil {
+			return nil, err
+		}
+
+		secret, err := virtualKubeClient.CoreV1().Secrets("default").Get(ctx, sleepmode.StandaloneSleepSecretName, metav1.GetOptions{})
+		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return &platformWorkloadSleepSecretTarget{
+					kubeClient: virtualKubeClient,
+					namespace:  "default",
+				}, nil
+			}
+			return nil, fmt.Errorf("get secret default/%s: %w", sleepmode.StandaloneSleepSecretName, err)
+		}
+
+		return &platformWorkloadSleepSecretTarget{
+			kubeClient: virtualKubeClient,
+			namespace:  "default",
+			secret:     secret,
+		}, nil
+	}
+
+	kClient, err := platformClient.Cluster(virtualClusterInstance.Spec.ClusterRef.Cluster)
+	if err != nil {
+		return nil, fmt.Errorf("create host cluster client: %w", err)
+	}
+
+	releaseName := virtualClusterInstance.Spec.ClusterRef.VirtualCluster
+	if releaseName == "" {
+		releaseName = fallbackVClusterName
+	}
+	secretName := "vc-config-" + releaseName
+	secret, err := kClient.CoreV1().Secrets(virtualClusterInstance.Spec.ClusterRef.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return &platformWorkloadSleepSecretTarget{
+				kubeClient: kClient,
+				namespace:  virtualClusterInstance.Spec.ClusterRef.Namespace,
+			}, nil
+		}
+		return nil, fmt.Errorf("get secret %s/%s: %w", virtualClusterInstance.Spec.ClusterRef.Namespace, secretName, err)
+	}
+
+	return &platformWorkloadSleepSecretTarget{
+		kubeClient: kClient,
+		namespace:  virtualClusterInstance.Spec.ClusterRef.Namespace,
+		secret:     secret,
+	}, nil
+}
+
+func isWorkloadSleepSecretSleeping(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+
+	_, sleeping := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	return sleeping
+}
+
+func isWorkloadSleepSecretAgentManaged(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+
+	_, agentInstalled := secret.Annotations[sleepmode.AnnotationAgentInstalled]
+	return agentInstalled
+}
+
+func secretVClusterConfig(secret *corev1.Secret) (*vclusterconfig.Config, bool, error) {
+	configBytes, ok := secret.Data["config.yaml"]
+	if !ok {
+		return nil, false, nil
+	}
+
+	var vClusterConfig vclusterconfig.Config
+	if err := yaml.Unmarshal(configBytes, &vClusterConfig); err != nil {
+		return nil, false, fmt.Errorf("unmarshal vcluster config from secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+
+	return &vClusterConfig, true, nil
+}
+
 // hostVClusterSleepModeConfig loads the host vc-config secret and returns the parsed vCluster
 // config when native workload sleep mode is configured and not managed by the agent.
 func hostVClusterSleepModeConfig(ctx context.Context, kClient kubernetes.Interface, namespace, vClusterName string) (*corev1.Secret, *vclusterconfig.Config, bool, error) {
@@ -101,20 +252,18 @@ func hostVClusterSleepModeConfig(ctx context.Context, kClient kubernetes.Interfa
 		return nil, nil, false, nil
 	}
 
-	configBytes, ok := configSecret.Data["config.yaml"]
-	if !ok {
-		return nil, nil, false, nil
+	vClusterConfig, hasConfig, err := secretVClusterConfig(configSecret)
+	if err != nil {
+		return nil, nil, false, err
 	}
-
-	var vClusterConfig vclusterconfig.Config
-	if err := yaml.Unmarshal(configBytes, &vClusterConfig); err != nil {
+	if !hasConfig {
 		return nil, nil, false, nil
 	}
 	if !vClusterConfig.IsConfiguredForSleepMode() {
 		return nil, nil, false, nil
 	}
 
-	return configSecret, &vClusterConfig, true, nil
+	return configSecret, vClusterConfig, true, nil
 }
 
 // patchSecretWithSleepAnnotations sets sleepType=forcedSleep, sleeping-since, and an optional

--- a/pkg/cli/sleepmode_helpers.go
+++ b/pkg/cli/sleepmode_helpers.go
@@ -103,7 +103,7 @@ func clearSleepAnnotations(secret *corev1.Secret) {
 	secret.Annotations[clusterv1.SleepModeLastActivityAnnotation] = strconv.FormatInt(time.Now().Unix(), 10)
 }
 
-func standaloneSleepKubeClient(vCluster *find.VCluster) (kubernetes.Interface, error) {
+func standaloneKubeClient(vCluster *find.VCluster) (kubernetes.Interface, error) {
 	if vCluster.ClientFactory == nil {
 		return nil, fmt.Errorf("cannot access standalone vCluster %s in namespace %s: kubeconfig is not available", vCluster.Name, vCluster.Namespace)
 	}
@@ -132,7 +132,7 @@ func standaloneSleepKubeClient(vCluster *find.VCluster) (kubernetes.Interface, e
 	return virtualKubeClient, nil
 }
 
-func standalonePlatformSleepKubeClient(platformClient platform.Client, projectName, vClusterName string) (kubernetes.Interface, error) {
+func standalonePlatformKubeClient(platformClient platform.Client, projectName, vClusterName string) (kubernetes.Interface, error) {
 	if projectName == "" {
 		projectName = defaultPlatformProjectName
 	}
@@ -167,7 +167,7 @@ func getPlatformWorkloadSleepSecret(ctx context.Context, platformClient platform
 			virtualClusterName = fallbackVClusterName
 		}
 
-		virtualKubeClient, err := standalonePlatformSleepKubeClient(platformClient, projectName, virtualClusterName)
+		virtualKubeClient, err := standalonePlatformKubeClient(platformClient, projectName, virtualClusterName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cli/sleepmode_helpers.go
+++ b/pkg/cli/sleepmode_helpers.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
+	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/platform/sleepmode"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// withSleepModeIgnore wraps the rest config to add X-Sleep-Mode-Ignore on every request.
+// This prevents the workload sleep mode controller from recording CLI traffic as user activity
+// or waking a sleeping cluster when the CLI only needs to read/update the sleep state secret.
+func withSleepModeIgnore(cfg *rest.Config) *rest.Config {
+	cp := *cfg
+	prior := cp.WrapTransport
+	cp.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if prior != nil {
+			rt = prior(rt)
+		}
+		return &sleepModeIgnoreTransport{base: rt}
+	}
+	return &cp
+}
+
+type sleepModeIgnoreTransport struct {
+	base http.RoundTripper
+}
+
+func (t *sleepModeIgnoreTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("X-Sleep-Mode-Ignore", "true")
+	return t.base.RoundTrip(req)
+}
+
+func forceDurationPtr(forceDuration int64) *int64 {
+	if forceDuration < 0 {
+		return nil
+	}
+
+	return &forceDuration
+}
+
+func platformVClusterValuesYAML(virtualClusterInstance *managementv1.VirtualClusterInstance) string {
+	if virtualClusterInstance == nil {
+		return ""
+	}
+	if virtualCluster := virtualClusterInstance.Status.VirtualCluster; virtualCluster != nil && virtualCluster.HelmRelease.Values != "" {
+		return virtualCluster.HelmRelease.Values
+	}
+	if virtualClusterInstance.Spec.Template == nil {
+		return ""
+	}
+
+	return virtualClusterInstance.Spec.Template.HelmRelease.Values
+}
+
+func applySleepAnnotations(secret *corev1.Secret, sleepingSince string, forceDuration *int64) {
+	secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation] = clusterv1.SleepTypeForced
+	secret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation] = sleepingSince
+
+	if forceDuration != nil {
+		secret.Annotations[clusterv1.SleepModeForceDurationAnnotation] = strconv.FormatInt(*forceDuration, 10)
+	} else {
+		delete(secret.Annotations, clusterv1.SleepModeForceDurationAnnotation)
+	}
+}
+
+func clearSleepAnnotations(secret *corev1.Secret) {
+	delete(secret.Annotations, clusterv1.SleepModeForceAnnotation)
+	delete(secret.Annotations, clusterv1.SleepModeSleepTypeAnnotation)
+	delete(secret.Annotations, clusterv1.SleepModeSleepingSinceAnnotation)
+	delete(secret.Annotations, clusterv1.SleepModeForceDurationAnnotation)
+	secret.Annotations[clusterv1.SleepModeLastActivityAnnotation] = strconv.FormatInt(time.Now().Unix(), 10)
+}
+
+// hostVClusterSleepModeConfig loads the host vc-config secret and returns the parsed vCluster
+// config when native workload sleep mode is configured and not managed by the agent.
+func hostVClusterSleepModeConfig(ctx context.Context, kClient kubernetes.Interface, namespace, vClusterName string) (*corev1.Secret, *vclusterconfig.Config, bool, error) {
+	configSecret, err := kClient.CoreV1().Secrets(namespace).Get(ctx, "vc-config-"+vClusterName, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, fmt.Errorf("get config secret: %w", err)
+	}
+
+	if _, agentInstalled := configSecret.Annotations[sleepmode.AnnotationAgentInstalled]; agentInstalled {
+		return nil, nil, false, nil
+	}
+
+	configBytes, ok := configSecret.Data["config.yaml"]
+	if !ok {
+		return nil, nil, false, nil
+	}
+
+	var vClusterConfig vclusterconfig.Config
+	if err := yaml.Unmarshal(configBytes, &vClusterConfig); err != nil {
+		return nil, nil, false, nil
+	}
+	if !vClusterConfig.IsConfiguredForSleepMode() {
+		return nil, nil, false, nil
+	}
+
+	return configSecret, &vClusterConfig, true, nil
+}
+
+// patchSecretWithSleepAnnotations sets sleepType=forcedSleep, sleeping-since, and an optional
+// force-duration on an already-fetched secret.
+func patchSecretWithSleepAnnotations(ctx context.Context, kClient kubernetes.Interface, namespace string, secret *corev1.Secret, sleepingSince string, forceDuration *int64) error {
+	return patchSecretAnnotations(ctx, kClient, namespace, secret, func(s *corev1.Secret) {
+		applySleepAnnotations(s, sleepingSince, forceDuration)
+	})
+}
+
+// clearSecretSleepAnnotations removes the workload sleep annotations from an already-fetched
+// secret, clears force-sleep metadata, and records fresh last-activity.
+func clearSecretSleepAnnotations(ctx context.Context, kClient kubernetes.Interface, namespace string, secret *corev1.Secret) error {
+	return patchSecretAnnotations(ctx, kClient, namespace, secret, func(s *corev1.Secret) {
+		clearSleepAnnotations(s)
+	})
+}
+
+// patchSecretAnnotations applies mutateFn to the secret and patches it on the cluster.
+func patchSecretAnnotations(ctx context.Context, kClient kubernetes.Interface, namespace string, secret *corev1.Secret, mutateFn func(*corev1.Secret)) error {
+	orig := secret.DeepCopy()
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	mutateFn(secret)
+	patch := client.MergeFrom(orig)
+	patchBytes, err := patch.Data(secret)
+	if err != nil {
+		return fmt.Errorf("create patch for secret %s/%s: %w", namespace, secret.Name, err)
+	}
+	if _, err := kClient.CoreV1().Secrets(namespace).Patch(ctx, secret.Name, patch.Type(), patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("patch secret %s/%s: %w", namespace, secret.Name, err)
+	}
+	return nil
+}
+
+// mutateSleepSecret fetches the named secret and applies mutateFn. If the secret does not
+// exist and initial is non-nil, the initial secret is mutated and created instead.
+// If initial is nil, a not-found error is silently ignored — suitable for wake operations
+// where there is nothing to do if the secret was never created.
+func mutateSleepSecret(ctx context.Context, kClient kubernetes.Interface, namespace, name string, initial *corev1.Secret, mutateFn func(*corev1.Secret)) error {
+	secret, err := kClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !kerrors.IsNotFound(err) {
+			return fmt.Errorf("get secret %s/%s: %w", namespace, name, err)
+		}
+		if initial == nil {
+			return nil
+		}
+		if initial.Annotations == nil {
+			initial.Annotations = map[string]string{}
+		}
+		mutateFn(initial)
+		if _, err := kClient.CoreV1().Secrets(namespace).Create(ctx, initial, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("create secret %s/%s: %w", namespace, name, err)
+		}
+		return nil
+	}
+	return patchSecretAnnotations(ctx, kClient, namespace, secret, mutateFn)
+}

--- a/pkg/cli/sleepmode_helpers.go
+++ b/pkg/cli/sleepmode_helpers.go
@@ -24,6 +24,12 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	defaultPlatformProjectName = "default"
+	defaultSleepModeNamespace  = "default"
+	vClusterConfigSecretPrefix = "vc-config-"
+)
+
 // withSleepModeIgnore wraps the rest config to add X-Sleep-Mode-Ignore on every request.
 // This prevents the workload sleep mode controller from recording CLI traffic as user activity
 // or waking a sleeping cluster when the CLI only needs to read/update the sleep state secret.
@@ -57,6 +63,10 @@ func forceDurationPtr(forceDuration int64) *int64 {
 	return &forceDuration
 }
 
+func vClusterConfigSecretName(releaseName string) string {
+	return vClusterConfigSecretPrefix + releaseName
+}
+
 func platformVClusterValuesYAML(virtualClusterInstance *managementv1.VirtualClusterInstance) string {
 	if virtualClusterInstance == nil {
 		return ""
@@ -83,6 +93,9 @@ func applySleepAnnotations(secret *corev1.Secret, sleepingSince string, forceDur
 }
 
 func clearSleepAnnotations(secret *corev1.Secret) {
+	// Native workload sleep writes sleep-type/sleeping-since directly to the secret, while older
+	// and control-plane sleep flows may also leave the legacy force annotation behind. Clear both
+	// forms here so wake always resets the full sleep state regardless of which path set it.
 	delete(secret.Annotations, clusterv1.SleepModeForceAnnotation)
 	delete(secret.Annotations, clusterv1.SleepModeSleepTypeAnnotation)
 	delete(secret.Annotations, clusterv1.SleepModeSleepingSinceAnnotation)
@@ -92,7 +105,7 @@ func clearSleepAnnotations(secret *corev1.Secret) {
 
 func standaloneSleepKubeClient(vCluster *find.VCluster) (kubernetes.Interface, error) {
 	if vCluster.ClientFactory == nil {
-		return nil, fmt.Errorf("cannot access standalone vCluster %s/%s: kubeconfig is not available", vCluster.Namespace, vCluster.Name)
+		return nil, fmt.Errorf("cannot access standalone vCluster %s in namespace %s: kubeconfig is not available", vCluster.Name, vCluster.Namespace)
 	}
 
 	rawConfig, err := vCluster.ClientFactory.RawConfig()
@@ -102,8 +115,8 @@ func standaloneSleepKubeClient(vCluster *find.VCluster) (kubernetes.Interface, e
 
 	vClusterCtxName := find.VClusterContextName(vCluster.Name, vCluster.Namespace, vCluster.Context)
 	if _, ok := rawConfig.Contexts[vClusterCtxName]; !ok {
-		return nil, fmt.Errorf("cannot access standalone vCluster %s/%s: context %q not found in kubeconfig, please run 'vcluster connect %s -n %s' first",
-			vCluster.Namespace, vCluster.Name, vClusterCtxName, vCluster.Name, vCluster.Namespace)
+		return nil, fmt.Errorf("cannot access standalone vCluster %s in namespace %s: context %q not found in kubeconfig, please run 'vcluster connect %s -n %s' first",
+			vCluster.Name, vCluster.Namespace, vClusterCtxName, vCluster.Name, vCluster.Namespace)
 	}
 
 	virtualRestConfig, err := clientcmd.NewDefaultClientConfig(rawConfig, &clientcmd.ConfigOverrides{CurrentContext: vClusterCtxName}).ClientConfig()
@@ -121,7 +134,7 @@ func standaloneSleepKubeClient(vCluster *find.VCluster) (kubernetes.Interface, e
 
 func standalonePlatformSleepKubeClient(platformClient platform.Client, projectName, vClusterName string) (kubernetes.Interface, error) {
 	if projectName == "" {
-		projectName = "default"
+		projectName = defaultPlatformProjectName
 	}
 
 	restConfig, err := platformClient.RestConfig("/kubernetes/project/" + url.PathEscape(projectName) + "/virtualcluster/" + url.PathEscape(vClusterName))
@@ -159,20 +172,20 @@ func getPlatformWorkloadSleepSecret(ctx context.Context, platformClient platform
 			return nil, err
 		}
 
-		secret, err := virtualKubeClient.CoreV1().Secrets("default").Get(ctx, sleepmode.StandaloneSleepSecretName, metav1.GetOptions{})
+		secret, err := virtualKubeClient.CoreV1().Secrets(defaultSleepModeNamespace).Get(ctx, sleepmode.StandaloneSleepSecretName, metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				return &platformWorkloadSleepSecretTarget{
 					kubeClient: virtualKubeClient,
-					namespace:  "default",
+					namespace:  defaultSleepModeNamespace,
 				}, nil
 			}
-			return nil, fmt.Errorf("get secret default/%s: %w", sleepmode.StandaloneSleepSecretName, err)
+			return nil, fmt.Errorf("get secret %s/%s: %w", defaultSleepModeNamespace, sleepmode.StandaloneSleepSecretName, err)
 		}
 
 		return &platformWorkloadSleepSecretTarget{
 			kubeClient: virtualKubeClient,
-			namespace:  "default",
+			namespace:  defaultSleepModeNamespace,
 			secret:     secret,
 		}, nil
 	}
@@ -186,7 +199,7 @@ func getPlatformWorkloadSleepSecret(ctx context.Context, platformClient platform
 	if releaseName == "" {
 		releaseName = fallbackVClusterName
 	}
-	secretName := "vc-config-" + releaseName
+	secretName := vClusterConfigSecretName(releaseName)
 	secret, err := kClient.CoreV1().Secrets(virtualClusterInstance.Spec.ClusterRef.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
@@ -210,8 +223,8 @@ func isWorkloadSleepSecretSleeping(secret *corev1.Secret) bool {
 		return false
 	}
 
-	_, sleeping := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
-	return sleeping
+	sleepType, sleeping := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	return sleeping && sleepType != ""
 }
 
 func isWorkloadSleepSecretAgentManaged(secret *corev1.Secret) bool {
@@ -240,7 +253,7 @@ func secretVClusterConfig(secret *corev1.Secret) (*vclusterconfig.Config, bool, 
 // hostVClusterSleepModeConfig loads the host vc-config secret and returns the parsed vCluster
 // config when native workload sleep mode is configured and not managed by the agent.
 func hostVClusterSleepModeConfig(ctx context.Context, kClient kubernetes.Interface, namespace, vClusterName string) (*corev1.Secret, *vclusterconfig.Config, bool, error) {
-	configSecret, err := kClient.CoreV1().Secrets(namespace).Get(ctx, "vc-config-"+vClusterName, metav1.GetOptions{})
+	configSecret, err := kClient.CoreV1().Secrets(namespace).Get(ctx, vClusterConfigSecretName(vClusterName), metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil, nil, false, nil

--- a/pkg/cli/sleepmode_helpers.go
+++ b/pkg/cli/sleepmode_helpers.go
@@ -145,7 +145,7 @@ type platformWorkloadSleepSecretTarget struct {
 
 func getPlatformWorkloadSleepSecret(ctx context.Context, platformClient platform.Client, projectName string, virtualClusterInstance *managementv1.VirtualClusterInstance, fallbackVClusterName string) (*platformWorkloadSleepSecretTarget, error) {
 	if virtualClusterInstance == nil {
-		return nil, nil
+		return &platformWorkloadSleepSecretTarget{}, nil
 	}
 
 	if virtualClusterInstance.Spec.Standalone {

--- a/pkg/cli/sleepmode_platform_test.go
+++ b/pkg/cli/sleepmode_platform_test.go
@@ -155,10 +155,14 @@ func TestResumePlatformWorkloadSleepModeIfConfiguredClearsForceState(t *testing.
 
 	secret, err := clusterClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
 	assert.NilError(t, err)
-	assert.Equal(t, secret.Annotations[clusterv1.SleepModeForceAnnotation], "")
-	assert.Equal(t, secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], "")
-	assert.Equal(t, secret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation], "")
-	assert.Equal(t, secret.Annotations[clusterv1.SleepModeForceDurationAnnotation], "")
+	_, hasForce := secret.Annotations[clusterv1.SleepModeForceAnnotation]
+	assert.Assert(t, !hasForce)
+	_, hasSleepType := secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation]
+	assert.Assert(t, !hasSleepType)
+	_, hasSleepingSince := secret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation]
+	assert.Assert(t, !hasSleepingSince)
+	_, hasForceDuration := secret.Annotations[clusterv1.SleepModeForceDurationAnnotation]
+	assert.Assert(t, !hasForceDuration)
 	assert.Assert(t, secret.Annotations[clusterv1.SleepModeLastActivityAnnotation] != "")
 }
 
@@ -173,8 +177,27 @@ func TestPausePlatformStandaloneIfConfiguredUsesRenderedValuesAndResolvedProject
 	virtualClusterInstance.Status.VirtualCluster = &storagev1.VirtualClusterTemplateDefinition{}
 	virtualClusterInstance.Status.VirtualCluster.HelmRelease.Values = "sleep:\n  auto:\n    afterInactivity: 1h\n"
 
-	used, err := pausePlatformStandaloneIfConfigured(ctx, platformClient, "resolved-project", 900, log.GetInstance(), "test", virtualClusterInstance)
+	used, err := pausePlatformStandaloneIfConfigured(ctx, platformClient, "resolved/project", 900, log.GetInstance(), "test", virtualClusterInstance)
 	assert.Check(t, used)
 	assert.ErrorContains(t, err, sentinelErr.Error())
-	assert.Equal(t, platformClient.lastRestConfigHostSuffix, "/kubernetes/project/resolved-project/virtualcluster/test")
+	assert.Equal(t, platformClient.lastRestConfigHostSuffix, "/kubernetes/project/resolved%2Fproject/virtualcluster/test")
+}
+
+func TestResumePlatformStandaloneIfConfiguredUsesRenderedValuesAndResolvedProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sentinelErr := errors.New("rest config error")
+	platformClient := &fakePlatformClient{restConfigErr: sentinelErr}
+
+	virtualClusterInstance := &managementv1.VirtualClusterInstance{}
+	virtualClusterInstance.Name = "test"
+	virtualClusterInstance.Spec.Standalone = true
+	virtualClusterInstance.Status.VirtualCluster = &storagev1.VirtualClusterTemplateDefinition{}
+	virtualClusterInstance.Status.VirtualCluster.HelmRelease.Values = "sleep:\n  auto:\n    afterInactivity: 1h\n"
+
+	used, err := resumePlatformStandaloneIfConfigured(ctx, platformClient, "resolved/project", log.GetInstance(), "test", virtualClusterInstance)
+	assert.Check(t, used)
+	assert.ErrorContains(t, err, sentinelErr.Error())
+	assert.Equal(t, platformClient.lastRestConfigHostSuffix, "/kubernetes/project/resolved%2Fproject/virtualcluster/test")
 }

--- a/pkg/cli/sleepmode_platform_test.go
+++ b/pkg/cli/sleepmode_platform_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
+	agentloftclient "github.com/loft-sh/agentapi/v4/pkg/clientset/versioned"
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
+	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
+	"github.com/loft-sh/api/v4/pkg/auth"
+	loftclient "github.com/loft-sh/api/v4/pkg/clientset/versioned"
+	"github.com/loft-sh/log"
+	cliconfig "github.com/loft-sh/vcluster/pkg/cli/config"
+	"github.com/loft-sh/vcluster/pkg/platform"
+	platformkube "github.com/loft-sh/vcluster/pkg/platform/kube"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+type fakePlatformKubeClient struct {
+	kubernetes.Interface
+}
+
+func (f *fakePlatformKubeClient) Loft() loftclient.Interface {
+	return nil
+}
+
+func (f *fakePlatformKubeClient) Agent() agentloftclient.Interface {
+	return nil
+}
+
+type fakePlatformClient struct {
+	clusterClient platformkube.Interface
+	clusterErr    error
+
+	lastRestConfigHostSuffix string
+	restConfig               *rest.Config
+	restConfigErr            error
+}
+
+func (f *fakePlatformClient) Login(string, bool, log.Logger) error {
+	return nil
+}
+
+func (f *fakePlatformClient) LoginWithAccessKey(string, string, bool) error {
+	return nil
+}
+
+func (f *fakePlatformClient) Logout(context.Context) error {
+	return nil
+}
+
+func (f *fakePlatformClient) Self() *managementv1.Self {
+	return nil
+}
+
+func (f *fakePlatformClient) RefreshSelf(context.Context) error {
+	return nil
+}
+
+func (f *fakePlatformClient) Management() (platformkube.Interface, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakePlatformClient) Cluster(string) (platformkube.Interface, error) {
+	return f.clusterClient, f.clusterErr
+}
+
+func (f *fakePlatformClient) VirtualCluster(string, string, string) (platformkube.Interface, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakePlatformClient) ManagementConfig() (*rest.Config, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakePlatformClient) RestConfig(hostSuffix string) (*rest.Config, error) {
+	f.lastRestConfigHostSuffix = hostSuffix
+	return f.restConfig, f.restConfigErr
+}
+
+func (f *fakePlatformClient) Config() *cliconfig.CLI {
+	return nil
+}
+
+func (f *fakePlatformClient) Save() error {
+	return nil
+}
+
+func (f *fakePlatformClient) Version() (*auth.Version, error) {
+	return &auth.Version{}, nil
+}
+
+var _ platform.Client = &fakePlatformClient{}
+
+func TestPausePlatformWorkloadSleepModeIfConfiguredSetsForceDuration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clusterClient := &fakePlatformKubeClient{Interface: k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{
+			"config.yaml": []byte("sleep:\n  auto:\n    afterInactivity: 1h\n"),
+		},
+	})}
+
+	virtualClusterInstance := &managementv1.VirtualClusterInstance{}
+	virtualClusterInstance.Spec.ClusterRef.Cluster = "host-cluster"
+	virtualClusterInstance.Spec.ClusterRef.Namespace = "test-ns"
+
+	used, err := pausePlatformWorkloadSleepModeIfConfigured(ctx, &fakePlatformClient{clusterClient: clusterClient}, "test-project", 600, log.GetInstance(), "test", virtualClusterInstance)
+	assert.NilError(t, err)
+	assert.Check(t, used)
+
+	secret, err := clusterClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], clusterv1.SleepTypeForced)
+	assert.Equal(t, secret.Annotations[clusterv1.SleepModeForceDurationAnnotation], "600")
+	assert.Assert(t, secret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation] != "")
+}
+
+func TestResumePlatformWorkloadSleepModeIfConfiguredClearsForceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clusterClient := &fakePlatformKubeClient{Interface: k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vc-config-test",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				clusterv1.SleepModeForceAnnotation:         "true",
+				clusterv1.SleepModeSleepTypeAnnotation:     clusterv1.SleepTypeForced,
+				clusterv1.SleepModeSleepingSinceAnnotation: "123",
+				clusterv1.SleepModeForceDurationAnnotation: "600",
+			},
+		},
+	})}
+
+	virtualClusterInstance := &managementv1.VirtualClusterInstance{}
+	virtualClusterInstance.Spec.ClusterRef.Cluster = "host-cluster"
+	virtualClusterInstance.Spec.ClusterRef.Namespace = "test-ns"
+
+	used, err := resumePlatformWorkloadSleepModeIfConfigured(ctx, &fakePlatformClient{clusterClient: clusterClient}, "test-project", log.GetInstance(), "test", virtualClusterInstance)
+	assert.NilError(t, err)
+	assert.Check(t, used)
+
+	secret, err := clusterClient.CoreV1().Secrets("test-ns").Get(ctx, "vc-config-test", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, secret.Annotations[clusterv1.SleepModeForceAnnotation], "")
+	assert.Equal(t, secret.Annotations[clusterv1.SleepModeSleepTypeAnnotation], "")
+	assert.Equal(t, secret.Annotations[clusterv1.SleepModeSleepingSinceAnnotation], "")
+	assert.Equal(t, secret.Annotations[clusterv1.SleepModeForceDurationAnnotation], "")
+	assert.Assert(t, secret.Annotations[clusterv1.SleepModeLastActivityAnnotation] != "")
+}
+
+func TestPausePlatformStandaloneIfConfiguredUsesRenderedValuesAndResolvedProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sentinelErr := errors.New("rest config error")
+	platformClient := &fakePlatformClient{restConfigErr: sentinelErr}
+
+	virtualClusterInstance := &managementv1.VirtualClusterInstance{}
+	virtualClusterInstance.Status.VirtualCluster = &storagev1.VirtualClusterTemplateDefinition{}
+	virtualClusterInstance.Status.VirtualCluster.HelmRelease.Values = "sleep:\n  auto:\n    afterInactivity: 1h\n"
+
+	used, err := pausePlatformStandaloneIfConfigured(ctx, platformClient, "resolved-project", 900, log.GetInstance(), "test", virtualClusterInstance)
+	assert.Check(t, used)
+	assert.ErrorContains(t, err, sentinelErr.Error())
+	assert.Equal(t, platformClient.lastRestConfigHostSuffix, "/kubernetes/project/resolved-project/virtualcluster/test")
+}

--- a/pkg/cli/sleepmode_platform_test.go
+++ b/pkg/cli/sleepmode_platform_test.go
@@ -117,7 +117,7 @@ func TestPausePlatformWorkloadSleepModeIfConfiguredSetsForceDuration(t *testing.
 	virtualClusterInstance.Spec.ClusterRef.Cluster = "host-cluster"
 	virtualClusterInstance.Spec.ClusterRef.Namespace = "test-ns"
 
-	used, err := pausePlatformWorkloadSleepModeIfConfigured(ctx, &fakePlatformClient{clusterClient: clusterClient}, "test-project", 600, log.GetInstance(), "test", virtualClusterInstance)
+	used, err := sleepPlatformWorkloadSleep(ctx, &fakePlatformClient{clusterClient: clusterClient}, "test-project", 600, log.GetInstance(), "test", virtualClusterInstance)
 	assert.NilError(t, err)
 	assert.Check(t, used)
 
@@ -149,7 +149,7 @@ func TestResumePlatformWorkloadSleepModeIfConfiguredClearsForceState(t *testing.
 	virtualClusterInstance.Spec.ClusterRef.Cluster = "host-cluster"
 	virtualClusterInstance.Spec.ClusterRef.Namespace = "test-ns"
 
-	used, err := resumePlatformWorkloadSleepModeIfConfigured(ctx, &fakePlatformClient{clusterClient: clusterClient}, "test-project", log.GetInstance(), "test", virtualClusterInstance)
+	used, err := wakePlatformWorkloadSleep(ctx, &fakePlatformClient{clusterClient: clusterClient}, "test-project", log.GetInstance(), "test", virtualClusterInstance)
 	assert.NilError(t, err)
 	assert.Check(t, used)
 
@@ -196,16 +196,24 @@ func TestResumePlatformStandaloneIfConfiguredUsesRenderedValuesAndResolvedProjec
 	virtualClusterInstance.Status.VirtualCluster = &storagev1.VirtualClusterTemplateDefinition{}
 	virtualClusterInstance.Status.VirtualCluster.HelmRelease.Values = "sleep:\n  auto:\n    afterInactivity: 1h\n"
 
-	used, err := resumePlatformStandaloneIfConfigured(ctx, platformClient, "resolved/project", log.GetInstance(), "test", virtualClusterInstance)
+	used, err := wakePlatformStandalone(ctx, platformClient, "resolved/project", log.GetInstance(), "test", virtualClusterInstance)
 	assert.Check(t, used)
 	assert.ErrorContains(t, err, sentinelErr.Error())
 	assert.Equal(t, platformClient.lastRestConfigHostSuffix, "/kubernetes/project/resolved%2Fproject/virtualcluster/test")
 }
 
+func TestWakePlatformStandaloneTargetWithoutSecretFallsBackToInstanceWake(t *testing.T) {
+	t.Parallel()
+
+	used, err := wakePlatformStandaloneTarget(context.Background(), log.GetInstance(), "test", &platformWorkloadSleepSecretTarget{})
+	assert.NilError(t, err)
+	assert.Assert(t, !used)
+}
+
 func TestPausePlatformWorkloadSleepModeIfConfiguredWithoutClusterRefFallsBack(t *testing.T) {
 	t.Parallel()
 
-	used, err := pausePlatformWorkloadSleepModeIfConfigured(context.Background(), &fakePlatformClient{}, "test-project", 600, log.GetInstance(), "test", &managementv1.VirtualClusterInstance{})
+	used, err := sleepPlatformWorkloadSleep(context.Background(), &fakePlatformClient{}, "test-project", 600, log.GetInstance(), "test", &managementv1.VirtualClusterInstance{})
 	assert.NilError(t, err)
 	assert.Assert(t, !used)
 }
@@ -213,7 +221,7 @@ func TestPausePlatformWorkloadSleepModeIfConfiguredWithoutClusterRefFallsBack(t 
 func TestResumePlatformWorkloadSleepModeIfConfiguredWithoutClusterRefFallsBack(t *testing.T) {
 	t.Parallel()
 
-	used, err := resumePlatformWorkloadSleepModeIfConfigured(context.Background(), &fakePlatformClient{}, "test-project", log.GetInstance(), "test", &managementv1.VirtualClusterInstance{})
+	used, err := wakePlatformWorkloadSleep(context.Background(), &fakePlatformClient{}, "test-project", log.GetInstance(), "test", &managementv1.VirtualClusterInstance{})
 	assert.NilError(t, err)
 	assert.Assert(t, !used)
 }

--- a/pkg/cli/sleepmode_platform_test.go
+++ b/pkg/cli/sleepmode_platform_test.go
@@ -201,3 +201,38 @@ func TestResumePlatformStandaloneIfConfiguredUsesRenderedValuesAndResolvedProjec
 	assert.ErrorContains(t, err, sentinelErr.Error())
 	assert.Equal(t, platformClient.lastRestConfigHostSuffix, "/kubernetes/project/resolved%2Fproject/virtualcluster/test")
 }
+
+func TestPausePlatformWorkloadSleepModeIfConfiguredWithoutClusterRefFallsBack(t *testing.T) {
+	t.Parallel()
+
+	used, err := pausePlatformWorkloadSleepModeIfConfigured(context.Background(), &fakePlatformClient{}, "test-project", 600, log.GetInstance(), "test", &managementv1.VirtualClusterInstance{})
+	assert.NilError(t, err)
+	assert.Assert(t, !used)
+}
+
+func TestResumePlatformWorkloadSleepModeIfConfiguredWithoutClusterRefFallsBack(t *testing.T) {
+	t.Parallel()
+
+	used, err := resumePlatformWorkloadSleepModeIfConfigured(context.Background(), &fakePlatformClient{}, "test-project", log.GetInstance(), "test", &managementv1.VirtualClusterInstance{})
+	assert.NilError(t, err)
+	assert.Assert(t, !used)
+}
+
+func TestIsWorkloadSleepSecretSleepingAcceptsInactivitySleep(t *testing.T) {
+	t.Parallel()
+
+	assert.Assert(t, !isWorkloadSleepSecretSleeping(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation: "",
+			},
+		},
+	}))
+	assert.Assert(t, isWorkloadSleepSecretSleeping(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				clusterv1.SleepModeSleepTypeAnnotation: clusterv1.SleepTypeInactivity,
+			},
+		},
+	}))
+}

--- a/pkg/platform/sleepmode/sleepmode.go
+++ b/pkg/platform/sleepmode/sleepmode.go
@@ -9,6 +9,15 @@ import (
 const (
 	Label                   = "loft.sh/sleep-mode"
 	SleepingSinceAnnotation = "sleepmode.loft.sh/sleeping-since"
+
+	// AnnotationAgentInstalled is set on the vc-config secret when the vCluster platform agent
+	// is installed and managing sleep state. When present, the native sleep mode controller defers
+	// to the agent.
+	AnnotationAgentInstalled = "vcluster.loft.sh/agent-installed"
+
+	// StandaloneSleepSecretName is the name of the secret in the virtual cluster's default namespace
+	// that tracks sleep state for standalone vClusters (ControlPlane.Standalone.Enabled = true).
+	StandaloneSleepSecretName = "vc-standalone-sleep-state"
 )
 
 const v32 = "v0.32.0-alpha.0"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bugfix  
/kind enhancement  
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves ENGPROV-376

This PR adds end-to-end CLI support for workload sleep/wake flows and fixes the related platform status handling.

It updates `pause` and `resume` so that when a vCluster is configured for workload sleep, the CLI now operates on the workload-sleep state instead of incorrectly falling back to full control-plane sleep/wake behavior. This covers both Helm and Platform drivers, including standalone vClusters.

It also updates platform `list` to show `Sleeping (workloads only)` when the workload-sleep state is present, without sending requests that would wake the cluster during detection.

The implementation includes a shared helper layer for:
- loading and interpreting workload-sleep state
- handling host `vc-config-*` secrets and standalone sleep-state secrets consistently
- using rendered Helm values and resolved project names for platform standalone vClusters
- sending the sleep-ignore header on standalone platform reads

Additional fixes included in this PR:
- preserve and clear the correct sleep annotations during pause/resume
- avoid spurious errors when a non-standalone instance has no cluster ref
- surface malformed config/YAML errors instead of silently falling back
- align standalone detection with `VirtualClusterInstance.Spec.Standalone`

Regression tests were added for Helm and Platform workload sleep/wake flows, list status detection, standalone behavior, and the shared helper edge cases.

**Please provide a short message that should be published in the vcluster release notes**  
Fixed CLI workload sleep/wake handling so `pause`, `resume`, and platform `list` correctly support workload-sleeping vClusters, including standalone platform vClusters.

**What else do we need to know?**  
This change is intentionally scoped to correctness and CLI behavior. It includes shared helper cleanup and test coverage, but does not add list-call parallelization.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites

```label-filter
none
