### PR TITLE
fix: skip telemetry on completion command

### DIFF
--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -31,6 +31,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const compCmdName = "completion"
+
 // NewRootCmd returns a new root command
 func NewRootCmd(log log.Logger) *cobra.Command {
 	return &cobra.Command{
@@ -38,7 +40,7 @@ func NewRootCmd(log log.Logger) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Short:         "Welcome to vcluster!",
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(cobraCmd *cobra.Command, _ []string) error {
 			if globalFlags == nil {
 				return errors.New("nil globalFlags")
 			}
@@ -51,8 +53,10 @@ func NewRootCmd(log log.Logger) *cobra.Command {
 				}
 			}
 
-			// start telemetry
-			telemetry.StartCLI(globalFlags.LoadedConfig(log))
+			// start telemetry — skip for completion commands
+			if !isCompletionCommand(cobraCmd) {
+				telemetry.StartCLI(globalFlags.LoadedConfig(log))
+			}
 
 			if globalFlags.Silent {
 				log.SetLevel(logrus.FatalLevel)
@@ -181,4 +185,17 @@ func recordAndFlush(err error, log log.Logger, globalFlags *flags.GlobalFlags) {
 
 	telemetry.CollectorCLI.RecordCLI(globalFlags.LoadedConfig(log), platform.Self, err)
 	telemetry.CollectorCLI.Flush()
+}
+
+func isCompletionCommand(cmd *cobra.Command) bool {
+	name := cmd.Name()
+	if name == cobra.ShellCompRequestCmd || name == cobra.ShellCompNoDescRequestCmd {
+		return true
+	}
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == compCmdName {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
If telemetry is not disabled explicitly(enabled by default on installation), it unnecessarily introduces lag to the completion script generation and completion generation during usage in shell.

This PR skips entirely telemetry when it is either the `completion` subcommand or hidden magic commands for completion script purpose.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Skip telemtry on vcluster CLI completion related commands.


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
