### PR TITLE
chore(e2e-next): Refactor snapshot/restore test

### DIFF
--- a/e2e-next/test_storage/snapshot/test_snapshot.go
+++ b/e2e-next/test_storage/snapshot/test_snapshot.go
@@ -333,47 +333,47 @@ func describeSnapshotRestore(s *snapshotCtx) {
 			createPVCWithData(ctx, s.vClusterClient, testNS, pvcToRestoreName, testFileName, pvcData)
 		})
 
-		It("Creates the snapshot", func(ctx context.Context) {
-			createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
-			waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
-		})
+		It("Creates the snapshot and verifies VolumeSnapshots are cleaned up", func(ctx context.Context) {
+			By("Creating the snapshot with volumes", func() {
+				createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
+				waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
+			})
 
-		It("Verifies VolumeSnapshots are cleaned up", func(ctx context.Context) {
-			vClusterRelease, err := helm.NewSecrets(s.hostClient).Get(ctx, s.vClusterName, s.vClusterNS)
-			Expect(err).To(Succeed())
-			vConfigValues, err := yaml.Marshal(vClusterRelease.Config)
-			Expect(err).To(Succeed())
-			vClusterConfig, err := vclusterconfig.ParseConfigBytes(vConfigValues, s.vClusterName, nil)
-			Expect(err).To(Succeed())
+			By("Verifying VolumeSnapshots are cleaned up after snapshot completes", func() {
+				vClusterRelease, err := helm.NewSecrets(s.hostClient).Get(ctx, s.vClusterName, s.vClusterNS)
+				Expect(err).To(Succeed())
+				vConfigValues, err := yaml.Marshal(vClusterRelease.Config)
+				Expect(err).To(Succeed())
+				vClusterConfig, err := vclusterconfig.ParseConfigBytes(vConfigValues, s.vClusterName, nil)
+				Expect(err).To(Succeed())
 
-			var restConfig *rest.Config
-			var vsNS string
-			if vClusterConfig.PrivateNodes.Enabled {
-				currentClusterName := cluster.CurrentClusterNameFrom(ctx)
-				restConfig = cluster.From(ctx, currentClusterName).KubernetesRestConfig()
-				vsNS = testNS
-			} else {
-				restConfig = cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig()
-				vsNS = s.vClusterNS
-			}
-			snapshotClient, err := snapshotsv1.NewForConfig(restConfig)
-			Expect(err).To(Succeed())
+				var restConfig *rest.Config
+				var vsNS string
+				if vClusterConfig.PrivateNodes.Enabled {
+					currentClusterName := cluster.CurrentClusterNameFrom(ctx)
+					restConfig = cluster.From(ctx, currentClusterName).KubernetesRestConfig()
+					vsNS = testNS
+				} else {
+					restConfig = cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig()
+					vsNS = s.vClusterNS
+				}
+				snapshotClient, err := snapshotsv1.NewForConfig(restConfig)
+				Expect(err).To(Succeed())
 
-			// After a snapshot-restore cycle, the controller should clean up all
-			// VolumeSnapshots it created. Use Eventually because cleanup is async.
-			Eventually(func(g Gomega) {
-				vs, err := snapshotClient.SnapshotV1().VolumeSnapshots(vsNS).List(ctx, metav1.ListOptions{
-					LabelSelector: "vcluster.loft.sh/persistentvolumeclaim",
-				})
-				g.Expect(err).To(Succeed())
-				g.Expect(vs.Items).To(BeEmpty(), "VolumeSnapshots still exist: %d remaining", len(vs.Items))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				Eventually(func(g Gomega) {
+					vs, err := snapshotClient.SnapshotV1().VolumeSnapshots(vsNS).List(ctx, metav1.ListOptions{
+						LabelSelector: "vcluster.loft.sh/persistentvolumeclaim",
+					})
+					g.Expect(err).To(Succeed())
+					g.Expect(vs.Items).To(BeEmpty(), "VolumeSnapshots still exist: %d remaining", len(vs.Items))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				vsc, err := snapshotClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
-				g.Expect(err).To(Succeed())
-				g.Expect(vsc.Items).To(BeEmpty(), "VolumeSnapshotContents still exist: %d remaining", len(vsc.Items))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				Eventually(func(g Gomega) {
+					vsc, err := snapshotClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
+					g.Expect(err).To(Succeed())
+					g.Expect(vsc.Items).To(BeEmpty(), "VolumeSnapshotContents still exist: %d remaining", len(vsc.Items))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			})
 		})
 
 		It("Restores vCluster with volumes and verifies PVC data", func(ctx context.Context) {
@@ -505,7 +505,7 @@ func describeSnapshotCanceling(s *snapshotCtx) {
 			// Brief pause to ensure the first snapshot request is registered before
 			// the second one arrives - tests the cancellation path where a new
 			// snapshot supersedes an in-progress one.
-			time.Sleep(time.Second)
+			time.Sleep(2 * time.Second)
 			createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
 		})
 

--- a/e2e-next/test_storage/snapshot/test_snapshot.go
+++ b/e2e-next/test_storage/snapshot/test_snapshot.go
@@ -52,9 +52,10 @@ func newSnapshotCtx(ctx context.Context) *snapshotCtx {
 	// Ensure host cluster kubernetes client is initialized. The framework's
 	// BeforeEach only initializes clients for the current (virtual) cluster,
 	// so the host cluster may be in the context without a ready client.
+	// Use SetupClients (not UseCluster) to avoid changing the current cluster.
 	if cluster.From(ctx, hostName) != nil && cluster.KubeClientFrom(ctx, hostName) == nil {
 		var err error
-		ctx, err = cluster.UseCluster(hostName)(ctx)
+		ctx, err = cluster.SetupClients(hostName)(ctx)
 		Expect(err).NotTo(HaveOccurred(), "failed to initialize host cluster client")
 	}
 	s.hostClient = cluster.KubeClientFrom(ctx, hostName)

--- a/e2e-next/test_storage/snapshot/test_snapshot.go
+++ b/e2e-next/test_storage/snapshot/test_snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -224,81 +223,75 @@ func describeSnapshotRestore(s *snapshotCtx) {
 			waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
 		})
 
-		It("Verifies only snapshot resources exist after restore", func(ctx context.Context) {
-			_, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).Create(ctx, configMapToDelete, metav1.CreateOptions{})
-			Expect(err).To(Succeed())
-			_, err = s.vClusterClient.CoreV1().Secrets(testNS).Create(ctx, secretToDelete, metav1.CreateOptions{})
-			Expect(err).To(Succeed())
-			svcCreated, err := s.vClusterClient.CoreV1().Services(testNS).Create(ctx, &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "snapshot-delete", Namespace: testNS, Labels: map[string]string{"snapshot": "delete"}},
-				Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "http", Port: 80}}, Type: corev1.ServiceTypeClusterIP},
-			}, metav1.CreateOptions{})
-			Expect(err).To(Succeed())
-			oldRV := svcCreated.ResourceVersion
+		// Single restore that verifies both:
+		// - post-snapshot resources are gone (added after snapshot, should disappear)
+		// - deleted pre-snapshot resources are recreated (deleted after snapshot, should reappear)
+		It("Mutates state and verifies restore reverts everything", func(ctx context.Context) {
+			By("Adding post-snapshot resources that should disappear after restore", func() {
+				_, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).Create(ctx, configMapToDelete, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				_, err = s.vClusterClient.CoreV1().Secrets(testNS).Create(ctx, secretToDelete, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				_, err = s.vClusterClient.CoreV1().Services(testNS).Create(ctx, &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: "snapshot-delete", Namespace: testNS, Labels: map[string]string{"snapshot": "delete"}},
+					Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "http", Port: 80}}, Type: corev1.ServiceTypeClusterIP},
+				}, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+			})
 
-			restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, true, false)
-			s.refreshClient(ctx)
+			By("Deleting pre-snapshot resources that should be recreated by restore", func() {
+				err := s.vClusterClient.CoreV1().ConfigMaps(testNS).Delete(ctx, configMapToRestore.Name, metav1.DeleteOptions{})
+				Expect(err).To(Succeed())
+				err = s.vClusterClient.CoreV1().Secrets(testNS).Delete(ctx, secretToRestore.Name, metav1.DeleteOptions{})
+				Expect(err).To(Succeed())
+			})
 
-			// Verify pre-snapshot resources exist
-			configmaps, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
-			Expect(err).To(Succeed())
-			Expect(configmaps.Items).To(HaveLen(1))
-			Expect(configmaps.Items[0].Data).To(Equal(configMapToRestore.Data))
-			newRV, _ := strconv.ParseInt(configmaps.Items[0].ResourceVersion, 10, 64)
-			oldRVi, _ := strconv.ParseInt(oldRV, 10, 64)
-			Expect(newRV).To(BeNumerically(">", oldRVi))
+			By("Restoring the vCluster from snapshot", func() {
+				restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, true, false)
+				s.refreshClient(ctx)
+			})
 
-			secrets, err := s.vClusterClient.CoreV1().Secrets(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
-			Expect(err).To(Succeed())
-			Expect(secrets.Items).To(HaveLen(1))
-			Expect(secrets.Items[0].Data).To(Equal(secretToRestore.Data))
+			By("Verifying pre-snapshot resources are restored", func() {
+				Eventually(func(g Gomega) {
+					cms, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
+					g.Expect(err).To(Succeed())
+					g.Expect(cms.Items).To(HaveLen(1),
+						"expected configmap %s to be recreated by restore", configMapToRestore.Name)
+					g.Expect(cms.Items[0].Data).To(Equal(configMapToRestore.Data))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			deps, err := s.vClusterClient.AppsV1().Deployments(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
-			Expect(err).To(Succeed())
-			Expect(deps.Items).To(HaveLen(1))
+				Eventually(func(g Gomega) {
+					secs, err := s.vClusterClient.CoreV1().Secrets(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
+					g.Expect(err).To(Succeed())
+					g.Expect(secs.Items).To(HaveLen(1),
+						"expected secret %s to be recreated by restore", secretToRestore.Name)
+					g.Expect(secs.Items[0].Data).To(Equal(secretToRestore.Data))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			// Verify post-snapshot resources are gone
-			Eventually(func(g Gomega) {
-				cms, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=delete"})
-				g.Expect(err).To(Succeed())
-				g.Expect(cms.Items).To(BeEmpty())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				deps, err := s.vClusterClient.AppsV1().Deployments(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
+				Expect(err).To(Succeed())
+				Expect(deps.Items).To(HaveLen(1), "expected deployment to survive restore")
+			})
 
-			Eventually(func(g Gomega) {
-				secs, err := s.vClusterClient.CoreV1().Secrets(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=delete"})
-				g.Expect(err).To(Succeed())
-				g.Expect(secs.Items).To(BeEmpty())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			By("Verifying post-snapshot resources are gone", func() {
+				Eventually(func(g Gomega) {
+					cms, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=delete"})
+					g.Expect(err).To(Succeed())
+					g.Expect(cms.Items).To(BeEmpty(), "post-snapshot configmap should be gone after restore")
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				svcs, err := s.vClusterClient.CoreV1().Services(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=delete"})
-				g.Expect(err).To(Succeed())
-				g.Expect(svcs.Items).To(BeEmpty())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
-		})
+				Eventually(func(g Gomega) {
+					secs, err := s.vClusterClient.CoreV1().Secrets(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=delete"})
+					g.Expect(err).To(Succeed())
+					g.Expect(secs.Items).To(BeEmpty(), "post-snapshot secret should be gone after restore")
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-		It("Verifies deleted resources are recreated after restore", func(ctx context.Context) {
-			err := s.vClusterClient.CoreV1().ConfigMaps(testNS).Delete(ctx, configMapToRestore.Name, metav1.DeleteOptions{})
-			Expect(err).To(Succeed())
-			err = s.vClusterClient.CoreV1().Secrets(testNS).Delete(ctx, secretToRestore.Name, metav1.DeleteOptions{})
-			Expect(err).To(Succeed())
-
-			restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, true, false)
-			s.refreshClient(ctx)
-
-			Eventually(func(g Gomega) {
-				cms, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
-				g.Expect(err).To(Succeed())
-				g.Expect(cms.Items).To(HaveLen(1))
-				g.Expect(cms.Items[0].Data).To(Equal(configMapToRestore.Data))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				secs, err := s.vClusterClient.CoreV1().Secrets(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=restore"})
-				g.Expect(err).To(Succeed())
-				g.Expect(secs.Items).To(HaveLen(1))
-				g.Expect(secs.Items[0].Data).To(Equal(secretToRestore.Data))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				Eventually(func(g Gomega) {
+					svcs, err := s.vClusterClient.CoreV1().Services(testNS).List(ctx, metav1.ListOptions{LabelSelector: "snapshot=delete"})
+					g.Expect(err).To(Succeed())
+					g.Expect(svcs.Items).To(BeEmpty(), "post-snapshot service should be gone after restore")
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			})
 		})
 
 		AfterAll(func(ctx context.Context) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

  Changes:
  - "without volumes" restore: merged two separate It blocks into one that does all state mutations (add post-snapshot resources + delete pre-snapshot resources) before a single restore, then verifies everything in one pass. Reduces from 2 vCluster restores to 1 (~30s saved per run).
  - "with volumes": merged "Creates the snapshot" and "Verifies VolumeSnapshot cleanup" into a single It block since cleanup verification happens immediately after snapshot creation anyway.
  - canceling: increased time.Sleep between back-to-back snapshots from 1s to 2s for more reliable cancellation testing on slower CI runners.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
