### PR TITLE
ci(e2e-ginkgo): post sticky PR comment with last e2e run status

### DIFF
--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -2,7 +2,7 @@ name: vCluster E2E CI (Ginkgo)
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   release:
@@ -289,3 +289,16 @@ jobs:
           done
 
           exit 1
+
+      - name: Upsert sticky e2e status comment
+        if: always() && github.event_name == 'pull_request'
+        uses: loft-sh/github-actions/.github/actions/sticky-pr-comment@sticky-pr-comment/v1
+        with:
+          marker: '<!-- e2e-ginkgo-status -->'
+          body: |
+            ### E2E Ginkgo Tests
+
+            | Status | Commit | Run |
+            | --- | --- | --- |
+            | ${{ job.status == 'success' && 'Passed' || (job.status == 'cancelled' && 'Cancelled' || 'Failed') }} | `${{ github.event.pull_request.head.sha }}` | [View run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -291,7 +291,9 @@ jobs:
           exit 1
 
       - name: Upsert sticky e2e status comment
-        if: always() && github.event_name == 'pull_request'
+        # Skip on fork PRs: GITHUB_TOKEN is read-only for forks regardless of
+        # the permissions block, so the upsert would 403.
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: loft-sh/github-actions/.github/actions/sticky-pr-comment@sticky-pr-comment/v1
         with:
           marker: '<!-- e2e-ginkgo-status -->'


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
Related to DEVOPS-856.

Mirrors loft-sh/loft-enterprise#6754 and loft-sh/vcluster-pro#1728 for the `e2e-ginkgo` workflow in this repo.

**Please provide a short message that should be published in the vcluster release notes**

NONE

**What else do we need to know?**

When the `e2e-ginkgo` workflow detects a PR description edit that does not change the `label-filter` block, it skips the `e2e-tests` job. GitHub then renders the PR check as "Skipped", hiding the actual status of the last real run.

This change posts a sticky comment from the `e2e-tests` job using `loft-sh/github-actions/.github/actions/sticky-pr-comment@sticky-pr-comment/v1`. The comment carries:

- Status (Passed / Failed / Cancelled, derived from `job.status` so build/setup failures also surface).
- Head commit SHA.
- A link to the workflow run.

Because the upsert step lives inside `e2e-tests` and not in a separate unconditional job, it is skipped together with the rest of the job — which is exactly what we want: the previous comment is preserved and the last real status stays visible on the PR.

The workflow-level permission was bumped from `pull-requests: read` to `pull-requests: write` so `secrets.GITHUB_TOKEN` can upsert the comment.

The marker (`<!-- e2e-ginkgo-status -->`) and title ("E2E Ginkgo Tests") are scoped to this workflow so it does not collide with the equivalent comments from `e2e-next` in vcluster-pro or `e2e-ginkgo` in loft-enterprise.

### Test plan

- [ ] First push triggers the workflow and a fresh sticky comment is created on the PR.
- [ ] Editing the PR description without changing the `label-filter` block causes `e2e-tests` to skip, the upsert step is skipped, and the existing comment stays in place.
- [ ] Pushing a code change re-runs `e2e-tests` and the comment is updated in place (same comment ID, new SHA / run link).
- [ ] A failing run reflects "Failed" in the comment.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```