### PR TITLE
fix: vcluster version command

### DIFF
--- a/cmd/vcluster/cmd/root.go
+++ b/cmd/vcluster/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/debug"
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/node"
 	"github.com/loft-sh/vcluster/cmd/vcluster/cmd/snapshot"
-	"github.com/loft-sh/vcluster/pkg/telemetry"
 	"github.com/loft-sh/vcluster/pkg/util/osutil"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -65,11 +64,9 @@ func RunRoot() {
 func BuildRoot() *cobra.Command {
 	rootCmd := NewRootCmd()
 
-	// Set version for --version flag
-	rootCmd.Version = telemetry.SyncerVersion
-
 	// add top level commands
 	rootCmd.AddCommand(NewStartCommand())
+	rootCmd.AddCommand(NewVersionCommand())
 	rootCmd.AddCommand(snapshot.NewSnapshotCommand())
 	rootCmd.AddCommand(snapshot.NewRestoreCommand())
 	rootCmd.AddCommand(NewPortForwardCommand())

--- a/cmd/vcluster/cmd/snapshot/restore.go
+++ b/cmd/vcluster/cmd/snapshot/restore.go
@@ -15,7 +15,7 @@ var (
 func NewRestoreCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restore",
-		Short: "restore a vCluster",
+		Short: "Restore a vCluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			envOptions, err := snapshot.ParseOptionsFromEnv()

--- a/cmd/vcluster/cmd/snapshot/snapshot.go
+++ b/cmd/vcluster/cmd/snapshot/snapshot.go
@@ -10,7 +10,7 @@ import (
 func NewSnapshotCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "snapshot",
-		Short: "snapshot a vCluster",
+		Short: "Manage vCluster snapshots",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			client := &snapshot.Client{}

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -36,7 +36,7 @@ func NewStartCommand() *cobra.Command {
 	startOptions := &StartOptions{}
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Execute the vcluster",
+		Short: "Start a vCluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) (err error) {
 			// execute command

--- a/cmd/vcluster/cmd/version.go
+++ b/cmd/vcluster/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/vcluster/pkg/telemetry"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the vCluster version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintln(cmd.OutOrStdout(), telemetry.SyncerVersion)
+		},
+	}
+}

--- a/cmd/vclusterctl/cmd/version.go
+++ b/cmd/vclusterctl/cmd/version.go
@@ -6,8 +6,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number of vcluster",
-	Long:  `All software has versions. This is Vcluster's.`,
+	Short: "Print the vCluster version",
 	Run: func(cmd *cobra.Command, _ []string) {
 		root := cmd.Root()
 		root.SetArgs([]string{"--version"})


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-457


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
