### PR TITLE
feat(metrics): expose kine metrics via /metrics/kine

### DIFF
--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -108,4 +108,25 @@ spec:
         name: vc-{{ .Release.Name }}
         key: client-key
   {{- end }}
+  {{- if not (or .Values.controlPlane.backingStore.etcd.embedded.enabled .Values.controlPlane.backingStore.etcd.deploy.enabled .Values.controlPlane.backingStore.etcd.external.enabled) }}
+  - interval: 30s
+    port: https
+    path: /metrics/kine
+    scheme: https
+    relabelings:
+      - targetLabel: endpoint
+        replacement: "kine"
+    tlsConfig:
+      ca:
+        secret:
+          name: vc-{{ .Release.Name }}
+          key: certificate-authority
+      cert:
+        secret:
+          name: vc-{{ .Release.Name }}
+          key: client-certificate
+      keySecret:
+        name: vc-{{ .Release.Name }}
+        key: client-key
+  {{- end }}
 {{- end }}

--- a/chart/tests/service-monitor_test.yaml
+++ b/chart/tests/service-monitor_test.yaml
@@ -30,10 +30,16 @@ tests:
           value: vcluster
       - lengthEqual:
           path: spec.endpoints
-          count: 2
+          count: 3
       - equal:
           path: spec.endpoints[1].path
           value: /metrics/controller-manager
+      - equal:
+          path: spec.endpoints[2].path
+          value: /metrics/kine
+      - equal:
+          path: spec.endpoints[2].relabelings[0].replacement
+          value: kine
 
   - it: override release label
     release:
@@ -70,10 +76,13 @@ tests:
         count: 1
     - lengthEqual:
         path: spec.endpoints
-        count: 3
+        count: 4
     - equal:
         path: spec.endpoints[2].path
         value: /metrics/scheduler
+    - equal:
+        path: spec.endpoints[3].path
+        value: /metrics/kine
 
   - it: check virtual scheduler (deprecated)
     release:
@@ -91,10 +100,13 @@ tests:
           count: 1
       - lengthEqual:
           path: spec.endpoints
-          count: 3
+          count: 4
       - equal:
           path: spec.endpoints[2].path
           value: /metrics/scheduler
+      - equal:
+          path: spec.endpoints[3].path
+          value: /metrics/kine
 
   - it: check embedded etcd
     release:
@@ -117,3 +129,75 @@ tests:
       - equal:
           path: spec.endpoints[2].path
           value: /metrics/etcd
+      - notContains:
+          path: spec.endpoints
+          content:
+            path: /metrics/kine
+
+  - it: check external database renders kine endpoint
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        backingStore:
+          database:
+            external:
+              enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.endpoints
+          count: 3
+      - equal:
+          path: spec.endpoints[2].path
+          value: /metrics/kine
+
+  - it: check deployed etcd omits kine endpoint
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        backingStore:
+          etcd:
+            deploy:
+              enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.endpoints
+          count: 2
+      - notContains:
+          path: spec.endpoints
+          content:
+            path: /metrics/kine
+
+  - it: check external etcd omits kine endpoint
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        backingStore:
+          etcd:
+            external:
+              enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.endpoints
+          count: 2
+      - notContains:
+          path: spec.endpoints
+          content:
+            path: /metrics/kine

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,6 +4,11 @@ import "path/filepath"
 
 const (
 	VClusterStorageOptionsEnv = "VCLUSTER_STORAGE_OPTIONS"
+
+	// LocalBackingStoreMetricsHost is the loopback host:port that the in-pod
+	// backing store (kine or embedded etcd) binds its Prometheus metrics
+	// endpoint to. The two are mutually exclusive, so they share a port.
+	LocalBackingStoreMetricsHost = "127.0.0.1:2381"
 )
 
 var (

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -278,7 +278,7 @@ func StartKineWithDone(ctx context.Context, dataSource, listenAddress string, ce
 				args = append(args, "--cert-file="+certificates.ServerCert)
 			}
 		}
-		args = append(args, "--metrics-bind-address=0")
+		args = append(args, "--metrics-bind-address="+constants.LocalBackingStoreMetricsHost)
 		args = append(args, "--listen-address="+listenAddress)
 		args = command.MergeArgs(args, extraArgs)
 

