### PR TITLE
fix: set UseLocationHost=true to fix kubectl logs/exec on Istio-fronted API servers

### DIFF
--- a/pkg/server/handler/handler.go
+++ b/pkg/server/handler/handler.go
@@ -87,6 +87,7 @@ func HandlerWithErrorResponder(prefix string, cfg *rest.Config, transport http.R
 	proxy := proxy.NewUpgradeAwareHandler(target, transport, false, false, responder)
 	proxy.UpgradeTransport = upgradeTransport
 	proxy.UseRequestLocation = true
+	proxy.UseLocationHost = true // send backend hostname as Host header, not the client's vcluster LB hostname
 
 	handler := http.Handler(proxy)
 	if len(prefix) > 0 {

--- a/pkg/server/handler/handler.go
+++ b/pkg/server/handler/handler.go
@@ -87,7 +87,9 @@ func HandlerWithErrorResponder(prefix string, cfg *rest.Config, transport http.R
 	proxy := proxy.NewUpgradeAwareHandler(target, transport, false, false, responder)
 	proxy.UpgradeTransport = upgradeTransport
 	proxy.UseRequestLocation = true
-	proxy.UseLocationHost = true // send backend hostname as Host header, not the client's vcluster LB hostname
+	// gateways in front of the API server (e.g. Istio) route on the HTTP Host header, so send
+	// the backend's own hostname rather than forwarding the client's vcluster LB hostname.
+	proxy.UseLocationHost = true
 
 	handler := http.Handler(proxy)
 	if len(prefix) > 0 {

--- a/pkg/server/handler/handler_test.go
+++ b/pkg/server/handler/handler_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/client-go/rest"
+)
+
+// fakeResponder satisfies the ErrorResponder interface for tests.
+type fakeResponder struct{}
+
+func (f *fakeResponder) Error(w http.ResponseWriter, _ *http.Request, err error) {
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+// TestHandlerWithErrorResponder_UseLocationHost verifies that the backend receives the correct Host header, not the client's vcluster LB hostname.
+func TestHandlerWithErrorResponder_UseLocationHost(t *testing.T) {
+	var receivedHost string
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	cfg := &rest.Config{
+		Host:            backend.URL,
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	}
+
+	h, err := HandlerWithErrorResponder("", cfg, nil, &fakeResponder{})
+	assert.NilError(t, err)
+
+	// Simulate a client request with a vcluster LB hostname as Host —
+	// this is what the UpgradeAwareHandler used to forward before the fix.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/test/log", nil)
+	req.Host = "vcluster.example.com"
+
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	// The backend must receive its own hostname, not the client's LB address.
+	assert.Equal(t, receivedHost, backend.Listener.Addr().String(),
+		"UpgradeAwareHandler must send Host: <backend hostname> (UseLocationHost=true), not the original client Host header")
+}

--- a/pkg/server/handler/handler_test.go
+++ b/pkg/server/handler/handler_test.go
@@ -9,14 +9,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// fakeResponder satisfies the ErrorResponder interface for tests.
-type fakeResponder struct{}
-
-func (f *fakeResponder) Error(w http.ResponseWriter, _ *http.Request, err error) {
-	http.Error(w, err.Error(), http.StatusInternalServerError)
-}
-
-// TestHandlerWithErrorResponder_UseLocationHost verifies that the backend receives the correct Host header, not the client's vcluster LB hostname.
+// TestHandlerWithErrorResponder_UseLocationHost verifies that the backend receives the correct
+// Host header, not the client's vcluster LB hostname, for plain HTTP requests (kubectl logs).
 func TestHandlerWithErrorResponder_UseLocationHost(t *testing.T) {
 	var receivedHost string
 	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -30,7 +24,7 @@ func TestHandlerWithErrorResponder_UseLocationHost(t *testing.T) {
 		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
 	}
 
-	h, err := HandlerWithErrorResponder("", cfg, nil, &fakeResponder{})
+	h, err := HandlerWithErrorResponder("", cfg, nil, nil)
 	assert.NilError(t, err)
 
 	// Simulate a client request with a vcluster LB hostname as Host —
@@ -38,9 +32,56 @@ func TestHandlerWithErrorResponder_UseLocationHost(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods/test/log", nil)
 	req.Host = "vcluster.example.com"
 
-	h.ServeHTTP(httptest.NewRecorder(), req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
 
+	assert.Equal(t, rec.Code, http.StatusOK, "proxy round-trip must succeed")
 	// The backend must receive its own hostname, not the client's LB address.
 	assert.Equal(t, receivedHost, backend.Listener.Addr().String(),
 		"UpgradeAwareHandler must send Host: <backend hostname> (UseLocationHost=true), not the original client Host header")
+}
+
+// TestHandlerWithErrorResponder_UseLocationHost_Upgrade verifies that the correct Host header
+// is forwarded on SPDY upgrade requests (kubectl exec, attach, port-forward).
+// httptest.ResponseRecorder cannot be hijacked, so we drive the handler through a real
+// httptest.Server so the connection supports hijacking.
+// No auth/impersonation is configured: those layers set HTTP headers on the outbound transport,
+// not req.Host, so they do not affect whether UseLocationHost works correctly.
+func TestHandlerWithErrorResponder_UseLocationHost_Upgrade(t *testing.T) {
+	hostCh := make(chan string, 1)
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostCh <- r.Host
+		w.Header().Set("Connection", "Upgrade")
+		w.Header().Set("Upgrade", "SPDY/3.1")
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	}))
+	defer backend.Close()
+
+	cfg := &rest.Config{
+		Host:            backend.URL,
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	}
+
+	h, err := HandlerWithErrorResponder("", cfg, nil, nil)
+	assert.NilError(t, err)
+
+	// Wrap the handler in a real server so the response writer supports hijacking.
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Host = "vcluster.example.com"
+		h.ServeHTTP(w, r)
+	}))
+	defer proxy.Close()
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/api/v1/namespaces/default/pods/test/exec", nil)
+	assert.NilError(t, err)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "SPDY/3.1")
+
+	//nolint:bodyclose
+	http.DefaultClient.Do(req) //nolint:errcheck // 101 is not an error per net/http
+
+	// The backend must receive its own hostname, not the client's LB address.
+	receivedHost := <-hostCh
+	assert.Equal(t, receivedHost, backend.Listener.Addr().String(),
+		"UpgradeAwareHandler must send Host: <backend hostname> on upgrade requests (UseLocationHost=true)")
 }


