### PR TITLE
chore(e2e-next): Fix lifecycle tests to do not use cluster.Use

### DIFF
--- a/e2e-next/suite_lifecycle_test.go
+++ b/e2e-next/suite_lifecycle_test.go
@@ -15,6 +15,10 @@ import (
 
 func init() {
 	suiteCLIVCluster()
+	// Tenant cluster lifecycle tests create their own vclusters via CLI
+	// (no cluster.Use dependency needed).
+	lifecycle.TenantClusterLifecycleSpec()
+	lifecycle.PauseResumeScaledDownSpec()
 }
 
 // Ordered because PauseResumeSpec is destructive - it kills the vcluster pods

--- a/e2e-next/test_core/lifecycle/test_lifecycle.go
+++ b/e2e-next/test_core/lifecycle/test_lifecycle.go
@@ -16,7 +16,10 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/random"
 )
 
-var _ = Describe("Tenant cluster lifecycle - create and delete", labels.Core, labels.PR, func() {
+// TenantClusterLifecycleSpec registers tenant cluster create/list/delete tests.
+// These tests create their own vclusters via the CLI (not framework-provisioned).
+func TenantClusterLifecycleSpec() {
+	Describe("Tenant cluster lifecycle - create and delete", labels.Core, labels.PR, func() {
 	Context("create, list and delete tenant cluster", Ordered, func() {
 		// Ordered because each spec operates on the tenant cluster
 		// created by the first spec, and the last spec deletes it.
@@ -145,4 +148,5 @@ var _ = Describe("Tenant cluster lifecycle - create and delete", labels.Core, la
 			})
 		})
 	})
-})
+	})
+}

