### PR TITLE
doc(e2e): add convention when to use gstruct

### DIFF
--- a/.claude/rules/e2e-conventions.md
+++ b/.claude/rules/e2e-conventions.md
@@ -17,6 +17,7 @@ Ginkgo v2 + Gomega, running against vCluster instances on Kind. Read existing te
 5. **Ordered contexts** — See the decision table below. Default to `BeforeEach`; only use `Ordered` for true sequential dependencies.
 6. **Package registration** — Test packages self-register via `var _ = Describe(...)`. The suite imports them as blank imports in `e2e_suite_test.go`.
 7. **Error assertion** — Prefer `ginkgo.Expect(...).To(ginkgo.Succeed())` over `ginkgo.Expect(...).NotTo(ginkgo.HaveOccurred())`
+8. **gstruct usage** — Do not use `gstruct` for simple field assertions (use `Expect(obj.Field).To(Equal(...))` instead). Use `gstruct` with `ContainElement` or similar matchers when asserting on elements within a collection (slice, map) to avoid manual loops.
 
 ## Setup Helpers
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind documentation

**What does this pull request do? Which issues does it resolve?**
Adds gstruct convention (#8) to `.claude/rules/e2e-conventions.md`. Don't use gstruct for simple field assertions; use it with `ContainElement` for collection assertions instead of manual loops.

**Please provide a short message that should be published in the vcluster release notes**
n/a — documentation-only change

**What else do we need to know?**
Nothing

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites

```label-filter
none
```