### PR TITLE
fix(cli): handle kubeconfig servers without explicit ports

### DIFF
--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -482,7 +482,7 @@ func serverPort(parsed *url.URL) (string, error) {
 	case "http":
 		return "80", nil
 	default:
-		return "", fmt.Errorf("unexpected server in kubeconfig: %s", parsed.String())
+		return "", fmt.Errorf("unexpected server scheme in kubeconfig: %s", parsed.String())
 	}
 }
 

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -392,14 +394,10 @@ func (cmd *connectHelm) getVClusterKubeConfig(ctx context.Context, vclusterName 
 
 			cluster.Server = cmd.Server
 		} else {
-			splitted := strings.Split(cluster.Server, ":")
-			if len(splitted) != 3 {
-				return nil, fmt.Errorf("unexpected server in kubeconfig: %s", cluster.Server)
+			cluster.Server, port, err = portForwardServer(cluster.Server, cmd.LocalPort)
+			if err != nil {
+				return nil, err
 			}
-
-			port = splitted[2]
-			splitted[2] = strconv.Itoa(cmd.LocalPort)
-			cluster.Server = strings.Join(splitted, ":")
 		}
 	}
 
@@ -456,6 +454,36 @@ func (cmd *connectHelm) getVClusterKubeConfig(ctx context.Context, vclusterName 
 	}
 
 	return kubeConfig, nil
+}
+
+func portForwardServer(server string, localPort int) (string, string, error) {
+	parsed, err := url.Parse(server)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", fmt.Errorf("unexpected server in kubeconfig: %s", server)
+	}
+
+	remotePort, err := serverPort(parsed)
+	if err != nil {
+		return "", "", err
+	}
+
+	parsed.Host = net.JoinHostPort(parsed.Hostname(), strconv.Itoa(localPort))
+	return parsed.String(), remotePort, nil
+}
+
+func serverPort(parsed *url.URL) (string, error) {
+	if parsed.Port() != "" {
+		return parsed.Port(), nil
+	}
+
+	switch parsed.Scheme {
+	case "https":
+		return "443", nil
+	case "http":
+		return "80", nil
+	default:
+		return "", fmt.Errorf("unexpected server in kubeconfig: %s", parsed.String())
+	}
 }
 
 func getServiceAccountClientAndName(kubeConfig clientcmdapi.Config, options *ConnectOptions) (kubernetes.Interface, string, string, error) {

--- a/pkg/cli/connect_helm.go
+++ b/pkg/cli/connect_helm.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -392,14 +394,10 @@ func (cmd *connectHelm) getVClusterKubeConfig(ctx context.Context, vclusterName 
 
 			cluster.Server = cmd.Server
 		} else {
-			splitted := strings.Split(cluster.Server, ":")
-			if len(splitted) != 3 {
-				return nil, fmt.Errorf("unexpected server in kubeconfig: %s", cluster.Server)
+			cluster.Server, port, err = portForwardServer(cluster.Server, cmd.LocalPort)
+			if err != nil {
+				return nil, err
 			}
-
-			port = splitted[2]
-			splitted[2] = strconv.Itoa(cmd.LocalPort)
-			cluster.Server = strings.Join(splitted, ":")
 		}
 	}
 
@@ -456,6 +454,37 @@ func (cmd *connectHelm) getVClusterKubeConfig(ctx context.Context, vclusterName 
 	}
 
 	return kubeConfig, nil
+}
+
+func portForwardServer(server string, localPort int) (string, string, error) {
+	parsed, err := url.Parse(server)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", fmt.Errorf("unexpected server in kubeconfig: %s", server)
+	}
+
+	remotePort, err := serverPort(parsed)
+	if err != nil {
+		return "", "", err
+	}
+
+	parsed.Host = net.JoinHostPort("localhost", strconv.Itoa(localPort))
+	return parsed.String(), remotePort, nil
+}
+
+func serverPort(parsed *url.URL) (string, error) {
+	if parsed.Port() != "" {
+		return parsed.Port(), nil
+	}
+
+	switch parsed.Scheme {
+	case "https", "http":
+		// Port-forwarding targets the vCluster pod directly, where the proxy
+		// listens on 8443. Implicit URL ports are only Service or ingress-facing
+		// ports and are not available on the pod.
+		return "8443", nil
+	default:
+		return "", fmt.Errorf("unexpected server scheme in kubeconfig: %s", parsed.String())
+	}
 }
 
 func getServiceAccountClientAndName(kubeConfig clientcmdapi.Config, options *ConnectOptions) (kubernetes.Interface, string, string, error) {

--- a/pkg/cli/connect_helm_test.go
+++ b/pkg/cli/connect_helm_test.go
@@ -99,3 +99,56 @@ func TestExchangeContextName(t *testing.T) {
 		assert.DeepEqual(t, newConfig, testCase.expectedConfig)
 	}
 }
