### PR TITLE
feat(k8s): supervise control-plane subprocess restarts in-process

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -108,18 +108,20 @@ func StartK8S(ctx context.Context, serviceCIDR string, vConfig *config.VirtualCl
 			// add extra args
 			args = command.MergeArgs(args, apiServer.ExtraArgs)
 
-			// wait until etcd is up and running
-			err := etcd.WaitForEtcd(ctx, etcdCertificates, etcdEndpoints)
-			if err != nil {
-				klog.Errorf("error waiting for etcd to be up: %s", err.Error())
-				osutil.Exit(1)
-				return
+			// Each supervised attempt waits for etcd, then runs apiserver. If
+			// etcd is briefly unavailable across a restart, the wait blocks
+			// until etcd recovers (or the context is cancelled), and the
+			// supervisor's backoff/budget treats it like any other failure.
+			runner := func(ctx context.Context) error {
+				if err := etcd.WaitForEtcd(ctx, etcdCertificates, etcdEndpoints); err != nil {
+					return fmt.Errorf("wait for etcd: %w", err)
+				}
+				return command.RunCommand(ctx, args, "apiserver")
 			}
 
-			// now start the api server
-			err = command.RunCommand(ctx, args, "apiserver")
+			err := runComponent(ctx, "apiserver", runner)
 			if err != nil {
-				klog.Errorf("error running apiserver: %s", err.Error())
+				klog.Errorf("apiserver supervisor exited: %v", err)
 				osutil.Exit(1)
 				return
 			}
@@ -198,9 +200,12 @@ func StartK8S(ctx context.Context, serviceCIDR string, vConfig *config.VirtualCl
 
 			// add extra args
 			args = command.MergeArgs(args, controllerManager.ExtraArgs)
-			err = command.RunCommand(ctx, args, "controller-manager")
+			runner := func(ctx context.Context) error {
+				return command.RunCommand(ctx, args, "controller-manager")
+			}
+			err = runComponent(ctx, "controller-manager", runner)
 			if err != nil {
-				klog.Errorf("error running controller-manager: %s", err.Error())
+				klog.Errorf("controller-manager supervisor exited: %v", err)
 				osutil.Exit(1)
 				return
 			}
@@ -228,9 +233,12 @@ func StartK8S(ctx context.Context, serviceCIDR string, vConfig *config.VirtualCl
 
 			// add extra args
 			args = command.MergeArgs(args, scheduler.ExtraArgs)
-			err = command.RunCommand(ctx, args, "scheduler")
+			runner := func(ctx context.Context) error {
+				return command.RunCommand(ctx, args, "scheduler")
+			}
+			err = runComponent(ctx, "scheduler", runner)
 			if err != nil {
-				klog.Errorf("error running scheduler: %s", err.Error())
+				klog.Errorf("scheduler supervisor exited: %v", err)
 				osutil.Exit(1)
 				return
 			}

--- a/pkg/k8s/supervisor.go
+++ b/pkg/k8s/supervisor.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/loft-sh/vcluster/pkg/util/command"
+)
+
+// ComponentSupervisorEnvVar is the env var that toggles in-process subprocess
+// supervision. It is a temporary local-development knob — the design doc
+// proposes promoting it to controlPlane.statefulSet.componentSupervisor.enabled
+// in vcluster.yaml before this lands. Default in this build is on, so a local
+// build can be validated without setting anything; production builds should
+// gate on the chart value before shipping.
+const ComponentSupervisorEnvVar = "VCLUSTER_COMPONENT_SUPERVISOR"
+
+// componentSupervisorEnabled returns true when the per-component supervisor
+// should wrap each control-plane subprocess. Reading the env var on every
+// component start lets tests and operators flip it without restarting the pod
+// (when used in conjunction with cgroup-aware test fixtures).
+func componentSupervisorEnabled() bool {
+	v := os.Getenv(ComponentSupervisorEnvVar)
+	if v == "" {
+		// Local validation default. Flip to false before this lands on
+		// main; the chart value will own the production default.
+		return true
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		// Unrecognized value: be conservative, take the legacy path.
+		return false
+	}
+	return enabled
+}
+
+// supervisorPolicy is the restart policy used when the supervisor is enabled.
+// It is a package-level variable so tests can substitute a faster policy
+// without burning real wall time on backoffs.
+var supervisorPolicy = command.DefaultRestartPolicy()
+
+// runComponent invokes runner under the supervisor (when enabled) or once
+// directly (legacy). Returns nil on graceful completion, ctx.Err() on
+// cancellation, or a non-nil error when the supervisor exhausts its restart
+// budget. Callers map the non-nil case to osutil.Exit(1) so kubelet's
+// CrashLoopBackoff still applies, preserving the contract from PR #2647.
+func runComponent(ctx context.Context, name string, runner command.ComponentRunner) error {
+	if componentSupervisorEnabled() {
+		return command.RunWithRestart(ctx, name, runner, supervisorPolicy, nil)
+	}
+	return runner(ctx)
+}

--- a/pkg/k8s/supervisor_envhelpers_test.go
+++ b/pkg/k8s/supervisor_envhelpers_test.go
@@ -1,0 +1,19 @@
+package k8s
+
+import "os"
+
+// Thin wrappers so the test file can manipulate the environment without
+// importing os directly (keeping the surface area of the tests minimal and
+// easy to grep for env accesses).
+
+func lookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+func setEnv(key, value string) error {
+	return os.Setenv(key, value)
+}
+
+func unsetEnv(key string) error {
+	return os.Unsetenv(key)
+}

--- a/pkg/k8s/supervisor_test.go
+++ b/pkg/k8s/supervisor_test.go
@@ -1,0 +1,155 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/loft-sh/vcluster/pkg/util/command"
+)
+
+// fastPolicy is a low-backoff policy used by integration tests in this
+// package so we don't sleep for seconds between attempts.
+var fastPolicy = command.RestartPolicy{
+	MaxFailures:   5,
+	FailureWindow: time.Minute,
+	MinBackoff:    time.Microsecond,
+	MaxBackoff:    time.Microsecond,
+}
+
+// withFastPolicy installs fastPolicy for the duration of the test.
+func withFastPolicy(t *testing.T) {
+	t.Helper()
+	prev := supervisorPolicy
+	t.Cleanup(func() { supervisorPolicy = prev })
+	supervisorPolicy = fastPolicy
+}
+
+// TestRunComponentSupervisorEnabled exercises the integration shape used by
+// each goroutine in pkg/k8s/k8s.go: build a runner closure, call runComponent,
+// expect graceful completion after a couple of transient failures.
+func TestRunComponentSupervisorEnabled(t *testing.T) {
+	t.Setenv(ComponentSupervisorEnvVar, "true")
+	withFastPolicy(t)
+
+	var attempts int32
+	runner := func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	}
+
+	if err := runComponent(context.Background(), "test-component", runner); err != nil {
+		t.Fatalf("expected nil after graceful completion, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 runner invocations, got %d", got)
+	}
+}
+
+// TestRunComponentSupervisorDisabled checks that with the env var explicitly
+// off, the legacy single-shot path runs and any error propagates immediately.
+func TestRunComponentSupervisorDisabled(t *testing.T) {
+	t.Setenv(ComponentSupervisorEnvVar, "false")
+
+	var attempts int32
+	wantErr := errors.New("legacy fail")
+	runner := func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return wantErr
+	}
+
+	err := runComponent(context.Background(), "test-component", runner)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wantErr, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 runner invocation in legacy mode, got %d", got)
+	}
+}
+
+// TestRunComponentEscalation verifies that exhausting the budget propagates
+// ErrEscalate so the goroutine in k8s.go can map it to osutil.Exit(1).
+//
+// We override supervisorPolicy locally with sub-millisecond backoffs so the
+// test runs in milliseconds rather than the 30+ s the real default would cost
+// after exponential backoff.
+func TestRunComponentEscalation(t *testing.T) {
+	t.Setenv(ComponentSupervisorEnvVar, "true")
+
+	prev := supervisorPolicy
+	t.Cleanup(func() { supervisorPolicy = prev })
+	supervisorPolicy = command.RestartPolicy{
+		MaxFailures:   2, // smaller budget than fastPolicy to keep iterations bounded
+		FailureWindow: time.Minute,
+		MinBackoff:    time.Microsecond,
+		MaxBackoff:    time.Microsecond,
+	}
+
+	runner := func(_ context.Context) error { return errors.New("always") }
+
+	err := runComponent(context.Background(), "test-component", runner)
+	if !errors.Is(err, command.ErrEscalate) {
+		t.Fatalf("expected ErrEscalate, got %v", err)
+	}
+}
+
+// TestRunComponentInvalidEnvFallsBackToLegacy guards the parsing branch: an
+// unrecognized env value should not silently enable the supervisor — we want
+// the safer path.
+func TestRunComponentInvalidEnvFallsBackToLegacy(t *testing.T) {
+	t.Setenv(ComponentSupervisorEnvVar, "yes-please")
+
+	var attempts int32
+	wantErr := errors.New("legacy fail")
+	runner := func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return wantErr
+	}
+
+	err := runComponent(context.Background(), "test-component", runner)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wantErr, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 runner invocation when env value is invalid, got %d", got)
+	}
+}
+
+// TestRunComponentEnvDefault verifies the local-validation default (env unset
+// → supervisor enabled). Restores the env so subsequent tests don't see this
+// override.
+func TestRunComponentEnvDefault(t *testing.T) {
+	// t.Setenv with empty string still sets the var; use Unsetenv so we
+	// hit the actual "not set" branch in componentSupervisorEnabled.
+	prev, hadPrev := lookupEnv(ComponentSupervisorEnvVar)
+	if hadPrev {
+		t.Cleanup(func() { _ = setEnv(ComponentSupervisorEnvVar, prev) })
+	} else {
+		t.Cleanup(func() { _ = unsetEnv(ComponentSupervisorEnvVar) })
+	}
+	if err := unsetEnv(ComponentSupervisorEnvVar); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
+	withFastPolicy(t)
+
+	var attempts int32
+	runner := func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			return errors.New("once")
+		}
+		return nil
+	}
+
+	if err := runComponent(context.Background(), "test-component", runner); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected supervisor to retry once and then succeed, got %d attempts", got)
+	}
+}

