### PR TITLE
ci(auto-approve): use bot-approver pat and refresh v1 pin

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   auto-approve:
-    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@auto-approve-bot-prs/v1 # 9d33031
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@auto-approve-bot-prs/v1 # a889ee9
     with:
       trusted-authors: 'loft-bot'
       auto-merge: false
     secrets:
-      gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      gh-access-token: ${{ secrets.BOT_APPROVER_PAT }}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   auto-approve:
+    if: startsWith(github.head_ref, 'backport/')
     uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@auto-approve-bot-prs/v1 # a889ee9
     with:
       trusted-authors: 'loft-bot'


### PR DESCRIPTION
## Summary

Switch the auto-approve caller workflow from `GH_ACCESS_TOKEN` (loft-bot's own PAT) to `BOT_APPROVER_PAT` (the dedicated `vcluster-bot-approver` identity), and refresh the pin comment to `a889ee9`.

## Why

Backport PRs here are authored by `loft-bot`. GitHub refuses self-approval, so passing loft-bot's own PAT into the approval step returns 422 and the job never approves. The same pattern is already live in `vcluster-docs` (see e.g. #1949, #1956, #1959) using the separate approver identity.

The pin bump also picks up the check-run dedupe fix (loft-sh/github-actions#119) and the mergeable-retry widening, and removes the now-deleted github-app token branch (#110).

## Scope

Only `loft-bot`-authored PRs are affected — `trusted-authors: 'loft-bot'` is unchanged. In this repo that means backport PRs plus the occasional `loft-bot` chore PR (OSS license updates, etc.); CI gating in the reusable workflow still blocks approval if checks fail.

References DEVOPS-714