### PR TITLE
chore: replace @loft-sh/cto-office with @loft-sh/eng-tech-leads in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,15 +4,15 @@
 
 /.github/workflows/ @loft-sh/devops-team
 /.github/workflows/backport.yaml @loft-sh/devops-team
-/.github/workflows/e2e*.yaml @loft-sh/eng-qa @loft-sh/cto-office
-/.github/workflows/release.yaml @loft-sh/devops-team @loft-sh/cto-office
-/.github/CODEOWNERS @loft-sh/cto-office
+/.github/workflows/e2e*.yaml @loft-sh/eng-qa @loft-sh/eng-tech-leads
+/.github/workflows/release.yaml @loft-sh/devops-team @loft-sh/eng-tech-leads
+/.github/CODEOWNERS @loft-sh/eng-tech-leads
 
-/chart/templates/ @loft-sh/cto-office
+/chart/templates/ @loft-sh/eng-tech-leads
 
-/cmd/vcluster/ @loft-sh/cto-office
+/cmd/vcluster/ @loft-sh/eng-tech-leads
 
-/config/ @loft-sh/cto-office
+/config/ @loft-sh/eng-tech-leads
 
 /docs/ @loft-sh/Eng-Docs-Admin
 
@@ -21,33 +21,33 @@
 
 /hack/email/ @zerbitx
 
-/pkg/authentication/ @loft-sh/cto-office
-/pkg/authorization/ @loft-sh/cto-office
+/pkg/authentication/ @loft-sh/eng-tech-leads
+/pkg/authorization/ @loft-sh/eng-tech-leads
 
-/pkg/config/config.go @loft-sh/cto-office
+/pkg/config/config.go @loft-sh/eng-tech-leads
 
-/pkg/controllers/k8sdefaultendpoint/ @loft-sh/cto-office
-/pkg/controllers/register.go @loft-sh/cto-office
-/pkg/controllers/resources/configmaps/ @loft-sh/cto-office
-/pkg/controllers/resources/endpoints/ @loft-sh/cto-office
-/pkg/controllers/resources/events/ @loft-sh/cto-office
-/pkg/controllers/resources/pods/ @loft-sh/cto-office
-/pkg/controllers/resources/secrets/ @loft-sh/cto-office
-/pkg/controllers/resources/services/ @loft-sh/cto-office
+/pkg/controllers/k8sdefaultendpoint/ @loft-sh/eng-tech-leads
+/pkg/controllers/register.go @loft-sh/eng-tech-leads
+/pkg/controllers/resources/configmaps/ @loft-sh/eng-tech-leads
+/pkg/controllers/resources/endpoints/ @loft-sh/eng-tech-leads
+/pkg/controllers/resources/events/ @loft-sh/eng-tech-leads
+/pkg/controllers/resources/pods/ @loft-sh/eng-tech-leads
+/pkg/controllers/resources/secrets/ @loft-sh/eng-tech-leads
+/pkg/controllers/resources/services/ @loft-sh/eng-tech-leads
 
-/pkg/k8s/ @loft-sh/cto-office
-/pkg/mappings/ @loft-sh/cto-office
-/pkg/platform/ @loft-sh/cto-office
-/pkg/plugin/ @loft-sh/cto-office
-/pkg/server/ @loft-sh/cto-office
-/pkg/setup/ @loft-sh/cto-office
-/pkg/syncer/ @loft-sh/cto-office
-/pkg/util/portforward/ @loft-sh/cto-office @lizardruss
-/pkg/util/servicecidr/ @loft-sh/cto-office @lizardruss
-/pkg/util/translate/ @loft-sh/cto-office
+/pkg/k8s/ @loft-sh/eng-tech-leads
+/pkg/mappings/ @loft-sh/eng-tech-leads
+/pkg/platform/ @loft-sh/eng-tech-leads
+/pkg/plugin/ @loft-sh/eng-tech-leads
+/pkg/server/ @loft-sh/eng-tech-leads
+/pkg/setup/ @loft-sh/eng-tech-leads
+/pkg/syncer/ @loft-sh/eng-tech-leads
+/pkg/util/portforward/ @loft-sh/eng-tech-leads @lizardruss
+/pkg/util/servicecidr/ @loft-sh/eng-tech-leads @lizardruss
+/pkg/util/translate/ @loft-sh/eng-tech-leads
 
-Dockerfile @loft-sh/cto-office
-Dockerfile.release @loft-sh/cto-office
-go.mod @loft-sh/cto-office
+Dockerfile @loft-sh/eng-tech-leads
+Dockerfile.release @loft-sh/eng-tech-leads
+go.mod @loft-sh/eng-tech-leads
 
 netlify.toml @loft-sh/Eng-Docs-Admin


### PR DESCRIPTION
## Summary
- Replace all `@loft-sh/cto-office` references with `@loft-sh/eng-tech-leads` in CODEOWNERS
- The eng-tech-leads team replaces the cto-office team for code review ownership

## Test plan
- [x] Verified `eng-tech-leads` GH team exists with correct members (Fabian, Josef, Marcin, Jan B, Russ, Piotr)
- [x] Verified no remaining `cto-office` references in CODEOWNERS
- [x] Preserved additional owners on shared lines (e.g., `@lizardruss`)

Closes DEVOPS-716