### PR TITLE
ci(codeowners): remove devops-team ownership from workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,8 @@
 
 * @loft-sh/eng-dev-vcluster-platform
 
-/.github/workflows/ @loft-sh/devops-team
-/.github/workflows/backport.yaml @loft-sh/devops-team
 /.github/workflows/e2e*.yaml @loft-sh/eng-qa @loft-sh/eng-tech-leads
-/.github/workflows/release.yaml @loft-sh/devops-team @loft-sh/eng-tech-leads
+/.github/workflows/release.yaml @loft-sh/eng-tech-leads
 /.github/CODEOWNERS @loft-sh/eng-tech-leads
 
 /chart/templates/ @loft-sh/eng-tech-leads


### PR DESCRIPTION
## Summary
- Remove `@loft-sh/devops-team` from `.github/CODEOWNERS` workflow entries
- Remove catch-all `/.github/workflows/` and `backport.yaml` ownership lines
- Remove `@loft-sh/devops-team` from `release.yaml` line (keep `@loft-sh/eng-tech-leads`)

Follows the same pattern as loft-enterprise PR #6418 (commit 35ba2bc4f).

Closes DEVOPS-757 (partial — vcluster repo)