### PR TITLE
fix(linear-sync): add stable release comment dedup

### DIFF
--- a/hack/linear-sync/linear.go
+++ b/hack/linear-sync/linear.go
@@ -267,12 +267,12 @@ func (l *LinearClient) MoveIssueToState(ctx context.Context, dryRun bool, issueI
 			return nil
 		}
 
-		// Check if a stable release comment already exists to avoid duplicates
+		// Check if a stable release comment for this specific tag already exists to avoid duplicates
 		comments, err := l.ListIssueComments(ctx, issueID)
 		if err != nil {
 			return fmt.Errorf("list issue comments: %w", err)
 		}
-		if hasStableReleaseComment(comments) {
+		if hasStableReleaseComment(comments, releaseTagName) {
 			logger.Debug("Issue already has stable release comment, skipping", "issueID", issueID)
 			return nil
 		}
@@ -385,10 +385,13 @@ func (l *LinearClient) ListIssueComments(ctx context.Context, issueID string) ([
 }
 
 // hasStableReleaseComment checks whether any of the given comment bodies
-// indicate that a stable release comment has already been posted.
-func hasStableReleaseComment(comments []string) bool {
+// indicate that a stable release comment for the specific release tag has
+// already been posted. This is scoped to the tag so that cherry-picks released
+// in a later stable version still get their own comment.
+func hasStableReleaseComment(comments []string, releaseTag string) bool {
+	expected := fmt.Sprintf("%s %s", stableReleaseCommentPrefix, releaseTag)
 	for _, body := range comments {
-		if strings.HasPrefix(body, stableReleaseCommentPrefix) {
+		if strings.HasPrefix(body, expected) {
 			return true
 		}
 	}

--- a/hack/linear-sync/linear_test.go
+++ b/hack/linear-sync/linear_test.go
@@ -389,45 +389,59 @@ func TestIsStableRelease(t *testing.T) {
 
 func TestHasStableReleaseComment(t *testing.T) {
 	testCases := []struct {
-		name     string
-		comments []string
-		expected bool
+		name       string
+		comments   []string
+		releaseTag string
+		expected   bool
 	}{
 		{
-			name:     "no comments",
-			comments: nil,
-			expected: false,
+			name:       "no comments",
+			comments:   nil,
+			releaseTag: "v0.27.0",
+			expected:   false,
 		},
 		{
-			name:     "unrelated comments only",
-			comments: []string{"This issue was first released in v0.27.0-alpha.1 on 2025-01-15"},
-			expected: false,
+			name:       "unrelated comments only",
+			comments:   []string{"This issue was first released in v0.27.0-alpha.1 on 2025-01-15"},
+			releaseTag: "v0.27.0",
+			expected:   false,
 		},
 		{
-			name:     "has stable release comment",
-			comments: []string{"Now available in stable release v0.27.0 (released 2025-02-01)"},
-			expected: true,
+			name:       "has matching stable release comment",
+			comments:   []string{"Now available in stable release v0.27.0 (released 2025-02-01)"},
+			releaseTag: "v0.27.0",
+			expected:   true,
 		},
 		{
-			name: "mixed comments with stable release",
+			name: "has stable release comment for different tag",
+			comments: []string{
+				"Now available in stable release v0.27.0 (released 2025-02-01)",
+			},
+			releaseTag: "v0.27.1",
+			expected:   false,
+		},
+		{
+			name: "mixed comments with matching stable release",
 			comments: []string{
 				"This issue was first released in v0.27.0-alpha.1 on 2025-01-15",
 				"Now available in stable release v0.27.0 (released 2025-02-01)",
 			},
-			expected: true,
+			releaseTag: "v0.27.0",
+			expected:   true,
 		},
 		{
-			name:     "empty comments",
-			comments: []string{},
-			expected: false,
+			name:       "empty comments",
+			comments:   []string{},
+			releaseTag: "v0.27.0",
+			expected:   false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := hasStableReleaseComment(tc.comments)
+			result := hasStableReleaseComment(tc.comments, tc.releaseTag)
 			if result != tc.expected {
-				t.Errorf("hasStableReleaseComment(%v) = %v, want %v", tc.comments, result, tc.expected)
+				t.Errorf("hasStableReleaseComment(%v, %q) = %v, want %v", tc.comments, tc.releaseTag, result, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Adds duplicate check for "Now available in stable release" comments before posting them
- Backports `ListIssueComments` and `hasStableReleaseComment` from vcluster-pro/loft-enterprise copies
- Part of cross-repo effort to bring all three `hack/linear-sync` copies to feature parity

Without this, the same stable release comment could be posted multiple times on an issue if a stable release was re-triggered or if the sync ran more than once for the same release.

## Cross-repo PRs
- vcluster-pro: adds ValidTeamKeys filtering (pending)
- loft-enterprise: adds ValidTeamKeys filtering + strict-filtering flag (pending)

Closes DEVOPS-713

## Test plan
- [x] Unit tests for `hasStableReleaseComment` added and passing
- [x] All existing tests pass (`go test ./... -count=1`)