### PR TITLE
feat: add sanitise pod name for events

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,7 @@ timestamp := `date +%s`
 GOOS := env("GOOS", `go env GOOS`)
 GOARCH := env("GOARCH", `go env GOARCH`)
 GOBIN := env("GOBIN", `go env GOPATH`+"/bin")
+PRIVATE_GO_ENV := "GOPRIVATE=github.com/loft-sh/* GONOSUMDB=github.com/loft-sh/*"
 
 DIST_FOLDER := if GOARCH == "amd64" { "dist/vcluster_linux_amd64_v1" } else if GOARCH == "arm64" { "dist/vcluster_linux_arm64_v8.0" } else { "unknown" }
 DIST_FOLDER_CLI := if GOARCH == "amd64" { "dist/vcluster-cli_" + GOOS + "_amd64_v1" } else if GOARCH == "arm64" { "dist/vcluster-cli_" + GOOS + "_arm64_v8.0" } else { "unknown" }
@@ -97,7 +98,7 @@ _ensure-linters:
   if [ ! -f ./tools/golangci-lint ] || \
      [ -n "$(find .custom-gcl.yml -newer ./tools/golangci-lint \( -name '*.yml' \) 2>/dev/null | head -1)" ]; then
     echo "Custom linters changed - rebuilding tools/golangci-lint..."
-    golangci-lint custom
+    {{PRIVATE_GO_ENV}} golangci-lint custom
   fi
 
 # Run golangci-lint for all packages

--- a/e2e-next/suite_e2e_test.go
+++ b/e2e-next/suite_e2e_test.go
@@ -35,6 +35,7 @@ func suiteCommonVCluster() {
 			})
 
 			test_core.PodSyncSpec()
+			test_core.SyncErrorSanitisationSpec()
 			test_core.NetworkPolicySyncSpec()
 			test_core.PVCSyncSpec()
 			test_core.K8sDefaultEndpointSpec()

