### PR TITLE
docs(readme): add CNCF Certified Kubernetes and AI Conformant badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 
 **[Website](https://www.vcluster.com)** • **[Quickstart](https://www.vcluster.com/docs/get-started/)** • **[Documentation](https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters)** • **[Blog](https://loft.sh/blog)** • **[Slack](https://slack.loft.sh/)**
 
+<br/>
+
+<a href="https://www.cncf.io/training/certification/software-conformance/"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" alt="Certified Kubernetes — Distribution" height="100"></a>
+&nbsp;&nbsp;&nbsp;&nbsp;
+<a href="https://github.com/cncf/k8s-ai-conformance/tree/main/v1.35/vcluster-private-nodes"><img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes-ai/versionless/color/CNCF_AI_Conformance_Logo-Color-V2.png" alt="Kubernetes AI Conformant" height="100"></a>
+
+**CNCF Certified Kubernetes — Distribution** · **Kubernetes AI Conformant** (v1.35)
+
 </div>
 
 ---
@@ -25,6 +33,8 @@
 **vCluster** creates **Tenant Clusters** — fully isolated Kubernetes environments that run on top of a Control Plane Cluster, on dedicated infrastructure, or standalone on bare metal. Each tenant gets its own API server, CRDs, and RBAC, with a cluster experience indistinguishable from a dedicated Kubernetes cluster.
 
 Built for production. Trusted in production. **40M+ Tenant Clusters deployed** by teams at Adobe, CoreWeave, NVIDIA, Lintasarta, Atlan, Deloitte, and hundreds of AI clouds, AI factories, and Fortune 500 platform organizations.
+
+**[CNCF Certified Kubernetes — Distribution](https://www.cncf.io/training/certification/software-conformance/)** and **[Kubernetes AI Conformant](https://github.com/cncf/k8s-ai-conformance/tree/main/v1.35/vcluster-private-nodes)** (v1.35) — every Tenant Cluster is upstream Kubernetes with no vendor lock‑in, validated for portable AI/ML workloads (training, inference, agentic).
 
 > **The public-cloud experience, on your own infrastructure.** Give every team the Kubernetes they need — with strict isolation, hardware-aware scheduling, and zero tenant sprawl — whether you run one region or 100K GPUs.
 


### PR DESCRIPTION
## Summary

Follow-up to #3876. Adds two CNCF certification badges to the README:

- **Certified Kubernetes — Distribution** (conformant through v1.34): https://www.cncf.io/training/certification/software-conformance/
- **Kubernetes AI Conformant** (v1.35): https://github.com/cncf/k8s-ai-conformance/tree/main/v1.35/vcluster-private-nodes (submission merged in cncf/k8s-ai-conformance#83)

Two changes:
1. Both official CNCF logos rendered in the centered header block, linked to the respective conformance pages.
2. One sentence in the "What is vCluster?" intro tying the certifications to substance — upstream Kubernetes portability and validated AI/ML workload support (training, inference, agentic).

Logos are the official `color` variants from `cncf/artwork`. They are self-contained blue "tombstone" shapes, so they render cleanly on both light and dark GitHub themes.

## Test plan

- [ ] Render README on GitHub light theme — badges display, links resolve
- [ ] Render README on GitHub dark theme — badges still readable
- [ ] Confirm both badge links open the correct CNCF pages