### PR TITLE
Refactor config load for standalone snapshots

### DIFF
--- a/cmd/vcluster/cmd/snapshot/create.go
+++ b/cmd/vcluster/cmd/snapshot/create.go
@@ -19,7 +19,7 @@ func NewCreateCmd() *cobra.Command {
 		Short: "create vCluster snapshots",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			vConfig, err := config.LoadAutoDetectedRuntimeConfig(os.Getenv("VCLUSTER_NAME"))
+			vConfig, err := config.LoadConfig(os.Getenv("VCLUSTER_NAME"))
 			if err != nil {
 				return err
 			}

--- a/cmd/vcluster/cmd/snapshot/delete.go
+++ b/cmd/vcluster/cmd/snapshot/delete.go
@@ -17,7 +17,7 @@ func NewDeleteCmd() *cobra.Command {
 		Short: "delete vCluster snapshot",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			vConfig, err := config.LoadAutoDetectedRuntimeConfig(os.Getenv("VCLUSTER_NAME"))
+			vConfig, err := config.LoadConfig(os.Getenv("VCLUSTER_NAME"))
 			if err != nil {
 				return err
 			}

--- a/cmd/vcluster/cmd/snapshot/restore.go
+++ b/cmd/vcluster/cmd/snapshot/restore.go
@@ -20,7 +20,7 @@ func NewRestoreCommand() *cobra.Command {
 		Short: "Restore a vCluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			vConfig, err := config.LoadAutoDetectedRuntimeConfig(os.Getenv("VCLUSTER_NAME"))
+			vConfig, err := config.LoadConfig(os.Getenv("VCLUSTER_NAME"))
 			if err != nil {
 				return err
 			}

--- a/cmd/vcluster/cmd/snapshot/snapshot.go
+++ b/cmd/vcluster/cmd/snapshot/snapshot.go
@@ -15,7 +15,7 @@ func NewSnapshotCommand() *cobra.Command {
 		Short: "Manage vCluster snapshots",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			vConfig, err := config.LoadAutoDetectedRuntimeConfig(os.Getenv("VCLUSTER_NAME"))
+			vConfig, err := config.LoadConfig(os.Getenv("VCLUSTER_NAME"))
 			if err != nil {
 				return err
 			}

--- a/cmd/vcluster/cmd/start.go
+++ b/cmd/vcluster/cmd/start.go
@@ -67,7 +67,7 @@ func ExecuteStart(ctx context.Context, options *StartOptions) error {
 func StartInCluster(ctx context.Context, options *StartOptions) error {
 	vClusterName := os.Getenv("VCLUSTER_NAME")
 	// load vCluster config
-	vConfig, err := config.LoadInClusterRuntimeConfig(vClusterName, options.Config, options.SetValues)
+	vConfig, err := config.LoadInClusterConfig(vClusterName, options.Config, options.SetValues)
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/restore.go
+++ b/cmd/vclusterctl/cmd/restore.go
@@ -24,6 +24,7 @@ type RestoreCmd struct {
 	Driver         string
 	Name           string
 	RestoreVolumes bool
+	Standalone     bool
 
 	Log log.Logger
 }
@@ -57,7 +58,15 @@ vcluster restore my-vcluster ./my-snapshot.tar.gz --driver docker
 vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 #######################################################
 	`,
-		Args:              nameValidator,
+		Args: func(cobraCmd *cobra.Command, args []string) error {
+			if cmd.Standalone {
+				if len(args) != 1 {
+					return fmt.Errorf("%s\nInvalid Args: received %d arguments, expected 1, please specify: %q\nRun with --help for more details on arguments", cobraCmd.UseLine(), len(args), "SNAPSHOT_URL")
+				}
+				return nil
+			}
+			return nameValidator(cobraCmd, args)
+		},
 		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			cfg := cmd.LoadedConfig(cmd.Log)
@@ -65,13 +74,16 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 			if err != nil {
 				return fmt.Errorf("parse driver type: %w", err)
 			}
+			if cmd.Standalone && driverType == config.DockerDriver {
+				return fmt.Errorf("--standalone cannot be used with --driver docker")
+			}
 			if driverType == config.DockerDriver {
 				if len(args) < 2 {
 					return fmt.Errorf("usage: vcluster restore VCLUSTER_NAME SNAPSHOT_FILE --driver docker")
 				}
 				return cli.RestoreDocker(cobraCmd.Context(), cmd.GlobalFlags, args[1], args[0], nil, cmd.Log)
 			}
-			return cli.Restore(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, &cmd.Pod, false, cmd.RestoreVolumes, cmd.Log)
+			return cli.Restore(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, &cmd.Pod, false, cmd.RestoreVolumes, cmd.Standalone, cmd.Log)
 		},
 	}
 
@@ -79,6 +91,7 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 	// add storage flags
 	pod.AddFlags(cobraCmd.Flags(), &cmd.Pod, true)
 	cobraCmd.Flags().BoolVar(&cmd.RestoreVolumes, "restore-volumes", false, "Restore volumes from volume snapshots")
+	cobraCmd.Flags().BoolVar(&cmd.Standalone, "standalone", false, "Target the local standalone vCluster on this host")
 	snapshotazure.AddFlags(cobraCmd.Flags(), &cmd.Snapshot.Azure)
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/snapshot/create.go
+++ b/cmd/vclusterctl/cmd/snapshot/create.go
@@ -20,6 +20,7 @@ type CreateCmd struct {
 	Snapshot       snapshot.Options
 	Driver         string
 	IncludeVolumes bool
+	Standalone     bool
 	Log            log.Logger
 }
 
@@ -29,7 +30,6 @@ func NewCreateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Log:         log.GetInstance(),
 	}
 
-	_, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Snapshot a virtual cluster",
@@ -53,13 +53,25 @@ vcluster snapshot create my-vcluster ./my-snapshot.tar.gz --driver docker
 vcluster snapshot create my-vcluster --driver docker
 ##############################################################
 	`,
-		Args:              nameValidator,
+		Args: func(cobraCmd *cobra.Command, args []string) error {
+			if cmd.Standalone {
+				if len(args) != 1 {
+					return fmt.Errorf("%s\nInvalid Args: received %d arguments, expected 1, please specify: %q\nRun with --help for more details on arguments", cobraCmd.UseLine(), len(args), "SNAPSHOT_URL")
+				}
+				return nil
+			}
+			_, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+			return nameValidator(cobraCmd, args)
+		},
 		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			cfg := cmd.LoadedConfig(cmd.Log)
 			driverType, err := config.ParseDriverType(cmp.Or(cmd.Driver, string(cfg.Driver.Type)))
 			if err != nil {
 				return fmt.Errorf("parse driver type: %w", err)
+			}
+			if cmd.Standalone && driverType == config.DockerDriver {
+				return fmt.Errorf("--standalone cannot be used with --driver docker")
 			}
 			if driverType == config.DockerDriver {
 				vClusterName := args[0]
@@ -71,11 +83,12 @@ vcluster snapshot create my-vcluster --driver docker
 				}
 				return cli.SnapshotDocker(cobraCmd.Context(), cmd.GlobalFlags, vClusterName, outputPath, cmd.Log)
 			}
-			return cli.CreateSnapshot(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, nil, cmd.Log, true)
+			return cli.CreateSnapshot(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, nil, cmd.Log, true, cmd.Standalone)
 		},
 	}
 
 	createCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm, platform, or docker.")
+	createCmd.Flags().BoolVar(&cmd.Standalone, "standalone", false, "Target the local standalone vCluster on this host")
 	// add storage flags
 	snapshot.AddFlags(createCmd.Flags(), &cmd.Snapshot)
 	return createCmd

--- a/cmd/vclusterctl/cmd/snapshot/get.go
+++ b/cmd/vclusterctl/cmd/snapshot/get.go
@@ -1,6 +1,8 @@
 package snapshot
 
 import (
+	"fmt"
+
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
@@ -12,8 +14,9 @@ import (
 
 type GetCmd struct {
 	*flags.GlobalFlags
-	Snapshot snapshot.Options
-	Log      log.Logger
+	Snapshot   snapshot.Options
+	Standalone bool
+	Log        log.Logger
 }
 
 func NewGetCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
@@ -22,7 +25,6 @@ func NewGetCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Log:         log.GetInstance(),
 	}
 
-	_, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
 	getCmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get virtual cluster snapshot",
@@ -40,14 +42,24 @@ vcluster snapshot get my-vcluster s3://my-bucket/my-bucket-key
 vcluster snapshot get my-vcluster container:///data/my-local-snapshot.tar.gz
 ##############################################################
 	`,
-		Args:              nameValidator,
+		Args: func(cobraCmd *cobra.Command, args []string) error {
+			if cmd.Standalone {
+				if len(args) != 1 {
+					return fmt.Errorf("%s\nInvalid Args: received %d arguments, expected 1, please specify: %q\nRun with --help for more details on arguments", cobraCmd.UseLine(), len(args), "SNAPSHOT_URL")
+				}
+				return nil
+			}
+			_, nameValidator := util.NamedPositionalArgsValidator(true, false, "VCLUSTER_NAME")
+			return nameValidator(cobraCmd, args)
+		},
 		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cli.GetSnapshots(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, cmd.Log)
+			return cli.GetSnapshots(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, cmd.Log, cmd.Standalone)
 		},
 	}
 
 	// add storage flags
+	getCmd.Flags().BoolVar(&cmd.Standalone, "standalone", false, "Target the local standalone vCluster on this host")
 	snapshot.AddFlags(getCmd.Flags(), &cmd.Snapshot)
 	return getCmd
 }

--- a/cmd/vclusterctl/cmd/snapshot/root.go
+++ b/cmd/vclusterctl/cmd/snapshot/root.go
@@ -1,6 +1,8 @@
 package snapshot
 
 import (
+	"fmt"
+
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
@@ -14,8 +16,9 @@ import (
 type RootCmd struct {
 	*flags.GlobalFlags
 
-	Snapshot snapshot.Options
-	Pod      pod.Options
+	Snapshot   snapshot.Options
+	Pod        pod.Options
+	Standalone bool
 
 	Log log.Logger
 }
@@ -45,15 +48,24 @@ vcluster snapshot my-vcluster s3://my-bucket/my-bucket-key
 vcluster snapshot my-vcluster container:///data/my-local-snapshot.tar.gz
 #######################################################
 	`,
-		Args:              nameValidator,
+		Args: func(cobraCmd *cobra.Command, args []string) error {
+			if rootCmd.Standalone {
+				if len(args) != 1 {
+					return fmt.Errorf("%s\nInvalid Args: received %d arguments, expected 1, please specify: %q\nRun with --help for more details on arguments", cobraCmd.UseLine(), len(args), "SNAPSHOT_URL")
+				}
+				return nil
+			}
+			return nameValidator(cobraCmd, args)
+		},
 		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cli.CreateSnapshot(cobraCmd.Context(), args, rootCmd.GlobalFlags, &rootCmd.Snapshot, &rootCmd.Pod, rootCmd.Log, false)
+			return cli.CreateSnapshot(cobraCmd.Context(), args, rootCmd.GlobalFlags, &rootCmd.Snapshot, &rootCmd.Pod, rootCmd.Log, false, rootCmd.Standalone)
 		},
 	}
 
 	// add storage flags
 	pod.AddFlags(cobraCmd.Flags(), &rootCmd.Pod, false)
+	cobraCmd.Flags().BoolVar(&rootCmd.Standalone, "standalone", false, "Target the local standalone vCluster on this host")
 	snapshot.AddFlags(cobraCmd.Flags(), &rootCmd.Snapshot)
 
 	// add subcommands

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -181,7 +181,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 				}
 
 				log.Infof("Restore vCluster %s...", vClusterName)
-				err = Restore(ctx, []string{vClusterName, cmd.Restore}, globalFlags, &snapshot.Options{}, &pod.Options{}, false, false, log)
+				err = Restore(ctx, []string{vClusterName, cmd.Restore}, globalFlags, &snapshot.Options{}, &pod.Options{}, false, false, false, log)
 				if err != nil {
 					return fmt.Errorf("restore vCluster %s: %w", vClusterName, err)
 				}
@@ -648,7 +648,7 @@ func (cmd *createHelm) deployChart(ctx context.Context, vClusterName, chartValue
 	// now restore if wanted
 	if cmd.Restore != "" {
 		cmd.log.Infof("Restore vCluster %s...", vClusterName)
-		err = Restore(ctx, []string{vClusterName, cmd.Restore}, cmd.GlobalFlags, &snapshot.Options{}, &pod.Options{}, true, false, cmd.log)
+		err = Restore(ctx, []string{vClusterName, cmd.Restore}, cmd.GlobalFlags, &snapshot.Options{}, &pod.Options{}, true, false, false, cmd.log)
 		if err != nil {
 			// delete the vcluster if the restore failed
 			deleteErr := helmClient.Delete(vClusterName, cmd.Namespace)

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -135,35 +135,6 @@ func GetPlatformVCluster(ctx context.Context, platformClient platform.Client, na
 	return nil, fmt.Errorf("unexpected error searching for selected virtual cluster")
 }
 
-// GetVClusterStandaloneOrVCluster supports both regular host-cluster lookup and
-// local standalone lookup. The CLI selector "local-standalone" explicitly targets
-// the standalone service on this host and makes standalone probe errors fatal.
-// For real runtime names, standalone lookup is only an opportunistic shortcut:
-// if the local standalone runtime name matches the requested name, use it;
-// otherwise fall back to regular host-cluster discovery so in-cluster vClusters
-// with arbitrary names keep working.
-func GetVClusterStandaloneOrVCluster(ctx context.Context, context, name, namespace string, log log.Logger) (*VCluster, error) {
-	if name == constants.VClusterStandaloneCLISelector {
-		vClusterStandalone, err := getVClusterStandalone()
-		if err != nil {
-			return nil, err
-		}
-		if vClusterStandalone == nil {
-			return nil, fmt.Errorf("local standalone vCluster not found on this host")
-		}
-		return vClusterStandalone, nil
-	}
-
-	vClusterStandalone, err := getVClusterStandalone()
-	if err != nil {
-		log.Debugf("standalone runtime-name probe skipped: %v", err)
-	} else if vClusterStandalone != nil && name == vClusterStandalone.Name {
-		return vClusterStandalone, nil
-	}
-
-	return GetVCluster(ctx, context, name, namespace, log)
-}
-
 func GetVCluster(ctx context.Context, context, name, namespace string, log log.Logger) (*VCluster, error) {
 	if name == "" {
 		return nil, fmt.Errorf("please specify a name")
@@ -741,11 +712,11 @@ func isScaledDown(object client.Object) bool {
 	return false
 }
 
-// getVClusterStandalone returns a vCluster for a standalone installation.
-// Detection relies on the systemd service file existing on the local filesystem,
-// so this only works when the CLI runs on the same host as the vCluster standalone.
-// Returns nil, nil when standalone is not detected.
-func getVClusterStandalone() (*VCluster, error) {
+// GetStandaloneVCluster returns a vCluster for a standalone installation on the
+// current host. Detection relies on the systemd service file existing on the
+// local filesystem, so this only works when the CLI runs on the same host as
+// the vCluster standalone. Returns nil, nil when standalone is not detected.
+func GetStandaloneVCluster() (*VCluster, error) {
 	unitData, found, err := standaloneutil.DetectStandaloneHost()
 	if err != nil {
 		return nil, fmt.Errorf("detect standalone host: %w", err)
@@ -755,7 +726,7 @@ func getVClusterStandalone() (*VCluster, error) {
 		return nil, nil
 	}
 
-	vConfig, err := vclusterconfig.LoadLocalStandaloneConfig("", nil)
+	vConfig, err := vclusterconfig.LoadStandaloneConfig("", nil)
 	if err != nil {
 		return nil, fmt.Errorf("load standalone config: %w", err)
 	}

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,9 +29,9 @@ const (
 	RestoreResourceQuota = "vcluster-restore"
 )
 
-func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshot.Options, podOpts *pod.Options, newVCluster, restoreVolumes bool, log log.Logger) error {
+func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshot.Options, podOpts *pod.Options, newVCluster, restoreVolumes, standalone bool, log log.Logger) error {
 	// init kube client and vCluster
-	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, true)
+	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, true, standalone)
 	if err != nil {
 		return err
 	}
@@ -73,11 +74,12 @@ func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, rest
 }
 
 // restoreStandaloneVCluster stops the standalone service, invokes the vcluster binary
-// directly to perform the restore, and restarts the service. The CLI must run on the
-// same host as the standalone installation because it needs filesystem access to the
-// binary and config.
-func restoreStandaloneVCluster(ctx context.Context, vCluster *find.VCluster, snapshotOpts *snapshot.Options, cmdArgs []string, log log.Logger) error {
-	vClusterConfig, err := vclusterconfig.LoadLocalStandaloneConfig("", nil)
+// directly to perform the restore, and always attempts to start the service again
+// before returning. If both the restore and restart fail, the returned error retains
+// both failures. The CLI must run on the same host as the standalone installation
+// because it needs filesystem access to the binary and config.
+func restoreStandaloneVCluster(ctx context.Context, vCluster *find.VCluster, snapshotOpts *snapshot.Options, cmdArgs []string, log log.Logger) (retErr error) {
+	vClusterConfig, err := vclusterconfig.LoadStandaloneConfig("", nil)
 	if err != nil {
 		return fmt.Errorf("load standalone config: %w", err)
 	}
@@ -96,13 +98,22 @@ func restoreStandaloneVCluster(ctx context.Context, vCluster *find.VCluster, sna
 		return fmt.Errorf("stop vCluster service: %w", err)
 	}
 
-	restoreErr := runRestoreBinary(vClusterConfig, snapshotOpts, cmdArgs)
+	defer func() {
+		log.Infof("Starting vCluster service")
+		if startErr := sm.Start(); startErr != nil {
+			restartErr := fmt.Errorf("restart vCluster service: %w", startErr)
+			if retErr != nil {
+				retErr = errors.Join(retErr, restartErr)
+			} else {
+				retErr = restartErr
+			}
+		}
+	}()
 
-	log.Infof("Starting vCluster service")
-	if startErr := sm.Start(); startErr != nil {
-		return fmt.Errorf("restore succeeded but failed to restart vCluster service (cluster is stopped): %w", startErr)
+	if err := runRestoreBinary(vClusterConfig, snapshotOpts, cmdArgs); err != nil {
+		return fmt.Errorf("restore standalone vCluster: %w", err)
 	}
-	return restoreErr
+	return nil
 }
 
 func runRestoreBinary(vClusterConfig *vclusterconfig.VirtualClusterConfig, snapshotOpts *snapshot.Options, args []string) error {

--- a/pkg/cli/snapshot_helm.go
+++ b/pkg/cli/snapshot_helm.go
@@ -12,7 +12,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
-	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/helm"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
 	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
@@ -27,9 +26,9 @@ const (
 	minAsyncSnapshotVersion = "0.29.0-alpha.1"
 )
 
-func CreateSnapshot(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshot.Options, podOptions *pod.Options, log log.Logger, delegateFromCLIToCluster bool) error {
+func CreateSnapshot(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshot.Options, podOptions *pod.Options, log log.Logger, delegateFromCLIToCluster, standalone bool) error {
 	// init kube client and vCluster
-	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, delegateFromCLIToCluster)
+	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, delegateFromCLIToCluster, standalone)
 	if err != nil {
 		return err
 	}
@@ -69,11 +68,11 @@ func CreateSnapshot(ctx context.Context, args []string, globalFlags *flags.Globa
 	return nil
 }
 
-func GetSnapshots(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshot.Options, log log.Logger) error {
-	if len(args) != 2 {
-		return fmt.Errorf("unexpected amount of arguments: %d, need exactly 2 arguments. E.g. vcluster snapshot get my-vcluster s3://my-bucket/my-key", len(args))
+func GetSnapshots(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshot.Options, log log.Logger, standalone bool) error {
+	_, snapshotURL, err := resolveSnapshotArgs(args, standalone)
+	if err != nil {
+		return err
 	}
-	snapshotURL := args[1]
 	parsedURL, err := url.Parse(snapshotURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse snapshot URL: %w", err)
@@ -82,7 +81,7 @@ func GetSnapshots(ctx context.Context, args []string, globalFlags *flags.GlobalF
 	// command runs on a local machine.
 	credentialsRequiredInCluster := parsedURL.Scheme == "container"
 	// init kube client and vCluster
-	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, credentialsRequiredInCluster)
+	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, credentialsRequiredInCluster, standalone)
 	if err != nil {
 		return fmt.Errorf("failed to init snapshot command: %w", err)
 	}
@@ -112,21 +111,33 @@ func initSnapshotCommand(
 	snapshotOptions *snapshot.Options,
 	log log.Logger,
 	credentialsRequiredInCluster bool,
+	standalone bool,
 ) (*find.VCluster, *kubernetes.Clientset, *rest.Config, error) {
-	if len(args) != 2 {
-		return nil, nil, nil, fmt.Errorf("unexpected amount of arguments: %d, need exactly 2 arguments. E.g. vcluster [snapshot|restore] my-vcluster s3://my-bucket/my-key", len(args))
+	vClusterName, snapshotURL, err := resolveSnapshotArgs(args, standalone)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
-	err := snapshotOptions.SetURLAndFillCredentials(ctx, args[1], credentialsRequiredInCluster)
+	err = snapshotOptions.SetURLAndFillCredentials(ctx, snapshotURL, credentialsRequiredInCluster)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to set snapshot url and fill credentials: %w", err)
 	}
 
 	// find the vCluster
-	vClusterName := args[0]
-	vCluster, err := find.GetVClusterStandaloneOrVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
-	if err != nil {
-		return nil, nil, nil, err
+	var vCluster *find.VCluster
+	if standalone {
+		vCluster, err = find.GetStandaloneVCluster()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if vCluster == nil {
+			return nil, nil, nil, fmt.Errorf("local standalone vCluster not found on this host")
+		}
+	} else {
+		vCluster, err = find.GetVCluster(ctx, globalFlags.Context, vClusterName, globalFlags.Namespace, log)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	// check if snapshot is supported
@@ -166,11 +177,10 @@ func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeCli
 		return fmt.Errorf("failed to create snapshot request resources: %w", err)
 	}
 
-	snapshotGetName := vCluster.Name
+	snapshotGetCommand := fmt.Sprintf("vcluster snapshot get %s %s", vCluster.Name, snapshotOpts.GetURL())
 	if vCluster.IsStandalone {
-		snapshotGetName = constants.VClusterStandaloneCLISelector
+		snapshotGetCommand = fmt.Sprintf("vcluster snapshot get %s --standalone", snapshotOpts.GetURL())
 	}
-	snapshotGetCommand := fmt.Sprintf("vcluster snapshot get %s %s", snapshotGetName, snapshotOpts.GetURL())
 	if snapshotOpts.Type == "azure" {
 		if snapshotOpts.Azure.SubscriptionID != "" {
 			snapshotGetCommand += fmt.Sprintf(" --azure-subscription-id %s", snapshotOpts.Azure.SubscriptionID)
@@ -181,6 +191,21 @@ func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeCli
 	}
 	log.Infof("Beginning snapshot creation... Check the snapshot status by running `%s`", snapshotGetCommand)
 	return nil
+}
+
+func resolveSnapshotArgs(args []string, standalone bool) (string, string, error) {
+	if standalone {
+		if len(args) != 1 {
+			return "", "", fmt.Errorf("unexpected amount of arguments: %d, need exactly 1 argument. E.g. vcluster [snapshot|restore] s3://my-bucket/my-key --standalone", len(args))
+		}
+		return "", args[0], nil
+	}
+
+	if len(args) != 2 {
+		return "", "", fmt.Errorf("unexpected amount of arguments: %d, need exactly 2 arguments. E.g. vcluster [snapshot|restore] my-vcluster s3://my-bucket/my-key", len(args))
+	}
+
+	return args[0], args[1], nil
 }
 
 func checkIfVClusterSupportsSnapshotRequests(vCluster *find.VCluster, log log.Logger) error {
@@ -204,7 +229,7 @@ func getVClusterConfig(ctx context.Context, vCluster *find.VCluster, kubeClient 
 		}
 	} else if vCluster.IsStandalone {
 		// Standalone config lives on disk, not in a Kubernetes Secret.
-		vClusterConfig, err = vclusterconfig.LoadLocalStandaloneConfig("", nil)
+		vClusterConfig, err = vclusterconfig.LoadStandaloneConfig("", nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse standalone vcluster config: %w", err)
 		}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"encoding/json"
+
+	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/strvals"
+	"sigs.k8s.io/yaml"
+)
+
+func mergeConfigBytesWithDefaults(rawConfig []byte) ([]byte, error) {
+	defaultConfig, err := vclusterconfig.NewDefaultConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	defaultConfigMap, err := convertConfigToMap(defaultConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	overrideMap := map[string]interface{}{}
+	if len(rawConfig) > 0 {
+		if err := yaml.Unmarshal(rawConfig, &overrideMap); err != nil {
+			return nil, err
+		}
+	}
+
+	return json.Marshal(strvals.MergeMaps(defaultConfigMap, overrideMap))
+}
+
+func convertConfigToMap(config *vclusterconfig.Config) (map[string]interface{}, error) {
+	raw, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -13,38 +13,36 @@ import (
 	standaloneutil "github.com/loft-sh/vcluster/pkg/util/standalone"
 )
 
-// LoadAutoDetectedRuntimeConfig loads vCluster config for commands that run in
-// an existing vCluster runtime and need to work in both standalone and
-// in-cluster mode. It may inspect local host-side standalone signals such as
-// systemd before falling back to the in-cluster config path. It is not intended
-// for standalone runtime startup, which should use LoadStandaloneRuntimeConfig
-// directly.
+// LoadConfig loads config for commands that should use the current
+// runtime context. It first respects the explicit VCLUSTER_STANDALONE
+// environment override, then falls back to local standalone host detection, and
+// finally falls back to the regular in-cluster config path.
 //
 // When VCLUSTER_STANDALONE is set, it acts as an explicit mode override:
 // "true" forces standalone loading and any other value forces the normal
 // in-cluster/default config path. Only when the env var is unset we fall back
 // to local standalone host detection via the systemd unit marker.
-func LoadAutoDetectedRuntimeConfig(vClusterName string) (*VirtualClusterConfig, error) {
+func LoadConfig(vClusterName string) (*VirtualClusterConfig, error) {
 	// Respect explicit runtime context from the caller before attempting any
 	// local host detection. This allows parent processes to force standalone or
 	// non-standalone behavior for child vcluster commands.
 	if standaloneEnv, ok := os.LookupEnv(constants.VClusterStandaloneEnvVar); ok {
 		if standaloneEnv == "true" {
-			vConfig, err := LoadLocalStandaloneConfig(vClusterName, nil)
+			vConfig, err := LoadStandaloneConfig(vClusterName, nil)
 			if err != nil {
 				return nil, fmt.Errorf("loading standalone vCluster config: %w", err)
 			}
 			return vConfig, nil
 		}
 
-		vConfig, err := LoadInClusterRuntimeConfig(vClusterName, "", nil)
+		vConfig, err := LoadInClusterConfig(vClusterName, "", nil)
 		if err != nil {
 			return nil, fmt.Errorf("loading vCluster config: %w", err)
 		}
 		return vConfig, nil
 	}
 
-	vConfig, err := LoadLocalStandaloneConfig(vClusterName, nil)
+	vConfig, err := LoadStandaloneConfig(vClusterName, nil)
 	if err == nil {
 		return vConfig, nil
 	}
@@ -52,18 +50,18 @@ func LoadAutoDetectedRuntimeConfig(vClusterName string) (*VirtualClusterConfig, 
 		return nil, fmt.Errorf("loading standalone vCluster config from systemd: %w", err)
 	}
 
-	vConfig, err = LoadInClusterRuntimeConfig(vClusterName, "", nil)
+	vConfig, err = LoadInClusterConfig(vClusterName, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("loading vCluster config: %w", err)
 	}
 	return vConfig, nil
 }
 
-// LoadInClusterRuntimeConfig loads config for a vCluster running as a regular
+// LoadInClusterConfig loads config for a vCluster running as a regular
 // in-cluster control plane. When path is empty, it falls back to the default
 // pod/container config location. It does not perform standalone detection or
 // standalone normalization.
-func LoadInClusterRuntimeConfig(name, path string, setValues []string) (*VirtualClusterConfig, error) {
+func LoadInClusterConfig(name, path string, setValues []string) (*VirtualClusterConfig, error) {
 	if path == "" {
 		path = constants.DefaultVClusterConfigLocation
 	}
@@ -71,35 +69,12 @@ func LoadInClusterRuntimeConfig(name, path string, setValues []string) (*Virtual
 	return ParseConfig(path, name, setValues)
 }
 
-// LoadStandaloneRuntimeConfig loads config for standalone runtime startup. It is
-// intended for standalone runtime paths that already know they are operating in
-// standalone mode, not for host-side command autodetection.
-//
-// For historical compatibility, when path is empty or points at the legacy
-// in-cluster config location, it resolves from shared standalone default
-// locations. Regardless of where the file was loaded from, the resulting config
-// is normalized as standalone.
-func LoadStandaloneRuntimeConfig(name, path string, setValues []string) (*VirtualClusterConfig, error) {
-	var err error
-
-	if path == "" || path == constants.DefaultVClusterConfigLocation {
-		path, err = resolveStandaloneConfigFromCandidates([]string{
-			constants.VClusterStandaloneDefaultConfigPath,
-			constants.DefaultVClusterConfigLocation,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	return loadNormalizedStandaloneConfig(name, path, setValues)
-}
-
-// LoadLocalStandaloneConfig loads config for a standalone vCluster installed on
+// LoadStandaloneConfig loads config for a standalone vCluster installed on
 // this host. It discovers the config path from the local systemd unit, uses the
-// runtime vCluster name from that unit when name is empty, and normalizes the
-// result as standalone. This is for host-side CLI/API flows such as
+// runtime vCluster name from that unit when name is empty, and then delegates
+// to LoadStandaloneRuntimeConfig. This is for host-side CLI/API flows such as
 // vclusterctl, not for standalone runtime startup.
-func LoadLocalStandaloneConfig(name string, setValues []string) (*VirtualClusterConfig, error) {
+func LoadStandaloneConfig(name string, setValues []string) (*VirtualClusterConfig, error) {
 	resolvedPath, unitData, err := resolveStandaloneConfigFromSystemd()
 	if err != nil {
 		return nil, err
@@ -108,30 +83,77 @@ func LoadLocalStandaloneConfig(name string, setValues []string) (*VirtualCluster
 		name = resolveStandaloneRuntimeName(unitData)
 	}
 
-	return loadNormalizedStandaloneConfig(name, resolvedPath, setValues)
+	return LoadStandaloneRuntimeConfig(name, resolvedPath, setValues)
 }
 
-func loadNormalizedStandaloneConfig(name, path string, setValues []string) (*VirtualClusterConfig, error) {
-	cfg, err := LoadInClusterRuntimeConfig(name, path, setValues)
+// LoadStandaloneRuntimeConfig loads a standalone config from the given path,
+// applies set values, overlays the chart default config values, and normalizes
+// it as standalone. When the path is one of the default standalone config
+// locations and the file does not exist, it falls back to an in-memory default
+// config before merging chart defaults. Missing custom config paths still
+// return an error.
+func LoadStandaloneRuntimeConfig(name, path string, setValues []string) (*VirtualClusterConfig, error) {
+	rawConfig, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) || !isDefaultStandaloneConfigPath(path) {
+			return nil, err
+		}
+		rawConfig = nil
+	}
+
+	rawConfig, err = applySetValues(rawConfig, setValues)
 	if err != nil {
 		return nil, err
 	}
-	if cfg == nil {
-		return nil, fmt.Errorf("config is nil")
+
+	mergedConfig, err := mergeConfigBytesWithDefaults(rawConfig)
+	if err != nil {
+		return nil, err
 	}
 
+	cfg, err := ParseConfigBytes(mergedConfig, name, nil)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Path = path
+	normalizeStandaloneConfig(cfg)
+
+	return cfg, nil
+}
+
+// ResolveStandaloneConfigPath resolves the standalone config path from an
+// explicit path or the default standalone locations. When path is empty or
+// points at the shared in-cluster default location, it prefers the standalone
+// default path and falls back to the in-cluster default path if that file
+// exists. If neither file exists, it returns the standalone default path.
+func ResolveStandaloneConfigPath(path string) (string, error) {
+	if path != "" && path != constants.DefaultVClusterConfigLocation {
+		return path, nil
+	}
+
+	configPath, err := resolveStandaloneConfigFromCandidates([]string{
+		constants.VClusterStandaloneDefaultConfigPath,
+		constants.DefaultVClusterConfigLocation,
+	})
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		return constants.VClusterStandaloneDefaultConfigPath, nil
+	}
+
+	return configPath, nil
+}
+
+// normalizeStandaloneConfig enforces the standalone runtime toggles that are
+// required for host-installed standalone vClusters, regardless of how the
+// underlying config was loaded.
+func normalizeStandaloneConfig(cfg *VirtualClusterConfig) {
 	cfg.ControlPlane.Standalone.Enabled = true
 	cfg.PrivateNodes.Enabled = true
 	if cfg.ControlPlane.Standalone.DataDir == "" {
 		cfg.ControlPlane.Standalone.DataDir = constants.VClusterStandaloneDefaultDataDir
 	}
-
-	err = ValidateConfigAndSetDefaults(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
 }
 
 // resolveStandaloneConfigFromSystemd resolves a standalone config path from the
@@ -151,14 +173,15 @@ func resolveStandaloneConfigFromSystemd() (string, []byte, error) {
 		return configPath, unitData, nil
 	}
 
-	configPath, err := resolveStandaloneConfigFromCandidates([]string{
-		constants.VClusterStandaloneDefaultConfigPath,
-		constants.DefaultVClusterConfigLocation,
-	})
+	configPath, err := ResolveStandaloneConfigPath("")
 	if err != nil {
 		return "", nil, err
 	}
 	return configPath, unitData, nil
+}
+
+func isDefaultStandaloneConfigPath(path string) bool {
+	return path == constants.VClusterStandaloneDefaultConfigPath || path == constants.DefaultVClusterConfigLocation
 }
 
 func resolveStandaloneRuntimeName(unitData []byte) string {

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -3,9 +3,9 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 )
 
@@ -16,9 +16,9 @@ func TestLoadNormalizedStandaloneConfig(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cfg, err := loadNormalizedStandaloneConfig("test", path, nil)
+	cfg, err := LoadStandaloneRuntimeConfig("test", path, nil)
 	if err != nil {
-		t.Fatalf("loadNormalizedStandaloneConfig() error = %v", err)
+		t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
 	}
 
 	if !cfg.ControlPlane.Standalone.Enabled {
@@ -29,6 +29,38 @@ func TestLoadNormalizedStandaloneConfig(t *testing.T) {
 	}
 	if cfg.ControlPlane.Standalone.DataDir != constants.VClusterStandaloneDefaultDataDir {
 		t.Fatalf("expected default data dir to be set, got %q", cfg.ControlPlane.Standalone.DataDir)
+	}
+}
+
+func TestResolveStandaloneConfigPath_DefaultConfigLocationFallsBackToStandaloneDefault(t *testing.T) {
+	path, err := ResolveStandaloneConfigPath(constants.DefaultVClusterConfigLocation)
+	if err != nil {
+		t.Fatalf("ResolveStandaloneConfigPath() error = %v", err)
+	}
+
+	expectedPath := constants.VClusterStandaloneDefaultConfigPath
+	if info, err := os.Stat(constants.VClusterStandaloneDefaultConfigPath); os.IsNotExist(err) {
+		if info, err := os.Stat(constants.DefaultVClusterConfigLocation); err == nil && !info.IsDir() {
+			expectedPath = constants.DefaultVClusterConfigLocation
+		}
+	} else if err != nil {
+		t.Fatalf("stat standalone default config path: %v", err)
+	} else if info.IsDir() {
+		t.Fatalf("expected standalone default config path %q to be a file", constants.VClusterStandaloneDefaultConfigPath)
+	}
+
+	if path != expectedPath {
+		t.Fatalf("expected resolved config path %q, got %q", expectedPath, path)
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_MissingCustomPath(t *testing.T) {
+	_, err := LoadStandaloneRuntimeConfig("test", filepath.Join(t.TempDir(), "missing.yaml"), nil)
+	if err == nil {
+		t.Fatal("expected missing custom config path to fail")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
 	}
 }
 
@@ -102,7 +134,7 @@ func TestResolveStandaloneConfigFromCandidates_FallbackOrder(t *testing.T) {
 	}
 }
 
-func TestValidateNormalizedStandaloneConfig(t *testing.T) {
+func TestLoadNormalizedStandaloneConfig_DoesNotValidate(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
 controlPlane: {}
@@ -114,11 +146,102 @@ integrations:
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err = loadNormalizedStandaloneConfig("test", path, nil)
-	if err == nil {
-		t.Fatal("expected standalone validation error")
+	cfg, err := LoadStandaloneRuntimeConfig("test", path, nil)
+	if err != nil {
+		t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "metrics-server integration is not supported in private nodes mode") {
-		t.Fatalf("expected private nodes validation error, got %v", err)
+	if !cfg.ControlPlane.Standalone.Enabled {
+		t.Fatalf("expected standalone to be enabled")
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_MergesDefaultsAndPreservesExplicitFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+deploy:
+  cni:
+    flannel:
+      enabled: false
+`), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadStandaloneRuntimeConfig("test", path, nil)
+	if err != nil {
+		t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
+	}
+
+	defaultConfig, err := vclusterconfig.NewDefaultConfig()
+	if err != nil {
+		t.Fatalf("NewDefaultConfig() error = %v", err)
+	}
+
+	if cfg.ControlPlane.StatefulSet.Image.Repository != defaultConfig.ControlPlane.StatefulSet.Image.Repository {
+		t.Fatalf("expected repository %q after merging defaults, got %q", defaultConfig.ControlPlane.StatefulSet.Image.Repository, cfg.ControlPlane.StatefulSet.Image.Repository)
+	}
+	if cfg.Deploy.CNI.Flannel.Enabled {
+		t.Fatal("expected explicit flannel.enabled=false to be preserved")
+	}
+}
+
+func TestLoadNormalizedStandaloneConfig_DefaultPathMissingUsesInMemoryDefaults(t *testing.T) {
+	if _, err := os.Stat(constants.VClusterStandaloneDefaultConfigPath); err == nil {
+		t.Skipf("default standalone config path %q exists on this host", constants.VClusterStandaloneDefaultConfigPath)
+	}
+
+	cfg, err := LoadStandaloneRuntimeConfig("test", constants.VClusterStandaloneDefaultConfigPath, nil)
+	if err != nil {
+		t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
+	}
+	if cfg.Path != constants.VClusterStandaloneDefaultConfigPath {
+		t.Fatalf("expected config path %q, got %q", constants.VClusterStandaloneDefaultConfigPath, cfg.Path)
+	}
+	if !cfg.ControlPlane.Standalone.Enabled {
+		t.Fatalf("expected standalone to be enabled")
+	}
+	if !cfg.PrivateNodes.Enabled {
+		t.Fatalf("expected private nodes to be enabled")
+	}
+	if cfg.ControlPlane.Standalone.DataDir != constants.VClusterStandaloneDefaultDataDir {
+		t.Fatalf("expected default data dir %q, got %q", constants.VClusterStandaloneDefaultDataDir, cfg.ControlPlane.Standalone.DataDir)
+	}
+}
+
+func TestLoadNormalizedStandaloneConfig_CustomMissingPathErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+
+	_, err := LoadStandaloneRuntimeConfig("test", path, nil)
+	if err == nil {
+		t.Fatal("expected error for missing custom standalone config path")
+	}
+}
+
+func TestMergeConfigBytesWithDefaults(t *testing.T) {
+	mergedConfig, err := mergeConfigBytesWithDefaults([]byte(`
+deploy:
+  cni:
+    flannel:
+      enabled: false
+`))
+	if err != nil {
+		t.Fatalf("mergeConfigBytesWithDefaults() error = %v", err)
+	}
+
+	cfg, err := ParseConfigBytes(mergedConfig, "test", nil)
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+
+	defaultConfig, err := vclusterconfig.NewDefaultConfig()
+	if err != nil {
+		t.Fatalf("NewDefaultConfig() error = %v", err)
+	}
+
+	if cfg.ControlPlane.StatefulSet.Image.Repository != defaultConfig.ControlPlane.StatefulSet.Image.Repository {
+		t.Fatalf("expected repository %q after merging defaults, got %q", defaultConfig.ControlPlane.StatefulSet.Image.Repository, cfg.ControlPlane.StatefulSet.Image.Repository)
+	}
+	if cfg.Deploy.CNI.Flannel.Enabled {
+		t.Fatal("expected explicit flannel.enabled=false to be preserved")
 	}
 }

--- a/pkg/constants/standalone.go
+++ b/pkg/constants/standalone.go
@@ -7,12 +7,6 @@ const (
 	VClusterStandaloneIPAddressEnvVar     = "VCLUSTER_STANDALONE_IP_ADDRESS"
 	VClusterStandaloneDefaultName         = "standalone"
 
-	// VClusterStandaloneCLISelector is a CLI-only alias that tells commands to target
-	// the local standalone service on this host. It triggers local systemd discovery
-	// and uses the standalone kubeconfig from disk; it is not the standalone runtime
-	// vCluster name used in request resources.
-	VClusterStandaloneCLISelector = "local-standalone"
-
 	// Standalone has no host-cluster namespace, so snapshot/restore request
 	// ConfigMaps and Secrets live in the virtual cluster's own kube-system.
 	VClusterStandaloneSnapshotNamespace = "kube-system"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
