### PR TITLE
fix LoadStandaloneRuntimeConfig

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 
 	"github.com/kballard/go-shellquote"
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	standaloneutil "github.com/loft-sh/vcluster/pkg/util/standalone"
+	"sigs.k8s.io/yaml"
 )
 
 // LoadConfig loads config for commands that should use the current
@@ -93,12 +95,20 @@ func LoadStandaloneConfig(name string, setValues []string) (*VirtualClusterConfi
 // config before merging chart defaults. Missing custom config paths still
 // return an error.
 func LoadStandaloneRuntimeConfig(name, path string, setValues []string) (*VirtualClusterConfig, error) {
+	if name == "" {
+		return nil, fmt.Errorf("empty vCluster name")
+	}
+
 	rawConfig, err := os.ReadFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) || !isDefaultStandaloneConfigPath(path) {
 			return nil, err
 		}
 		rawConfig = nil
+	}
+
+	if err := validateStrictStandaloneRawConfig(rawConfig); err != nil {
+		return nil, err
 	}
 
 	rawConfig, err = applySetValues(rawConfig, setValues)
@@ -111,12 +121,11 @@ func LoadStandaloneRuntimeConfig(name, path string, setValues []string) (*Virtua
 		return nil, err
 	}
 
-	cfg, err := ParseConfigBytes(mergedConfig, name, nil)
+	cfg, err := ParseStandaloneConfigBytes(mergedConfig, name, nil)
 	if err != nil {
 		return nil, err
 	}
 	cfg.Path = path
-	normalizeStandaloneConfig(cfg)
 
 	return cfg, nil
 }
@@ -145,17 +154,6 @@ func ResolveStandaloneConfigPath(path string) (string, error) {
 	return configPath, nil
 }
 
-// normalizeStandaloneConfig enforces the standalone runtime toggles that are
-// required for host-installed standalone vClusters, regardless of how the
-// underlying config was loaded.
-func normalizeStandaloneConfig(cfg *VirtualClusterConfig) {
-	cfg.ControlPlane.Standalone.Enabled = true
-	cfg.PrivateNodes.Enabled = true
-	if cfg.ControlPlane.Standalone.DataDir == "" {
-		cfg.ControlPlane.Standalone.DataDir = constants.VClusterStandaloneDefaultDataDir
-	}
-}
-
 // resolveStandaloneConfigFromSystemd resolves a standalone config path from the
 // local systemd unit, falling back to shared standalone default locations when
 // the unit does not provide an explicit config flag. This is intended for
