### PR TITLE
fix(ci): add bridge netfilter and parallel procs to nightly e2e

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,10 +10,9 @@ ignore:
   # - "SC2086:"
 
 # Define self-hosted runner labels to validate against
-# runners:
-#   - self-hosted
-#   - linux
-#   - gpu
+self-hosted-runner:
+  labels:
+    - large-8_32
 
 # Configure shell-check
 shellcheck:

--- a/.github/workflows/e2e-ginkgo-nightly.yaml
+++ b/.github/workflows/e2e-ginkgo-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
   e2e-tests:
     name: Run Ginkgo E2E Tests
     if: github.repository_owner == 'loft-sh'
-    runs-on: ubuntu-latest
+    runs-on: large-8_32
     timeout-minutes: 180
 
     steps:


### PR DESCRIPTION
the nightly workflow was missing two things that the PR workflow (run-ginkgo-e2e action) already had:

1. bridge netfilter modules - without bridge-nf-call-iptables, NetworkPolicy enforcement on Kind does not work correctly. isolation mode tests use networkPolicy: enabled which requires this kernel module for pod-to-pod and pod-to-apiserver traffic.

2. --procs=8 - nightly was running with the default procs=1 (sequential). this matches the PR action which already uses --procs=8.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