--- a/pkg/server/filters/k8s_metrics.go
+++ b/pkg/server/filters/k8s_metrics.go
@@ -3,6 +3,8 @@ package filters
 import (
 	"net/http"
 
+	"github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/server/handler"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	requestpkg "github.com/loft-sh/vcluster/pkg/util/request"
@@ -12,7 +14,7 @@ import (
 const (
 	controllerManagerMetricsHost = "https://127.0.0.1:10257"
 	schedulerMetricsHost         = "https://127.0.0.1:10259"
-	embeddedEtcdMetricsHost      = "http://127.0.0.1:2381"
+	localBackingStoreMetricsURL  = "http://" + constants.LocalBackingStoreMetricsHost
 )
 
 func WithK8sMetrics(h http.Handler, registerCtx *synccontext.RegisterContext) http.Handler {
@@ -43,7 +45,14 @@ func metricsRestConfig(path string, registerCtx *synccontext.RegisterContext) *r
 		return localK8sMetricsConfig(registerCtx, schedulerMetricsHost)
 	case "/metrics/etcd":
 		if registerCtx.Config.ControlPlane.BackingStore.Etcd.Embedded.Enabled {
-			return &rest.Config{Host: embeddedEtcdMetricsHost}
+			return &rest.Config{Host: localBackingStoreMetricsURL}
+		}
+	case "/metrics/kine":
+		switch registerCtx.Config.BackingStoreType() {
+		case config.StoreTypeEmbeddedDatabase, config.StoreTypeExternalDatabase:
+			return &rest.Config{Host: localBackingStoreMetricsURL}
+		case config.StoreTypeEmbeddedEtcd, config.StoreTypeExternalEtcd, config.StoreTypeDeployedEtcd:
+			// kine is not used with etcd backing stores
 		}
 	}
 

--- a/pkg/server/filters/k8s_metrics_test.go
+++ b/pkg/server/filters/k8s_metrics_test.go
@@ -14,6 +14,10 @@ func TestMetricsRestConfig(t *testing.T) {
 		name         string
 		path         string
 		embeddedEtcd bool
+		externalEtcd bool
+		deployedEtcd bool
+		externalDB   bool
+		embeddedDB   bool
 		wantHost     string
 		wantNil      bool
 	}{
@@ -41,12 +45,47 @@ func TestMetricsRestConfig(t *testing.T) {
 			name:         "embedded etcd route",
 			path:         "/metrics/etcd",
 			embeddedEtcd: true,
-			wantHost:     embeddedEtcdMetricsHost,
+			wantHost:     localBackingStoreMetricsURL,
 		},
 		{
 			name:    "etcd route disabled without embedded etcd",
 			path:    "/metrics/etcd",
 			wantNil: true,
+		},
+		{
+			name:     "kine route default backing store (embedded sqlite)",
+			path:     "/metrics/kine",
+			wantHost: localBackingStoreMetricsURL,
+		},
+		{
+			name:       "kine route explicit embedded database",
+			path:       "/metrics/kine",
+			embeddedDB: true,
+			wantHost:   localBackingStoreMetricsURL,
+		},
+		{
+			name:       "kine route external database",
+			path:       "/metrics/kine",
+			externalDB: true,
+			wantHost:   localBackingStoreMetricsURL,
+		},
+		{
+			name:         "kine route disabled with embedded etcd",
+			path:         "/metrics/kine",
+			embeddedEtcd: true,
+			wantNil:      true,
+		},
+		{
+			name:         "kine route disabled with deployed etcd",
+			path:         "/metrics/kine",
+			deployedEtcd: true,
+			wantNil:      true,
+		},
+		{
+			name:         "kine route disabled with external etcd",
+			path:         "/metrics/kine",
+			externalEtcd: true,
+			wantNil:      true,
 		},
 		{
 			name:    "unrelated route",
@@ -65,6 +104,22 @@ func TestMetricsRestConfig(t *testing.T) {
 								Etcd: rawconfig.Etcd{
 									Embedded: rawconfig.EtcdEmbedded{
 										Enabled: tt.embeddedEtcd,
+									},
+									Deploy: rawconfig.EtcdDeploy{
+										Enabled: tt.deployedEtcd,
+									},
+									External: rawconfig.EtcdExternal{
+										Enabled: tt.externalEtcd,
+									},
+								},
+								Database: rawconfig.Database{
+									Embedded: rawconfig.DatabaseKine{
+										Enabled: tt.embeddedDB,
+									},
+									External: rawconfig.ExternalDatabaseKine{
+										DatabaseKine: rawconfig.DatabaseKine{
+											Enabled: tt.externalDB,
+										},
 									},
 								},
 							},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -333,6 +333,10 @@ func metricsAuthNonResources() []delegatingauthorizer.PathVerb {
 			Path: "/metrics/etcd",
 			Verb: "*",
 		},
+		{
+			Path: "/metrics/kine",
+			Verb: "*",
+		},
 	}
 
 	return pathVerbs

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -9,6 +9,7 @@ func TestMetricsAuthNonResources(t *testing.T) {
 		"/metrics/controller-manager": {},
 		"/metrics/scheduler":          {},
 		"/metrics/etcd":               {},
+		"/metrics/kine":               {},
 	}
 
 	got := metricsAuthNonResources()

--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -626,7 +626,10 @@ func setLatestRevisionSQLite(ctx context.Context, file string, revision int64) e
 	defer cancel()
 
 	// start & stop kine to create the database
-	doneChan := k8s.StartKineWithDone(kineCtx, fmt.Sprintf("sqlite://%s%s", file, k8s.SQLiteParams), constants.K8sKineEndpoint, nil, nil)
+	doneChan := k8s.StartKineWithDone(kineCtx, fmt.Sprintf("sqlite://%s%s", file, k8s.SQLiteParams), constants.K8sKineEndpoint, nil,
+		// disable the kine metrics listener, not required for snapshots and would conflict on port
+		[]string{"--metrics-bind-address=0"},
+	)
 
 	// wait until file is created or kine fails or timeout
 	kineStartTimeout := 30 * time.Second


### PR DESCRIPTION
## Summary

- Bind kine's metrics listener to `127.0.0.1:2381` instead of `0` (disabled), so kine's Prometheus metrics are reachable inside the pod.
- Proxy them through the control plane on `/metrics/kine`, gated to non-etcd backing stores (embedded sqlite, embedded database, external database).
- Add a ServiceMonitor endpoint scraping `/metrics/kine` for non-etcd deployments, with corresponding chart unit tests.
- Disable the listener in the snapshot restore path to avoid a port conflict with the running kine.

Closes ENGCP-400

## Test plan

- [x] go build ./... in vcluster
- [x] go test ./pkg/server/... ./pkg/k8s/... ./pkg/snapshot/...
- [x] helm unittest against chart/tests/service-monitor_test.yaml (default sqlite, virtual scheduler, embedded etcd, deployed etcd, external etcd, external database)
- [x] In-cluster verification: curl -k https://<vcluster-pod>:<port>/metrics/kine returns Prometheus metrics; ServiceMonitor scrape succeeds in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)