### PR TITLE
Add DRA granular status authorization RBAC rules

### DIFF
--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -104,6 +104,12 @@ rules:
   - apiGroups: ["resource.k8s.io"]
     resources: ["resourceclaims/status"]
     verbs: ["patch", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims/binding"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims/driver"]
+    verbs: ["associated-node:update", "associated-node:patch", "arbitrary-node:update", "arbitrary-node:patch"]
   {{- end }}
   {{ if .Values.sync.toHost.resourceClaimTemplates.enabled}}
   - apiGroups: ["resource.k8s.io"]


### PR DESCRIPTION
## Summary

- Adds `resourceclaims/binding` with `update`/`patch` verbs for scheduler-like allocation operations
- Adds `resourceclaims/driver` with `associated-node:update`, `associated-node:patch`, `arbitrary-node:update`, `arbitrary-node:patch` verbs for proxying DRA driver status updates
- Both rules are gated behind the existing `sync.toHost.resourceClaims.enabled` conditional

Starting in Kubernetes v1.36, the `DRAResourceClaimGranularStatusAuthorization` feature gate (beta, on-by-default) enforces fine-grained authorization on ResourceClaim status updates. Since vcluster proxies all ResourceClaim operations, it needs permissions on both new synthetic subresources. These permissions are inert on earlier Kubernetes versions.

Ref: kubernetes/kubernetes#138149

## Test plan

- [ ] Verified via SubjectAccessReview that without fix, `resourceclaims/binding` and `resourceclaims/driver` return `false`
- [ ] Verified via SubjectAccessReview that with fix, all new permissions return `true`
- [ ] Helm template renders correctly with `sync.toHost.resourceClaims.enabled=true`
- [ ] Confirm no regression on older clusters (new permissions are inert)