### PR TITLE
feat(ci): add slack alert on release pipeline failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,16 +200,17 @@ jobs:
           LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
 
   notify_failure:
-    if: ${{ failure() && github.repository_owner == 'loft-sh' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository_owner == 'loft-sh' }}
     needs:
       - check_minimum_version_tag
       - publish
       - publish-chart
       - sync_linear
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Notify Slack of release pipeline failure
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }}


### PR DESCRIPTION
Adds a `notify_failure` job to the release workflow that posts to #product-releases
when any job in the pipeline fails. Currently release failures go unnoticed unless
someone manually checks.

The job uses `if: always() && contains(needs.*.result, 'failure')` and depends on
all jobs in the workflow. `always()` ensures the condition is evaluated even when
intermediate jobs are skipped after an upstream failure. Uses SLACK_WEBHOOK_URL_PRODUCT_RELEASES.

### Tested in isolation

Simulated the release pipeline's job chain in [vClusterLabs-Experiments/release-failure-alert-test](https://github.com/vClusterLabs-Experiments/release-failure-alert-test/actions) with configurable failure injection, using the `always() && contains(...)` condition:

| Test case | notify_failure result | Expected |
|-----------|----------------------|----------|
| Mid-chain failure (sync_api) | triggered | yes |
| Early failure (get_version) | triggered | yes |
| All jobs pass | skipped | yes |

Test runs (with `always()` condition):
- [sync_api failure](https://github.com/vClusterLabs-Experiments/release-failure-alert-test/actions/runs/23849642012)
- [success path](https://github.com/vClusterLabs-Experiments/release-failure-alert-test/actions/runs/23849643446)
- [get_version failure](https://github.com/vClusterLabs-Experiments/release-failure-alert-test/actions/runs/23849644720)

References DEVOPS-680

### Companion PRs
- loft-sh/loft-enterprise#6538 (primary, Closes DEVOPS-680)
- loft-sh/vcluster-pro#1621