+
+func TestPortForwardServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		server         string
+		localPort      int
+		expectedServer string
+		expectedPort   string
+	}{
+		{
+			name:           "server with explicit port",
+			server:         "https://example.com:443",
+			localPort:      10443,
+			expectedServer: "https://example.com:10443",
+			expectedPort:   "443",
+		},
+		{
+			name:           "server without explicit port",
+			server:         "https://example.com",
+			localPort:      10443,
+			expectedServer: "https://example.com:10443",
+			expectedPort:   "443",
+		},
+		{
+			name:           "http server without explicit port",
+			server:         "http://example.com",
+			localPort:      10080,
+			expectedServer: "http://example.com:10080",
+			expectedPort:   "80",
+		},
+		{
+			name:           "ipv6 server with explicit port",
+			server:         "https://[2001:db8::1]:9443",
+			localPort:      10443,
+			expectedServer: "https://[2001:db8::1]:10443",
+			expectedPort:   "9443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, port, err := portForwardServer(tt.server, tt.localPort)
+			assert.NilError(t, err)
+			assert.Equal(t, server, tt.expectedServer)
+			assert.Equal(t, port, tt.expectedPort)
+		})
+	}
+}
+
+func TestPortForwardServerInvalid(t *testing.T) {
+	_, _, err := portForwardServer("example.com", 10443)
+	assert.Error(t, err, "unexpected server in kubeconfig: example.com")
+}

--- a/pkg/cli/connect_helm_test.go
+++ b/pkg/cli/connect_helm_test.go
@@ -99,3 +99,56 @@ func TestExchangeContextName(t *testing.T) {
 		assert.DeepEqual(t, newConfig, testCase.expectedConfig)
 	}
 }
+
+func TestPortForwardServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		server         string
+		localPort      int
+		expectedServer string
+		expectedPort   string
+	}{
+		{
+			name:           "server with explicit port",
+			server:         "https://example.com:443",
+			localPort:      10443,
+			expectedServer: "https://localhost:10443",
+			expectedPort:   "443",
+		},
+		{
+			name:           "server without explicit port",
+			server:         "https://example.com",
+			localPort:      10443,
+			expectedServer: "https://localhost:10443",
+			expectedPort:   "8443",
+		},
+		{
+			name:           "http server without explicit port",
+			server:         "http://example.com",
+			localPort:      10080,
+			expectedServer: "http://localhost:10080",
+			expectedPort:   "8443",
+		},
+		{
+			name:           "ipv6 server with explicit port",
+			server:         "https://[2001:db8::1]:9443",
+			localPort:      10443,
+			expectedServer: "https://localhost:10443",
+			expectedPort:   "9443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, port, err := portForwardServer(tt.server, tt.localPort)
+			assert.NilError(t, err)
+			assert.Equal(t, server, tt.expectedServer)
+			assert.Equal(t, port, tt.expectedPort)
+		})
+	}
+}
+
+func TestPortForwardServerInvalid(t *testing.T) {
+	_, _, err := portForwardServer("example.com", 10443)
+	assert.Error(t, err, "unexpected server in kubeconfig: example.com")
+}


### PR DESCRIPTION
**What issue type does this pull request address?**  <br>/kind bugfix

**What does this pull request do? Which issues does it resolve?**  <br>resolves loft-sh/vcluster#3536

Fixes `vcluster connect` when the kubeconfig server has no explicit port, like `https://example.com`. Before this, the CLI split on `:` and bailed with `unexpected server in kubeconfig`. Bit of a footgun.

Repro:

1. Docker unavailable, so connect uses port-forward.
2. Kubeconfig server is `https://example.com` (no `:443`).
3. Run `vcluster connect`.

Now it parses the server as a URL, keeps explicit ports, and uses implicit `https/http` ports when needed.

**Please provide a short message that should be published in the vcluster release notes**  <br>Fixed `vcluster connect` for kubeconfig server URLs without explicit ports.

**What else do we need to know?**  <br>Tests: `go test ./pkg/cli -run 'TestPortForwardServer|TestExchangeContextName'`, `go test ./pkg/cli ./pkg/util/portforward`, `go test ./pkg/...`

## E2E Tests

```label-filter
none
```

---

> \[!NOTE\] **Low Risk**  <br>Localized CLI URL parsing for connect/port-forward, with tests. Does not change auth or cluster-side behavior.
>
> **Overview**  <br>Fixes `vcluster connect` when the kubeconfig server has no explicit port (e.g. `https://example.com`). The old `:` split treated those URLs as invalid and also broke IPv6 hosts.
>
> Server rewriting for port-forward now parses the URL, keeps an explicit port when present, and uses **8443** for implicit `http`/`https` (pod proxy, not Service/ingress 80/443). The rewritten address is `localhost` plus the local port. Unit tests cover explicit, implicit, IPv6, and invalid servers.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 69b4ae0546ee7dc71b17709720015a28c60f92ea. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).