### PR TITLE
ci: add auto-approve workflow for bot prs

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -10,8 +10,7 @@ permissions:
 
 jobs:
   auto-approve:
-    if: startsWith(github.head_ref, 'backport/')
-    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@main
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@auto-approve-bot-prs/v1 # 9d33031
     with:
       trusted-authors: 'loft-bot'
       auto-merge: false

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -1,0 +1,14 @@
+name: Auto-approve bot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-approve:
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@main
+    with:
+      trusted-authors: 'loft-bot'
+      auto-merge: false
+    secrets:
+      gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   auto-approve:
+    if: startsWith(github.head_ref, 'backport/')
     uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@main
     with:
       trusted-authors: 'loft-bot'

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-approve:
     if: startsWith(github.head_ref, 'backport/')


### PR DESCRIPTION
## Summary

- Adds thin caller workflow for the shared `auto-approve-bot-prs` reusable workflow from `loft-sh/github-actions`
- Scoped to `loft-bot` only (backport PR author), with auto-merge disabled
- Matches the pattern already deployed to hosted-platform, loft-prod, and vcluster-docs

## Why

Backport PRs created by `loft-bot` trigger auto-requested CODEOWNERS reviews that clutter team dashboards. The code was already reviewed on main — these reviews add noise without value.

## Test plan

- [ ] Verify workflow appears in Actions tab after merge
- [ ] Create a test backport PR authored by `loft-bot` and confirm auto-approve fires
- [ ] Confirm non-bot PRs are unaffected (workflow skips ineligible authors)

References DEVOPS-714