### PR TITLE
refactor: metrics for components

### DIFF
--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -49,7 +49,7 @@ spec:
         key: client-key
   - interval: 30s
     port: https
-    path: /controller-manager/metrics
+    path: /metrics/controller-manager
     scheme: https
     relabelings:
       - targetLabel: endpoint
@@ -69,11 +69,32 @@ spec:
   {{- if or .Values.controlPlane.distro.k8s.scheduler.enabled .Values.controlPlane.advanced.virtualScheduler.enabled }}
   - interval: 30s
     port: https
-    path: /scheduler/metrics
+    path: /metrics/scheduler
     scheme: https
     relabelings:
       - targetLabel: endpoint
         replacement: "scheduler"
+    tlsConfig:
+      ca:
+        secret:
+          name: vc-{{ .Release.Name }}
+          key: certificate-authority
+      cert:
+        secret:
+          name: vc-{{ .Release.Name }}
+          key: client-certificate
+      keySecret:
+        name: vc-{{ .Release.Name }}
+        key: client-key
+  {{- end }}
+  {{- if .Values.controlPlane.backingStore.etcd.embedded.enabled }}
+  - interval: 30s
+    port: https
+    path: /metrics/etcd
+    scheme: https
+    relabelings:
+      - targetLabel: endpoint
+        replacement: "etcd"
     tlsConfig:
       ca:
         secret:

--- a/chart/tests/service-monitor_test.yaml
+++ b/chart/tests/service-monitor_test.yaml
@@ -31,6 +31,9 @@ tests:
       - lengthEqual:
           path: spec.endpoints
           count: 2
+      - equal:
+          path: spec.endpoints[1].path
+          value: /metrics/controller-manager
 
   - it: override release label
     release:
@@ -68,6 +71,9 @@ tests:
     - lengthEqual:
         path: spec.endpoints
         count: 3
+    - equal:
+        path: spec.endpoints[2].path
+        value: /metrics/scheduler
 
   - it: check virtual scheduler (deprecated)
     release:
@@ -86,3 +92,28 @@ tests:
       - lengthEqual:
           path: spec.endpoints
           count: 3
+      - equal:
+          path: spec.endpoints[2].path
+          value: /metrics/scheduler
+
+  - it: check embedded etcd
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        backingStore:
+          etcd:
+            embedded:
+              enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.endpoints
+          count: 3
+      - equal:
+          path: spec.endpoints[2].path
+          value: /metrics/etcd

--- a/pkg/server/filters/k8s_metrics.go
+++ b/pkg/server/filters/k8s_metrics.go
@@ -9,16 +9,17 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	controllerManagerMetricsHost = "https://127.0.0.1:10257"
+	schedulerMetricsHost         = "https://127.0.0.1:10259"
+	embeddedEtcdMetricsHost      = "http://127.0.0.1:2381"
+)
+
 func WithK8sMetrics(h http.Handler, registerCtx *synccontext.RegisterContext) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == "/controller-manager/metrics" {
-			restConfig := rest.CopyConfig(registerCtx.VirtualManager.GetConfig())
-			restConfig.Host = "https://127.0.0.1:10257"
-			restConfig.TLSClientConfig.Insecure = true
-			restConfig.TLSClientConfig.CAData = nil
-			restConfig.TLSClientConfig.CAFile = ""
-
-			h, err := handler.Handler("", restConfig, nil)
+		restConfig := metricsRestConfig(req.URL.Path, registerCtx)
+		if restConfig != nil {
+			metricsHandler, err := handler.Handler("", restConfig, nil)
 			if err != nil {
 				requestpkg.FailWithStatus(w, req, http.StatusInternalServerError, err)
 				return
@@ -26,27 +27,34 @@ func WithK8sMetrics(h http.Handler, registerCtx *synccontext.RegisterContext) ht
 
 			req.URL.Path = "/metrics"
 			req.Header.Del("Authorization")
-			h.ServeHTTP(w, req)
-			return
-		} else if req.URL.Path == "/scheduler/metrics" {
-			restConfig := rest.CopyConfig(registerCtx.VirtualManager.GetConfig())
-			restConfig.Host = "https://127.0.0.1:10259"
-			restConfig.TLSClientConfig.Insecure = true
-			restConfig.TLSClientConfig.CAData = nil
-			restConfig.TLSClientConfig.CAFile = ""
-
-			h, err := handler.Handler("", restConfig, nil)
-			if err != nil {
-				requestpkg.FailWithStatus(w, req, http.StatusInternalServerError, err)
-				return
-			}
-
-			req.URL.Path = "/metrics"
-			req.Header.Del("Authorization")
-			h.ServeHTTP(w, req)
+			metricsHandler.ServeHTTP(w, req)
 			return
 		}
 
 		h.ServeHTTP(w, req)
 	})
