### PR TITLE
ci: fix detect-changes workflow tag from @v1 to @detect-changes/v1

### DIFF
--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -98,7 +98,7 @@ jobs:
 
   detect_changes:
     needs: [parse_label-filter]
-    uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@v1
+    uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
     with:
       paths: |
         - "go.mod"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   detect_changes:
-    uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@v1
+    uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
     with:
       paths: |
         - "go.mod"

--- a/.github/workflows/push-head-images.yaml
+++ b/.github/workflows/push-head-images.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   chart-changes:
     if: github.repository_owner == 'loft-sh' # do not run on forks
-    uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@v1
+    uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
     with:
       paths: |
         - "chart/**"


### PR DESCRIPTION
## Summary

- Fix incorrect tag reference `@v1` → `@detect-changes/v1` for the centralized detect-changes workflow
- Affects 3 workflows: e2e, e2e-ginkgo, push-head-images

## Test plan

- [ ] CI passes — detect-changes jobs resolve correctly with the namespaced tag