--- a/pkg/util/command/supervisor.go
+++ b/pkg/util/command/supervisor.go
@@ -1,0 +1,240 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// ComponentRunner runs a single attempt of a long-running component (typically
+// a subprocess wrapped by RunCommand). It must return when ctx is done. A nil
+// return means the component finished gracefully and should not be restarted.
+// Any non-nil return is treated as a crash and counted against the restart
+// budget.
+type ComponentRunner func(ctx context.Context) error
+
+// RestartPolicy controls how Supervisor restarts a component on failure.
+type RestartPolicy struct {
+	// MaxFailures is the number of failures permitted within FailureWindow
+	// before the supervisor escalates (returns ErrEscalate). 0 disables
+	// restart entirely (any failure escalates immediately).
+	MaxFailures int
+
+	// FailureWindow is the sliding window over which failures accumulate.
+	// Failures older than (now - FailureWindow) are forgotten.
+	FailureWindow time.Duration
+
+	// MinBackoff is the wait before the first restart attempt after a
+	// failure. Each subsequent failure within FailureWindow doubles the
+	// backoff, capped at MaxBackoff.
+	MinBackoff time.Duration
+
+	// MaxBackoff caps the exponential backoff between restart attempts.
+	MaxBackoff time.Duration
+}
+
+// DefaultRestartPolicy is a conservative default: tolerate up to 5 failures in
+// 5 minutes with 1s..30s backoff before escalating.
+func DefaultRestartPolicy() RestartPolicy {
+	return RestartPolicy{
+		MaxFailures:   5,
+		FailureWindow: 5 * time.Minute,
+		MinBackoff:    1 * time.Second,
+		MaxBackoff:    30 * time.Second,
+	}
+}
+
+// ErrEscalate is returned by RunWithRestart when the restart budget is
+// exhausted and the caller should propagate the failure (e.g. by exiting the
+// container so kubelet's CrashLoopBackoff takes over).
+var ErrEscalate = errors.New("supervisor: restart budget exhausted")
+
+// SupervisorMetrics is an optional sink the supervisor calls when restart
+// events happen. The default Supervisor uses a no-op metrics implementation;
+// callers can plug in a Prometheus-backed one without changing the supervisor
+// API.
+type SupervisorMetrics interface {
+	// ObserveRestart is called once per restart attempt, after the backoff
+	// has elapsed but before the runner is invoked.
+	ObserveRestart(component string, attempt int, sinceLast time.Duration)
+
+	// ObserveExit is called once each time the runner returns (with err nil
+	// for graceful, non-nil for crash). It is also called for the final
+	// escalation when the budget is exhausted (with the wrapped error).
+	ObserveExit(component string, err error)
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) ObserveRestart(string, int, time.Duration) {}
+func (noopMetrics) ObserveExit(string, error)                 {}
+
+// RunWithRestart runs the given component, restarting it on failure according
+// to policy. It returns:
+//
+//   - nil when the runner returns nil (graceful completion).
+//   - ctx.Err() when ctx is cancelled while the runner is running or the
+//     supervisor is sleeping between attempts.
+//   - ErrEscalate (wrapped via fmt.Errorf("...: %w", lastErr, ErrEscalate))
+//     when the restart budget is exhausted.
+//
+// The metrics argument may be nil; it is replaced with a no-op implementation.
+func RunWithRestart(ctx context.Context, name string, runner ComponentRunner, policy RestartPolicy, metrics SupervisorMetrics) error {
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
+	s := &Supervisor{
+		Name:    name,
+		Runner:  runner,
+		Policy:  policy,
+		Metrics: metrics,
+	}
+	return s.Run(ctx)
+}
+
+// Supervisor wraps a single ComponentRunner with restart-on-failure semantics.
+// Construct one per component (apiserver, controller-manager, scheduler, kine).
+//
+// A Supervisor is single-shot: it returns from Run() when the runner finishes
+// gracefully, the context is cancelled, or the restart budget is exhausted.
+// It is not safe to call Run concurrently from multiple goroutines.
+type Supervisor struct {
+	Name    string
+	Runner  ComponentRunner
+	Policy  RestartPolicy
+	Metrics SupervisorMetrics
+
+	// now is overridable for tests so we don't have to wait on real
+	// time.Now() to verify FailureWindow accounting.
+	now func() time.Time
+
+	// sleep is overridable for tests so we can advance the clock without
+	// burning real wall time during backoff.
+	sleep func(ctx context.Context, d time.Duration) error
+
+	mu       sync.Mutex
+	failures []time.Time // truncated to entries within FailureWindow
+}
+
+// Run executes the runner repeatedly until graceful completion, ctx
+// cancellation, or budget exhaustion.
+func (s *Supervisor) Run(ctx context.Context) error {
+	if s.Metrics == nil {
+		s.Metrics = noopMetrics{}
+	}
+	if s.now == nil {
+		s.now = time.Now
+	}
+	if s.sleep == nil {
+		s.sleep = ctxSleep
+	}
+
+	var (
+		attempt int
+		lastErr error
+	)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// Backoff before retry (skip on first attempt).
+		if attempt > 0 {
+			backoff := s.computeBackoff(attempt)
+			if err := s.sleep(ctx, backoff); err != nil {
+				return err
+			}
+			s.Metrics.ObserveRestart(s.Name, attempt, backoff)
+			klog.InfoS("Restarting component", "component", s.Name, "attempt", attempt, "backoff", backoff, "lastErr", lastErr)
+		}
+
+		err := s.Runner(ctx)
+		s.Metrics.ObserveExit(s.Name, err)
+
+		// Distinguish three terminal cases:
+		// 1. Graceful exit (err == nil) — caller signalled completion.
+		// 2. Context cancellation — return ctx.Err() and let the caller
+		//    decide. This is not a crash and does not consume budget.
+		// 3. Real failure — record and either retry or escalate.
+		if err == nil {
+			klog.InfoS("Component finished gracefully", "component", s.Name)
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+
+		lastErr = err
+		if !s.recordFailure(err) {
+			klog.ErrorS(lastErr, "Component restart budget exhausted, escalating", "component", s.Name, "maxFailures", s.Policy.MaxFailures, "window", s.Policy.FailureWindow)
+			return fmt.Errorf("%s: %w: %v", s.Name, ErrEscalate, lastErr)
+		}
+		attempt++
+	}
+}
+
+// recordFailure stores a new failure timestamp and returns whether the
+// supervisor should keep retrying (true) or escalate (false).
+//
+// Callers must not hold any other locks when invoking this method.
+func (s *Supervisor) recordFailure(_ error) bool {
+	if s.Policy.MaxFailures <= 0 {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	cutoff := now.Add(-s.Policy.FailureWindow)
+
+	// Drop failures older than the sliding window.
+	pruned := s.failures[:0]
+	for _, t := range s.failures {
+		if t.After(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	pruned = append(pruned, now)
+	s.failures = pruned
+
+	return len(s.failures) <= s.Policy.MaxFailures
+}
+
+// computeBackoff returns an exponentially-growing wait clamped to
+// [MinBackoff, MaxBackoff]. attempt is 1-indexed (attempt 1 is the first
+// retry, i.e. after the first failure).
+func (s *Supervisor) computeBackoff(attempt int) time.Duration {
+	if s.Policy.MinBackoff <= 0 {
+		return 0
+	}
+	d := s.Policy.MinBackoff
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if s.Policy.MaxBackoff > 0 && d >= s.Policy.MaxBackoff {
+			return s.Policy.MaxBackoff
+		}
+	}
+	if s.Policy.MaxBackoff > 0 && d > s.Policy.MaxBackoff {
+		d = s.Policy.MaxBackoff
+	}
+	return d
+}
+
+func ctxSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/pkg/util/command/supervisor_test.go
+++ b/pkg/util/command/supervisor_test.go
@@ -1,0 +1,418 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClock provides a deterministic time source so we don't depend on
+// wall-clock advancement for FailureWindow / backoff assertions.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// fakeSleep replaces real time.Sleep in tests; it advances the fake clock by
+// the requested duration without actually blocking, but still respects ctx
+// cancellation so we can verify cancel-during-backoff behavior.
+func fakeSleep(clock *fakeClock, observed *[]time.Duration, observedMu *sync.Mutex) func(ctx context.Context, d time.Duration) error {
+	return func(ctx context.Context, d time.Duration) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		observedMu.Lock()
+		*observed = append(*observed, d)
+		observedMu.Unlock()
+		clock.Advance(d)
+		return nil
+	}
+}
+
+func newTestSupervisor(t *testing.T, runner ComponentRunner, policy RestartPolicy) (*Supervisor, *fakeClock, *[]time.Duration) {
+	t.Helper()
+	clock := newFakeClock()
+	var observed []time.Duration
+	var observedMu sync.Mutex
+	return &Supervisor{
+		Name:   "test",
+		Runner: runner,
+		Policy: policy,
+		now:    clock.Now,
+		sleep:  fakeSleep(clock, &observed, &observedMu),
+	}, clock, &observed
+}
+
+// TestRestartOnError verifies that a runner that fails a few times then
+// succeeds returns nil from the supervisor (graceful completion path).
+func TestRestartOnError(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return fmt.Errorf("transient failure %d", n)
+		}
+		return nil
+	}
+
+	s, _, observed := newTestSupervisor(t, runner, RestartPolicy{
+		MaxFailures:   5,
+		FailureWindow: time.Minute,
+		MinBackoff:    time.Second,
+		MaxBackoff:    10 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Run(ctx); err != nil {
+		t.Fatalf("expected nil after graceful completion, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 runner invocations, got %d", got)
+	}
+	if len(*observed) != 2 {
+		t.Errorf("expected 2 backoff sleeps before the third attempt, got %d (%v)", len(*observed), *observed)
+	}
+}
+
+// TestEscalateAfterBudget verifies that exceeding MaxFailures within
+// FailureWindow returns an ErrEscalate-wrapped error.
+func TestEscalateAfterBudget(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("always fails")
+	}
+
+	s, _, _ := newTestSupervisor(t, runner, RestartPolicy{
+		MaxFailures:   3,
+		FailureWindow: time.Minute,
+		MinBackoff:    time.Millisecond,
+		MaxBackoff:    time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := s.Run(ctx)
+	if !errors.Is(err, ErrEscalate) {
+		t.Fatalf("expected ErrEscalate, got %v", err)
+	}
+	// MaxFailures=3 means the supervisor tolerates 3 failures and escalates
+	// on the 4th.
+	if got := atomic.LoadInt32(&attempts); got != 4 {
+		t.Errorf("expected 4 runner invocations (3 retries + escalating attempt), got %d", got)
+	}
+}
+
+// TestExponentialBackoff verifies the backoff schedule grows geometrically and
+// caps at MaxBackoff.
+func TestExponentialBackoff(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("fail")
+	}
+
+	policy := RestartPolicy{
+		MaxFailures:   100,
+		FailureWindow: time.Hour,
+		MinBackoff:    time.Second,
+		MaxBackoff:    8 * time.Second,
+	}
+	s, _, observed := newTestSupervisor(t, runner, policy)
+
+	// Cancel after a few attempts so the test terminates.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Wait until at least 5 attempts have been observed, then cancel.
+		for atomic.LoadInt32(&attempts) < 5 {
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+	}()
+
+	if err := s.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	want := []time.Duration{
+		1 * time.Second, // attempt 1: MinBackoff
+		2 * time.Second, // attempt 2: doubled
+		4 * time.Second, // attempt 3: doubled
+		8 * time.Second, // attempt 4: MaxBackoff (cap)
+	}
+	if len(*observed) < len(want) {
+		t.Fatalf("expected at least %d observed sleeps, got %d (%v)", len(want), len(*observed), *observed)
+	}
+	for i, d := range want {
+		if (*observed)[i] != d {
+			t.Errorf("backoff[%d] = %v, want %v", i, (*observed)[i], d)
+		}
+	}
+	// All subsequent observed sleeps should also be capped at MaxBackoff.
+	for i := len(want); i < len(*observed); i++ {
+		if (*observed)[i] != policy.MaxBackoff {
+			t.Errorf("backoff[%d] = %v, want capped at %v", i, (*observed)[i], policy.MaxBackoff)
+		}
+	}
+}
+
+// TestContextCancelDuringRun verifies the supervisor returns ctx.Err()
+// without retrying when ctx is cancelled while the runner is executing.
+func TestContextCancelDuringRun(t *testing.T) {
+	runnerStarted := make(chan struct{})
+	runner := func(ctx context.Context) error {
+		close(runnerStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	s, _, _ := newTestSupervisor(t, runner, DefaultRestartPolicy())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-runnerStarted
+		cancel()
+	}()
+
+	err := s.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestContextCancelDuringBackoff verifies that ctx cancellation interrupts a
+// pending backoff sleep.
+func TestContextCancelDuringBackoff(t *testing.T) {
+	// Use real time here (briefly) so cancellation actually races with the
+	// sleep loop; the fake sleep checks ctx and returns immediately.
+	runner := func(_ context.Context) error {
+		return errors.New("fail once")
+	}
+	s := &Supervisor{
+		Name:   "test",
+		Runner: runner,
+		Policy: RestartPolicy{
+			MaxFailures:   10,
+			FailureWindow: time.Minute,
+			MinBackoff:    50 * time.Millisecond,
+			MaxBackoff:    50 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel while supervisor is sleeping during backoff.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := s.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestGracefulCompletionDoesNotRestart verifies that a runner returning nil
+// causes the supervisor to return nil immediately, without invoking the runner
+// again.
+func TestGracefulCompletionDoesNotRestart(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return nil
+	}
+	s, _, _ := newTestSupervisor(t, runner, DefaultRestartPolicy())
+
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 runner invocation, got %d", got)
+	}
+}
+
+// TestFailureWindowReset verifies that failures spread across more than
+// FailureWindow do not accumulate, so a long-running but infrequently-failing
+// component is supported indefinitely.
+func TestFailureWindowReset(t *testing.T) {
+	clock := newFakeClock()
+	var attempts int32
+	maxAttempts := int32(10)
+
+	runner := func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n >= maxAttempts {
+			return nil
+		}
+		return errors.New("periodic failure")
+	}
+
+	s := &Supervisor{
+		Name:   "test",
+		Runner: runner,
+		Policy: RestartPolicy{
+			MaxFailures:   2,
+			FailureWindow: time.Second,
+			MinBackoff:    time.Millisecond,
+			MaxBackoff:    time.Millisecond,
+		},
+		now: clock.Now,
+		// Custom sleep that also advances the clock past the failure
+		// window so each failure looks isolated.
+		sleep: func(ctx context.Context, d time.Duration) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			clock.Advance(2 * time.Second)
+			return nil
+		},
+	}
+
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("expected supervisor to keep restarting and finish gracefully, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != maxAttempts {
+		t.Errorf("expected %d attempts, got %d", maxAttempts, got)
+	}
+}
+
+// TestMaxFailuresZeroEscalatesImmediately verifies the documented
+// "MaxFailures==0 disables restart" behavior.
+func TestMaxFailuresZeroEscalatesImmediately(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("fail")
+	}
+	s, _, _ := newTestSupervisor(t, runner, RestartPolicy{
+		MaxFailures: 0,
+	})
+
+	err := s.Run(context.Background())
+	if !errors.Is(err, ErrEscalate) {
+		t.Fatalf("expected ErrEscalate, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 runner invocation, got %d", got)
+	}
+}
+
+// TestMetricsCallbacks verifies the metrics interface receives the expected
+// number of restart and exit events.
+func TestMetricsCallbacks(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return fmt.Errorf("fail %d", n)
+		}
+		return nil
+	}
+
+	m := &recordingMetrics{}
+	s, _, _ := newTestSupervisor(t, runner, RestartPolicy{
+		MaxFailures:   5,
+		FailureWindow: time.Minute,
+		MinBackoff:    time.Millisecond,
+		MaxBackoff:    time.Millisecond,
+	})
+	s.Metrics = m
+
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if got, want := m.restartCount(), 2; got != want {
+		t.Errorf("ObserveRestart count = %d, want %d", got, want)
+	}
+	if got, want := m.exitCount(), 3; got != want {
+		t.Errorf("ObserveExit count = %d, want %d", got, want)
+	}
+}
+
+type recordingMetrics struct {
+	mu       sync.Mutex
+	restarts []restartEvent
+	exits    []exitEvent
+}
+
+type restartEvent struct {
+	component string
+	attempt   int
+	backoff   time.Duration
+}
+
+type exitEvent struct {
+	component string
+	err       error
+}
+
+func (m *recordingMetrics) ObserveRestart(component string, attempt int, backoff time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.restarts = append(m.restarts, restartEvent{component, attempt, backoff})
+}
+
+func (m *recordingMetrics) ObserveExit(component string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.exits = append(m.exits, exitEvent{component, err})
+}
+
+func (m *recordingMetrics) restartCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.restarts)
+}
+
+func (m *recordingMetrics) exitCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.exits)
+}
+
+// TestRunWithRestartFunc smoke-tests the convenience function wrapper.
+func TestRunWithRestartFunc(t *testing.T) {
+	var attempts int32
+	runner := func(_ context.Context) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			return errors.New("once")
+		}
+		return nil
+	}
+	policy := RestartPolicy{
+		MaxFailures:   3,
+		FailureWindow: time.Second,
+		MinBackoff:    time.Microsecond,
+		MaxBackoff:    time.Microsecond,
+	}
+	if err := RunWithRestart(context.Background(), "test", runner, policy, nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected 2 runner invocations, got %d", got)
+	}
+}


### PR DESCRIPTION
  Wrap apiserver, kube-controller-manager, and kube-scheduler in a
  per-component supervisor so a single subprocess crash restarts only
  that binary instead of bouncing the whole syncer container and losing
  caches, plugin connections, and in-flight reconciles.

  Preserves the PR #2647 contract: budget exhaustion (5 failures / 5 min
  default) still calls osutil.Exit(1) so kubelet's CrashLoopBackoff
  remains the safety net for genuinely broken components.

  Gated on VCLUSTER_COMPONENT_SUPERVISOR for now; the chart value
  controlPlane.statefulSet.componentSupervisor.enabled replaces it
  before merge. Kine, subgroup-restart for the KCM/scheduler
  virtual-apiserver lease cascade, chart values, and chaos e2e are
  deferred — see design doc.

  Refs: ENGCP-47

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
