### PR TITLE
fix: allow external api ingress and skip unused network policies for private nodes

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -6,6 +6,7 @@
       "heritage" .Release.Service) .Values.policies.networkPolicy.labels -}}
 {{- $annotations := merge dict .Values.controlPlane.advanced.globalMetadata.annotations .Values.policies.networkPolicy.annotations -}}
 {{- $labelsAndAnnotations := dict "labels" $labels "annotations" $annotations -}}
+{{- if not .Values.privateNodes.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -68,6 +69,7 @@ spec:
 {{- if .Values.policies.networkPolicy.workload.ingress }}
 {{ toYaml .Values.policies.networkPolicy.workload.ingress | indent 4 }}
 {{- end }}
+{{- end }}
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -126,6 +128,13 @@ spec:
 {{- end }}
 
   ingress:
+    # Allow external ingress to the vCluster API server.
+    # Without this, enabling network policies blocks all external access
+    # (kubectl, ingress controllers, Gateway API, Konnectivity agents).
+    - ports:
+        - port: 8443
+          protocol: TCP
+
     # Allow ingress from vcluster control plane peers, including etcd peers, when using etcd as the backend in HA mode.
     - from:
         - podSelector:
@@ -162,7 +171,7 @@ spec:
 {{ toYaml .Values.policies.networkPolicy.controlPlane.ingress | indent 4 }}
 {{- end }}
 
-{{- if and .Values.controlPlane.coredns.enabled (not .Values.controlPlane.coredns.embedded) }}
+{{- if and .Values.controlPlane.coredns.enabled (not .Values.controlPlane.coredns.embedded) (not .Values.privateNodes.enabled) }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/chart/tests/networkpolicy_test.yaml
+++ b/chart/tests/networkpolicy_test.yaml
@@ -57,7 +57,7 @@ tests:
           value: vc-cp-my-release
         lengthEqual:
           path: spec.ingress
-          count: 4
+          count: 5
       - documentSelector:
           path: metadata.name
           value: vc-kube-dns-my-release
@@ -163,5 +163,87 @@ tests:
           path: metadata.name
           value: vc-cp-my-release
         equal:
-          path: spec.ingress[4].ports[0].port
+          path: spec.ingress[5].ports[0].port
           value: 12340
+
+  - it: should allow external API ingress by default
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      policies:
+        networkPolicy:
+          enabled: true
+    asserts:
+      # First ingress rule allows port 8443 from any source
+      - documentSelector:
+          path: metadata.name
+          value: vc-cp-my-release
+        equal:
+          path: spec.ingress[0].ports[0].port
+          value: 8443
+      - documentSelector:
+          path: metadata.name
+          value: vc-cp-my-release
+        equal:
+          path: spec.ingress[0].ports[0].protocol
+          value: TCP
+      # No 'from' field means allow from all sources
+      - documentSelector:
+          path: metadata.name
+          value: vc-cp-my-release
+        isNull:
+          path: spec.ingress[0].from
+
+  - it: should not create workload or dns policy when privateNodes enabled
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      policies:
+        networkPolicy:
+          enabled: true
+      privateNodes:
+        enabled: true
+    asserts:
+      # Only 2 documents: cp + snapshot (workload and dns are skipped)
+      - hasDocuments:
+          count: 2
+      - documentIndex: &cpIndexPN 0
+        equal:
+          path: metadata.name
+          value: vc-cp-my-release
+      - documentIndex: &snapshotIndexPN 1
+        equal:
+          path: metadata.name
+          value: vc-snapshot-my-release
+
+  - it: should create all policies when privateNodes disabled (default)
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      policies:
+        networkPolicy:
+          enabled: true
+      privateNodes:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: &workIndex 0
+        equal:
+          path: metadata.name
+          value: vc-work-my-release
+      - documentIndex: &cpIndex 1
+        equal:
+          path: metadata.name
+          value: vc-cp-my-release
+      - documentIndex: &dnsIndex 2
+        equal:
+          path: metadata.name
+          value: vc-kube-dns-my-release
+      - documentIndex: &snapshotIndex 3
+        equal:
+          path: metadata.name
+          value: vc-snapshot-my-release


### PR DESCRIPTION
When network policies are enabled, the control plane NetworkPolicy blocks all external access to the vCluster API (kubectl, ingress controllers, Gateway API, Konnectivity agents), requiring users to manually add an ingress rule for port 8443. Add a default open ingress rule for port 8443/TCP so the API is reachable out of the box.

Skip the workload (vc-work-*) and DNS (vc-kube-dns-*) NetworkPolicies when privateNodes is enabled, since no workload or CoreDNS pods run on the host in that mode — the policies target zero pods and are no-ops.

Closes ENGNODE-267