@@ -182,6 +180,14 @@ func resolveStandaloneConfigFromSystemd() (string, []byte, error) {
 
 func isDefaultStandaloneConfigPath(path string) bool {
 	return path == constants.VClusterStandaloneDefaultConfigPath || path == constants.DefaultVClusterConfigLocation
+}
+
+func validateStrictStandaloneRawConfig(rawConfig []byte) error {
+	if len(rawConfig) == 0 {
+		return nil
+	}
+
+	return yaml.UnmarshalStrict(rawConfig, &vclusterconfig.Config{})
 }
 
 func resolveStandaloneRuntimeName(unitData []byte) string {

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
@@ -61,6 +62,22 @@ func TestLoadStandaloneRuntimeConfig_MissingCustomPath(t *testing.T) {
 	}
 	if !os.IsNotExist(err) {
 		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_EmptyNameErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte("controlPlane: {}\n"), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err = LoadStandaloneRuntimeConfig("", path, nil)
+	if err == nil {
+		t.Fatal("expected empty vCluster name to fail")
+	}
+	if !strings.Contains(err.Error(), "empty vCluster name") {
+		t.Fatalf("expected empty name error, got %v", err)
 	}
 }
 
@@ -134,13 +151,14 @@ func TestResolveStandaloneConfigFromCandidates_FallbackOrder(t *testing.T) {
 	}
 }
 
-func TestLoadNormalizedStandaloneConfig_DoesNotValidate(t *testing.T) {
+func TestLoadStandaloneRuntimeConfig_ForcesStandaloneFlags(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
-controlPlane: {}
-integrations:
-  metricsServer:
-    enabled: true
+controlPlane:
+  standalone:
+    enabled: false
+privateNodes:
+  enabled: false
 `), 0o600)
 	if err != nil {
 		t.Fatalf("write config: %v", err)
@@ -152,6 +170,200 @@ integrations:
 	}
 	if !cfg.ControlPlane.Standalone.Enabled {
 		t.Fatalf("expected standalone to be enabled")
+	}
+	if !cfg.PrivateNodes.Enabled {
+		t.Fatalf("expected private nodes to be enabled")
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_AllowsNullStandaloneParents(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "controlPlane null",
+			config: `controlPlane: null
+`,
+		},
+		{
+			name: "controlPlane.standalone null",
+			config: `controlPlane:
+  standalone: null
+`,
+		},
+		{
+			name: "privateNodes null",
+			config: `privateNodes: null
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			err := os.WriteFile(path, []byte(test.config), 0o600)
+			if err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			cfg, err := LoadStandaloneRuntimeConfig("test", path, nil)
+			if err != nil {
+				t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
+			}
+			if !cfg.ControlPlane.Standalone.Enabled {
+				t.Fatalf("expected standalone to be enabled")
+			}
+			if !cfg.PrivateNodes.Enabled {
+				t.Fatalf("expected private nodes to be enabled")
+			}
+			if cfg.ControlPlane.Standalone.DataDir != constants.VClusterStandaloneDefaultDataDir {
+				t.Fatalf("expected default data dir %q, got %q", constants.VClusterStandaloneDefaultDataDir, cfg.ControlPlane.Standalone.DataDir)
+			}
+		})
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_AllowsPrivateNodesOptionsWithoutExplicitEnable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+privateNodes:
+  autoNodes:
+  - provider: test-provider
+    static:
+    - name: workers
+      quantity: 1
+`), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadStandaloneRuntimeConfig("test", path, nil)
+	if err != nil {
+		t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
+	}
+	if !cfg.PrivateNodes.Enabled {
+		t.Fatalf("expected private nodes to be enabled")
+	}
+	if len(cfg.PrivateNodes.AutoNodes) != 1 {
+		t.Fatalf("expected 1 auto node configuration, got %d", len(cfg.PrivateNodes.AutoNodes))
+	}
+	if cfg.PrivateNodes.AutoNodes[0].Provider != "test-provider" {
+		t.Fatalf("expected provider %q, got %q", "test-provider", cfg.PrivateNodes.AutoNodes[0].Provider)
+	}
+	if len(cfg.PrivateNodes.AutoNodes[0].Static) != 1 {
+		t.Fatalf("expected 1 static node pool, got %d", len(cfg.PrivateNodes.AutoNodes[0].Static))
+	}
+	if cfg.PrivateNodes.AutoNodes[0].Static[0].Name != "workers" {
+		t.Fatalf("expected node pool name %q, got %q", "workers", cfg.PrivateNodes.AutoNodes[0].Static[0].Name)
+	}
+	if cfg.PrivateNodes.AutoNodes[0].Static[0].Quantity != 1 {
+		t.Fatalf("expected node pool quantity %d, got %d", 1, cfg.PrivateNodes.AutoNodes[0].Static[0].Quantity)
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_AllowsStandaloneOptionsWithoutExplicitEnable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+controlPlane:
+  standalone:
+    autoNodes:
+      provider: test-provider
+      quantity: 2
+`), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadStandaloneRuntimeConfig("test", path, nil)
+	if err != nil {
+		t.Fatalf("LoadStandaloneRuntimeConfig() error = %v", err)
+	}
+	if !cfg.ControlPlane.Standalone.Enabled {
+		t.Fatalf("expected standalone to be enabled")
+	}
+	if cfg.ControlPlane.Standalone.DataDir != constants.VClusterStandaloneDefaultDataDir {
+		t.Fatalf("expected default data dir %q, got %q", constants.VClusterStandaloneDefaultDataDir, cfg.ControlPlane.Standalone.DataDir)
+	}
+	if cfg.ControlPlane.Standalone.AutoNodes.Provider != "test-provider" {
+		t.Fatalf("expected provider %q, got %q", "test-provider", cfg.ControlPlane.Standalone.AutoNodes.Provider)
+	}
+	if cfg.ControlPlane.Standalone.AutoNodes.Quantity != 2 {
+		t.Fatalf("expected auto node quantity %d, got %d", 2, cfg.ControlPlane.Standalone.AutoNodes.Quantity)
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_ValidatesStandaloneConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+controlPlane:
+  standalone:
+    enabled: false
+privateNodes:
+  enabled: false
+integrations:
+  metricsServer:
+    enabled: true
+`), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err = LoadStandaloneRuntimeConfig("test", path, nil)
+	if err == nil {
+		t.Fatal("expected standalone validation error")
+	}
+	if !strings.Contains(err.Error(), "metrics-server integration is not supported in private nodes mode") {
+		t.Fatalf("expected private nodes validation error, got %v", err)
+	}
+}
+
+func TestLoadStandaloneRuntimeConfig_StrictRawConfigValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		contains string
+	}{
+		{
+			name: "invalid bool type is not masked by standalone overrides",
+			config: `privateNodes:
+  enabled: not-a-bool
+`,
+			contains: "cannot unmarshal string into Go struct field",
+		},
+		{
+			name: "duplicate key in raw config fails strict unmarshal",
+			config: `privateNodes:
+  enabled: false
+  enabled: true
+`,
+			contains: `key "enabled" already set in map`,
+		},
+		{
+			name: "unknown field in raw config fails strict unmarshal",
+			config: `privateNodes:
+  madeUpField: true
+`,
+			contains: `unknown field "madeUpField"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			err := os.WriteFile(path, []byte(test.config), 0o600)
+			if err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			_, err = LoadStandaloneRuntimeConfig("test", path, nil)
+			if err == nil {
+				t.Fatal("expected strict raw config validation error")
+			}
+			if !strings.Contains(err.Error(), test.contains) {
+				t.Fatalf("expected error containing %q, got %v", test.contains, err)
+			}
+		})
 	}
 }
 

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -52,6 +52,35 @@ func ParseConfigBytes(data []byte, name string, setValues []string) (*VirtualClu
 		return nil, err
 	}
 
