### PR TITLE
feat(standalone): add standalone-hosts annotation constant

### DIFF
--- a/pkg/constants/standalone.go
+++ b/pkg/constants/standalone.go
@@ -2,6 +2,7 @@ package constants
 
 const (
 	VClusterStandaloneEndpointsAnnotation = "vcluster.loft.sh/standalone-endpoints"
+	VClusterStandaloneHostsAnnotation     = "vcluster.loft.sh/standalone-hosts"
 	VClusterStandalonePortAnnotation      = "vcluster.loft.sh/standalone-port"
 	VClusterStandaloneEnvVar              = "VCLUSTER_STANDALONE"
 	VClusterStandaloneIPAddressEnvVar     = "VCLUSTER_STANDALONE_IP_ADDRESS"


### PR DESCRIPTION
## Summary

Adds the `VClusterStandaloneHostsAnnotation` constant (`vcluster.loft.sh/standalone-hosts`) used by vcluster-pro to track per-master `hostname -> last-known-IP` on the `default/kubernetes` service.

Paired with [vcluster-pro#1777](https://github.com/loft-sh/vcluster-pro/pull/1777), which consumes this constant to clean up stale IPs from the standalone-endpoints annotation when a master's IP changes across restarts — without depending on the on-disk runtime metadata file (which can be lost on data-dir wipe / VM replacement).

Linear: https://linear.app/loft/issue/ENGCP-733


🤖 Generated with [Claude Code](https://claude.com/claude-code)