+}
+
+func metricsRestConfig(path string, registerCtx *synccontext.RegisterContext) *rest.Config {
+	switch path {
+	case "/controller-manager/metrics", "/metrics/controller-manager":
+		return localK8sMetricsConfig(registerCtx, controllerManagerMetricsHost)
+	case "/scheduler/metrics", "/metrics/scheduler":
+		return localK8sMetricsConfig(registerCtx, schedulerMetricsHost)
+	case "/metrics/etcd":
+		if registerCtx.Config.ControlPlane.BackingStore.Etcd.Embedded.Enabled {
+			return &rest.Config{Host: embeddedEtcdMetricsHost}
+		}
+	}
+
+	return nil
+}
+
+func localK8sMetricsConfig(registerCtx *synccontext.RegisterContext, host string) *rest.Config {
+	restConfig := rest.CopyConfig(registerCtx.VirtualManager.GetConfig())
+	restConfig.Host = host
+	restConfig.TLSClientConfig.Insecure = true
+	restConfig.TLSClientConfig.CAData = nil
+	restConfig.TLSClientConfig.CAFile = ""
+	return restConfig
 }

--- a/pkg/server/filters/k8s_metrics_test.go
+++ b/pkg/server/filters/k8s_metrics_test.go
@@ -1,0 +1,92 @@
+package filters
+
+import (
+	"testing"
+
+	rawconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	vtesting "github.com/loft-sh/vcluster/pkg/util/testing"
+)
+
+func TestMetricsRestConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		embeddedEtcd bool
+		wantHost     string
+		wantNil      bool
+	}{
+		{
+			name:     "old controller manager route",
+			path:     "/controller-manager/metrics",
+			wantHost: controllerManagerMetricsHost,
+		},
+		{
+			name:     "new controller manager route",
+			path:     "/metrics/controller-manager",
+			wantHost: controllerManagerMetricsHost,
+		},
+		{
+			name:     "old scheduler route",
+			path:     "/scheduler/metrics",
+			wantHost: schedulerMetricsHost,
+		},
+		{
+			name:     "new scheduler route",
+			path:     "/metrics/scheduler",
+			wantHost: schedulerMetricsHost,
+		},
+		{
+			name:         "embedded etcd route",
+			path:         "/metrics/etcd",
+			embeddedEtcd: true,
+			wantHost:     embeddedEtcdMetricsHost,
+		},
+		{
+			name:    "etcd route disabled without embedded etcd",
+			path:    "/metrics/etcd",
+			wantNil: true,
+		},
+		{
+			name:    "unrelated route",
+			path:    "/metrics",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registerCtx := &synccontext.RegisterContext{
+				Config: &config.VirtualClusterConfig{
+					Config: rawconfig.Config{
+						ControlPlane: rawconfig.ControlPlane{
+							BackingStore: rawconfig.BackingStore{
+								Etcd: rawconfig.Etcd{
+									Embedded: rawconfig.EtcdEmbedded{
+										Enabled: tt.embeddedEtcd,
+									},
+								},
+							},
+						},
+					},
+				},
+				VirtualManager: vtesting.NewFakeManager(nil),
+			}
+
+			got := metricsRestConfig(tt.path, registerCtx)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil config, got host %q", got.Host)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected config for %q", tt.path)
+			}
+			if got.Host != tt.wantHost {
+				t.Fatalf("expected host %q, got %q", tt.wantHost, got.Host)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -140,6 +140,7 @@ func NewServer(ctx *synccontext.ControllerContext) (*Server, error) {
 	}
 
 	// add filters if not dedicated
+	h = filters.WithK8sMetrics(h, registerCtx)
 	if !ctx.Config.PrivateNodes.Enabled {
 		localConfig := ctx.HostManager.GetConfig()
 		uncachedLocalClient, err := client.New(localConfig, client.Options{
@@ -153,7 +154,6 @@ func NewServer(ctx *synccontext.ControllerContext) (*Server, error) {
 
 		h = filters.WithServiceCreateRedirect(h, registerCtx, uncachedLocalClient, uncachedVirtualClient)
 		h = filters.WithRedirect(h, registerCtx, uncachedVirtualClient, admissionHandler, s.redirectResources)
-		h = filters.WithK8sMetrics(h, registerCtx)
 		h = filters.WithMetricsProxy(h, registerCtx)
 
 		// inject apis
@@ -259,6 +259,10 @@ func (s *Server) ServeOnListenerTLS(ctx *synccontext.ControllerContext) error {
 			Verb: "*",
 		},
 	)
+	redirectAuthNonResources = append(
+		redirectAuthNonResources,
+		metricsAuthNonResources()...,
+	)
 	serverConfig.Authorization.Authorizer = union.New(
 		kubeletauthorizer.New(s.uncachedVirtualClient),
 		delegatingauthorizer.New(s.uncachedVirtualClient, redirectAuthResources, redirectAuthNonResources),
@@ -305,6 +309,33 @@ func (s *Server) ServeOnListenerTLS(ctx *synccontext.ControllerContext) error {
 
 	<-stopped
 	return nil
+}
+
+func metricsAuthNonResources() []delegatingauthorizer.PathVerb {
+	pathVerbs := []delegatingauthorizer.PathVerb{
+		{
+			Path: "/controller-manager/metrics",
+			Verb: "*",
+		},
+		{
+			Path: "/scheduler/metrics",
+			Verb: "*",
+		},
+		{
+			Path: "/metrics/controller-manager",
+			Verb: "*",
+		},
+		{
+			Path: "/metrics/scheduler",
+			Verb: "*",
+		},
+		{
+			Path: "/metrics/etcd",
+			Verb: "*",
+		},
+	}
+
+	return pathVerbs
 }
 
 func (s *Server) buildHandlerChain(ctx *synccontext.ControllerContext, serverConfig *server.Config) http.Handler {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,31 @@
+package server
+
+import "testing"
+
+func TestMetricsAuthNonResources(t *testing.T) {
+	wantPaths := map[string]struct{}{
+		"/controller-manager/metrics": {},
+		"/scheduler/metrics":          {},
+		"/metrics/controller-manager": {},
+		"/metrics/scheduler":          {},
+		"/metrics/etcd":               {},
+	}
+
+	got := metricsAuthNonResources()
+	if len(got) != len(wantPaths) {
+		t.Fatalf("expected %d metrics auth paths, got %d", len(wantPaths), len(got))
+	}
+
+	for _, pathVerb := range got {
+		if _, ok := wantPaths[pathVerb.Path]; !ok {
+			t.Fatalf("unexpected metrics auth path %q", pathVerb.Path)
+		}
+		if pathVerb.Verb != "*" {
+			t.Fatalf("expected path %q to delegate all verbs, got %q", pathVerb.Path, pathVerb.Verb)
+		}
+		delete(wantPaths, pathVerb.Path)
+	}
+	if len(wantPaths) > 0 {
+		t.Fatalf("missing metrics auth paths: %v", wantPaths)
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

Changes:
* Fixed an issue where the routes /controller-manager/metrics and /scheduler/metrics were not authenticated correctly
* Added authenticated routes `/metrics/etcd`, `/metrics/scheduler` and `/metrics/controller-manger` to expose metrics correctly
* Allow metrics endpoints for private nodes / standalone