### PR TITLE
fix: use PV/SC mapper for volumeName and storageClassName translation

### DIFF
--- a/pkg/controllers/resources/persistentvolumeclaims/translate.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/translate.go
@@ -55,7 +55,7 @@ func (s *persistentVolumeClaimSyncer) translateSelector(ctx *synccontext.SyncCon
 
 	// translate storage class if we manage those in vcluster
 	if s.storageClassesEnabled && storageClassName != "" {
-		translated := translate.Default.HostNameCluster(storageClassName)
+		translated := mappings.VirtualToHostName(ctx, storageClassName, "", mappings.StorageClasses())
 		delete(vPvc.Annotations, deprecatedStorageClassAnnotation)
 		vPvc.Spec.StorageClassName = &translated
 	}
@@ -67,7 +67,7 @@ func (s *persistentVolumeClaimSyncer) translateSelector(ctx *synccontext.SyncCon
 				vPvc.Spec.Selector = translate.HostLabelSelector(vPvc.Spec.Selector)
 			}
 			if vPvc.Spec.VolumeName != "" {
-				vPvc.Spec.VolumeName = translate.Default.HostNameCluster(vPvc.Spec.VolumeName)
+				vPvc.Spec.VolumeName = mappings.VirtualToHostName(ctx, vPvc.Spec.VolumeName, "", mappings.PersistentVolumes())
 			}
 			// check if the storage class exists in the physical cluster
 			if !s.storageClassesEnabled && storageClassName != "" {
@@ -75,12 +75,12 @@ func (s *persistentVolumeClaimSyncer) translateSelector(ctx *synccontext.SyncCon
 				if vPvc.Spec.Selector == nil && vPvc.Spec.VolumeName == "" {
 					err := ctx.HostClient.Get(ctx, types.NamespacedName{Name: storageClassName}, &storagev1.StorageClass{})
 					if err != nil && kerrors.IsNotFound(err) {
-						translated := translate.Default.HostNameCluster(storageClassName)
+						translated := mappings.VirtualToHostName(ctx, storageClassName, "", mappings.StorageClasses())
 						delete(vPvc.Annotations, deprecatedStorageClassAnnotation)
 						vPvc.Spec.StorageClassName = &translated
 					}
 				} else {
-					translated := translate.Default.HostNameCluster(storageClassName)
+					translated := mappings.VirtualToHostName(ctx, storageClassName, "", mappings.StorageClasses())
 					delete(vPvc.Annotations, deprecatedStorageClassAnnotation)
 					vPvc.Spec.StorageClassName = &translated
 				}

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -248,7 +248,7 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 	// update host object
 	if event.Virtual.Annotations[constants.HostClusterPersistentVolumeAnnotation] == "" {
 		// TODO: translate the storage secrets
-		event.Host.Spec.StorageClassName = translate.Default.HostNameCluster(event.Virtual.Spec.StorageClassName)
+		event.Host.Spec.StorageClassName = mappings.VirtualToHostName(ctx, event.Virtual.Spec.StorageClassName, "", mappings.StorageClasses())
 	}
 
 	// bi-directional sync of annotations and labels

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -17,7 +17,7 @@ func (s *persistentVolumeSyncer) translate(ctx *synccontext.SyncContext, vPv *co
 
 	// TODO: translate the storage secrets
 	if pPV.Spec.StorageClassName != "" {
-		pPV.Spec.StorageClassName = translate.Default.HostNameCluster(vPv.Spec.StorageClassName)
+		pPV.Spec.StorageClassName = mappings.VirtualToHostName(ctx, vPv.Spec.StorageClassName, "", mappings.StorageClasses())
 	}
 	return pPV, nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** 

The PVC syncer's translateSelector function calls translate.Default.HostNameCluster() directly to translate volumeName and storageClassName, bypassing the PV and SC mappers. This unconditionally mangles these names even when the PV was synced from the host (has vcluster.loft.sh/host-pv annotation), making it impossible to bind a PVC to a pre-existing host PV by name.
Additionally, the PV syncer's translate function has the same pattern for storageClassName, causing SC name mismatches between PVs and PVCs on the host when toHost.storageClasses.enabled is false.
This fix replaces 5 instances of HostNameCluster() with mappings.VirtualToHostName() across 2 files, routing through the proper mappers which conditionally translate based on resource origin — host-synced resources retain their original names, vCluster-created resources still get translated normally.
resolves #3810

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vCluster unconditionally mangled volumeName and storageClassName when syncing PVCs to the host, even for PVs synced from the host with the vcluster.loft.sh/host-pv annotation. PVCs with explicit volumeName pointing to a pre-existing host PV now bind correctly.


**What else do we need to know?** 
The PV mapper (pkg/mappings/resources/persistentvolumes.go:18-29) already had the correct annotation-aware logic — this fix simply ensures the PVC and PV syncers use it instead of bypassing it.
The fix also addresses the PV syncer's storageClassName translation (persistentvolumes/translate.go:20) to prevent SC name mismatches between PVs and PVCs on the host when toHost.storageClasses.enabled is false (mirror mapper scenario).

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```