### PR TITLE
ci: replace inline disk cleanup with jlumbroso/free-disk-space

### DIFF
--- a/.github/workflows/e2e-ginkgo-nightly.yaml
+++ b/.github/workflows/e2e-ginkgo-nightly.yaml
@@ -34,13 +34,10 @@ jobs:
     timeout-minutes: 180
 
     steps:
-      - name: Remove default packages to free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/share/boost || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo docker image prune --all --force || true
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,14 +40,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Remove default packages
-        run: |
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/share/boost || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          sudo docker image prune --all --force || true
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- Replace inline `sudo rm -rf` + `docker image prune` blocks with `jlumbroso/free-disk-space@v1.3.1`
- Affected workflows: e2e-ginkgo-nightly, release

The action is more thorough and stays current with runner image changes.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify nightly e2e and release workflows still have enough free space