### PR TITLE
add a vcluster restore setup for vCluster standalone

### DIFF
--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -16,7 +16,6 @@ import (
 	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/lifecycle"
-	"github.com/loft-sh/vcluster/pkg/pro"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
 	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
 	standaloneutil "github.com/loft-sh/vcluster/pkg/util/standalone"
@@ -87,10 +86,6 @@ func restoreStandaloneVCluster(ctx context.Context, vCluster *find.VCluster, sna
 
 	sm, err := standaloneutil.NewServiceManager()
 	if err != nil {
-		return err
-	}
-
-	if err := pro.CheckStandaloneHA(ctx, vClusterConfig); err != nil {
 		return err
 	}
 

--- a/pkg/pro/standalone.go
+++ b/pkg/pro/standalone.go
@@ -1,10 +1,6 @@
 package pro
 
-import (
-	"context"
-
-	"github.com/loft-sh/vcluster/pkg/config"
-)
+import "github.com/loft-sh/vcluster/pkg/config"
 
 // SetStandaloneConstants remaps global constant paths to the standalone data directory.
 // Injected by vcluster-pro at startup; the noop default is never reached in practice
@@ -13,10 +9,10 @@ var SetStandaloneConstants = func(_ *config.VirtualClusterConfig) error {
 	return nil
 }
 
-// CheckStandaloneHA checks whether the standalone cluster is running in HA mode and
-// returns an error if so, because HA restore requires coordinated multi-node shutdown.
-// Injected by vcluster-pro; the noop default allows the restore to proceed in OSS builds
-// (which do not support standalone at all).
-var CheckStandaloneHA = func(context context.Context, _ *config.VirtualClusterConfig) error {
-	return nil
+// SetupStandaloneRestore allows vcluster-pro to adjust standalone restore state
+// before the restore client opens the backing store and returns a rollback
+// closure for failures that happen later in the restore flow. The noop default
+// leaves OSS behavior unchanged.
+var SetupStandaloneRestore = func(_ *config.VirtualClusterConfig) (func() error, error) {
+	return func() error { return nil }, nil
 }

--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -135,12 +135,28 @@ func (o *RestoreClient) Run(ctx context.Context, vConfig *config.VirtualClusterC
 	encoder := protobuf.NewSerializer(scheme.Scheme, scheme.Scheme)
 
 	var err error
+	revertStandaloneRestore := func() error { return nil }
+
 	if vConfig.ControlPlane.Standalone.Enabled {
 		vConfig.HostNamespace = constants.VClusterStandaloneSnapshotNamespace
 		err = pro.SetStandaloneConstants(vConfig)
 		if err != nil {
 			return fmt.Errorf("set standalone constants: %w", err)
 		}
+
+		revertStandaloneRestore, err = pro.SetupStandaloneRestore(vConfig)
+		if err != nil {
+			return fmt.Errorf("setup standalone restore: %w", err)
+		}
+
+		defer func() {
+			if retErr != nil {
+				revertErr := revertStandaloneRestore()
+				if revertErr != nil {
+					retErr = errors.Join(retErr, fmt.Errorf("revert standalone restore state: %w", revertErr))
+				}
+			}
+		}()
 	}
 
 	// make sure to validate options


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
