### PR TITLE
fix(platform): respect prevent-wakeup on connect/create

### DIFF
--- a/cmd/vclusterctl/cmd/platform/connect/space.go
+++ b/cmd/vclusterctl/cmd/platform/connect/space.go
@@ -101,7 +101,7 @@ func (cmd *NamespaceCmd) connectSpace(ctx context.Context, platformClient platfo
 	}
 
 	// wait until space is ready
-	spaceInstance, err := platform.WaitForSpaceInstance(ctx, managementClient, projectutil.ProjectNamespace(cmd.Project), spaceName, !cmd.SkipWait, cmd.log)
+	spaceInstance, err := platform.WaitForSpaceInstance(ctx, managementClient, projectutil.ProjectNamespace(cmd.Project), spaceName, !cmd.SkipWait, false, cmd.log)
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/create/space.go
+++ b/cmd/vclusterctl/cmd/platform/create/space.go
@@ -308,7 +308,7 @@ func (cmd *NamespaceCmd) createSpace(ctx context.Context, platformClient platfor
 	}
 
 	// wait until space is ready
-	spaceInstance, err = platform.WaitForSpaceInstance(ctx, managementClient, spaceInstance.Namespace, spaceInstance.Name, !cmd.SkipWait, cmd.Log)
+	spaceInstance, err = platform.WaitForSpaceInstance(ctx, managementClient, spaceInstance.Namespace, spaceInstance.Name, !cmd.SkipWait, false, cmd.Log)
 	if err != nil {
 		return err
 	}

--- a/cmd/vclusterctl/cmd/platform/wakeup/space.go
+++ b/cmd/vclusterctl/cmd/platform/wakeup/space.go
@@ -79,7 +79,7 @@ func (cmd *NamespaceCmd) spaceWakeUp(ctx context.Context, platformClient platfor
 		return err
 	}
 
