### PR TITLE
fix(ci): read permissions for notify-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -233,7 +233,8 @@ jobs:
       - publish
       - publish-chart
       - sync_linear
-    permissions: {}
+    permissions:
+      contents: read
     uses: loft-sh/github-actions/.github/workflows/notify-release.yaml@55d5b751b3c096231e7fc1e291c152a3d2449b9c # release-notification/v2
     with:
       release_version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Fixes an issue when release workflow can not be triggered

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-11858