### PR TITLE
auto detect embedded etcd IP

### DIFF
--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/loft-sh/log"
+	rawconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
@@ -138,6 +139,13 @@ func runRestoreBinary(vClusterConfig *vclusterconfig.VirtualClusterConfig, snaps
 		constants.VClusterStandaloneEnvVar+"=true",
 		constants.VClusterStorageOptionsEnv+"="+optionsString,
 	)
+	if vClusterConfig.BackingStoreType() == rawconfig.StoreTypeEmbeddedEtcd && os.Getenv(constants.VClusterStandaloneIPAddressEnvVar) == "" {
+		standaloneIPAddress, err := standaloneutil.ResolveStandaloneIPAddress(vClusterConfig.ControlPlane.Standalone.DataDir)
+		if err != nil {
+			return fmt.Errorf("resolve standalone IP address for restore: %w", err)
+		}
+		env = append(env, constants.VClusterStandaloneIPAddressEnvVar+"="+standaloneIPAddress)
+	}
 
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Env = env

--- a/pkg/constants/standalone.go
+++ b/pkg/constants/standalone.go
@@ -25,4 +25,7 @@ const (
 	// VClusterStandaloneDefaultConfigPath is the config location for a standalone binary installation.
 	// Kept outside the data directory so it survives a data wipe or re-install.
 	VClusterStandaloneDefaultConfigPath = "/etc/vcluster/vcluster.yaml"
+
+	// StandaloneRuntimeMetadataFileName stores persisted standalone runtime metadata in the data directory.
+	StandaloneRuntimeMetadataFileName = "standalone-runtime-metadata"
 )

--- a/pkg/util/standalone/metadata.go
+++ b/pkg/util/standalone/metadata.go
@@ -1,0 +1,53 @@
+package standalone
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/constants"
+)
+
+type RuntimeMetadata struct {
+	Version   string `json:"version,omitempty"`
+	IPAddress string `json:"ip,omitempty"`
+	NodeClaim string `json:"nodeClaim,omitempty"`
+	StartTime string `json:"startTime,omitempty"`
+}
+
+func LoadRuntimeMetadata(dataDir string) (*RuntimeMetadata, error) {
+	raw, err := os.ReadFile(filepath.Join(dataDir, constants.StandaloneRuntimeMetadataFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := &RuntimeMetadata{}
+	if err := json.Unmarshal(raw, metadata); err != nil {
+		return nil, fmt.Errorf("unmarshal runtime metadata: %w", err)
+	}
+
+	return metadata, nil
+}
+
+func ResolveStandaloneIPAddress(dataDir string) (string, error) {
+	metadata, err := LoadRuntimeMetadata(dataDir)
+	if err == nil {
+		ipAddress := strings.TrimSpace(metadata.IPAddress)
+		if ipAddress == "" {
+			return "", fmt.Errorf("runtime metadata does not contain standalone IP address")
+		}
+		return ipAddress, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	ipAddress := strings.TrimSpace(os.Getenv(constants.VClusterStandaloneIPAddressEnvVar))
+	if ipAddress == "" {
+		return "", fmt.Errorf("could not determine the IP address for the embedded etcd peer")
+	}
+
+	return ipAddress, nil
+}

--- a/pkg/util/standalone/metadata_test.go
+++ b/pkg/util/standalone/metadata_test.go
@@ -1,0 +1,58 @@
+package standalone
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"gotest.tools/v3/assert"
+)
+
+func TestLoadRuntimeMetadata(t *testing.T) {
+	dataDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dataDir, constants.StandaloneRuntimeMetadataFileName), []byte(`{"version":"v0.30.0","ip":"10.0.0.12","nodeClaim":"node-claim-1","startTime":"2026-04-21T10:00:00Z"}`), 0644)
+	assert.NilError(t, err)
+
+	metadata, err := LoadRuntimeMetadata(dataDir)
+	assert.NilError(t, err)
+	assert.Equal(t, metadata.Version, "v0.30.0")
+	assert.Equal(t, metadata.IPAddress, "10.0.0.12")
+	assert.Equal(t, metadata.NodeClaim, "node-claim-1")
+	assert.Equal(t, metadata.StartTime, "2026-04-21T10:00:00Z")
+}
+
+func TestResolveStandaloneIPAddress(t *testing.T) {
+	t.Run("metadata first", func(t *testing.T) {
+		t.Setenv(constants.VClusterStandaloneIPAddressEnvVar, "10.0.0.99")
+		dataDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dataDir, constants.StandaloneRuntimeMetadataFileName), []byte(`{"ip":"10.0.0.12"}`), 0644)
+		assert.NilError(t, err)
+
+		ipAddress, err := ResolveStandaloneIPAddress(dataDir)
+		assert.NilError(t, err)
+		assert.Equal(t, ipAddress, "10.0.0.12")
+	})
+
+	t.Run("env fallback when metadata file missing", func(t *testing.T) {
+		t.Setenv(constants.VClusterStandaloneIPAddressEnvVar, "10.0.0.99")
+
+		ipAddress, err := ResolveStandaloneIPAddress(t.TempDir())
+		assert.NilError(t, err)
+		assert.Equal(t, ipAddress, "10.0.0.99")
+	})
+
+	t.Run("error when metadata and env missing", func(t *testing.T) {
+		_, err := ResolveStandaloneIPAddress(t.TempDir())
+		assert.ErrorContains(t, err, "could not determine the IP address")
+	})
+
+	t.Run("error when metadata exists without ip", func(t *testing.T) {
+		dataDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dataDir, constants.StandaloneRuntimeMetadataFileName), []byte(`{"version":"v0.30.0"}`), 0644)
+		assert.NilError(t, err)
+
+		_, err = ResolveStandaloneIPAddress(dataDir)
+		assert.ErrorContains(t, err, "runtime metadata does not contain standalone IP address")
+	})
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
