### PR TITLE
chore(e2e-next): Update framework depenency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/loft-sh/agentapi/v4 v4.8.0-alpha.1
 	github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 	github.com/loft-sh/api/v4 v4.8.0-alpha.1
-	github.com/loft-sh/e2e-framework v0.0.0-20260226211029-dc642849b244
+	github.com/loft-sh/e2e-framework v0.0.0-20260401095027-4666f06d1a86
 	github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364
 	github.com/loft-sh/utils v0.0.29
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/loft-sh/api/v4 v4.8.0-alpha.1 h1:qzgXdxjQKS7pbAuUJlLs8Eh6AlTaYjMkJg52
 github.com/loft-sh/api/v4 v4.8.0-alpha.1/go.mod h1:gfOsUSefE/SAxHgCfXiNSWwUYe/gvOC+pR0UkG77sEo=
 github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96 h1:MnvrgRnVm7X8zQPyVS2U2veIxacmVUYSFTHsoi6sJrw=
 github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96/go.mod h1:yBY01KhmW2XAWoqbAx8rx3xqwVwGMa3OYwiM2eYalY4=
-github.com/loft-sh/e2e-framework v0.0.0-20260226211029-dc642849b244 h1:ZlxEsxInYe7GXvVN0PnV3k0L6r0WmQSKlPcGsCdwE4s=
-github.com/loft-sh/e2e-framework v0.0.0-20260226211029-dc642849b244/go.mod h1:o9z8GQTFYGgX+AzYJoJvO7zVAYt6zDtYhMU2Ma7rSvA=
+github.com/loft-sh/e2e-framework v0.0.0-20260401095027-4666f06d1a86 h1:xWOM5u4M1XE2rTxkAM9IcSxWAOQAtZTNlkOwOQcFxLY=
+github.com/loft-sh/e2e-framework v0.0.0-20260401095027-4666f06d1a86/go.mod h1:o9z8GQTFYGgX+AzYJoJvO7zVAYt6zDtYhMU2Ma7rSvA=
 github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364 h1:vSuqHqh4w2zrG+WvnyH64JAUhX+Bou19n0gvCrPirOs=
 github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364/go.mod h1:niVPRwWFUSA8FihY9e5hGAp5IbKmbCdckGxJGSTKTUs=
 github.com/loft-sh/log v0.0.0-20240219160058-26d83ffb46ac h1:Gz/7Lb7WgdgIv+KJz87ORA1zvQW52tUqKPGyunlp4dQ=

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/core_dsl.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/core_dsl.go
@@ -33,6 +33,20 @@ func SetTeardownOnly(b bool) {
 
 type ContextMiddleware func(context.Context) context.Context
 
+// DeferCleanupCtx registers a cleanup function that receives the caller's
+// context values merged into the Ginkgo defer context. This ensures that values
+// on ctx at the call site (e.g. clients added in BeforeAll or resources created
+// in It) are available when the cleanup runs.
+//
+// Usage:
+//
+//	e2e.DeferCleanupCtx(ctx, cluster.Destroy(name))
+func DeferCleanupCtx(ctx context.Context, fn func(context.Context) (context.Context, error)) {
+	ginkgo.DeferCleanup(func(deferCtx context.Context) (context.Context, error) {
+		return fn(e2econtext.WithValues(deferCtx, ctx))
+	})
+}
+
 func ContextualAroundNode(ctx context.Context) context.Context {
 	report := ginkgo.CurrentSpecReport()
 	events := report.SpecEvents.WithType(types.SpecEventNodeStart)

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/provider/vcluster/vcluster.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/provider/vcluster/vcluster.go
@@ -48,6 +48,7 @@ func init() {
 const (
 	vclusterVersion = "v0.20.0"
 	vclusterPath    = "vclusterctl"
+	driverHelm      = "helm"
 )
 
 type Cluster struct {
@@ -59,8 +60,10 @@ type Cluster struct {
 	hostKubeCfg          string // kubeconfig file for the host cluster
 	hostKubeContext      string // kubeconfig context for the host cluster
 	upgrade              bool
+	add                  *bool // nil = default CLI behavior, non-nil = explicit --add=true/false
 	localChartDir        string
 	backgroundProxyImage string
+	driver               string
 	rc                   *rest.Config
 }
 
@@ -139,6 +142,28 @@ func WithBackgroundProxyImage(backgroundProxyImage string) support.ClusterOpts {
 	}
 }
 
+// WithAdd controls whether the vcluster CLI registers the vcluster with the
+// platform (--add flag). When set to false, the CLI skips the platform login
+// check, which is required for pro features in environments without platform
+// connectivity.
+func WithAdd(add bool) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.add = &add
+		}
+	}
+}
+
+func WithDriver(driver string) support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.driver = driver
+		}
+	}
+}
+
 func (c *Cluster) WithName(name string) support.E2EClusterProvider {
 	c.name = name
 	return c
@@ -203,6 +228,20 @@ func (c *Cluster) Create(ctx context.Context, args ...string) (string, error) {
 		args = append(args, "--background-proxy-image", c.backgroundProxyImage)
 	}
 
+	if c.add != nil {
+		if *c.add {
+			args = append(args, "--add=true")
+		} else {
+			args = append(args, "--add=false")
+		}
+	}
+
+	driver := c.driver
+	if driver == "" {
+		driver = driverHelm
+	}
+	args = append(args, "--driver", driver)
+
 	command := fmt.Sprintf("%s create %s --connect=false", c.path, c.name)
 	if len(args) > 0 {
 		command = fmt.Sprintf("%s %s", command, strings.Join(args, " "))
@@ -242,6 +281,74 @@ func (c *Cluster) CreateWithConfig(ctx context.Context, configFile string) (stri
 		args = append(args, "--values", configFile)
 	}
 	return c.Create(ctx, args...)
+}
+
+// Upgrade applies new configuration to an already-running vcluster. This runs
+// `vcluster create <name> --upgrade --values <file> --connect=false` which
+// performs a Helm upgrade. This is a destructive operation that restarts the
+// syncer pod and invalidates existing client connections. Call Reconnect
+// afterwards to re-establish the REST config.
+func (c *Cluster) Upgrade(ctx context.Context, valuesFile string, extraArgs ...string) error {
+	log.V(4).Info("Upgrading vcluster ", c.name)
+	if err := c.findOrInstallVcluster(); err != nil {
+		return err
+	}
+
+	args := []string{"--upgrade", "--connect=false"}
+
+	if valuesFile != "" {
+		args = append(args, "--values", valuesFile)
+	}
+	if c.namespace != "" {
+		args = append(args, "--namespace", c.namespace)
+	}
+	if c.hostKubeContext != "" {
+		args = append(args, "--context", c.hostKubeContext)
+	}
+	if c.localChartDir != "" {
+		args = append(args, "--local-chart-dir", c.localChartDir)
+	}
+	if c.add != nil && !*c.add {
+		args = append(args, "--add=false")
+	}
+	args = append(args, extraArgs...)
+
+	command := fmt.Sprintf("%s create %s %s", c.path, c.name, strings.Join(args, " "))
+	log.V(4).Info("Launching:", command)
+
+	echo := gexe.New()
+	if c.hostKubeCfg != "" {
+		echo = echo.SetVar("kubecfg", c.hostKubeCfg)
+		command = `/bin/sh -c "KUBECONFIG=${kubecfg} ` + command + `"`
+	}
+
+	p := echo.RunProc(command)
+	if p.Err() != nil {
+		outBytes, _ := io.ReadAll(p.Out())
+		return fmt.Errorf("vcluster: failed to upgrade cluster %q: %s: %s: %s", c.name, p.Err(), p.Result(), string(outBytes))
+	}
+
+	return nil
+}
+
+// Reconnect re-fetches the kubeconfig and reinitializes the REST config for
+// the vcluster. Call this after any destructive operation (Upgrade, cert
+// rotation, etc.)
+func (c *Cluster) Reconnect(ctx context.Context) (*rest.Config, error) {
+	log.V(4).Info("Reconnecting to vcluster ", c.name)
+
+	if c.kubecfgFile != "" {
+		_ = os.Remove(c.kubecfgFile)
+		c.kubecfgFile = ""
+	}
+
+	if _, err := c.getKubeconfig(); err != nil {
+		return nil, fmt.Errorf("reconnect: get kubeconfig: %w", err)
+	}
+	if err := c.initKubernetesAccessClients(); err != nil {
+		return nil, fmt.Errorf("reconnect: init clients: %w", err)
+	}
+	return c.rc, nil
 }
 
 func (c *Cluster) GetKubeconfig() string {
@@ -301,7 +408,7 @@ func (c *Cluster) Destroy(ctx context.Context) error {
 	}
 
 	log.V(4).Info("Removing kubeconfig file ", c.kubecfgFile)
-	if err := os.Remove(c.kubecfgFile); err != nil {
+	if err := os.Remove(c.kubecfgFile); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("vcluster: failed to remove kubeconfig file %q: %w", c.kubecfgFile, err)
 	}
 	return nil
@@ -359,6 +466,7 @@ type clusterJSON struct {
 	HostKubeCfg          string `json:"hostKubeCfg"`
 	HostKubeContext      string `json:"hostKubeContext"`
 	Upgrade              bool   `json:"upgrade"`
+	Add                  *bool  `json:"add,omitempty"`
 	LocalChartDir        string `json:"localChartDir"`
 	BackgroundProxyImage string `json:"backgroundProxyImage"`
 }
@@ -377,6 +485,7 @@ func (c *Cluster) UnmarshalJSON(data []byte) error {
 	c.hostKubeContext = clusterData.HostKubeContext
 	c.hostKubeCfg = clusterData.HostKubeCfg
 	c.upgrade = clusterData.Upgrade
+	c.add = clusterData.Add
 	c.version = clusterData.Version
 	c.localChartDir = clusterData.LocalChartDir
 	c.backgroundProxyImage = clusterData.BackgroundProxyImage
@@ -402,6 +511,7 @@ func (c *Cluster) MarshalJSON() ([]byte, error) {
 		HostKubeCfg:          c.hostKubeCfg,
 		HostKubeContext:      c.hostKubeContext,
 		Upgrade:              c.upgrade,
+		Add:                  c.add,
 		LocalChartDir:        c.localChartDir,
 		BackgroundProxyImage: c.backgroundProxyImage,
 	})

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/setup/suite/suite.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/setup/suite/suite.go
@@ -2,6 +2,9 @@ package suite
 
 import (
 	"context"
+	"fmt"
+	"runtime"
+	"strings"
 
 	"github.com/loft-sh/e2e-framework/pkg/setup"
 	. "github.com/onsi/ginkgo/v2"
@@ -152,13 +155,18 @@ func AddDependency(dep Dependency) Options {
 	}
 }
 
+// Define registers a new dependency. If a dependency with the same label
+// already exists, the existing instance is returned. This allows multiple
+// Go packages (e.g. an OSS test library and a pro wrapper) to independently
+// call Define with the same label without panicking - whoever initializes
+// first wins, and subsequent callers get the same instance.
 func Define(opts ...Options) Dependency {
 	d := &dependency{}
 	for _, opt := range opts {
 		opt(d)
 	}
-	if dependencies[d.label] != nil {
-		panic("dependency already defined")
+	if existing := dependencies[d.label]; existing != nil {
+		return existing
 	}
 	dependencies[d.label] = d
 	return d
@@ -200,6 +208,23 @@ func NodeTransformer(nodeType types.NodeType, _ Offset, text string, args []any)
 		default:
 			newArgs = append(newArgs, x)
 		}
+	}
+
+	// Runtime safety net: detect package-level var _ = Describe(...) with
+	// cluster dependencies. These auto-registrations break cross-repo imports
+	// because Go compiles the entire package on import, registering tests
+	// against clusters that may not exist in the importing repo.
+	// The correct pattern is an exported function that takes the dependency.
+	if nodeType == types.NodeTypeContainer && len(deps) > 0 && isCalledFromPackageInit() {
+		depLabels := make([]string, 0, len(deps))
+		for _, d := range deps {
+			depLabels = append(depLabels, d.label)
+		}
+		return text, newArgs, []error{fmt.Errorf(
+			"Describe(%q) with cluster dependencies %v is auto-registered via package-level var; "+
+				"use an exported function instead: func Describe<Name>(dep suite.Dependency) bool { return Describe(..., cluster.Use(dep), ...) }",
+			text, depLabels,
+		)}
 	}
 
 	var (
@@ -275,4 +300,39 @@ func NodeTransformer(nodeType types.NodeType, _ Offset, text string, args []any)
 	}
 
 	return text, newArgs, nil
+}
+
+// isCalledFromPackageInit walks the call stack to determine whether the current
+// Describe call originates from a package-level var initialization (init).
+// Go runs package-level `var _ = Describe(...)` inside compiler-generated init
+// functions whose names follow the pattern "<pkg>.init" or "<pkg>.init.func<N>".
+// If the Describe is called from an exported function like DescribeMyFeature(),
+// the stack will contain that function name before any init frame.
+func isCalledFromPackageInit() bool {
+	var pcs [20]uintptr
+	n := runtime.Callers(3, pcs[:]) // skip Callers, isCalledFromPackageInit, NodeTransformer
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		// Skip Ginkgo internals and our framework code.
+		if strings.Contains(frame.Function, "github.com/onsi/ginkgo") ||
+			strings.Contains(frame.Function, "github.com/loft-sh/e2e-framework") {
+			if !more {
+				break
+			}
+			continue
+		}
+		// The first non-framework frame tells us the call site.
+		// init functions: "pkg.init", "pkg.init.func1", "pkg.init.func1.1", etc.
+		funcName := frame.Function
+		lastDot := strings.LastIndex(funcName, ".")
+		if lastDot >= 0 {
+			shortName := funcName[lastDot+1:]
+			if shortName == "init" || strings.HasPrefix(shortName, "init.") {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/setup/types.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/setup/types.go
@@ -1,5 +1,28 @@
 package setup
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+)
 
 type Func func(ctx context.Context) (context.Context, error)
+
+// Named wraps a Func with a human-readable name for diagnostic logging.
+// When used with AllConcurrent, the name will appear in progress logs.
+func Named(name string, fn Func) Func {
+	return func(ctx context.Context) (context.Context, error) {
+		start := time.Now()
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %s: starting\n", name)
+		ctx, err := fn(ctx)
+		elapsed := time.Since(start).Truncate(time.Millisecond)
+		if err != nil {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %s: FAILED after %s: %v\n", name, elapsed, err)
+		} else {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %s: done (%s)\n", name, elapsed)
+		}
+		return ctx, err
+	}
+}

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/setup/util.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/setup/util.go
@@ -116,10 +116,14 @@ func AllWithResults(fns ...Func) Func {
 
 func AllConcurrent(fns ...Func) Func {
 	return func(ctx context.Context) (context.Context, error) {
-		resultsChan := make(chan Result, len(fns))
+		total := len(fns)
+		resultsChan := make(chan Result, total)
 
 		wg := new(sync.WaitGroup)
-		wg.Add(len(fns))
+		wg.Add(total)
+
+		setupStart := time.Now()
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] starting %d concurrent setup functions\n", total)
 
 		for _, fn := range fns {
 			go func(setupFn Func) {
@@ -141,16 +145,28 @@ func AllConcurrent(fns ...Func) Func {
 			errs = append(errs, res.Err)
 		}
 
-		return ctx, errors.NewAggregate(errs)
+		elapsed := time.Since(setupStart).Truncate(time.Millisecond)
+		aggErr := errors.NewAggregate(errs)
+		if aggErr != nil {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %d concurrent setup functions finished in %s with errors: %v\n", total, elapsed, aggErr)
+		} else {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %d concurrent setup functions finished in %s\n", total, elapsed)
+		}
+
+		return ctx, aggErr
 	}
 }
 
 func AllConcurrentWithResults(fns ...Func) Func {
 	return func(ctx context.Context) (context.Context, error) {
-		resultsChan := make(chan Result, len(fns))
+		total := len(fns)
+		resultsChan := make(chan Result, total)
 
 		wg := new(sync.WaitGroup)
-		wg.Add(len(fns))
+		wg.Add(total)
+
+		setupStart := time.Now()
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] starting %d concurrent setup functions\n", total)
 
 		for _, fn := range fns {
 			go func(setupFn Func) {
@@ -173,7 +189,15 @@ func AllConcurrentWithResults(fns ...Func) Func {
 			errs = append(errs, res.Err)
 		}
 
-		return WithResults(ctx, results), errors.NewAggregate(errs)
+		elapsed := time.Since(setupStart).Truncate(time.Millisecond)
+		aggErr := errors.NewAggregate(errs)
+		if aggErr != nil {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %d concurrent setup functions finished in %s with errors: %v\n", total, elapsed, aggErr)
+		} else {
+			_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "[setup] %d concurrent setup functions finished in %s\n", total, elapsed)
+		}
+
+		return WithResults(ctx, results), aggErr
 	}
 }
 
@@ -183,6 +207,21 @@ func AsCleanup(fn Func) func(ctx context.Context) func(ctx context.Context) erro
 			_, err := fn(e2econtext.WithValues(specContext, curr))
 			return err
 		}
+	}
+}
+
+// DeferCtx wraps a setup.Func so that the context captured at registration
+// time is merged into the DeferCleanup context when the cleanup runs. This
+// ensures that context values (e.g. clients) available at the call site are
+// also available during cleanup, even if the stack-based context no longer
+// carries them.
+//
+// Usage:
+//
+//	DeferCleanup(setup.DeferCtx(ctx, cluster.Destroy(name)))
+func DeferCtx(capturedCtx context.Context, fn Func) func(context.Context) (context.Context, error) {
+	return func(deferCtx context.Context) (context.Context, error) {
+		return fn(e2econtext.WithValues(deferCtx, capturedCtx))
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -711,7 +711,7 @@ github.com/loft-sh/api/v4/pkg/vclusterconfig/constants
 # github.com/loft-sh/apiserver v0.0.0-20260113122925-594495a02e96
 ## explicit; go 1.25.0
 github.com/loft-sh/apiserver/pkg/builders
-# github.com/loft-sh/e2e-framework v0.0.0-20260226211029-dc642849b244
+# github.com/loft-sh/e2e-framework v0.0.0-20260401095027-4666f06d1a86
 ## explicit; go 1.24.0
 github.com/loft-sh/e2e-framework/pkg/context
 github.com/loft-sh/e2e-framework/pkg/e2e


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