-	_, err = platform.WaitForSpaceInstance(ctx, managementClient, projectutil.ProjectNamespace(cmd.Project), spaceName, true, cmd.Log)
+	_, err = platform.WaitForSpaceInstance(ctx, managementClient, projectutil.ProjectNamespace(cmd.Project), spaceName, true, true, cmd.Log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/connect_platform.go
+++ b/pkg/cli/connect_platform.go
@@ -62,7 +62,7 @@ func ConnectPlatform(ctx context.Context, options *ConnectOptions, globalFlags *
 		return errors.New("nil virtual cluster object")
 	}
 
-	vc, err := platform.WaitForVirtualClusterInstance(ctx, managementClient, vCluster.VirtualCluster.Namespace, vCluster.VirtualCluster.Name, true, log)
+	vc, err := platform.WaitForVirtualClusterInstance(ctx, managementClient, vCluster.VirtualCluster.Namespace, vCluster.VirtualCluster.Name, true, false, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/create_platform.go
+++ b/pkg/cli/create_platform.go
@@ -135,7 +135,7 @@ func CreatePlatform(ctx context.Context, options *CreateOptions, globalFlags *fl
 	}
 
 	// wait until virtual cluster is ready
-	virtualClusterInstance, err = platform.WaitForVirtualClusterInstance(ctx, managementClient, virtualClusterInstance.Namespace, virtualClusterInstance.Name, !options.SkipWait, log)
+	virtualClusterInstance, err = platform.WaitForVirtualClusterInstance(ctx, managementClient, virtualClusterInstance.Namespace, virtualClusterInstance.Name, !options.SkipWait, false, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/resume_platform.go
+++ b/pkg/cli/resume_platform.go
@@ -45,7 +45,7 @@ func ResumePlatform(ctx context.Context, options *ResumeOptions, config *config.
 	}
 
 	log.Infof("Waking up virtual cluster %s in project %s", vCluster.VirtualCluster.Name, vCluster.Project.Name)
-	_, err = platform.WaitForVirtualClusterInstance(ctx, managementClient, vCluster.VirtualCluster.Namespace, vCluster.VirtualCluster.Name, true, log)
+	_, err = platform.WaitForVirtualClusterInstance(ctx, managementClient, vCluster.VirtualCluster.Namespace, vCluster.VirtualCluster.Name, true, true, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/platform/helper.go
+++ b/pkg/platform/helper.go
@@ -550,7 +550,7 @@ func GetCurrentUser(ctx context.Context, managementClient kube.Interface) (*mana
 	return self.Status.User, self.Status.Team, nil
 }
 
-func WaitForSpaceInstance(ctx context.Context, managementClient kube.Interface, namespace, name string, waitUntilReady bool, log log.Logger) (*managementv1.SpaceInstance, error) {
+func WaitForSpaceInstance(ctx context.Context, managementClient kube.Interface, namespace, name string, waitUntilReady, forceWakeup bool, log log.Logger) (*managementv1.SpaceInstance, error) {
 	pollInterval := min(clihelper.Timeout()/5, defaultPollInterval)
 	now := time.Now()
 	nextMessage := now.Add(pollInterval)
@@ -560,6 +560,15 @@ func WaitForSpaceInstance(ctx context.Context, managementClient kube.Interface, 
 	}
 
 	if spaceInstance.Status.Phase == storagev1.InstanceSleeping {
+		if !forceWakeup {
+			if err := canAutoWakeup(spaceInstance); err != nil {
+				project := projectutil.ProjectFromNamespace(spaceInstance.Namespace)
+				return nil, fmt.Errorf(
+					"space %s is force-sleeping (%s is set) and will not be auto-woken. Wake it explicitly: vcluster platform wakeup space %s --project %s",
+					spaceInstance.Name, clusterv1.SleepModeForceDurationAnnotation, spaceInstance.Name, project,
+				)
+			}
+		}
 		log.Info("Wait until space wakes up")
 		defer log.Donef("Successfully woken up space %s", name)
 		err := wakeupSpace(ctx, managementClient, spaceInstance)
@@ -1021,7 +1030,7 @@ func ListVClusters(ctx context.Context, client Client, virtualClusterName, proje
 	return virtualClusters, nil
 }
 
-func WaitForVirtualClusterInstance(ctx context.Context, managementClient kube.Interface, namespace, name string, waitUntilReady bool, log log.Logger) (*managementv1.VirtualClusterInstance, error) {
+func WaitForVirtualClusterInstance(ctx context.Context, managementClient kube.Interface, namespace, name string, waitUntilReady, forceWakeup bool, log log.Logger) (*managementv1.VirtualClusterInstance, error) {
 	now := time.Now()
 	pollInterval := min(clihelper.Timeout()/5, defaultPollInterval)
 	nextMessage := now.Add(pollInterval)
@@ -1031,6 +1040,15 @@ func WaitForVirtualClusterInstance(ctx context.Context, managementClient kube.In
 	}
 
 	if virtualClusterInstance.Status.Phase == storagev1.InstanceSleeping {
+		if !forceWakeup {
+			if err := canAutoWakeup(virtualClusterInstance); err != nil {
+				project := projectutil.ProjectFromNamespace(virtualClusterInstance.Namespace)
+				return nil, fmt.Errorf(
+					"tenant cluster %s is force-sleeping (%s is set) and will not be auto-woken. Wake it explicitly: vcluster platform wakeup vcluster %s --project %s",
+					virtualClusterInstance.Name, clusterv1.SleepModeForceDurationAnnotation, virtualClusterInstance.Name, project,
+				)
+			}
+		}
 		log.Info("Wait until vcluster instance wakes up")
 		defer log.Donef("virtual cluster %s wakeup successful", name)
 		err := wakeupVCluster(ctx, managementClient, virtualClusterInstance)
@@ -1206,6 +1224,27 @@ func wakeupSpace(ctx context.Context, managementClient kube.Interface, spaceInst
 	_, err = managementClient.Loft().ManagementV1().SpaceInstances(spaceInstance.Namespace).Patch(ctx, spaceInstance.Name, patch.Type(), patchData, metav1.PatchOptions{})
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func canAutoWakeup(obj metav1.Object) error {
+	annotations := obj.GetAnnotations()
+	raw, ok := annotations[clusterv1.SleepModeForceDurationAnnotation]
+	if !ok {
+		return nil
+	}
+	duration, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || duration < 0 {
+		return nil
+	}
+	if duration == 0 {
+		return fmt.Errorf("instance is force-sleeping")
+	}
+	sleepingSince, _ := strconv.ParseInt(annotations[clusterv1.SleepModeSleepingSinceAnnotation], 10, 64)
+	if sleepingSince > 0 && time.Now().Before(time.Unix(sleepingSince+duration, 0)) {
+		return fmt.Errorf("instance is force-sleeping")
 	}
 
 	return nil
@@ -1426,7 +1465,7 @@ func EnablePlatformManagement(ctx context.Context, kubeClient *kubernetes.Client
 	vciNamespace := ns.Labels[namespaceLabel]
 
 	log.Infof("Waiting until the virtual cluster instance %s/%s is ready", vciNamespace, vciName)
-	_, err = WaitForVirtualClusterInstance(ctx, managementClient, vciNamespace, vciName, true, log)
+	_, err = WaitForVirtualClusterInstance(ctx, managementClient, vciNamespace, vciName, true, false, log)
 	if err != nil {
 		return fmt.Errorf("failed while waiting for the virtual cluster instance %s/%s to be ready: %w", vciNamespace, vciName, err)
 	}
@@ -1469,7 +1508,7 @@ func EnablePlatformManagement(ctx context.Context, kubeClient *kubernetes.Client
 	}
 
 	log.Infof("Waiting until the virtual cluster instance %s/%s is ready", vciNamespace, vciName)
-	_, err = WaitForVirtualClusterInstance(ctx, managementClient, vciNamespace, vciName, true, log)
+	_, err = WaitForVirtualClusterInstance(ctx, managementClient, vciNamespace, vciName, true, false, log)
 	if err != nil {
 		return fmt.Errorf("failed while waiting for the virtual cluster instance %s/%s to be ready: %w", vciNamespace, vciName, err)
 	}

--- a/pkg/platform/helper_test.go
+++ b/pkg/platform/helper_test.go
@@ -1,0 +1,93 @@
+package platform
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
+	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCanAutoWakeup(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantBlocked bool
+	}{
+		{
+			name:        "no force-duration → allow",
+			annotations: nil,
+			wantBlocked: false,
+		},
+		{
+			name: "force-duration with sleeping-since within window → block",
+			annotations: map[string]string{
+				clusterv1.SleepModeForceDurationAnnotation: "600",
+				clusterv1.SleepModeSleepingSinceAnnotation: strconv.FormatInt(now-60, 10),
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "force-duration but window elapsed → allow",
+			annotations: map[string]string{
+				clusterv1.SleepModeForceDurationAnnotation: "60",
+				clusterv1.SleepModeSleepingSinceAnnotation: strconv.FormatInt(now-3600, 10),
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "force-duration=0 (sleep until explicit wake) → block",
+			annotations: map[string]string{
+				clusterv1.SleepModeForceDurationAnnotation: "0",
+				clusterv1.SleepModeSleepingSinceAnnotation: strconv.FormatInt(now-3600, 10),
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "force-duration without sleeping-since → allow",
+			annotations: map[string]string{
+				clusterv1.SleepModeForceDurationAnnotation: "600",
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "malformed force-duration → allow (permissive)",
+			annotations: map[string]string{
+				clusterv1.SleepModeForceDurationAnnotation: "not-a-number",
+				clusterv1.SleepModeSleepingSinceAnnotation: strconv.FormatInt(now-60, 10),
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "negative force-duration → allow (permissive)",
+			annotations: map[string]string{
+				clusterv1.SleepModeForceDurationAnnotation: "-1",
+				clusterv1.SleepModeSleepingSinceAnnotation: strconv.FormatInt(now-60, 10),
+			},
+			wantBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vci := &managementv1.VirtualClusterInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-tenant",
+					Namespace:   "loft-p-my-project",
+					Annotations: tt.annotations,
+				},
+			}
+			err := canAutoWakeup(vci)
+			if tt.wantBlocked && err == nil {
+				t.Fatalf("expected block, got nil")
+			}
+			if !tt.wantBlocked && err != nil {
+				t.Fatalf("expected allow, got error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)

resolves [ENGCP-349](https://linear.app/loft/issue/ENGCP-349/vcluster-connect-command-always-wakes-up-sleeping-vcluster)

`vcluster connect` (and `vcluster create`, `vcluster platform connect|create vcluster|space`, `vcluster platform add vcluster`) previously woke a sleeping Tenant Cluster regardless of `--prevent-wakeup`, defeating the prevent-wakeup contract that customers rely on for non-interactive scripts.

These commands now refuse to auto-wake a force-sleeping Tenant Cluster and return an error pointing the user at the explicit wakeup command. `vcluster resume` and `vcluster platform wakeup vcluster|space` continue to wake the cluster as before — they are the escape hatch.

Backwards compatible for any non-force-duration sleep state (inactivity, scheduled): auto-wake continues to work as before.

**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where `vcluster connect` and related commands would silently wake a Tenant Cluster that had been paused with `--prevent-wakeup`. Sleeping instances with an unexpired prevent-wakeup duration now return an error pointing at `vcluster platform wakeup vcluster|space` instead.

**What else do we need to know?**

Scheduled sleep is intentionally out of scope for this V1.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```