### PR TITLE
ci(release): use large runner for publish job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [check_minimum_version_tag]
     name: Publish vcluster
-    runs-on: ubuntu-22.04
+    runs-on: large-8_32
 
     outputs:
       release_version: ${{ steps.get_version.outputs.release_version }}


### PR DESCRIPTION
## Summary
- Switch the `publish` job in release.yaml from `ubuntu-22.04` to `large-8_32`
- GoReleaser currently takes ~18 min of the 20 min publish job (90%)
- large-8_32 (8 vCPU, 32GB) is already proven in e2e workflows
- Conservative estimate: ~2x speedup, reducing publish from ~20 min to ~10 min

## Test plan
- [ ] Next release pipeline run uses the large runner
- [ ] Monitor duration via `hack/ci-workflow-snapshot.py`

Closes DEVOPS-715