### PR TITLE
chore(e2e-next): readme update

### DIFF
--- a/e2e-next/README.md
+++ b/e2e-next/README.md
@@ -130,6 +130,19 @@ Each suite file maps to one vCluster. One file, one vCluster, one function.
 | `networkpolicies` | NetworkPolicy sync (requires Calico CNI) |
 | `non-default` | Tests requiring special infra (e.g. Calico CNI) - excluded by default |
 
+## Timeout Constants
+
+Use these instead of hardcoded durations. Defined in `constants/timeouts.go`.
+
+| Constant | Duration | Use for |
+|----------|----------|---------|
+| `PollingInterval` | 2s | Polling interval for all `Eventually`/`Consistently` |
+| `PollingTimeoutVeryShort` | 5s | Immediate state checks (resource already exists) |
+| `PollingTimeoutShort` | 20s | Quick API operations (get, list, delete) |
+| `PollingTimeout` | 60s | Standard operations (pod ready, secret created) |
+| `PollingTimeoutLong` | 120s | Resource creation (namespace, VCI becoming Ready) |
+| `PollingTimeoutVeryLong` | 300s | vCluster startup, cluster creation |
+
 ## Running Tests
 
 ### Prerequisites
@@ -263,7 +276,7 @@ from `.custom-gcl.yml`). These run in CI and locally via `just lint ./e2e-next/.
 
 | Linter | What it checks |
 |--------|---------------|
-| `describefunc` | Spec functions in `test_*` packages must not call `Describe()` with `cluster.Use()`. Cluster binding belongs in suite files, not in specs. |
+| `describefunc` | Spec functions in `test_*` packages must not call `Describe()` with `cluster.Use()`. Cluster binding belongs in suite files, not in specs. This is critical because spec functions are imported by vcluster-pro via Go vendoring - if they contain `cluster.Use`, they hardcode OSS cluster references that conflict with Pro's own cluster definitions (different image, platform, `pro: true`). |
 | `defercleanupcluster` | `cluster.Create()` calls must have a matching `DeferCleanup(cluster.Destroy(...))`. |
 | `defercleanupctx` | `DeferCleanup` must not be called with a `setup.Func`; use `e2e.DeferCleanupCtx(ctx, fn)` instead. |
 | `ginkgoreturnctx` | Ginkgo node functions that reassign `context.Context` must return it. |


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