### PR DESCRIPTION
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

`kubectl logs`, `kubectl exec`, `kubectl port-forward`, and `kubectl attach` fail with:

```
Error from server (NotFound): the server could not find the requested resource
```

on any vcluster whose host cluster API server is fronted by an Istio proxy (e.g. Gardener shoots).

**Root cause**

When `WithRedirect` (`pkg/server/filters/redirect.go`) proxies `pods/log|exec|portforward|attach` to the host cluster, it calls `HandlerWithErrorResponder()` which creates an `UpgradeAwareHandler`. The handler's `UseLocationHost` field defaults to `false`, so the outbound HTTP request carries the **original client's `Host` header** (the vcluster LoadBalancer hostname, e.g. `abc123.us-west-2.elb.amazonaws.com`) instead of the actual backend API server hostname.

On clusters with an Istio-fronted API server, Istio enforces virtual host routing and returns `404 Not Found` (Content-Length: 0) for any `Host` value it doesn't recognise — before the request ever reaches the kube-apiserver.

Note: `UseRequestLocation = true` (already set) only rewrites the URL path. It does **not** fix the `Host` header.

**The fix**

```go
// pkg/server/handler/handler.go — HandlerWithErrorResponder()
proxy.UseRequestLocation = true
proxy.UseLocationHost = true  // ← add this line
```

`UseLocationHost = true` tells the `UpgradeAwareHandler` to overwrite `req.Host` with `h.Location.Host` (the actual backend hostname) before forwarding. This is the correct behaviour for a transparent reverse proxy.

**Verification — wget from inside the syncer pod**

```bash
# Correct Host → 200 OK
wget --header="Host: api.vclster-hst.isbnco-poc.internal.canary.k8s.ondemand.com" \
  "https://api.vclster-hst.isbnco-poc.internal.canary.k8s.ondemand.com/api/v1/.../log"
# → HTTP/1.1 200 OK

# Wrong Host (what vcluster currently sends) → 404
wget --header="Host: abc123.us-west-2.elb.amazonaws.com" \
  "https://api.vclster-hst.isbnco-poc.internal.canary.k8s.ondemand.com/api/v1/.../log"
# → HTTP/1.1 404 Not Found, server: istio-envoy, Content-Length: 0
```

Patched image tested end-to-end on a Gardener shoot — `kubectl logs`, `kubectl exec`, and `kubectl port-forward` all work after the fix.

**Why this only surfaces on certain clusters**

| Environment | API server behind Istio? | Result with wrong Host header |
|---|---|---|
| Gardener shoot | Yes (`server: istio-envoy` in every response) | `404 Not Found` — Istio rejects unknown virtual host |
| Kyma cluster | No (Istio only for workload traffic, not API server) | Ignored — plain kube-apiserver accepts any Host |
| Kind / vanilla k8s | No | Ignored — plain kube-apiserver accepts any Host |

The bug exists in all environments but is only observable where Istio sits in front of the API server.

**Please provide a short message that should be published in the vcluster release notes**

Fixed `kubectl logs`, `kubectl exec`, `kubectl port-forward`, and `kubectl attach` returning `Error from server (NotFound)` on clusters with an Istio-fronted API server (e.g. Gardener shoots). The `UpgradeAwareHandler` was forwarding the client's original `Host` header to the backend instead of the backend's own hostname, causing Istio virtual host routing to reject the request with HTTP 404.