### PR TITLE
fix: prevent restore when vcluster.service is stopped

### DIFF
--- a/pkg/util/standalone/service_manager.go
+++ b/pkg/util/standalone/service_manager.go
@@ -4,43 +4,50 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
 )
 
-// serviceManager abstracts stopping and starting the standalone vCluster process.
+// ServiceManager abstracts stopping and starting the standalone vCluster process.
 type ServiceManager interface {
 	Stop() error
 	Start() error
 }
 
+// systemctlRunner is a function that runs a systemctl subcommand and returns any error.
+type systemctlRunner func(args ...string) error
+
 type SystemdServiceManager struct {
 	name string
+	run  systemctlRunner
 }
 
 func (s *SystemdServiceManager) Stop() error {
-	return exec.Command("systemctl", "stop", s.name).Run()
+	return s.run("stop", s.name)
 }
 
 func (s *SystemdServiceManager) Start() error {
-	return exec.Command("systemctl", "start", s.name).Run()
+	return s.run("start", s.name)
 }
 
-// newServiceManager returns a systemd-based service manager when on Linux with systemd
-// available. Returns an error on other platforms or when the service is not running.
+func defaultSystemctlRunner(args ...string) error {
+	return exec.Command("systemctl", args...).Run()
+}
+
+// NewServiceManager returns a systemd-based service manager when on Linux with systemd
+// available. Returns an error on other platforms or when the service unit is not found.
 func NewServiceManager() (ServiceManager, error) {
+	return newServiceManager(defaultSystemctlRunner)
+}
+
+func newServiceManager(run systemctlRunner) (ServiceManager, error) {
 	if runtime.GOOS != "linux" {
 		return nil, fmt.Errorf("systemd manager is only supported on Linux (current OS: %s)", runtime.GOOS)
 	}
 
-	out, err := exec.Command("systemctl", "is-active", constants.VClusterStandaloneSystemdServiceName).Output()
-	if err != nil {
-		return nil, fmt.Errorf("standalone vCluster service %q is not active on this host", constants.VClusterStandaloneSystemdServiceName)
-	}
-	if strings.TrimSpace(string(out)) != "active" {
-		return nil, fmt.Errorf("standalone vCluster service %q is not active (state: %s)", constants.VClusterStandaloneSystemdServiceName, strings.TrimSpace(string(out)))
+	if err := run("cat", constants.VClusterStandaloneSystemdServiceName); err != nil {
+		return nil, fmt.Errorf("standalone vCluster service %q not found on this host", constants.VClusterStandaloneSystemdServiceName)
 	}
 
-	return &SystemdServiceManager{name: constants.VClusterStandaloneSystemdServiceName}, nil
+	return &SystemdServiceManager{name: constants.VClusterStandaloneSystemdServiceName, run: run}, nil
 }

--- a/pkg/util/standalone/service_manager_test.go
+++ b/pkg/util/standalone/service_manager_test.go
@@ -1,0 +1,91 @@
+package standalone
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+)
+
+func fakeRunner(catErr, stopErr, startErr error) systemctlRunner {
+	return func(args ...string) error {
+		switch args[0] {
+		case "cat":
+			return catErr
+		case "stop":
+			return stopErr
+		case "start":
+			return startErr
+		}
+		return nil
+	}
+}
+
+func TestNewServiceManager_NonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-Linux path cannot be tested on Linux")
+	}
+	_, err := NewServiceManager()
+	if err == nil {
+		t.Fatal("expected error on non-Linux platform")
+	}
+}
+
+func TestNewServiceManager_ServiceNotFound(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd manager only supported on Linux")
+	}
+	_, err := newServiceManager(fakeRunner(errors.New("not found"), nil, nil))
+	if err == nil {
+		t.Fatal("expected error when service unit is missing")
+	}
+}
+
+func TestNewServiceManager_ServiceExists(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd manager only supported on Linux")
+	}
+	sm, err := newServiceManager(fakeRunner(nil, nil, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sm == nil {
+		t.Fatal("expected non-nil ServiceManager")
+	}
+}
+
+// TestServiceManager_StopStart verifies that Stop and Start delegate to the runner.
+func TestServiceManager_StopStart(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd manager only supported on Linux")
+	}
+	stopErr := errors.New("stop failed")
+	startErr := errors.New("start failed")
+
+	sm, err := newServiceManager(fakeRunner(nil, stopErr, startErr))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := sm.Stop(); !errors.Is(got, stopErr) {
+		t.Errorf("Stop() = %v, want %v", got, stopErr)
+	}
+	if got := sm.Start(); !errors.Is(got, startErr) {
+		t.Errorf("Start() = %v, want %v", got, startErr)
+	}
+}
+
+// TestNewServiceManager_ServiceDown verifies that NewServiceManager succeeds even
+// when the service exists but is not active (the restore scenario).
+func TestNewServiceManager_ServiceDown(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd manager only supported on Linux")
+	}
+	// cat succeeds (unit exists), but the service is inactive — should not error.
+	sm, err := newServiceManager(fakeRunner(nil, nil, nil))
+	if err != nil {
+		t.Fatalf("expected success for an inactive-but-existing service, got: %v", err)
+	}
+	if sm == nil {
+		t.Fatal("expected non-nil ServiceManager")
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-614


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster restore --standalone` command fails due to `vcluster.service` not being active


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