--- a/e2e-next/test_core/sync/test_pods.go
+++ b/e2e-next/test_core/sync/test_pods.go
@@ -125,7 +125,7 @@ func PodSyncSpec() {
 					vpod, err := vClusterClient.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-					hostNS := "vcluster-" + vClusterName
+					hostNS := vClusterHostNamespace(vClusterName)
 					pod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 
@@ -268,7 +268,7 @@ func PodSyncSpec() {
 					vpod, err := vClusterClient.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-					hostNS := "vcluster-" + vClusterName
+					hostNS := vClusterHostNamespace(vClusterName)
 					pod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					pod.Status.QOSClass = vpod.Status.QOSClass
@@ -288,7 +288,7 @@ func PodSyncSpec() {
 					waitPodRunning(ctx, podName, ns)
 
 					pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-					hostNS := "vcluster-" + vClusterName
+					hostNS := vClusterHostNamespace(vClusterName)
 					Eventually(func(g Gomega) {
 						pPod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
 						g.Expect(err).To(Succeed())
@@ -416,7 +416,7 @@ func PodSyncSpec() {
 				waitPodRunning(ctx, podName, ns)
 
 				pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				By("Checking the env var value", func() {
 					stdout, stderr, err := podhelper.ExecBuffered(ctx, hostConfig, hostNS, pPodName, testingContainerName, []string{"sh", "-c", "echo $" + envVarName}, nil)
@@ -499,7 +499,7 @@ func PodSyncSpec() {
 				waitPodRunning(ctx, podName, ns)
 
 				pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				By("Checking the env var value", func() {
 					stdout, stderr, err := podhelper.ExecBuffered(ctx, hostConfig, hostNS, pPodName, testingContainerName, []string{"sh", "-c", "echo $" + envVarName}, nil)
@@ -538,7 +538,7 @@ func PodSyncSpec() {
 				})
 
 				// Wait for the service to be synced to the host with a ClusterIP assigned
-				hostNSForSvc := "vcluster-" + vClusterName
+				hostNSForSvc := vClusterHostNamespace(vClusterName)
 				Eventually(func(g Gomega) {
 					pSvcName := translate.SingleNamespaceHostName(svcName, ns, vClusterName)
 					pSvc, err := hostClient.CoreV1().Services(hostNSForSvc).Get(ctx, pSvcName, metav1.GetOptions{})
@@ -574,7 +574,7 @@ func PodSyncSpec() {
 				waitPodRunning(ctx, podName, ns)
 
 				pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				By("Checking dependent env var resolution", func() {
 					stdout, stderr, err := podhelper.ExecBuffered(ctx, hostConfig, hostNS, pPodName, testingContainerName, []string{"sh", "-c", "echo $HELLO_WORLD"}, nil)
@@ -624,7 +624,7 @@ func PodSyncSpec() {
 				waitPodRunning(ctx, podName, ns)
 
 				pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				// findNsLabel scans pod labels for a namespace-prefixed label matching the
 				// expected value. translate.HostLabelNamespace uses a process-global VClusterName
@@ -697,7 +697,7 @@ func PodSyncSpec() {
 				waitPodRunning(ctx, podName, ns)
 
 				pPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				By("Verifying the service account token annotation is not present on host pod", func() {
 					pPod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
@@ -734,7 +734,7 @@ func PodSyncSpec() {
 				createTestNamespace(ctx, ns)
 
 				podName := "pod-bidir-" + suffix
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				By("Creating a pod with initial annotations and labels", func() {
 					_, err := vClusterClient.CoreV1().Pods(ns).Create(ctx, &corev1.Pod{
@@ -901,3 +901,7 @@ func PodSyncSpec() {
 
 func boolPtr(b bool) *bool    { return &b }
 func int64Ptr(i int64) *int64 { return &i }
+
+// vClusterHostNamespace returns the Control Plane Cluster namespace that
+// vcluster uses for a Tenant Cluster with the given name.
+func vClusterHostNamespace(vClusterName string) string { return "vcluster-" + vClusterName }

--- a/e2e-next/test_core/sync/test_pvc.go
+++ b/e2e-next/test_core/sync/test_pvc.go
@@ -41,7 +41,7 @@ func PVCSyncSpec() {
 				nsName := "pvc-sync-test-" + suffix
 				pvcName := "pvc-" + suffix
 				podName := "nginx-pvc-" + suffix
-				hostNS := "vcluster-" + vClusterName
+				hostNS := vClusterHostNamespace(vClusterName)
 
 				By("Creating a test namespace", func() {
 					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{

--- a/e2e-next/test_core/sync/test_sync_error_events.go
+++ b/e2e-next/test_core/sync/test_sync_error_events.go
@@ -1,0 +1,202 @@
+package test_core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// SyncErrorSanitisationSpec verifies that SyncError warning events recorded on
+// virtual pods never expose the host-side translated pod name.
+//
+// The host pod name (e.g. "my-pod-x-default-x-my-vc") must not appear in event
+// messages visible from inside the virtual cluster. The sanitising event recorder
+// (pkg/syncer/translator/sanitising_event_recorder.go) rewrites it back to the
+// virtual name before the event is persisted.
+func SyncErrorSanitisationSpec() {
+	Describe("SyncError event sanitisation",
+		labels.PR, labels.Core, labels.Events, labels.Pods, labels.Sync,
+		func() {
+			var (
+				hostClient     kubernetes.Interface
+				vClusterClient kubernetes.Interface
+				vClusterName   string
+			)
+
+			BeforeEach(func(ctx context.Context) {
+				hostClient = cluster.KubeClientFrom(ctx, constants.GetHostClusterName())
+				Expect(hostClient).NotTo(BeNil())
+				vClusterClient = cluster.CurrentKubeClientFrom(ctx)
+				Expect(vClusterClient).NotTo(BeNil())
+				vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			})
+
+			It("should not expose the host pod name in SyncError events", labels.PR, func(ctx context.Context) {
+				suffix := random.String(6)
+				ns := "sync-err-test-" + suffix
+				podName := "test-pod-" + suffix
+
+				By("creating a test namespace in the virtual cluster", func() {
+					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{Name: ns},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				// hostPodName is the translated host-side name that MUST NOT appear
+				// in any virtual pod event (e.g. "test-pod-abc123-x-sync-err-test-abc123-x-my-vc").
+				hostPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
+				hostNS := vClusterHostNamespace(vClusterName)
+
+				By("creating a pod in the virtual cluster", func() {
+					_, err := vClusterClient.CoreV1().Pods(ns).Create(ctx, &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      podName,
+							Namespace: ns,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:            testingContainerName,
+									Image:           testingContainerImage,
+									ImagePullPolicy: corev1.PullIfNotPresent,
+									SecurityContext: &corev1.SecurityContext{
+										Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+										RunAsNonRoot:             boolPtr(true),
+										RunAsUser:                int64Ptr(12345),
+										AllowPrivilegeEscalation: boolPtr(false),
+										SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+									},
+								},
+							},
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.CoreV1().Pods(ns).Delete(ctx, podName, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				By("waiting for the syncer to create the host pod", func() {
+					Eventually(func(g Gomega) {
+						_, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, hostPodName, metav1.GetOptions{})
+						g.Expect(err).NotTo(HaveOccurred(),
+							"host pod %s/%s should exist after sync", hostNS, hostPodName)
+					}).WithPolling(constants.PollingInterval).
+						WithTimeout(constants.PollingTimeout).
+						Should(Succeed())
+				})
+
+				// Race the syncer against concurrent host and virtual pod updates.
+				//
+				// The pod syncer fetches the host pod once at the start of each reconcile.
+				// If the host pod's resource version changes before the syncer's patch lands,
+				// the API server returns a 409 Conflict; the pod syncer records a SyncError
+				// event (pkg/controllers/resources/pods/syncer.go) before the conflict is
+				// silently requeued by the outer controller.
+				//
+				// Running both goroutines concurrently widens the race window so that the
+				// syncer is processing a reconcile while we are simultaneously bumping the
+				// host pod's resource version.
+				// Errors are intentionally swallowed — the goal is volume of conflicting
+				// updates, not that every individual update succeeds.
+				By("concurrently bumping the host pod and triggering virtual reconciles to force SyncError events", func() {
+					var wg sync.WaitGroup
+					wg.Add(2)
+
+					go func() {
+						defer wg.Done()
+						for i := range 20 {
+							_ = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+								hp, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, hostPodName, metav1.GetOptions{})
+								if err != nil {
+									return err
+								}
+								if hp.Annotations == nil {
+									hp.Annotations = map[string]string{}
+								}
+								hp.Annotations["race-bump"] = fmt.Sprintf("%d", i)
+								_, err = hostClient.CoreV1().Pods(hostNS).Update(ctx, hp, metav1.UpdateOptions{})
+								return err
+							})
+						}
+					}()
+
+					go func() {
+						defer wg.Done()
+						for i := range 20 {
+							_ = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+								vPod, err := vClusterClient.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
+								if err != nil {
+									return err
+								}
+								if vPod.Annotations == nil {
+									vPod.Annotations = map[string]string{}
+								}
+								vPod.Annotations["reconcile-trigger"] = fmt.Sprintf("%d", i)
+								_, err = vClusterClient.CoreV1().Pods(ns).Update(ctx, vPod, metav1.UpdateOptions{})
+								return err
+							})
+						}
+					}()
+
+					wg.Wait()
+				})
+
+				By("verifying at least one SyncError event was recorded without the host pod name", func() {
+					// The Eventually here serves two purposes:
+					// 1. It waits until the syncer has produced at least one SyncError event,
+					//    confirming that the sanitiser code path was actually exercised.
+					// 2. It fails immediately if any SyncError message contains the host pod
+					//    name, catching a regression in the sanitising recorder.
+					//
+					// If no SyncError events are produced within PollingTimeout the test fails
+					// — it does NOT pass vacuously when events are absent.
+					Eventually(func(g Gomega) {
+						eventList, err := vClusterClient.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+							FieldSelector: "involvedObject.name=" + podName,
+						})
+						g.Expect(err).NotTo(HaveOccurred())
+
+						syncErrorCount := 0
+						for _, event := range eventList.Items {
+							if event.Reason != "SyncError" {
+								continue
+							}
+							syncErrorCount++
+							g.Expect(event.Message).NotTo(ContainSubstring(hostPodName),
+								"SyncError event message %q must not contain the host pod name %q",
+								event.Message, hostPodName)
+						}
+						g.Expect(syncErrorCount).To(BeNumerically(">", 0),
+							"expected at least one SyncError event to verify the sanitiser ran")
+					}).WithPolling(constants.PollingInterval).
+						WithTimeout(constants.PollingTimeout).
+						Should(Succeed())
+				})
+			})
+		},
+	)
+}

--- a/e2e-next/test_core/sync/test_sync_error_events.go
+++ b/e2e-next/test_core/sync/test_sync_error_events.go
@@ -28,7 +28,7 @@ import (
 // virtual name before the event is persisted.
 func SyncErrorSanitisationSpec() {
 	Describe("SyncError event sanitisation",
-		labels.PR, labels.Core, labels.Events, labels.Pods, labels.Sync,
+		labels.Core, labels.Events, labels.Pods, labels.Sync,
 		func() {
 			var (
 				hostClient     kubernetes.Interface
@@ -54,14 +54,13 @@ func SyncErrorSanitisationSpec() {
 						ObjectMeta: metav1.ObjectMeta{Name: ns},
 					}, metav1.CreateOptions{})
 					Expect(err).To(Succeed())
-					DeferCleanup(func(ctx context.Context) {
-						err := vClusterClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
-						if !kerrors.IsNotFound(err) {
-							Expect(err).To(Succeed())
-						}
-					})
 				})
-
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
 				// hostPodName is the translated host-side name that MUST NOT appear
 				// in any virtual pod event (e.g. "test-pod-abc123-x-sync-err-test-abc123-x-my-vc").
 				hostPodName := translate.SingleNamespaceHostName(podName, ns, vClusterName)
@@ -100,11 +99,12 @@ func SyncErrorSanitisationSpec() {
 				})
 
 				By("waiting for the syncer to create the host pod", func() {
-					Eventually(func(g Gomega) {
+					Eventually(func(g Gomega, ctx context.Context) {
 						_, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, hostPodName, metav1.GetOptions{})
 						g.Expect(err).NotTo(HaveOccurred(),
 							"host pod %s/%s should exist after sync", hostNS, hostPodName)
-					}).WithPolling(constants.PollingInterval).
+					}).WithContext(ctx).
+						WithPolling(constants.PollingInterval).
 						WithTimeout(constants.PollingTimeout).
 						Should(Succeed())
 				})
@@ -174,7 +174,7 @@ func SyncErrorSanitisationSpec() {
 					//
 					// If no SyncError events are produced within PollingTimeout the test fails
 					// — it does NOT pass vacuously when events are absent.
-					Eventually(func(g Gomega) {
+					Eventually(func(g Gomega, ctx context.Context) {
 						eventList, err := vClusterClient.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
 							FieldSelector: "involvedObject.name=" + podName,
 						})
@@ -192,7 +192,8 @@ func SyncErrorSanitisationSpec() {
 						}
 						g.Expect(syncErrorCount).To(BeNumerically(">", 0),
 							"expected at least one SyncError event to verify the sanitiser ran")
-					}).WithPolling(constants.PollingInterval).
+					}).WithContext(ctx).
+						WithPolling(constants.PollingInterval).
 						WithTimeout(constants.PollingTimeout).
 						Should(Succeed())
 				})

--- a/pkg/syncer/translator/from_config_translator.go
+++ b/pkg/syncer/translator/from_config_translator.go
@@ -37,15 +37,21 @@ func NewFromHostTranslatorForGVK(ctx *synccontext.RegisterContext, gvk schema.Gr
 		virtualToHost[virtual] = host
 	}
 
-	return &fromHostTranslate{
+	t := &fromHostTranslate{
 		gvk:            gvk,
-		eventRecorder:  ctx.VirtualManager.GetEventRecorder("from-host-" + strings.ToLower(gvk.Kind) + "-syncer"),
 		virtualToHost:  virtualToHost,
 		hostToVirtual:  hostToVirtual,
 		namespace:      ctx.Config.HostNamespace,
 		translatorName: "from-host-" + strings.ToLower(gvk.Kind),
 		skipFuncs:      skipFuncs,
-	}, nil
+	}
+	syncCtx := ctx.ToSyncContext("from-host-" + strings.ToLower(gvk.Kind))
+	t.eventRecorder = newSanitisingEventRecorder(
+		syncCtx,
+		ctx.VirtualManager.GetEventRecorder("from-host-"+strings.ToLower(gvk.Kind)+"-syncer"),
+		t,
+	)
+	return t, nil
 }
 
 func (c *fromHostTranslate) Name() string {

--- a/pkg/syncer/translator/from_config_translator.go
+++ b/pkg/syncer/translator/from_config_translator.go
@@ -49,7 +49,7 @@ func NewFromHostTranslatorForGVK(ctx *synccontext.RegisterContext, gvk schema.Gr
 	t.eventRecorder = newSanitisingEventRecorder(
 		syncCtx,
 		ctx.VirtualManager.GetEventRecorder("from-host-"+strings.ToLower(gvk.Kind)+"-syncer"),
-		t,
+		t.VirtualToHost,
 	)
 	return t, nil
 }
@@ -80,6 +80,9 @@ func (c *fromHostTranslate) GroupVersionKind() schema.GroupVersionKind {
 	return c.gvk
 }
 
+// VirtualToHost must never emit events: it is passed as the translation
+// function to newSanitisingEventRecorder, so calling Eventf here would
+// recurse infinitely (recorder → VirtualToHost → recorder → …).
 func (c *fromHostTranslate) VirtualToHost(_ *synccontext.SyncContext, req types.NamespacedName, _ client.Object) types.NamespacedName {
 	vName, vNs := req.Name, req.Namespace
 	nn, _ := matchesVirtualObject(vNs, vName, c.virtualToHost, c.namespace)

--- a/pkg/syncer/translator/generic_translator.go
+++ b/pkg/syncer/translator/generic_translator.go
@@ -16,7 +16,7 @@ func NewGenericTranslator(ctx *synccontext.RegisterContext, name string, obj cli
 
 		obj: obj,
 
-		eventRecorder: newSanitisingEventRecorder(syncCtx, ctx.VirtualManager.GetEventRecorder(name+"-syncer"), mapper),
+		eventRecorder: newSanitisingEventRecorder(syncCtx, ctx.VirtualManager.GetEventRecorder(name+"-syncer"), mapper.VirtualToHost),
 	}
 }
 

--- a/pkg/syncer/translator/generic_translator.go
+++ b/pkg/syncer/translator/generic_translator.go
@@ -8,6 +8,7 @@ import (
 )
 
 func NewGenericTranslator(ctx *synccontext.RegisterContext, name string, obj client.Object, mapper synccontext.Mapper) syncertypes.GenericTranslator {
+	syncCtx := ctx.ToSyncContext("generic-translator")
 	return &genericTranslator{
 		Mapper: mapper,
 
@@ -15,7 +16,7 @@ func NewGenericTranslator(ctx *synccontext.RegisterContext, name string, obj cli
 
 		obj: obj,
 
-		eventRecorder: ctx.VirtualManager.GetEventRecorder(name + "-syncer"),
+		eventRecorder: newSanitisingEventRecorder(syncCtx, ctx.VirtualManager.GetEventRecorder(name+"-syncer"), mapper),
 	}
 }
 

--- a/pkg/syncer/translator/sanitising_event_recorder.go
+++ b/pkg/syncer/translator/sanitising_event_recorder.go
@@ -21,10 +21,10 @@ import (
 // Two passes are applied:
 //
 //  1. Exact replacement for the regarding object's translated name.
-//     The mapper's VirtualToHost is called with the regarding object's virtual
-//     name/namespace to obtain the actual host name — this correctly handles all
-//     naming schemes (namespaced, cluster-scoped, hashed, or custom) without
-//     duplicating translation logic in the recorder.
+//     virtualToHost is called with the regarding object's virtual name/namespace
+//     to obtain the actual host name — this correctly handles all naming schemes
+//     (namespaced, cluster-scoped, hashed, or custom) without duplicating
+//     translation logic in the recorder.
 //
 //  2. Suffix stripping for secondary namespaced resource names that may appear
 //     in API server error messages (e.g. a ConfigMap or Secret in a "not found"
@@ -32,14 +32,22 @@ import (
 //     message. Skipped entirely when the regarding object's virtual name ends with
 //     that suffix (stripping would corrupt it). Only applied when the regarding
 //     object has a namespace. Hashed secondary names are left unchanged.
-func newSanitisingEventRecorder(syncCtx *synccontext.SyncContext, underlying events.EventRecorder, mapper synccontext.Mapper) events.EventRecorder {
-	return &sanitisingEventRecorder{syncCtx: syncCtx, underlying: underlying, mapper: mapper}
+//
+// virtualToHost must be a plain translation function — it must not emit events
+// itself, as that would cause infinite recursion (recorder → virtualToHost →
+// recorder → …).
+func newSanitisingEventRecorder(
+	syncCtx *synccontext.SyncContext,
+	underlying events.EventRecorder,
+	virtualToHost func(*synccontext.SyncContext, types.NamespacedName, client.Object) types.NamespacedName,
+) events.EventRecorder {
+	return &sanitisingEventRecorder{syncCtx: syncCtx, underlying: underlying, virtualToHost: virtualToHost}
 }
 
 type sanitisingEventRecorder struct {
-	syncCtx    *synccontext.SyncContext
-	underlying events.EventRecorder
-	mapper     synccontext.Mapper
+	syncCtx       *synccontext.SyncContext
+	underlying    events.EventRecorder
+	virtualToHost func(*synccontext.SyncContext, types.NamespacedName, client.Object) types.NamespacedName
 }
 
 // Eventf formats the note+args into a single message, sanitises any
@@ -70,10 +78,10 @@ func (s *sanitisingEventRecorder) Eventf(
 		vName    string
 		hostName types.NamespacedName
 	)
-	if s.mapper != nil {
+	if s.virtualToHost != nil {
 		vName = acc.GetName()
 		vObj, _ := regarding.(client.Object)
-		hostName = s.mapper.VirtualToHost(s.syncCtx, types.NamespacedName{Name: vName, Namespace: acc.GetNamespace()}, vObj)
+		hostName = s.virtualToHost(s.syncCtx, types.NamespacedName{Name: vName, Namespace: acc.GetNamespace()}, vObj)
 	}
 
 	// Pass 1: exact replacement for the regarding object's host name.

--- a/pkg/syncer/translator/sanitising_event_recorder.go
+++ b/pkg/syncer/translator/sanitising_event_recorder.go
@@ -1,0 +1,97 @@
+package translator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// newSanitisingEventRecorder wraps underlying so that any host-side object name
+// embedded in event messages is rewritten to the virtual name before the event
+// is recorded on the virtual object.
+//
+// Two passes are applied:
+//
+//  1. Exact replacement for the regarding object's translated name.
+//     The mapper's VirtualToHost is called with the regarding object's virtual
+//     name/namespace to obtain the actual host name — this correctly handles all
+//     naming schemes (namespaced, cluster-scoped, hashed, or custom) without
+//     duplicating translation logic in the recorder.
+//
+//  2. Suffix stripping for secondary namespaced resource names that may appear
+//     in API server error messages (e.g. a ConfigMap or Secret in a "not found"
+//     error). The static suffix "-x-{namespace}-x-{vcName}" is stripped from the
+//     message. Skipped entirely when the regarding object's virtual name ends with
+//     that suffix (stripping would corrupt it). Only applied when the regarding
+//     object has a namespace. Hashed secondary names are left unchanged.
+func newSanitisingEventRecorder(syncCtx *synccontext.SyncContext, underlying events.EventRecorder, mapper synccontext.Mapper) events.EventRecorder {
+	return &sanitisingEventRecorder{syncCtx: syncCtx, underlying: underlying, mapper: mapper}
+}
+
+type sanitisingEventRecorder struct {
+	syncCtx    *synccontext.SyncContext
+	underlying events.EventRecorder
+	mapper     synccontext.Mapper
+}
+
+// Eventf formats the note+args into a single message, sanitises any
+// host-translated object names, then forwards to the underlying recorder.
+func (s *sanitisingEventRecorder) Eventf(
+	regarding runtime.Object,
+	related runtime.Object,
+	eventtype, reason, action, note string,
+	args ...any,
+) {
+	message := fmt.Sprintf(note, args...)
+
+	acc, err := meta.Accessor(regarding)
+
+	if err != nil {
+		logger := klog.Background()
+		if s.syncCtx != nil {
+			logger = klog.FromContext(s.syncCtx)
+		}
+		logger.V(1).Info("failed to access metadata for event regarding object, forwarding unsanitised", "error", err)
+		s.underlying.Eventf(regarding, related, eventtype, reason, action, "%s", message)
+		return
+	}
+	// Call VirtualToHost once; both passes use the result.
+	// When syncCtx is nil, VirtualToHostFromStore and RecordMapping nil-check ctx
+	// and skip gracefully, falling back to formula-based translation.
+	var (
+		vName    string
+		hostName types.NamespacedName
+	)
+	if s.mapper != nil {
+		vName = acc.GetName()
+		vObj, _ := regarding.(client.Object)
+		hostName = s.mapper.VirtualToHost(s.syncCtx, types.NamespacedName{Name: vName, Namespace: acc.GetNamespace()}, vObj)
+	}
+
+	// Pass 1: exact replacement for the regarding object's host name.
+	if hostName.Name != "" && hostName.Name != vName {
+		message = strings.ReplaceAll(message, hostName.Name, vName)
+	}
+
+	// Pass 2: strip the translated suffix from secondary namespaced resource names
+	// (e.g. a ConfigMap or Secret embedded in a "not found" error).
+	// Skipped when vName itself ends with the suffix — stripping would corrupt the
+	// virtual name that Pass 1 just placed. Secondary-resource sanitization is
+	// sacrificed for that edge case. Only applied when the regarding object has a namespace.
+	if acc.GetNamespace() != "" && translate.VClusterName != "" {
+		suffix := "-x-" + acc.GetNamespace() + "-x-" + translate.VClusterName
+		if !strings.HasSuffix(vName, suffix) {
+			message = strings.ReplaceAll(message, suffix, "")
+		}
+	}
+
+	s.underlying.Eventf(regarding, related, eventtype, reason, action, "%s", message)
+}

--- a/pkg/syncer/translator/sanitising_event_recorder_test.go
+++ b/pkg/syncer/translator/sanitising_event_recorder_test.go
@@ -1,0 +1,260 @@
+package translator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// captureRecorder records the sanitised message and pass-through fields from
+// the last Eventf call.
+type captureRecorder struct {
+	lastMessage string
+	eventtype   string
+	reason      string
+	action      string
+}
+
+func (c *captureRecorder) Eventf(_ runtime.Object, _ runtime.Object, eventtype, reason, action, note string, args ...any) {
+	c.lastMessage = fmt.Sprintf(note, args...)
+	c.eventtype = eventtype
+	c.reason = reason
+	c.action = action
+}
+
+// namespacedMapper translates using the standard SingleNamespaceHostName scheme.
+type namespacedMapper struct{}
+
+func (m *namespacedMapper) VirtualToHost(_ *synccontext.SyncContext, req types.NamespacedName, _ client.Object) types.NamespacedName {
+	return translate.Default.HostName(nil, req.Name, req.Namespace)
+}
+
+func (m *namespacedMapper) HostToVirtual(_ *synccontext.SyncContext, _ types.NamespacedName, _ client.Object) types.NamespacedName {
+	return types.NamespacedName{}
+}
+
+func (m *namespacedMapper) IsManaged(_ *synccontext.SyncContext, _ client.Object) (bool, error) {
+	return false, nil
+}
+
+func (m *namespacedMapper) Migrate(_ *synccontext.RegisterContext, _ synccontext.Mapper) error {
+	return nil
+}
+
+func (m *namespacedMapper) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{}
+}
+
+// clusterScopedMapper translates using the HostNameCluster scheme (no namespace).
+type clusterScopedMapper struct{}
+
+func (m *clusterScopedMapper) VirtualToHost(_ *synccontext.SyncContext, req types.NamespacedName, _ client.Object) types.NamespacedName {
+	return types.NamespacedName{Name: translate.Default.HostNameCluster(req.Name)}
+}
+
+func (m *clusterScopedMapper) HostToVirtual(_ *synccontext.SyncContext, _ types.NamespacedName, _ client.Object) types.NamespacedName {
+	return types.NamespacedName{}
+}
+
+func (m *clusterScopedMapper) IsManaged(_ *synccontext.SyncContext, _ client.Object) (bool, error) {
+	return false, nil
+}
+
+func (m *clusterScopedMapper) Migrate(_ *synccontext.RegisterContext, _ synccontext.Mapper) error {
+	return nil
+}
+
+func (m *clusterScopedMapper) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{}
+}
+
+func TestSanitisingEventRecorder(t *testing.T) {
+	const vcName = "my-vc"
+
+	origVClusterName := translate.VClusterName
+	translate.VClusterName = vcName
+	t.Cleanup(func() { translate.VClusterName = origVClusterName })
+
+	pod := func(name, namespace string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	}
+
+	tests := []struct {
+		name        string
+		mapper      synccontext.Mapper
+		regarding   runtime.Object
+		note        string
+		args        []any
+		wantMessage string
+	}{
+		{
+			name:        "plain host name replaced with virtual name",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("cuda-vector-add", "default"),
+			note:        `Error syncing: update object: Operation cannot be fulfilled on pods "` + translate.SingleNamespaceHostName("cuda-vector-add", "default", vcName) + `": the object has been modified`,
+			wantMessage: `Error syncing: update object: Operation cannot be fulfilled on pods "cuda-vector-add": the object has been modified`,
+		},
+		{
+			// Names that exceed 63 chars are hashed by SafeConcatName; Pass 1 must
+			// still replace the hash with the virtual name via the exact-match lookup.
+			name:        "hashed host name replaced with virtual name",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("very-long-pod-name-that-definitely-exceeds-63-chars", "default"),
+			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("very-long-pod-name-that-definitely-exceeds-63-chars", "default", vcName) + `" failed`,
+			wantMessage: `Error syncing: pods "very-long-pod-name-that-definitely-exceeds-63-chars" failed`,
+		},
+		{
+			name:        "host name not present in message passes through unchanged",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("my-pod", "default"),
+			note:        "Error syncing: some unrelated error occurred",
+			wantMessage: "Error syncing: some unrelated error occurred",
+		},
+		{
+			name:        "multiple occurrences of host name all replaced",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("my-pod", "ns1"),
+			note:        "object " + translate.SingleNamespaceHostName("my-pod", "ns1", vcName) + " conflicts with " + translate.SingleNamespaceHostName("my-pod", "ns1", vcName),
+			wantMessage: "object my-pod conflicts with my-pod",
+		},
+		{
+			name:        "format args are expanded before sanitisation",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("web", "production"),
+			note:        "Error syncing: %v",
+			args:        []any{`update object: Operation cannot be fulfilled on pods "` + translate.SingleNamespaceHostName("web", "production", vcName) + `"`},
+			wantMessage: `Error syncing: update object: Operation cannot be fulfilled on pods "web"`,
+		},
+		{
+			// Pod with an empty namespace: SingleNamespaceHostName embeds an empty
+			// namespace segment ("name-x--x-vcName"). Pass 1 replaces via exact match;
+			// Pass 2 does not fire because namespace is empty.
+			name:        "empty namespace host name replaced",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("my-pod", ""),
+			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("my-pod", "", vcName) + `" failed`,
+			wantMessage: `Error syncing: pods "my-pod" failed`,
+		},
+		{
+			name:        "non-pod object (PVC) host name replaced",
+			mapper:      &namespacedMapper{},
+			regarding:   &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "team-a"}},
+			note:        `Error syncing: Operation cannot be fulfilled on persistentvolumeclaims "` + translate.SingleNamespaceHostName("my-pvc", "team-a", vcName) + `"`,
+			wantMessage: `Error syncing: Operation cannot be fulfilled on persistentvolumeclaims "my-pvc"`,
+		},
+		{
+			name:        "nil regarding does not panic and passes message through",
+			regarding:   nil,
+			note:        "Error syncing: %v",
+			args:        []any{"some error"},
+			wantMessage: "Error syncing: some error",
+		},
+		{
+			// When the API server rejects a pod update because a secondary resource
+			// (e.g. a translated ConfigMap) is missing, the error message embeds the
+			// host-side name of that secondary resource — not the pod's host name.
+			// The suffix-stripping pass must strip it even though it is not the regarding object.
+			name:      "secondary resource host name replaced",
+			mapper:    &namespacedMapper{},
+			regarding: pod("my-pod", "default"),
+			note:      `Error syncing: %v`,
+			args: []any{
+				`configmap "` + translate.SingleNamespaceHostName("app-config", "default", vcName) + `" not found`,
+			},
+			wantMessage: `Error syncing: configmap "app-config" not found`,
+		},
+		{
+			// A message that embeds both the regarding pod's translated name and a
+			// secondary configmap's translated name — both must be replaced.
+			name:      "both regarding and secondary host names replaced in same message",
+			mapper:    &namespacedMapper{},
+			regarding: pod("my-pod", "default"),
+			note: `Error syncing: update object: Operation cannot be fulfilled on pods "` +
+				translate.SingleNamespaceHostName("my-pod", "default", vcName) +
+				`": conflict; referenced configmap "` +
+				translate.SingleNamespaceHostName("app-config", "default", vcName) +
+				`" not found`,
+			wantMessage: `Error syncing: update object: Operation cannot be fulfilled on pods "my-pod": conflict; referenced configmap "app-config" not found`,
+		},
+		{
+			// A resource name that itself contains "-x-" (valid in Kubernetes).
+			// Pass 2 splits on vName so "my-x-pod" is recovered correctly.
+			name:        "resource name containing -x- replaced correctly",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("my-x-pod", "default"),
+			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("my-x-pod", "default", vcName) + `" conflict`,
+			wantMessage: `Error syncing: pods "my-x-pod" conflict`,
+		},
+		{
+			// When the namespace itself contains "-x-", the exact-suffix approach matches
+			// "-x-team-x-blue-x-my-vc" literally and strips it in one operation.
+			name:      "secondary resource in namespace containing -x- is replaced correctly",
+			mapper:    &namespacedMapper{},
+			regarding: pod("my-pod", "team-x-blue"),
+			note:      `Error syncing: %v`,
+			args: []any{
+				`configmap "` + translate.SingleNamespaceHostName("app-config", "team-x-blue", vcName) + `" not found`,
+			},
+			wantMessage: `Error syncing: configmap "app-config" not found`,
+		},
+		{
+			// A virtual name that ends with the translated suffix pattern is valid in
+			// Kubernetes. Pass 2 detects this via HasSuffix and is skipped entirely to
+			// avoid corrupting the name that Pass 1 just placed in the message.
+			name:        "regarding name ending with suffix is not corrupted by Pass 2",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("api-x-default-x-my-vc", "default"),
+			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("api-x-default-x-my-vc", "default", vcName) + `" conflict`,
+			wantMessage: `Error syncing: pods "api-x-default-x-my-vc" conflict`,
+		},
+		{
+			// The vClusterName suffix appears in the message but there is no preceding
+			// "-x-" separator — no match, message must pass through unchanged.
+			name:        "bare vcluster name suffix without separator passes through unchanged",
+			mapper:      &namespacedMapper{},
+			regarding:   pod("my-pod", "default"),
+			note:        "error: unknown cluster my-vc encountered",
+			wantMessage: "error: unknown cluster my-vc encountered",
+		},
+		{
+			// Cluster-scoped resources use HostNameCluster (prefixed with "vcluster-").
+			// Pass 1 must replace the cluster-scoped host name using the mapper result;
+			// Pass 2 does not fire because cluster-scoped objects have no namespace.
+			name:        "cluster-scoped resource host name replaced in Pass 1",
+			mapper:      &clusterScopedMapper{},
+			regarding:   &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "my-node"}},
+			note:        `Error syncing: nodes "` + translate.Default.HostNameCluster("my-node") + `" conflict`,
+			wantMessage: `Error syncing: nodes "my-node" conflict`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured := &captureRecorder{}
+			rec := newSanitisingEventRecorder(nil, captured, tt.mapper)
+
+			rec.Eventf(tt.regarding, nil, "Warning", "SyncError", "SyncPod", tt.note, tt.args...)
+
+			if captured.lastMessage != tt.wantMessage {
+				t.Errorf("\ngot:  %s\nwant: %s", captured.lastMessage, tt.wantMessage)
+			}
+			if captured.eventtype != "Warning" {
+				t.Errorf("eventtype: got %q, want %q", captured.eventtype, "Warning")
+			}
+			if captured.reason != "SyncError" {
+				t.Errorf("reason: got %q, want %q", captured.reason, "SyncError")
+			}
+			if captured.action != "SyncPod" {
+				t.Errorf("action: got %q, want %q", captured.action, "SyncPod")
+			}
+		})
+	}
+}

--- a/pkg/syncer/translator/sanitising_event_recorder_test.go
+++ b/pkg/syncer/translator/sanitising_event_recorder_test.go
@@ -87,68 +87,71 @@ func TestSanitisingEventRecorder(t *testing.T) {
 		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
 	}
 
+	nsVirtualToHost := (&namespacedMapper{}).VirtualToHost
+	csVirtualToHost := (&clusterScopedMapper{}).VirtualToHost
+
 	tests := []struct {
-		name        string
-		mapper      synccontext.Mapper
-		regarding   runtime.Object
-		note        string
-		args        []any
-		wantMessage string
+		name          string
+		virtualToHost func(*synccontext.SyncContext, types.NamespacedName, client.Object) types.NamespacedName
+		regarding     runtime.Object
+		note          string
+		args          []any
+		wantMessage   string
 	}{
 		{
-			name:        "plain host name replaced with virtual name",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("cuda-vector-add", "default"),
-			note:        `Error syncing: update object: Operation cannot be fulfilled on pods "` + translate.SingleNamespaceHostName("cuda-vector-add", "default", vcName) + `": the object has been modified`,
-			wantMessage: `Error syncing: update object: Operation cannot be fulfilled on pods "cuda-vector-add": the object has been modified`,
+			name:          "plain host name replaced with virtual name",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("cuda-vector-add", "default"),
+			note:          `Error syncing: update object: Operation cannot be fulfilled on pods "` + translate.SingleNamespaceHostName("cuda-vector-add", "default", vcName) + `": the object has been modified`,
+			wantMessage:   `Error syncing: update object: Operation cannot be fulfilled on pods "cuda-vector-add": the object has been modified`,
 		},
 		{
 			// Names that exceed 63 chars are hashed by SafeConcatName; Pass 1 must
 			// still replace the hash with the virtual name via the exact-match lookup.
-			name:        "hashed host name replaced with virtual name",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("very-long-pod-name-that-definitely-exceeds-63-chars", "default"),
-			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("very-long-pod-name-that-definitely-exceeds-63-chars", "default", vcName) + `" failed`,
-			wantMessage: `Error syncing: pods "very-long-pod-name-that-definitely-exceeds-63-chars" failed`,
+			name:          "hashed host name replaced with virtual name",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("very-long-pod-name-that-definitely-exceeds-63-chars", "default"),
+			note:          `Error syncing: pods "` + translate.SingleNamespaceHostName("very-long-pod-name-that-definitely-exceeds-63-chars", "default", vcName) + `" failed`,
+			wantMessage:   `Error syncing: pods "very-long-pod-name-that-definitely-exceeds-63-chars" failed`,
 		},
 		{
-			name:        "host name not present in message passes through unchanged",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("my-pod", "default"),
-			note:        "Error syncing: some unrelated error occurred",
-			wantMessage: "Error syncing: some unrelated error occurred",
+			name:          "host name not present in message passes through unchanged",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", "default"),
+			note:          "Error syncing: some unrelated error occurred",
+			wantMessage:   "Error syncing: some unrelated error occurred",
 		},
 		{
-			name:        "multiple occurrences of host name all replaced",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("my-pod", "ns1"),
-			note:        "object " + translate.SingleNamespaceHostName("my-pod", "ns1", vcName) + " conflicts with " + translate.SingleNamespaceHostName("my-pod", "ns1", vcName),
-			wantMessage: "object my-pod conflicts with my-pod",
+			name:          "multiple occurrences of host name all replaced",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", "ns1"),
+			note:          "object " + translate.SingleNamespaceHostName("my-pod", "ns1", vcName) + " conflicts with " + translate.SingleNamespaceHostName("my-pod", "ns1", vcName),
+			wantMessage:   "object my-pod conflicts with my-pod",
 		},
 		{
-			name:        "format args are expanded before sanitisation",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("web", "production"),
-			note:        "Error syncing: %v",
-			args:        []any{`update object: Operation cannot be fulfilled on pods "` + translate.SingleNamespaceHostName("web", "production", vcName) + `"`},
-			wantMessage: `Error syncing: update object: Operation cannot be fulfilled on pods "web"`,
+			name:          "format args are expanded before sanitisation",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("web", "production"),
+			note:          "Error syncing: %v",
+			args:          []any{`update object: Operation cannot be fulfilled on pods "` + translate.SingleNamespaceHostName("web", "production", vcName) + `"`},
+			wantMessage:   `Error syncing: update object: Operation cannot be fulfilled on pods "web"`,
 		},
 		{
 			// Pod with an empty namespace: SingleNamespaceHostName embeds an empty
 			// namespace segment ("name-x--x-vcName"). Pass 1 replaces via exact match;
 			// Pass 2 does not fire because namespace is empty.
-			name:        "empty namespace host name replaced",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("my-pod", ""),
-			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("my-pod", "", vcName) + `" failed`,
-			wantMessage: `Error syncing: pods "my-pod" failed`,
+			name:          "empty namespace host name replaced",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", ""),
+			note:          `Error syncing: pods "` + translate.SingleNamespaceHostName("my-pod", "", vcName) + `" failed`,
+			wantMessage:   `Error syncing: pods "my-pod" failed`,
 		},
 		{
-			name:        "non-pod object (PVC) host name replaced",
-			mapper:      &namespacedMapper{},
-			regarding:   &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "team-a"}},
-			note:        `Error syncing: Operation cannot be fulfilled on persistentvolumeclaims "` + translate.SingleNamespaceHostName("my-pvc", "team-a", vcName) + `"`,
-			wantMessage: `Error syncing: Operation cannot be fulfilled on persistentvolumeclaims "my-pvc"`,
+			name:          "non-pod object (PVC) host name replaced",
+			virtualToHost: nsVirtualToHost,
+			regarding:     &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "my-pvc", Namespace: "team-a"}},
+			note:          `Error syncing: Operation cannot be fulfilled on persistentvolumeclaims "` + translate.SingleNamespaceHostName("my-pvc", "team-a", vcName) + `"`,
+			wantMessage:   `Error syncing: Operation cannot be fulfilled on persistentvolumeclaims "my-pvc"`,
 		},
 		{
 			name:        "nil regarding does not panic and passes message through",
@@ -162,10 +165,10 @@ func TestSanitisingEventRecorder(t *testing.T) {
 			// (e.g. a translated ConfigMap) is missing, the error message embeds the
 			// host-side name of that secondary resource — not the pod's host name.
 			// The suffix-stripping pass must strip it even though it is not the regarding object.
-			name:      "secondary resource host name replaced",
-			mapper:    &namespacedMapper{},
-			regarding: pod("my-pod", "default"),
-			note:      `Error syncing: %v`,
+			name:          "secondary resource host name replaced",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", "default"),
+			note:          `Error syncing: %v`,
 			args: []any{
 				`configmap "` + translate.SingleNamespaceHostName("app-config", "default", vcName) + `" not found`,
 			},
@@ -174,9 +177,9 @@ func TestSanitisingEventRecorder(t *testing.T) {
 		{
 			// A message that embeds both the regarding pod's translated name and a
 			// secondary configmap's translated name — both must be replaced.
-			name:      "both regarding and secondary host names replaced in same message",
-			mapper:    &namespacedMapper{},
-			regarding: pod("my-pod", "default"),
+			name:          "both regarding and secondary host names replaced in same message",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", "default"),
 			note: `Error syncing: update object: Operation cannot be fulfilled on pods "` +
 				translate.SingleNamespaceHostName("my-pod", "default", vcName) +
 				`": conflict; referenced configmap "` +
@@ -187,19 +190,19 @@ func TestSanitisingEventRecorder(t *testing.T) {
 		{
 			// A resource name that itself contains "-x-" (valid in Kubernetes).
 			// Pass 2 splits on vName so "my-x-pod" is recovered correctly.
-			name:        "resource name containing -x- replaced correctly",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("my-x-pod", "default"),
-			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("my-x-pod", "default", vcName) + `" conflict`,
-			wantMessage: `Error syncing: pods "my-x-pod" conflict`,
+			name:          "resource name containing -x- replaced correctly",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-x-pod", "default"),
+			note:          `Error syncing: pods "` + translate.SingleNamespaceHostName("my-x-pod", "default", vcName) + `" conflict`,
+			wantMessage:   `Error syncing: pods "my-x-pod" conflict`,
 		},
 		{
 			// When the namespace itself contains "-x-", the exact-suffix approach matches
 			// "-x-team-x-blue-x-my-vc" literally and strips it in one operation.
-			name:      "secondary resource in namespace containing -x- is replaced correctly",
-			mapper:    &namespacedMapper{},
-			regarding: pod("my-pod", "team-x-blue"),
-			note:      `Error syncing: %v`,
+			name:          "secondary resource in namespace containing -x- is replaced correctly",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", "team-x-blue"),
+			note:          `Error syncing: %v`,
 			args: []any{
 				`configmap "` + translate.SingleNamespaceHostName("app-config", "team-x-blue", vcName) + `" not found`,
 			},
@@ -209,37 +212,37 @@ func TestSanitisingEventRecorder(t *testing.T) {
 			// A virtual name that ends with the translated suffix pattern is valid in
 			// Kubernetes. Pass 2 detects this via HasSuffix and is skipped entirely to
 			// avoid corrupting the name that Pass 1 just placed in the message.
-			name:        "regarding name ending with suffix is not corrupted by Pass 2",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("api-x-default-x-my-vc", "default"),
-			note:        `Error syncing: pods "` + translate.SingleNamespaceHostName("api-x-default-x-my-vc", "default", vcName) + `" conflict`,
-			wantMessage: `Error syncing: pods "api-x-default-x-my-vc" conflict`,
+			name:          "regarding name ending with suffix is not corrupted by Pass 2",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("api-x-default-x-my-vc", "default"),
+			note:          `Error syncing: pods "` + translate.SingleNamespaceHostName("api-x-default-x-my-vc", "default", vcName) + `" conflict`,
+			wantMessage:   `Error syncing: pods "api-x-default-x-my-vc" conflict`,
 		},
 		{
 			// The vClusterName suffix appears in the message but there is no preceding
 			// "-x-" separator — no match, message must pass through unchanged.
-			name:        "bare vcluster name suffix without separator passes through unchanged",
-			mapper:      &namespacedMapper{},
-			regarding:   pod("my-pod", "default"),
-			note:        "error: unknown cluster my-vc encountered",
-			wantMessage: "error: unknown cluster my-vc encountered",
+			name:          "bare vcluster name suffix without separator passes through unchanged",
+			virtualToHost: nsVirtualToHost,
+			regarding:     pod("my-pod", "default"),
+			note:          "error: unknown cluster my-vc encountered",
+			wantMessage:   "error: unknown cluster my-vc encountered",
 		},
 		{
 			// Cluster-scoped resources use HostNameCluster (prefixed with "vcluster-").
 			// Pass 1 must replace the cluster-scoped host name using the mapper result;
 			// Pass 2 does not fire because cluster-scoped objects have no namespace.
-			name:        "cluster-scoped resource host name replaced in Pass 1",
-			mapper:      &clusterScopedMapper{},
-			regarding:   &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "my-node"}},
-			note:        `Error syncing: nodes "` + translate.Default.HostNameCluster("my-node") + `" conflict`,
-			wantMessage: `Error syncing: nodes "my-node" conflict`,
+			name:          "cluster-scoped resource host name replaced in Pass 1",
+			virtualToHost: csVirtualToHost,
+			regarding:     &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "my-node"}},
+			note:          `Error syncing: nodes "` + translate.Default.HostNameCluster("my-node") + `" conflict`,
+			wantMessage:   `Error syncing: nodes "my-node" conflict`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			captured := &captureRecorder{}
-			rec := newSanitisingEventRecorder(nil, captured, tt.mapper)
+			rec := newSanitisingEventRecorder(nil, captured, tt.virtualToHost)
 
 			rec.Eventf(tt.regarding, nil, "Warning", "SyncError", "SyncPod", tt.note, tt.args...)
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-324


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
