### PR TITLE
feat: propagate workloadServiceAccount imagePullSecrets to selected synced ServiceAccounts

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -922,6 +922,10 @@
           "type": "array",
           "description": "ImagePullSecrets defines extra image pull secrets for the workload service account."
         },
+        "imagePullSecretSelector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "ImagePullSecretSelector selects which virtual ServiceAccounts receive the imagePullSecrets\nabove on the host side when serviceAccount syncing is enabled. If empty, no propagation\noccurs. Use matchLabels: {} to match all ServiceAccounts."
+        },
         "annotations": {
           "additionalProperties": {
             "type": "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -746,6 +746,10 @@ controlPlane:
       name: ""
       # ImagePullSecrets defines extra image pull secrets for the workload service account.
       imagePullSecrets: []
+      # ImagePullSecretSelector selects which virtual ServiceAccounts receive the imagePullSecrets
+      # above on the host side when serviceAccount syncing is enabled. If empty, no propagation
+      # occurs. Use matchLabels: {} to match all ServiceAccounts.
+      imagePullSecretSelector: {}
       annotations: {}
       labels: {}
     # HeadlessService specifies options for the headless service used for the vCluster StatefulSet.

--- a/config/config.go
+++ b/config/config.go
@@ -2594,6 +2594,11 @@ type ControlPlaneWorkloadServiceAccount struct {
 	// ImagePullSecrets defines extra image pull secrets for the workload service account.
 	ImagePullSecrets []ImagePullSecretName `json:"imagePullSecrets,omitempty"`
 
+	// ImagePullSecretSelector selects which virtual ServiceAccounts receive the imagePullSecrets
+	// above on the host side when serviceAccount syncing is enabled. If empty, no propagation
+	// occurs. Use matchLabels: {} to match all ServiceAccounts.
+	ImagePullSecretSelector StandardLabelSelector `json:"imagePullSecretSelector,omitempty"`
+
 	// Annotations are extra annotations for this resource.
 	Annotations map[string]string `json:"annotations,omitempty"`
 

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -403,6 +403,7 @@ controlPlane:
       enabled: true
       name: ""
       imagePullSecrets: []
+      imagePullSecretSelector: {}
       annotations: {}
       labels: {}
 

--- a/e2e-next/clusters/sa_imagepullsecrets.go
+++ b/e2e-next/clusters/sa_imagepullsecrets.go
@@ -1,0 +1,16 @@
+package clusters
+
+import _ "embed"
+
+// SAImagePullSecretsVCluster has ServiceAccount syncing enabled and configures
+// workloadServiceAccount.imagePullSecrets with a label selector so that only
+// virtual ServiceAccounts labelled inject-pull-secrets=true receive the
+// imagePullSecrets on the corresponding host ServiceAccount.
+
+//go:embed vcluster-sa-imagepullsecrets.yaml
+var saImagePullSecretsVClusterYAML string
+
+var (
+	SAImagePullSecretsVClusterName = "sa-imagepullsecrets-vcluster"
+	SAImagePullSecretsVCluster     = register(SAImagePullSecretsVClusterName, saImagePullSecretsVClusterYAML)
+)

--- a/e2e-next/clusters/vcluster-sa-imagepullsecrets.yaml
+++ b/e2e-next/clusters/vcluster-sa-imagepullsecrets.yaml
@@ -1,0 +1,17 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+  advanced:
+    workloadServiceAccount:
+      imagePullSecrets:
+        - name: e2e-test-registry-secret
+      imagePullSecretSelector:
+        matchLabels:
+          inject-pull-secrets: "true"
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true

--- a/e2e-next/labels/labels.go
+++ b/e2e-next/labels/labels.go
@@ -17,6 +17,7 @@ var (
 	Vind        = Label("vind")
 
 	// Resource-specific labels for fromHost sync tests
+	ServiceAccounts = Label("serviceaccounts")
 	PriorityClasses = Label("priorityclasses")
 	RuntimeClasses  = Label("runtimeclasses")
 	StorageClasses  = Label("storageclasses")

--- a/e2e-next/suite_serviceaccount_test.go
+++ b/e2e-next/suite_serviceaccount_test.go
@@ -1,0 +1,26 @@
+// Suite: sa-imagepullsecrets-vcluster
+// vCluster: SAImagePullSecretsVCluster (workloadServiceAccount.imagePullSecrets config)
+// Run:      just run-e2e 'pr && sa-imagepullsecrets-vcluster'
+package e2e_next
+
+import (
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	test_core "github.com/loft-sh/vcluster/e2e-next/test_core/sync"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func init() {
+	suiteSAImagePullSecretsVCluster()
+}
+
+func suiteSAImagePullSecretsVCluster() {
+	Describe("sa-imagepullsecrets-vcluster", labels.PR,
+		cluster.Use(clusters.SAImagePullSecretsVCluster),
+		cluster.Use(clusters.HostCluster),
+		func() {
+			test_core.DescribeSAImagePullSecrets()
+		},
+	)
+}

--- a/e2e-next/test_core/sync/test_serviceaccount_imagepullsecrets.go
+++ b/e2e-next/test_core/sync/test_serviceaccount_imagepullsecrets.go
@@ -1,0 +1,212 @@
+package test_core
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// hostSAAnnotationName is the annotation set by the SA syncer to record the virtual SA name.
+const hostSAAnnotationName = "vcluster.loft.sh/object-name"
+
+// hostSANamespaceLabel is the label set by the SA syncer to record the virtual namespace.
+const hostSANamespaceLabel = "vcluster.loft.sh/namespace"
+
+// expectedPullSecret is the imagePullSecret name configured in vcluster-sa-imagepullsecrets.yaml.
+const expectedPullSecret = "e2e-test-registry-secret"
+
+// selectorLabel is the label key/value that the imagePullSecretSelector matches on.
+const selectorLabelKey = "inject-pull-secrets"
+const selectorLabelValue = "true"
+
+// DescribeSAImagePullSecrets registers tests that verify workloadServiceAccount imagePullSecrets
+// are propagated to synced host ServiceAccounts when they match the configured selector.
+func DescribeSAImagePullSecrets() {
+	Describe("ServiceAccount imagePullSecrets propagation",
+		labels.Core,
+		labels.PR,
+		labels.Sync,
+		labels.ServiceAccounts,
+		func() {
+			var (
+				hostClient     kubernetes.Interface
+				vClusterClient kubernetes.Interface
+			)
+
+			BeforeEach(func(ctx context.Context) {
+				hostClient = cluster.KubeClientFrom(ctx, constants.GetHostClusterName())
+				Expect(hostClient).NotTo(BeNil())
+				vClusterClient = cluster.CurrentKubeClientFrom(ctx)
+				Expect(vClusterClient).NotTo(BeNil())
+			})
+
+			// findHostSA lists host ServiceAccounts for the given virtual namespace and returns
+			// the one whose vcluster ownership annotation matches saName.
+			findHostSA := func(ctx context.Context, g Gomega, virtualNS, saName string) *corev1.ServiceAccount {
+				GinkgoHelper()
+				sas, err := hostClient.CoreV1().ServiceAccounts("").List(ctx, metav1.ListOptions{
+					LabelSelector: hostSANamespaceLabel + "=" + virtualNS,
+				})
+				g.Expect(err).To(Succeed(), "listing host SAs for virtual namespace %q", virtualNS)
+
+				for i := range sas.Items {
+					if sas.Items[i].Annotations[hostSAAnnotationName] == saName {
+						return &sas.Items[i]
+					}
+				}
+				g.Expect(false).To(BeTrue(), "host SA for virtual SA %q/%q not found yet", virtualNS, saName)
+				return nil
+			}
+
+			It("propagates imagePullSecrets to a SA whose labels match the selector", func(ctx context.Context) {
+				suffix := random.String(6)
+				nsName := "sa-pull-secret-test-" + suffix
+				saName := "sa-matching-" + suffix
+
+				By("creating a virtual namespace", func() {
+					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx,
+						&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}},
+						metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				By("creating a virtual SA with the matching label", func() {
+					_, err := vClusterClient.CoreV1().ServiceAccounts(nsName).Create(ctx,
+						&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+							Name:      saName,
+							Namespace: nsName,
+							Labels:    map[string]string{selectorLabelKey: selectorLabelValue},
+						}},
+						metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+
+				By("waiting for the host SA to have the configured imagePullSecrets", func() {
+					Eventually(func(g Gomega) {
+						hostSA := findHostSA(ctx, g, nsName, saName)
+						g.Expect(hostSA.ImagePullSecrets).To(ContainElement(
+							corev1.LocalObjectReference{Name: expectedPullSecret},
+						), "host SA imagePullSecrets should contain %q", expectedPullSecret)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
+			})
+
+			It("does not propagate imagePullSecrets to a SA whose labels do not match the selector", func(ctx context.Context) {
+				suffix := random.String(6)
+				nsName := "sa-pull-secret-test-" + suffix
+				saName := "sa-nonmatching-" + suffix
+
+				By("creating a virtual namespace", func() {
+					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx,
+						&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}},
+						metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				By("creating a virtual SA without the matching label", func() {
+					_, err := vClusterClient.CoreV1().ServiceAccounts(nsName).Create(ctx,
+						&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+							Name:      saName,
+							Namespace: nsName,
+							// no inject-pull-secrets label
+						}},
+						metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+
+				By("waiting for the host SA to exist and verifying it has no imagePullSecrets", func() {
+					Consistently(func(g Gomega) {
+						hostSA := findHostSA(ctx, g, nsName, saName)
+						g.Expect(hostSA.ImagePullSecrets).To(BeEmpty(),
+							"host SA imagePullSecrets should be empty for a non-matching SA")
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
+			})
+
+			// Ordered: the second spec removes the SA label; it must run after the first spec
+			// has verified that imagePullSecrets were initially set.
+			Context("when the SA label is removed after initial sync", Ordered, func() {
+				var (
+					nsName string
+					saName string
+				)
+
+				BeforeAll(func(ctx context.Context) {
+					suffix := random.String(6)
+					nsName = "sa-pull-secret-test-" + suffix
+					saName = "sa-label-removed-" + suffix
+
+					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx,
+						&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}},
+						metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+
+					_, err = vClusterClient.CoreV1().ServiceAccounts(nsName).Create(ctx,
+						&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+							Name:      saName,
+							Namespace: nsName,
+							Labels:    map[string]string{selectorLabelKey: selectorLabelValue},
+						}},
+						metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+
+				It("host SA initially has imagePullSecrets while the SA matches the selector", func(ctx context.Context) {
+					By("waiting for imagePullSecrets to appear on the host SA", func() {
+						Eventually(func(g Gomega) {
+							hostSA := findHostSA(ctx, g, nsName, saName)
+							g.Expect(hostSA.ImagePullSecrets).To(ContainElement(
+								corev1.LocalObjectReference{Name: expectedPullSecret},
+							), "host SA should have imagePullSecrets while selector label is set")
+						}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+					})
+				})
+
+				It("host SA loses imagePullSecrets after the selector label is removed", func(ctx context.Context) {
+					By("removing the selector label from the virtual SA", func() {
+						sa, err := vClusterClient.CoreV1().ServiceAccounts(nsName).Get(ctx, saName, metav1.GetOptions{})
+						Expect(err).To(Succeed())
+						delete(sa.Labels, selectorLabelKey)
+						_, err = vClusterClient.CoreV1().ServiceAccounts(nsName).Update(ctx, sa, metav1.UpdateOptions{})
+						Expect(err).To(Succeed())
+					})
+
+					By("waiting for imagePullSecrets to be cleared on the host SA", func() {
+						Eventually(func(g Gomega) {
+							hostSA := findHostSA(ctx, g, nsName, saName)
+							g.Expect(hostSA.ImagePullSecrets).To(BeEmpty(),
+								"host SA imagePullSecrets should be cleared after selector label is removed")
+						}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+					})
+				})
+			})
+		},
+	)
+}

--- a/pkg/controllers/resources/serviceaccounts/syncer.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer.go
@@ -3,6 +3,7 @@ package serviceaccounts
 import (
 	"fmt"
 
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/patcher"
 	"github.com/loft-sh/vcluster/pkg/pro"
@@ -11,13 +12,13 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/translator"
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	corev1 "k8s.io/api/core/v1"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
@@ -26,15 +27,48 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		return nil, err
 	}
 
+	workloadSA := ctx.Config.ControlPlane.Advanced.WorkloadServiceAccount
+	refs := make([]corev1.LocalObjectReference, 0, len(workloadSA.ImagePullSecrets))
+	for _, s := range workloadSA.ImagePullSecrets {
+		refs = append(refs, corev1.LocalObjectReference{Name: s.Name})
+	}
+
 	return &serviceAccountSyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "serviceaccount", &corev1.ServiceAccount{}, mapper),
-		Importer:          pro.NewImporter(mapper),
+		GenericTranslator:       translator.NewGenericTranslator(ctx, "serviceaccount", &corev1.ServiceAccount{}, mapper),
+		Importer:                pro.NewImporter(mapper),
+		imagePullSecrets:        refs,
+		imagePullSecretSelector: workloadSA.ImagePullSecretSelector,
 	}, nil
 }
 
 type serviceAccountSyncer struct {
 	syncertypes.GenericTranslator
 	syncertypes.Importer
+
+	imagePullSecrets        []corev1.LocalObjectReference
+	imagePullSecretSelector vclusterconfig.StandardLabelSelector
+}
+
+// pullSecretsFor returns the configured imagePullSecrets if the virtual SA matches
+// the selector, or nil otherwise.
+// A zero-value selector (MatchLabels nil and no MatchExpressions) means no propagation
+// is configured. An explicit empty MatchLabels ({}) matches all ServiceAccounts.
+func (s *serviceAccountSyncer) pullSecretsFor(virtualSA *corev1.ServiceAccount) []corev1.LocalObjectReference {
+	if len(s.imagePullSecrets) == 0 {
+		return nil
+	}
+	if s.imagePullSecretSelector.MatchLabels == nil && len(s.imagePullSecretSelector.MatchExpressions) == 0 {
+		return nil
+	}
+	matches, err := s.imagePullSecretSelector.Matches(virtualSA)
+	if err != nil {
+		klog.Errorf("failed to evaluate imagePullSecretSelector for ServiceAccount %s/%s: %v", virtualSA.Namespace, virtualSA.Name, err)
+		return nil
+	}
+	if !matches {
+		return nil
+	}
+	return s.imagePullSecrets
 }
 
 var _ syncertypes.OptionsProvider = &serviceAccountSyncer{}
@@ -61,7 +95,7 @@ func (s *serviceAccountSyncer) SyncToHost(ctx *synccontext.SyncContext, event *s
 	// Don't sync the secrets here as we will override them anyways
 	pObj.Secrets = nil
 	pObj.AutomountServiceAccountToken = &[]bool{false}[0]
-	pObj.ImagePullSecrets = nil
+	pObj.ImagePullSecrets = s.pullSecretsFor(event.Virtual)
 
 	err := pro.ApplyPatchesHostObject(ctx, nil, pObj, event.Virtual, ctx.Config.Sync.ToHost.ServiceAccounts.Patches, false)
 	if err != nil {
@@ -92,6 +126,9 @@ func (s *serviceAccountSyncer) Sync(ctx *synccontext.SyncContext, event *synccon
 			)
 		}
 	}()
+
+	// enforce configured imagePullSecrets on the host SA
+	event.Host.ImagePullSecrets = s.pullSecretsFor(event.Virtual)
 
 	// bi-directional sync of annotations and labels
 	event.Virtual.Annotations, event.Host.Annotations = translate.AnnotationsBidirectionalUpdate(event)

--- a/pkg/controllers/resources/serviceaccounts/syncer_test.go
+++ b/pkg/controllers/resources/serviceaccounts/syncer_test.go
@@ -3,6 +3,7 @@ package serviceaccounts
 import (
 	"testing"
 
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
@@ -71,6 +72,267 @@ func TestSync(t *testing.T) {
 			Sync: func(ctx *synccontext.RegisterContext) {
 				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
 				_, err := syncer.(*serviceAccountSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vSA))
+				assert.NilError(t, err)
+			},
+		},
+	})
+}
+
+// TestPullSecretsFor verifies the selector logic of pullSecretsFor directly.
+func TestPullSecretsFor(t *testing.T) {
+	refs := []corev1.LocalObjectReference{{Name: "my-registry-creds"}}
+
+	cases := []struct {
+		name    string
+		syncer  *serviceAccountSyncer
+		sa      *corev1.ServiceAccount
+		wantNil bool
+	}{
+		{
+			name: "no imagePullSecrets configured returns nil",
+			syncer: &serviceAccountSyncer{
+				imagePullSecrets:        nil,
+				imagePullSecretSelector: vclusterconfig.StandardLabelSelector{MatchLabels: map[string]string{}},
+			},
+			sa:      &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa"}},
+			wantNil: true,
+		},
+		{
+			name: "empty selector returns nil regardless of imagePullSecrets",
+			syncer: &serviceAccountSyncer{
+				imagePullSecrets:        refs,
+				imagePullSecretSelector: vclusterconfig.StandardLabelSelector{},
+			},
+			sa:      &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa"}},
+			wantNil: true,
+		},
+		{
+			name: "matchLabels empty matches all SAs",
+			syncer: &serviceAccountSyncer{
+				imagePullSecrets:        refs,
+				imagePullSecretSelector: vclusterconfig.StandardLabelSelector{MatchLabels: map[string]string{}},
+			},
+			sa:      &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa"}},
+			wantNil: false,
+		},
+		{
+			name: "label selector matching SA labels returns refs",
+			syncer: &serviceAccountSyncer{
+				imagePullSecrets:        refs,
+				imagePullSecretSelector: vclusterconfig.StandardLabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+			},
+			sa: &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name:   "sa",
+				Labels: map[string]string{"env": "prod"},
+			}},
+			wantNil: false,
+		},
+		{
+			name: "label selector not matching SA labels returns nil",
+			syncer: &serviceAccountSyncer{
+				imagePullSecrets:        refs,
+				imagePullSecretSelector: vclusterconfig.StandardLabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+			},
+			sa: &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name:   "sa",
+				Labels: map[string]string{"env": "dev"},
+			}},
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.syncer.pullSecretsFor(tc.sa)
+			if tc.wantNil {
+				assert.Assert(t, result == nil, "expected nil, got %v", result)
+			} else {
+				assert.DeepEqual(t, refs, result)
+			}
+		})
+	}
+}
+
+// TestSyncToHostWithImagePullSecrets verifies that SyncToHost writes imagePullSecrets
+// onto the host ServiceAccount when the virtual SA matches the configured selector.
+func TestSyncToHostWithImagePullSecrets(t *testing.T) {
+	const pullSecretName = "my-registry-creds"
+
+	vSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-serviceaccount",
+			Namespace: "test",
+		},
+	}
+
+	// expected host SA without imagePullSecrets
+	basePSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      translate.Default.HostName(nil, vSA.Name, vSA.Namespace).Name,
+			Namespace: "test",
+			Annotations: map[string]string{
+				translate.NameAnnotation:          vSA.Name,
+				translate.NamespaceAnnotation:     vSA.Namespace,
+				translate.UIDAnnotation:           "",
+				translate.KindAnnotation:          corev1.SchemeGroupVersion.WithKind("ServiceAccount").String(),
+				translate.HostNamespaceAnnotation: "test",
+				translate.HostNameAnnotation:      translate.Default.HostName(nil, vSA.Name, vSA.Namespace).Name,
+			},
+			Labels: map[string]string{
+				translate.NamespaceLabel: vSA.Namespace,
+			},
+		},
+		AutomountServiceAccountToken: &[]bool{false}[0],
+	}
+
+	// expected host SA with imagePullSecrets
+	pSAWithSecrets := basePSA.DeepCopy()
+	pSAWithSecrets.ImagePullSecrets = []corev1.LocalObjectReference{{Name: pullSecretName}}
+
+	syncertesting.RunTests(t, []*syncertesting.SyncTest{
+		{
+			Name:                "matchLabels empty propagates imagePullSecrets to all SAs",
+			InitialVirtualState: []runtime.Object{vSA},
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.ServiceAccounts.Enabled = true
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecrets = []vclusterconfig.ImagePullSecretName{{Name: pullSecretName}}
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecretSelector = vclusterconfig.StandardLabelSelector{
+					MatchLabels: map[string]string{},
+				}
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): {pSAWithSecrets},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*serviceAccountSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vSA))
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                "empty selector does not propagate imagePullSecrets",
+			InitialVirtualState: []runtime.Object{vSA},
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.ServiceAccounts.Enabled = true
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecrets = []vclusterconfig.ImagePullSecretName{{Name: pullSecretName}}
+				// no ImagePullSecretSelector set
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): {basePSA},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*serviceAccountSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vSA))
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                "non-matching selector does not propagate imagePullSecrets",
+			InitialVirtualState: []runtime.Object{vSA},
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.ServiceAccounts.Enabled = true
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecrets = []vclusterconfig.ImagePullSecretName{{Name: pullSecretName}}
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecretSelector = vclusterconfig.StandardLabelSelector{
+					MatchLabels: map[string]string{"inject-pull-secrets": "true"},
+				}
+				// vSA has no labels, so selector will not match
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): {basePSA},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*serviceAccountSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vSA))
+				assert.NilError(t, err)
+			},
+		},
+	})
+}
+
+// TestSyncWithImagePullSecrets verifies that the Sync (reconcile/update) path enforces
+// the configured imagePullSecrets on the host SA, overwriting any stale values.
+func TestSyncWithImagePullSecrets(t *testing.T) {
+	const pullSecretName = "my-registry-creds"
+
+	vSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-serviceaccount",
+			Namespace: "test",
+		},
+	}
+
+	hostSAName := translate.Default.HostName(nil, vSA.Name, vSA.Namespace).Name
+	baseAnnotations := map[string]string{
+		translate.NameAnnotation:          vSA.Name,
+		translate.NamespaceAnnotation:     vSA.Namespace,
+		translate.UIDAnnotation:           "",
+		translate.KindAnnotation:          corev1.SchemeGroupVersion.WithKind("ServiceAccount").String(),
+		translate.HostNamespaceAnnotation: "test",
+		translate.HostNameAnnotation:      hostSAName,
+	}
+	baseLabels := map[string]string{translate.NamespaceLabel: vSA.Namespace}
+
+	// host SA that was previously synced but has a stale imagePullSecret
+	hostSAStale := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        hostSAName,
+			Namespace:   "test",
+			Annotations: baseAnnotations,
+			Labels:      baseLabels,
+		},
+		AutomountServiceAccountToken: &[]bool{false}[0],
+		ImagePullSecrets:             []corev1.LocalObjectReference{{Name: "stale-secret"}},
+	}
+
+	// after Sync, host SA should have the correct imagePullSecrets
+	pSAAfterSync := hostSAStale.DeepCopy()
+	pSAAfterSync.ImagePullSecrets = []corev1.LocalObjectReference{{Name: pullSecretName}}
+
+	syncertesting.RunTests(t, []*syncertesting.SyncTest{
+		{
+			Name:                 "Sync replaces stale imagePullSecrets with configured ones",
+			InitialVirtualState:  []runtime.Object{vSA},
+			InitialPhysicalState: []runtime.Object{hostSAStale},
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.ServiceAccounts.Enabled = true
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecrets = []vclusterconfig.ImagePullSecretName{{Name: pullSecretName}}
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecretSelector = vclusterconfig.StandardLabelSelector{
+					MatchLabels: map[string]string{},
+				}
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): {pSAAfterSync},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*serviceAccountSyncer).Sync(syncCtx, synccontext.NewSyncEventWithOld(hostSAStale.DeepCopy(), hostSAStale.DeepCopy(), vSA.DeepCopy(), vSA.DeepCopy()))
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                 "Sync clears imagePullSecrets when selector no longer matches",
+			InitialVirtualState:  []runtime.Object{vSA},
+			InitialPhysicalState: []runtime.Object{hostSAStale},
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.ServiceAccounts.Enabled = true
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecrets = []vclusterconfig.ImagePullSecretName{{Name: pullSecretName}}
+				// selector requires a label the vSA does not have
+				vConfig.ControlPlane.Advanced.WorkloadServiceAccount.ImagePullSecretSelector = vclusterconfig.StandardLabelSelector{
+					MatchLabels: map[string]string{"inject-pull-secrets": "true"},
+				}
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"): {
+					func() *corev1.ServiceAccount {
+						s := hostSAStale.DeepCopy()
+						s.ImagePullSecrets = nil
+						return s
+					}(),
+				},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*serviceAccountSyncer).Sync(syncCtx, synccontext.NewSyncEventWithOld(hostSAStale.DeepCopy(), hostSAStale.DeepCopy(), vSA.DeepCopy(), vSA.DeepCopy()))
 				assert.NilError(t, err)
 			},
 		},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-93


**Please provide a short message that should be published in the vcluster release notes**


When sync.toHost.serviceAccounts.enabled is true, each virtual SA is synced  to the host and pods use their own SA instead of the shared workloadServiceAccount. Previously, imagePullSecrets configured on workloadServiceAccount were silently                      
dropped for all synced host SAs.                                                                     
                                                                                                     
Adds imagePullSecretSelector (StandardLabelSelector) to controlPlane.advanced.workloadServiceAccount. When a virtual SA matches the selector, the configured imagePullSecrets are written onto its corresponding  host SA on both creation and every reconcile. An empty or absent selector means  no propagation (safe default — explicit opt-in required). Setting matchLabels: {} matches all virtual SAs.                                                                             
                                                                                                     
The selector is evaluated against the virtual SA labels before the bidirectional label sync so the original desired state is used for matching.


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
