### PR TITLE
chore(e2e-next): Upload Ginkgo JSON report

### DIFF
--- a/.github/workflows/e2e-ginkgo-nightly.yaml
+++ b/.github/workflows/e2e-ginkgo-nightly.yaml
@@ -33,6 +33,9 @@ jobs:
     runs-on: large-8_32
     timeout-minutes: 180
 
+    outputs:
+      failure-summary: ${{ steps.run-tests.outputs.failure-summary }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -90,12 +93,21 @@ jobs:
           fi
 
       - name: Run e2e-next tests
+        id: run-tests
         uses: loft-sh/github-actions/.github/actions/run-ginkgo@run-ginkgo/v1
         with:
           ginkgo-label: ${{ inputs.ginkgo-label }}
           timeout: "60m"
           additional-args: "--vcluster-image=${{ env.REPOSITORY_NAME }}:${{ env.TAG_NAME }} --teardown=false"
           additional-ginkgo-flags: "-v"
+
+      - name: Upload Ginkgo JSON report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ginkgo-report
+          path: test-reports/report.json
+          if-no-files-found: ignore
 
       - name: Collect debug info on failure
         if: failure()
@@ -147,7 +159,9 @@ jobs:
         with:
           test-name: "vCluster E2E Nightly"
           status: ${{ needs.e2e-tests.result }}
-          details: "E2E Tests: ${{ needs.e2e-tests.result }}"
+          details: |
+            E2E Tests Job: ${{ needs.e2e-tests.result }}
+            ${{ needs.e2e-tests.result == 'failure' && needs.e2e-tests.outputs.failure-summary || '' }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
 
       - name: Notify dev-vcluster
@@ -156,5 +170,7 @@ jobs:
         with:
           test-name: "vCluster E2E Nightly"
           status: ${{ needs.e2e-tests.result }}
-          details: "E2E Tests: ${{ needs.e2e-tests.result }}"
+          details: |
+            E2E Tests Job: ${{ needs.e2e-tests.result }}
+            ${{ needs.e2e-tests.outputs.failure-summary || 'No detailed failure summary available. Check the build logs for more details.' }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_DEV_VCLUSTER }}

--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -242,6 +242,14 @@ jobs:
           additional-ginkgo-flags: "-v --show-node-events"
         continue-on-error: true
 
+      - name: Upload Ginkgo JSON report
+        if: success() || failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ginkgo-report
+          path: test-reports/report.json
+          if-no-files-found: ignore
+
       - name: Collect debug info on failure
         if: steps.execute-e2e-tests.outcome == 'failure'
         run: |


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
