### PR TITLE
fix(node upgrade): forward --bundle-repository to upgrade pod

### DIFF
--- a/cmd/vclusterctl/cmd/node/upgrade.go
+++ b/cmd/vclusterctl/cmd/node/upgrade.go
@@ -50,7 +50,7 @@ func NewUpgradeCommand(globalFlags *flags.GlobalFlags) *cobra.Command {
 		},
 	}
 
-	upgradeCmd.Flags().StringVar(&options.BundleRepository, "bundle-repository", "https://github.com/loft-sh/kubernetes/releases/download", "The repository to use for downloading the Kubernetes bundle")
+	upgradeCmd.Flags().StringVar(&options.BundleRepository, "bundle-repository", "", "The repository to use for downloading the Kubernetes bundle. If empty, the default baked into the upgrade image is used.")
 	upgradeCmd.Flags().StringVar(&options.BinariesPath, "binaries-path", "/usr/local/bin", "The path to the kubeadm binaries")
 	upgradeCmd.Flags().StringVar(&options.CNIBinariesPath, "cni-binaries-path", "/opt/cni/bin", "The path to the CNI binaries")
 	upgradeCmd.Flags().StringVar(&options.Image, "image", "", "The image to use for the upgrade")
@@ -97,6 +97,9 @@ func (o *UpgradeOptions) Run(ctx context.Context, args []string) error {
 	}
 	if o.CNIBinariesPath != "" {
 		command = append(command, "--cni-binaries-path", o.CNIBinariesPath)
+	}
+	if o.BundleRepository != "" {
+		command = append(command, "--bundle-repository", o.BundleRepository)
 	}
 
 	// create a pod with the image


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
`vcluster node upgrade` accepted a `--bundle-repository` flag on the local CLI but never forwarded it into the in-pod `/vcluster node upgrade` command, so setting it was a silent no-op. The flag default was also a hard-coded GitHub URL, which meant overriding it in the upgrade pod unconditionally bypassed whatever default the upgrade image (or CP-served bundle path) had baked in.

Changes:
- Default the CLI flag to empty — "use whatever the upgrade image bakes in".
- When non-empty, pass through as `--bundle-repository <value>` to the spawned upgrade pod.

Resolves [ENGCP-562](https://linear.app/loft/issue/ENGCP-562).

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster node upgrade --bundle-repository` was silently ignored; the flag is now forwarded into the upgrade pod.

**What else do we need to know?**
Enables CP-served Kubernetes bundles and air-gapped custom bundle sources to actually take effect during auto-upgrade. Companion PR in vcluster-pro: loft-sh/vcluster-pro#1716.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically.

### Additional test suites

\`\`\`label-filter
none
\`\`\`