### PR TITLE
chore(codeowners): add eng-devops as release.yaml owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 * @loft-sh/eng-dev-vcluster-platform
 
 /.github/workflows/e2e*.yaml @loft-sh/eng-qa @loft-sh/eng-tech-leads
-/.github/workflows/release.yaml @loft-sh/eng-tech-leads
+/.github/workflows/release.yaml @loft-sh/eng-devops @loft-sh/eng-tech-leads
 /.github/CODEOWNERS @loft-sh/eng-tech-leads
 
 /chart/templates/ @loft-sh/eng-tech-leads


### PR DESCRIPTION
## Summary
- Add `@loft-sh/eng-devops` as a co-owner of `.github/workflows/release.yaml`, alongside the existing `@loft-sh/eng-tech-leads`.
- Aligns vcluster with the DevOps team scope: explicit ownership of release pipelines only.

## Why
DevOps is the team that operates the release pipeline; making them an explicit CODEOWNER of `release.yaml` ensures release-pipeline review/approval routes to them directly without depending on team membership in `eng-tech-leads`.

## Test plan
- [ ] CODEOWNERS syntax check (GitHub UI / actionlint)
- [ ] Confirm a draft PR touching `release.yaml` requests review from `@loft-sh/eng-devops`

Refs DEVOPS-757