--- a/e2e-next/test_core/lifecycle/test_lifecycle.go
+++ b/e2e-next/test_core/lifecycle/test_lifecycle.go
@@ -20,133 +20,133 @@ import (
 // These tests create their own vclusters via the CLI (not framework-provisioned).
 func TenantClusterLifecycleSpec() {
 	Describe("Tenant cluster lifecycle - create and delete", labels.Core, labels.PR, func() {
-	Context("create, list and delete tenant cluster", Ordered, func() {
-		// Ordered because each spec operates on the tenant cluster
-		// created by the first spec, and the last spec deletes it.
-		var (
-			suffix      string
-			clusterName string
-			namespace   string
-			hostClient  kubernetes.Interface
-		)
+		Context("create, list and delete tenant cluster", Ordered, func() {
+			// Ordered because each spec operates on the tenant cluster
+			// created by the first spec, and the last spec deletes it.
+			var (
+				suffix      string
+				clusterName string
+				namespace   string
+				hostClient  kubernetes.Interface
+			)
 
-		BeforeAll(func(ctx context.Context) {
-			suffix = random.String(6)
-			clusterName = "e2e-cld-" + suffix
-			namespace = clusterName
-			hostClient = hostKubeClient()
-		})
+			BeforeAll(func(ctx context.Context) {
+				suffix = random.String(6)
+				clusterName = "e2e-cld-" + suffix
+				namespace = clusterName
+				hostClient = hostKubeClient()
+			})
 
-		AfterAll(func(ctx context.Context) {
-			_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace", "--ignore-not-found")
-			Expect(err).To(Succeed())
-		})
-
-		It("should create a tenant cluster", func(ctx context.Context) {
-			By("Creating a tenant cluster", func() {
-				_, err := runVClusterCmd(ctx, createArgs(clusterName, namespace)...)
+			AfterAll(func(ctx context.Context) {
+				_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace", "--ignore-not-found")
 				Expect(err).To(Succeed())
 			})
 
-			By("Waiting for tenant cluster to be ready", func() {
-				waitForVClusterReady(ctx, hostClient, clusterName, namespace)
-			})
-		})
+			It("should create a tenant cluster", func(ctx context.Context) {
+				By("Creating a tenant cluster", func() {
+					_, err := runVClusterCmd(ctx, createArgs(clusterName, namespace)...)
+					Expect(err).To(Succeed())
+				})
 
-		It("should list the tenant cluster as Running", func(ctx context.Context) {
-			Eventually(func(g Gomega, ctx context.Context) {
-				entries, err := listVClusters(ctx, namespace)
-				g.Expect(err).To(Succeed())
-				found := findByName(entries, clusterName)
-				g.Expect(found).NotTo(BeNil(), "tenant cluster %s not found in list", clusterName)
-				g.Expect(found.Status).To(Equal(string(find.StatusRunning)),
-					"tenant cluster %s has status %s, expected %s", clusterName, found.Status, find.StatusRunning)
-			}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
-		})
-
-		It("should delete a running tenant cluster", func(ctx context.Context) {
-			By("Deleting the running tenant cluster", func() {
-				_, err := runVClusterCmd(ctx, "delete", clusterName,
-					"-n", namespace, "--delete-namespace")
-				Expect(err).To(Succeed())
+				By("Waiting for tenant cluster to be ready", func() {
+					waitForVClusterReady(ctx, hostClient, clusterName, namespace)
+				})
 			})
 
-			By("Verifying namespace is gone", func() {
-				Eventually(func(g Gomega, ctx context.Context) {
-					_, err := hostClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
-						"namespace %s should be deleted", namespace)
-				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
-			})
-		})
-	})
-
-	Context("list and delete a scaled-down tenant cluster", Ordered, func() {
-		// Ordered because each spec operates on the tenant cluster
-		// created by the first spec. The second spec scales it down,
-		// and subsequent specs depend on it being scaled down.
-		var (
-			suffix      string
-			clusterName string
-			namespace   string
-			hostClient  kubernetes.Interface
-		)
-
-		BeforeAll(func(ctx context.Context) {
-			suffix = random.String(6)
-			clusterName = "e2e-csld-" + suffix
-			namespace = clusterName
-			hostClient = hostKubeClient()
-		})
-
-		AfterAll(func(ctx context.Context) {
-			_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace", "--ignore-not-found")
-			Expect(err).To(Succeed())
-		})
-
-		It("should create a tenant cluster", func(ctx context.Context) {
-			By("Creating a tenant cluster", func() {
-				_, err := runVClusterCmd(ctx, createArgs(clusterName, namespace)...)
-				Expect(err).To(Succeed())
-			})
-
-			By("Waiting for tenant cluster to be ready", func() {
-				waitForVClusterReady(ctx, hostClient, clusterName, namespace)
-			})
-		})
-
-		It("should list the tenant cluster as ScaledDown after scaling down", func(ctx context.Context) {
-			By("Scaling down the tenant cluster StatefulSet to 0 replicas", func() {
-				scaleDownVCluster(ctx, hostClient, clusterName, namespace)
-			})
-
-			By("Verifying it appears in list with ScaledDown status", func() {
+			It("should list the tenant cluster as Running", func(ctx context.Context) {
 				Eventually(func(g Gomega, ctx context.Context) {
 					entries, err := listVClusters(ctx, namespace)
 					g.Expect(err).To(Succeed())
 					found := findByName(entries, clusterName)
 					g.Expect(found).NotTo(BeNil(), "tenant cluster %s not found in list", clusterName)
-					g.Expect(found.Status).To(Equal(string(find.StatusScaledDown)),
-						"tenant cluster %s has status %s, expected %s", clusterName, found.Status, find.StatusScaledDown)
-				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+					g.Expect(found.Status).To(Equal(string(find.StatusRunning)),
+						"tenant cluster %s has status %s, expected %s", clusterName, found.Status, find.StatusRunning)
+				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			})
+
+			It("should delete a running tenant cluster", func(ctx context.Context) {
+				By("Deleting the running tenant cluster", func() {
+					_, err := runVClusterCmd(ctx, "delete", clusterName,
+						"-n", namespace, "--delete-namespace")
+					Expect(err).To(Succeed())
+				})
+
+				By("Verifying namespace is gone", func() {
+					Eventually(func(g Gomega, ctx context.Context) {
+						_, err := hostClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"namespace %s should be deleted", namespace)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
 			})
 		})
 
-		It("should delete a scaled-down tenant cluster", func(ctx context.Context) {
-			By("Deleting the scaled-down tenant cluster", func() {
-				_, err := runVClusterCmd(ctx, "delete", clusterName,
-					"-n", namespace, "--delete-namespace")
+		Context("list and delete a scaled-down tenant cluster", Ordered, func() {
+			// Ordered because each spec operates on the tenant cluster
+			// created by the first spec. The second spec scales it down,
+			// and subsequent specs depend on it being scaled down.
+			var (
+				suffix      string
+				clusterName string
+				namespace   string
+				hostClient  kubernetes.Interface
+			)
+
+			BeforeAll(func(ctx context.Context) {
+				suffix = random.String(6)
+				clusterName = "e2e-csld-" + suffix
+				namespace = clusterName
+				hostClient = hostKubeClient()
+			})
+
+			AfterAll(func(ctx context.Context) {
+				_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace", "--ignore-not-found")
 				Expect(err).To(Succeed())
 			})
 
-			By("Verifying namespace is gone", func() {
-				Eventually(func(g Gomega, ctx context.Context) {
-					_, err := hostClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
-						"namespace %s should be deleted", namespace)
-				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			It("should create a tenant cluster", func(ctx context.Context) {
+				By("Creating a tenant cluster", func() {
+					_, err := runVClusterCmd(ctx, createArgs(clusterName, namespace)...)
+					Expect(err).To(Succeed())
+				})
+
+				By("Waiting for tenant cluster to be ready", func() {
+					waitForVClusterReady(ctx, hostClient, clusterName, namespace)
+				})
+			})
+
+			It("should list the tenant cluster as ScaledDown after scaling down", func(ctx context.Context) {
+				By("Scaling down the tenant cluster StatefulSet to 0 replicas", func() {
+					scaleDownVCluster(ctx, hostClient, clusterName, namespace)
+				})
+
+				By("Verifying it appears in list with ScaledDown status", func() {
+					Eventually(func(g Gomega, ctx context.Context) {
+						entries, err := listVClusters(ctx, namespace)
+						g.Expect(err).To(Succeed())
+						found := findByName(entries, clusterName)
+						g.Expect(found).NotTo(BeNil(), "tenant cluster %s not found in list", clusterName)
+						g.Expect(found.Status).To(Equal(string(find.StatusScaledDown)),
+							"tenant cluster %s has status %s, expected %s", clusterName, found.Status, find.StatusScaledDown)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
+			})
+
+			It("should delete a scaled-down tenant cluster", func(ctx context.Context) {
+				By("Deleting the scaled-down tenant cluster", func() {
+					_, err := runVClusterCmd(ctx, "delete", clusterName,
+						"-n", namespace, "--delete-namespace")
+					Expect(err).To(Succeed())
+				})
+
+				By("Verifying namespace is gone", func() {
+					Eventually(func(g Gomega, ctx context.Context) {
+						_, err := hostClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"namespace %s should be deleted", namespace)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
 			})
 		})
-	})
 	})
 }

--- a/e2e-next/test_core/lifecycle/test_pause_resume.go
+++ b/e2e-next/test_core/lifecycle/test_pause_resume.go
@@ -120,7 +120,10 @@ func PauseResumeSpec() {
 	)
 }
 
-var _ = Describe("pause and resume a scaled-down tenant cluster", labels.Core, labels.PR, Ordered, func() {
+// PauseResumeScaledDownSpec registers pause/resume tests for a scaled-down tenant cluster.
+// These tests create their own vcluster via the CLI (not framework-provisioned).
+func PauseResumeScaledDownSpec() {
+	Describe("pause and resume a scaled-down tenant cluster", labels.Core, labels.PR, Ordered, func() {
 	// Ordered because each spec depends on the state from the prior spec:
 	// create → scale down → pause → resume.
 	var (
@@ -189,4 +192,5 @@ var _ = Describe("pause and resume a scaled-down tenant cluster", labels.Core, l
 			}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 		})
 	})
-})
+	})
+}

--- a/e2e-next/test_core/lifecycle/test_pause_resume.go
+++ b/e2e-next/test_core/lifecycle/test_pause_resume.go
@@ -124,73 +124,73 @@ func PauseResumeSpec() {
 // These tests create their own vcluster via the CLI (not framework-provisioned).
 func PauseResumeScaledDownSpec() {
 	Describe("pause and resume a scaled-down tenant cluster", labels.Core, labels.PR, Ordered, func() {
-	// Ordered because each spec depends on the state from the prior spec:
-	// create → scale down → pause → resume.
-	var (
-		suffix      string
-		clusterName string
-		namespace   string
-		hostClient  kubernetes.Interface
-	)
+		// Ordered because each spec depends on the state from the prior spec:
+		// create → scale down → pause → resume.
+		var (
+			suffix      string
+			clusterName string
+			namespace   string
+			hostClient  kubernetes.Interface
+		)
 
-	BeforeAll(func(ctx context.Context) {
-		suffix = random.String(6)
-		clusterName = "e2e-pause-resume-sd-" + suffix
-		namespace = clusterName
-		hostClient = hostKubeClient()
-		createAndWaitForReady(ctx, hostClient, clusterName, namespace)
-		scaleDownVCluster(ctx, hostClient, clusterName, namespace)
-	})
+		BeforeAll(func(ctx context.Context) {
+			suffix = random.String(6)
+			clusterName = "e2e-pause-resume-sd-" + suffix
+			namespace = clusterName
+			hostClient = hostKubeClient()
+			createAndWaitForReady(ctx, hostClient, clusterName, namespace)
+			scaleDownVCluster(ctx, hostClient, clusterName, namespace)
+		})
 
-	AfterAll(func(ctx context.Context) {
-		_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace")
-		Expect(err).To(Succeed())
-	})
-
-	It("should pause a scaled-down tenant cluster", func(ctx context.Context) {
-		By("Pausing the scaled-down tenant cluster", func() {
-			_, err := runVClusterCmd(ctx, "pause", clusterName, "-n", namespace)
+		AfterAll(func(ctx context.Context) {
+			_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace")
 			Expect(err).To(Succeed())
 		})
 
-		By("Verifying paused annotations are set on the StatefulSet", func() {
-			sts, err := hostClient.AppsV1().StatefulSets(namespace).Get(ctx, clusterName, metav1.GetOptions{})
-			Expect(err).To(Succeed())
-			Expect(sts.Annotations).To(HaveKeyWithValue("loft.sh/paused", "true"),
-				"StatefulSet %s/%s should have loft.sh/paused=true annotation", namespace, clusterName)
-			Expect(sts.Annotations).To(HaveKeyWithValue("loft.sh/paused-replicas", "1"),
-				"StatefulSet %s/%s should have loft.sh/paused-replicas=1 annotation", namespace, clusterName)
-		})
-	})
+		It("should pause a scaled-down tenant cluster", func(ctx context.Context) {
+			By("Pausing the scaled-down tenant cluster", func() {
+				_, err := runVClusterCmd(ctx, "pause", clusterName, "-n", namespace)
+				Expect(err).To(Succeed())
+			})
 
-	It("should resume the tenant cluster after pause", func(ctx context.Context) {
-		By("Resuming the tenant cluster", func() {
-			_, err := runVClusterCmd(ctx, "resume", clusterName, "-n", namespace)
-			Expect(err).To(Succeed())
-		})
-
-		By("Waiting for tenant cluster to be ready", func() {
-			waitForVClusterReady(ctx, hostClient, clusterName, namespace)
+			By("Verifying paused annotations are set on the StatefulSet", func() {
+				sts, err := hostClient.AppsV1().StatefulSets(namespace).Get(ctx, clusterName, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(sts.Annotations).To(HaveKeyWithValue("loft.sh/paused", "true"),
+					"StatefulSet %s/%s should have loft.sh/paused=true annotation", namespace, clusterName)
+				Expect(sts.Annotations).To(HaveKeyWithValue("loft.sh/paused-replicas", "1"),
+					"StatefulSet %s/%s should have loft.sh/paused-replicas=1 annotation", namespace, clusterName)
+			})
 		})
 
-		By("Verifying StatefulSet has correct replica count", func() {
-			sts, err := hostClient.AppsV1().StatefulSets(namespace).Get(ctx, clusterName, metav1.GetOptions{})
-			Expect(err).To(Succeed())
-			Expect(sts.Spec.Replicas).NotTo(BeNil())
-			Expect(*sts.Spec.Replicas).To(Equal(int32(1)),
-				"StatefulSet %s/%s should have 1 replica, got %d", namespace, clusterName, *sts.Spec.Replicas)
-		})
+		It("should resume the tenant cluster after pause", func(ctx context.Context) {
+			By("Resuming the tenant cluster", func() {
+				_, err := runVClusterCmd(ctx, "resume", clusterName, "-n", namespace)
+				Expect(err).To(Succeed())
+			})
 
-		By("Verifying list shows Running status", func() {
-			Eventually(func(g Gomega, ctx context.Context) {
-				entries, err := listVClusters(ctx, namespace)
-				g.Expect(err).To(Succeed())
-				found := findByName(entries, clusterName)
-				g.Expect(found).NotTo(BeNil(), "tenant cluster %s not found in list", clusterName)
-				g.Expect(found.Status).To(Equal(string(find.StatusRunning)),
-					"tenant cluster %s has status %s, expected %s", clusterName, found.Status, find.StatusRunning)
-			}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			By("Waiting for tenant cluster to be ready", func() {
+				waitForVClusterReady(ctx, hostClient, clusterName, namespace)
+			})
+
+			By("Verifying StatefulSet has correct replica count", func() {
+				sts, err := hostClient.AppsV1().StatefulSets(namespace).Get(ctx, clusterName, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(sts.Spec.Replicas).NotTo(BeNil())
+				Expect(*sts.Spec.Replicas).To(Equal(int32(1)),
+					"StatefulSet %s/%s should have 1 replica, got %d", namespace, clusterName, *sts.Spec.Replicas)
+			})
+
+			By("Verifying list shows Running status", func() {
+				Eventually(func(g Gomega, ctx context.Context) {
+					entries, err := listVClusters(ctx, namespace)
+					g.Expect(err).To(Succeed())
+					found := findByName(entries, clusterName)
+					g.Expect(found).NotTo(BeNil(), "tenant cluster %s not found in list", clusterName)
+					g.Expect(found.Status).To(Equal(string(find.StatusRunning)),
+						"tenant cluster %s has status %s, expected %s", clusterName, found.Status, find.StatusRunning)
+				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			})
 		})
-	})
 	})
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