+	return parseConfigBytes(name, rawConfig)
+}
+
+func ParseStandaloneConfigBytes(data []byte, name string, setValues []string) (*VirtualClusterConfig, error) {
+	// apply set values
+	rawFile, err := applySetValues(data, setValues)
+	if err != nil {
+		return nil, fmt.Errorf("apply set values: %w", err)
+	}
+
+	// create a new strict decoder
+	rawConfig := &config.Config{}
+	err = yaml.UnmarshalStrict(rawFile, rawConfig)
+	if err != nil {
+		fmt.Printf("%#+v\n", errors.Unwrap(err))
+		return nil, err
+	}
+
+	// set standalone config
+	rawConfig.ControlPlane.Standalone.Enabled = true
+	rawConfig.PrivateNodes.Enabled = true
+	if rawConfig.ControlPlane.Standalone.DataDir == "" {
+		rawConfig.ControlPlane.Standalone.DataDir = constants.VClusterStandaloneDefaultDataDir
+	}
+
+	return parseConfigBytes(name, rawConfig)
+}
+
+func parseConfigBytes(name string, rawConfig *config.Config) (*VirtualClusterConfig, error) {
 	// build config
 	retConfig := &VirtualClusterConfig{
 		Config: *rawConfig,
@@ -59,7 +88,7 @@ func ParseConfigBytes(data []byte, name string, setValues []string) (*VirtualClu
 	}
 
 	// validate config
-	err = ValidateConfigAndSetDefaults(retConfig)
+	err := ValidateConfigAndSetDefaults(retConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
