### PR TITLE
fix: validate TLS certificate when downloading Kubernetes bundle

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -72,6 +72,10 @@
         "containerSecurityContext": {
           "type": "object",
           "description": "ContainerSecurityContext specifies security context options on the container level for the upgrade container."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "Insecure skips TLS certificate verification when the upgrade pod downloads\nthe Kubernetes bundle. Set to true only when the bundle repository (typically\nthe in-cluster /node/download endpoint) is served by a non-publicly-trusted CA."
         }
       },
       "additionalProperties": false,

--- a/cmd/vcluster/cmd/node/upgrade.go
+++ b/cmd/vcluster/cmd/node/upgrade.go
@@ -27,6 +27,7 @@ func NewUpgradeCommand() *cobra.Command {
 	upgradeCmd.Flags().StringVar(&options.BundleRepository, "bundle-repository", "https://github.com/loft-sh/kubernetes/releases/download", "The repository to use for downloading the Kubernetes bundle")
 	upgradeCmd.Flags().StringVar(&options.BinariesPath, "binaries-path", "/usr/local/bin", "The path to the kubeadm binaries")
 	upgradeCmd.Flags().StringVar(&options.CNIBinariesPath, "cni-binaries-path", "/opt/cni/bin", "The path to the CNI binaries")
+	upgradeCmd.Flags().BoolVar(&options.Insecure, "insecure", false, "Skip TLS certificate verification when downloading the Kubernetes bundle")
 
 	return upgradeCmd
 }

--- a/cmd/vclusterctl/cmd/node/upgrade.go
+++ b/cmd/vclusterctl/cmd/node/upgrade.go
@@ -30,6 +30,7 @@ type UpgradeOptions struct {
 	BinariesPath     string
 	CNIBinariesPath  string
 	BundleRepository string
+	Insecure         bool
 
 	Image           string
 	ImagePullPolicy string
@@ -53,6 +54,7 @@ func NewUpgradeCommand(globalFlags *flags.GlobalFlags) *cobra.Command {
 	upgradeCmd.Flags().StringVar(&options.BundleRepository, "bundle-repository", "https://github.com/loft-sh/kubernetes/releases/download", "The repository to use for downloading the Kubernetes bundle")
 	upgradeCmd.Flags().StringVar(&options.BinariesPath, "binaries-path", "/usr/local/bin", "The path to the kubeadm binaries")
 	upgradeCmd.Flags().StringVar(&options.CNIBinariesPath, "cni-binaries-path", "/opt/cni/bin", "The path to the CNI binaries")
+	upgradeCmd.Flags().BoolVar(&options.Insecure, "insecure", false, "Skip TLS certificate verification when downloading the Kubernetes bundle")
 	upgradeCmd.Flags().StringVar(&options.Image, "image", "", "The image to use for the upgrade")
 	upgradeCmd.Flags().StringVar(&options.ImagePullPolicy, "image-pull-policy", "IfNotPresent", "The image pull policy")
 
@@ -97,6 +99,9 @@ func (o *UpgradeOptions) Run(ctx context.Context, args []string) error {
 	}
 	if o.CNIBinariesPath != "" {
 		command = append(command, "--cni-binaries-path", o.CNIBinariesPath)
+	}
+	if o.Insecure {
+		command = append(command, "--insecure")
 	}
 
 	// create a pod with the image

--- a/config/config.go
+++ b/config/config.go
@@ -619,6 +619,11 @@ type AutoUpgrade struct {
 
 	// ContainerSecurityContext specifies security context options on the container level for the upgrade container.
 	ContainerSecurityContext map[string]interface{} `json:"containerSecurityContext,omitempty"`
+
+	// Insecure skips TLS certificate verification when the upgrade pod downloads
+	// the Kubernetes bundle. Set to true only when the bundle repository (typically
+	// the in-cluster /node/download endpoint) is served by a non-publicly-trusted CA.
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 type Kubelet struct {

--- a/pkg/pro/privatenodes.go
+++ b/pkg/pro/privatenodes.go
@@ -48,6 +48,7 @@ type UpgradeOptions struct {
 	BinariesPath      string
 	CNIBinariesPath   string
 	BundleRepository  string
+	Insecure          bool
 }
 
 var UpgradeNode = func(_ context.Context, _ *UpgradeOptions) error {


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

Adds the OSS-side wiring for an `--insecure` flag on the node upgrade flow:

- `vcluster node upgrade --insecure` (in-pod binary)
- `vclusterctl node upgrade <node> --insecure` (user-facing CLI; threaded through to the upgrade pod's command)
- `privateNodes.autoUpgrade.insecure` config field for the auto-upgrade controller

All paths default to **verifying TLS**. Operators using a non-publicly-trusted bundle repository (most commonly the in-cluster `/node/download` fallback that's served by a self-signed control plane certificate) must opt in explicitly.

The actual gating in the download path lives in vcluster-pro: https://github.com/loft-sh/vcluster-pro/pull/1730


**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where the private-node upgrade flow skipped TLS verification when downloading the Kubernetes bundle from `github.com/loft-sh/kubernetes`. TLS verification is now enabled by default; pass `--insecure` (manual upgrade) or set `privateNodes.autoUpgrade.insecure: true` (auto-upgrade) when the bundle repository is served by a non-publicly-trusted CA.

**What else do we need to know?**

- **Behavior change** for `privateNodes.autoUpgrade` against a self-signed control plane endpoint: auto-upgrades will fail until `insecure: true` is set. Worth a release-notes call-out.
- The implementation that gates the actual TLS verification lives in vcluster-pro; this PR is the OSS wiring (struct fields, flags, pod command threading). vcluster-pro PR: https://github.com/loft-sh/vcluster-pro/pull/1730

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
