### PR TITLE
adds: file protocol for snapshot and restore

### DIFF
--- a/cmd/vclusterctl/cmd/restore.go
+++ b/cmd/vclusterctl/cmd/restore.go
@@ -46,6 +46,8 @@ func NewRestore(globalFlags *flags.GlobalFlags) *cobra.Command {
 Restore a virtual cluster.
 
 Example:
+# Restore from a local file on this machine
+vcluster restore my-vcluster file:///home/user/my-snapshot.tar.gz
 # Restore from oci image
 vcluster restore my-vcluster oci://ghcr.io/my-user/my-repo:my-tag
 # Restore from s3 bucket

--- a/cmd/vclusterctl/cmd/snapshot/create.go
+++ b/cmd/vclusterctl/cmd/snapshot/create.go
@@ -42,6 +42,8 @@ request, which will be processed asynchronously by a vCluster
 controller.
 
 Example:
+# Snapshot to a local file on this machine
+vcluster snapshot create my-vcluster file:///home/user/my-snapshot.tar.gz
 # Snapshot to oci image
 vcluster snapshot create my-vcluster oci://ghcr.io/my-user/my-repo:my-tag
 # Snapshot to s3 bucket

--- a/e2e-next/test_storage/snapshot/test_snapshot.go
+++ b/e2e-next/test_storage/snapshot/test_snapshot.go
@@ -200,6 +200,7 @@ func SnapshotAllSpec() {
 			describeSnapshotRestore(&s)
 			describeSnapshotCanceling(&s)
 			describeSnapshotDeletion(&s)
+			describeFileProtocol(&s)
 		},
 	)
 }
@@ -757,6 +758,70 @@ func describeSnapshotDeletion(s *snapshotCtx) {
 		})
 	},
 	)
+}
+
+func describeFileProtocol(s *snapshotCtx) {
+	// Ordered: create snapshot via file:// -> verify file exists locally -> restore -> verify resources.
+	// Each spec depends on the snapshot created in spec 1.
+	Describe("file protocol snapshot and restore", Ordered, func() {
+		var (
+			testNS             string
+			snapshotPath       string
+			configMapToRestore *corev1.ConfigMap
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			testNS = "file-snapshot-" + random.String(6)
+			snapshotPath = "file:///tmp/vcluster-file-snapshot-" + testNS + ".tar.gz"
+			cleanupAllSnapshotArtifacts(ctx, s.hostClient, s.vClusterNS)
+			cmr, _, _, _, _, _ := s.deployTestResources(ctx, testNS)
+			configMapToRestore = cmr
+		})
+
+		It("Creates the snapshot and writes to local filesystem", func(ctx context.Context) {
+			By("Creating the snapshot via file protocol", func() {
+				createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, false)
+				// The CLI blocks until the snapshot completes and the file is downloaded locally.
+				waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
+			})
+
+			By("Verifying the snapshot file exists on local filesystem", func() {
+				localPath := strings.TrimPrefix(snapshotPath, "file://")
+				_, err := os.Stat(localPath)
+				Expect(err).To(Succeed(), "snapshot file should exist at %s", localPath)
+			})
+		})
+
+		It("Restores from local file and verifies resources", func(ctx context.Context) {
+			By("Deleting pre-snapshot resources that should be recreated by restore", func() {
+				err := s.vClusterClient.CoreV1().ConfigMaps(testNS).Delete(ctx, configMapToRestore.Name, metav1.DeleteOptions{})
+				Expect(err).To(Succeed())
+			})
+
+			By("Restoring the tenant cluster from local snapshot file", func() {
+				restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, s.kubeconfig, true, false)
+				s.refreshClient(ctx)
+			})
+
+			By("Verifying pre-snapshot resources are restored", func() {
+				Eventually(func(g Gomega) {
+					cms, err := s.vClusterClient.CoreV1().ConfigMaps(testNS).List(ctx, metav1.ListOptions{
+						LabelSelector: "snapshot=restore",
+					})
+					g.Expect(err).To(Succeed())
+					g.Expect(cms.Items).To(HaveLen(1),
+						"expected configmap %s to be recreated by restore", configMapToRestore.Name)
+					g.Expect(cms.Items[0].Data).To(Equal(configMapToRestore.Data))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+		})
+
+		AfterAll(func(ctx context.Context) {
+			localPath := strings.TrimPrefix(snapshotPath, "file://")
+			_ = os.Remove(localPath)
+			deleteSnapshotRequestConfigMaps(ctx, s.hostClient, s.vClusterNS)
+		})
+	})
 }
 
 // --- Volume helpers ---

--- a/go.mod
+++ b/go.mod
@@ -294,3 +294,5 @@ require (
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 )
+
+replace github.com/loft-sh/api/v4 => /Users/josesilva/Development/loft/github/loft-enterprise/staging/src/github.com/loft-sh/api/v4

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0
-	github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2
+	github.com/loft-sh/agentapi/v4 v4.10.0-alpha.3
 	github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
-	github.com/loft-sh/api/v4 v4.10.0-alpha.2
+	github.com/loft-sh/api/v4 v4.10.0-alpha.3
 	github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979
 	github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364
 	github.com/loft-sh/utils v0.0.29
@@ -294,5 +294,3 @@ require (
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 )
-
-replace github.com/loft-sh/api/v4 => /Users/josesilva/Development/loft/github/loft-enterprise/staging/src/github.com/loft-sh/api/v4

--- a/go.sum
+++ b/go.sum
@@ -320,12 +320,12 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0 h1:12fy1LhhyuQ46ls272yWn6HpAMLNUClsBYqRvu+qTC0=
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0/go.mod h1:pp+2PgOsRCTb1DXnEev/HCc0gvj5t0nHuTIMU8C8b90=
-github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2 h1:xWQUCRnORLKVeAW5r6l/NeKwN3k6LtzwPiyPL6P8ip4=
-github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2/go.mod h1:3bAQUMI7xhTSlODdKXXQgRePg1TifgRd1sBSnMX5OvM=
+github.com/loft-sh/agentapi/v4 v4.10.0-alpha.3 h1:RTXwGnHk1mlHwSipBCF1shy+bplWekmR1zJ+9V6v8WM=
+github.com/loft-sh/agentapi/v4 v4.10.0-alpha.3/go.mod h1:3bAQUMI7xhTSlODdKXXQgRePg1TifgRd1sBSnMX5OvM=
 github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e h1:JcPnMaoczikvpasi8OJ47dCkWZjfgFubWa4V2SZo7h0=
 github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e/go.mod h1:FFWcGASyM2QlWTDTCG/WBVM/XYr8btqYt335TFNRCFg=
-github.com/loft-sh/api/v4 v4.10.0-alpha.2 h1:an0xLCdlbwnJLD0kVzckpN3T+I0L1W0EzTAE9zm9/0g=
-github.com/loft-sh/api/v4 v4.10.0-alpha.2/go.mod h1:iRNMIrbfQ3j3nIQ+bszoubOUxGtHKVB64UQvpk1JdYU=
+github.com/loft-sh/api/v4 v4.10.0-alpha.3 h1:+HgUriF3Bj9gPql7+8rNhQp5WJH+AR//cQ0RfjzHmqY=
+github.com/loft-sh/api/v4 v4.10.0-alpha.3/go.mod h1:azenGE6ppl2J7zYAt5c13Ty5EnAfP5qwKQiXrQQ0WxE=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530 h1:2B4XhZ30FVt17PbWj2iRKcqys8a+3DoPLabvxGswPmU=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530/go.mod h1:YfIUirXHfVcUb3bVtj7yzIAVT6etrHj9wkOkMgnEuz0=
 github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979 h1:5nhHRJIGlxkvJappR0SdBEsuM/ziBke+Z2dVI+A4G3I=

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -48,6 +48,10 @@ func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, rest
 		cmdArgs = append(cmdArgs, "--restore-volumes")
 	}
 
+	if snapshotOpts.Type == "file" {
+		return restoreFromLocalFile(ctx, vCluster, kubeClient, restConfig, snapshotOpts, podOptions, restoreVolumes, log)
+	}
+
 	if vCluster.IsStandalone {
 		return restoreStandaloneVCluster(ctx, vCluster, snapshotOpts, cmdArgs, log)
 	}

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -39,11 +39,7 @@ func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags,
 	return restoreVCluster(ctx, kubeClient, restConfig, vCluster, snapshotOpts, podOpts, newVCluster, restoreVolumes, log)
 }
 
-<<<<<<< HEAD
-func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshotapi.Options, podOptions *pod.Options, newVCluster bool, restoreVolumes bool, log log.Logger) error {
-=======
-func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshot.Options, podOpts *pod.Options, newVCluster bool, restoreVolumes bool, log log.Logger) error {
->>>>>>> 6b18cd836 (add store for file protocol)
+func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshotapi.Options, podOpts *pod.Options, newVCluster bool, restoreVolumes bool, log log.Logger) error {
 	cmdArgs := []string{"restore"}
 	if newVCluster {
 		cmdArgs = append(cmdArgs, "--new-vcluster")
@@ -65,7 +61,7 @@ func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, rest
 
 // runRestorePod runs the restore pod with the given options. It pauses the vCluster before starting the restore and resumes it afterwards.
 // The restore pod will perform the restore and resume the vCluster when it's done.
-func runRestorePod(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshot.Options, podOpts *pod.Options, log log.Logger, cmdArgs []string) error {
+func runRestorePod(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshotapi.Options, podOpts *pod.Options, log log.Logger, cmdArgs []string) error {
 	// pause vCluster
 	log.Infof("Pausing vCluster %s", vCluster.Name)
 	err := pauseVCluster(ctx, kubeClient, vCluster, log)
@@ -92,11 +88,7 @@ func runRestorePod(ctx context.Context, kubeClient *kubernetes.Clientset, restCo
 // before returning. If both the restore and restart fail, the returned error retains
 // both failures. The CLI must run on the same host as the standalone installation
 // because it needs filesystem access to the binary and config.
-<<<<<<< HEAD
-func restoreStandaloneVCluster(ctx context.Context, vCluster *find.VCluster, snapshotOpts *snapshotapi.Options, cmdArgs []string, log log.Logger) (retErr error) {
-=======
-func restoreStandaloneVCluster(snapshotOpts *snapshot.Options, cmdArgs []string, log log.Logger) (retErr error) {
->>>>>>> 6b18cd836 (add store for file protocol)
+func restoreStandaloneVCluster(snapshotOpts *snapshotapi.Options, cmdArgs []string, log log.Logger) (retErr error) {
 	vClusterConfig, err := vclusterconfig.LoadStandaloneConfig("", nil)
 	if err != nil {
 		return fmt.Errorf("load standalone config: %w", err)

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -39,7 +39,11 @@ func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags,
 	return restoreVCluster(ctx, kubeClient, restConfig, vCluster, snapshotOpts, podOpts, newVCluster, restoreVolumes, log)
 }
 
+<<<<<<< HEAD
 func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshotapi.Options, podOptions *pod.Options, newVCluster bool, restoreVolumes bool, log log.Logger) error {
+=======
+func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshot.Options, podOpts *pod.Options, newVCluster bool, restoreVolumes bool, log log.Logger) error {
+>>>>>>> 6b18cd836 (add store for file protocol)
 	cmdArgs := []string{"restore"}
 	if newVCluster {
 		cmdArgs = append(cmdArgs, "--new-vcluster")
@@ -49,13 +53,19 @@ func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, rest
 	}
 
 	if snapshotOpts.Type == "file" {
-		return restoreFromLocalFile(ctx, vCluster, kubeClient, restConfig, snapshotOpts, podOptions, restoreVolumes, log)
+		return restoreFromLocalFile(ctx, vCluster, kubeClient, restConfig, snapshotOpts, podOpts, log, cmdArgs)
 	}
 
 	if vCluster.IsStandalone {
-		return restoreStandaloneVCluster(ctx, vCluster, snapshotOpts, cmdArgs, log)
+		return restoreStandaloneVCluster(snapshotOpts, cmdArgs, log)
 	}
 
+	return runRestorePod(ctx, kubeClient, restConfig, vCluster, snapshotOpts, podOpts, log, cmdArgs)
+}
+
+// runRestorePod runs the restore pod with the given options. It pauses the vCluster before starting the restore and resumes it afterwards.
+// The restore pod will perform the restore and resume the vCluster when it's done.
+func runRestorePod(ctx context.Context, kubeClient *kubernetes.Clientset, restConfig *rest.Config, vCluster *find.VCluster, snapshotOpts *snapshot.Options, podOpts *pod.Options, log log.Logger, cmdArgs []string) error {
 	// pause vCluster
 	log.Infof("Pausing vCluster %s", vCluster.Name)
 	err := pauseVCluster(ctx, kubeClient, vCluster, log)
@@ -74,7 +84,7 @@ func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, rest
 
 	// set missing pod options and run snapshot restore pod
 	command := append([]string{"/vcluster"}, cmdArgs...)
-	return pod.RunSnapshotPod(ctx, restConfig, kubeClient, command, vCluster, podOptions, snapshotOpts, log)
+	return pod.RunSnapshotPod(ctx, restConfig, kubeClient, command, vCluster, podOpts, snapshotOpts, log)
 }
 
 // restoreStandaloneVCluster stops the standalone service, invokes the vcluster binary
@@ -82,7 +92,11 @@ func restoreVCluster(ctx context.Context, kubeClient *kubernetes.Clientset, rest
 // before returning. If both the restore and restart fail, the returned error retains
 // both failures. The CLI must run on the same host as the standalone installation
 // because it needs filesystem access to the binary and config.
+<<<<<<< HEAD
 func restoreStandaloneVCluster(ctx context.Context, vCluster *find.VCluster, snapshotOpts *snapshotapi.Options, cmdArgs []string, log log.Logger) (retErr error) {
+=======
+func restoreStandaloneVCluster(snapshotOpts *snapshot.Options, cmdArgs []string, log log.Logger) (retErr error) {
+>>>>>>> 6b18cd836 (add store for file protocol)
 	vClusterConfig, err := vclusterconfig.LoadStandaloneConfig("", nil)
 	if err != nil {
 		return fmt.Errorf("load standalone config: %w", err)

--- a/pkg/cli/snapshot_helm.go
+++ b/pkg/cli/snapshot_helm.go
@@ -62,7 +62,7 @@ func CreateSnapshot(ctx context.Context, args []string, globalFlags *flags.Globa
 	}
 
 	// create the snapshot request which will be reconciled by the vCluster controller
-	err = createSnapshotRequest(ctx, vCluster, kubeClient, snapshotOpts, log)
+	err = createSnapshotRequest(ctx, vCluster, kubeClient, snapshotOpts, log, restConfig)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func initSnapshotCommand(
 	return vCluster, kubeClient, restClient, nil
 }
 
-func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeClient *kubernetes.Clientset, snapshotOpts *snapshotapi.Options, log log.Logger) error {
+func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeClient *kubernetes.Clientset, snapshotOpts *snapshotapi.Options, log log.Logger, restConfig *rest.Config) error {
 	err := checkIfVClusterSupportsSnapshotRequests(vCluster, log)
 	if err != nil {
 		return fmt.Errorf("vCluster version check failed: %w", err)
@@ -172,6 +172,11 @@ func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeCli
 	if err != nil {
 		return fmt.Errorf("failed to get vcluster config: %w", err)
 	}
+
+	if snapshotOpts.Type == "file" {
+		return snapshotToLocalFile(ctx, vCluster, kubeClient, restConfig, snapshotOpts, log, vClusterConfig)
+	}
+
 	// Create snapshot request resources
 	_, err = snapshot.CreateSnapshotRequestResources(ctx, vCluster.Namespace, vClusterConfig.Name, vClusterConfig, snapshotOpts, kubeClient)
 	if err != nil {

--- a/pkg/cli/snapshot_local.go
+++ b/pkg/cli/snapshot_local.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/loft-sh/log"
 	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
-	"github.com/loft-sh/vcluster/pkg/lifecycle"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
-	"github.com/loft-sh/vcluster/pkg/snapshot/container"
 	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
 	corev1 "k8s.io/api/core/v1"
@@ -28,18 +26,16 @@ const dataMountPath = "/data"
 func snapshotToLocalFile(ctx context.Context, vCluster *find.VCluster,
 	kubeClient *kubernetes.Clientset, restConfig *rest.Config,
 	snapshotOpts *snapshot.Options, log log.Logger, vClusterConfig *vclusterconfig.VirtualClusterConfig) error {
-
-	localPath := snapshotOpts.LocalPath
 	tempPath := fmt.Sprintf("%s/vcluster-snapshot-%d.tar.gz", dataMountPath, time.Now().Unix())
-
-	// Translate to container:// for the in-cluster controller.
-	containerOpts := *snapshotOpts
-	containerOpts.Type = "container"
-	containerOpts.Container = container.Options{Path: tempPath}
+	localPath := snapshotOpts.File.Path
+	if !vCluster.IsStandalone {
+		// For non-standalone, we need to write the snapshot to the syncer PVC first, then download it via exec.
+		snapshotOpts.File.Path = tempPath
+	}
 
 	log.Infof("Creating snapshot request...")
 	snapshotRequest, err := snapshot.CreateSnapshotRequestResources(
-		ctx, vCluster.Namespace, vClusterConfig.Name, vClusterConfig, &containerOpts, kubeClient)
+		ctx, vCluster.Namespace, vClusterConfig.Name, vClusterConfig, snapshotOpts, kubeClient)
 	if err != nil {
 		return fmt.Errorf("create snapshot request: %w", err)
 	}
@@ -92,29 +88,20 @@ func snapshotToLocalFile(ctx context.Context, vCluster *find.VCluster,
 func restoreFromLocalFile(ctx context.Context, vCluster *find.VCluster,
 	kubeClient *kubernetes.Clientset, restConfig *rest.Config,
 	snapshotOpts *snapshot.Options, podOpts *pod.Options,
-	restoreVolumes bool, log log.Logger) error {
-
-	localPath := snapshotOpts.LocalPath
+	log log.Logger, cmdArgs []string) error {
+	tempPath := fmt.Sprintf("%s/vcluster-restore-%d.tar.gz", dataMountPath, time.Now().Unix())
+	localPath := snapshotOpts.File.Path
 	if _, err := os.Stat(localPath); os.IsNotExist(err) {
 		return fmt.Errorf("snapshot file not found: %s", localPath)
 	}
 
-	containerOpts := *snapshotOpts
-	containerOpts.Type = "container"
-
-	cmdArgs := []string{"restore"}
-	if restoreVolumes {
-		cmdArgs = append(cmdArgs, "--restore-volumes")
-	}
-
 	if vCluster.IsStandalone {
-		containerOpts.Container = container.Options{Path: localPath}
-		return restoreStandaloneVCluster(ctx, vCluster, &containerOpts, cmdArgs, log)
+		// For standalone, we can read directly from the local file instead of going through the syncer PVC.
+		return restoreStandaloneVCluster(snapshotOpts, cmdArgs, log)
 	}
 
 	// For non-standalone, we need to upload the local file into the syncer container first, then point the restore command at it.
-	tempPath := fmt.Sprintf("%s/vcluster-restore-%d.tar.gz", dataMountPath, time.Now().Unix())
-	containerOpts.Container = container.Options{Path: tempPath}
+	snapshotOpts.File.Path = tempPath
 
 	// Stream the local file into the syncer PVC via exec before pausing.
 	// The PVC (and the staged file) persist through scale-to-zero.
@@ -142,24 +129,11 @@ func restoreFromLocalFile(ctx context.Context, vCluster *find.VCluster,
 		return fmt.Errorf("upload snapshot to pod: %w", err)
 	}
 
-	log.Infof("Pausing vCluster %s", vCluster.Name)
-	if err := pauseVCluster(ctx, kubeClient, vCluster, log); err != nil {
-		return fmt.Errorf("pause vCluster %s: %w", vCluster.Name, err)
-	}
-	defer func() {
-		log.Infof("Resuming vCluster %s", vCluster.Name)
-		if err := lifecycle.ResumeVCluster(ctx, kubeClient, vCluster.Name, vCluster.Namespace, true, log); err != nil {
-			log.Warnf("Error resuming vCluster %s: %v", vCluster.Name, err)
-		}
-	}()
-
-	command := append([]string{"/vcluster"}, cmdArgs...)
-	return pod.RunSnapshotPod(ctx, restConfig, kubeClient, command, vCluster, podOpts, &containerOpts, log)
+	return runRestorePod(ctx, kubeClient, restConfig, vCluster, snapshotOpts, podOpts, log, cmdArgs)
 }
 
 func waitForSnapshotRequest(ctx context.Context, kubeClient *kubernetes.Clientset,
 	namespace, name string) error {
-
 	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
 			cm, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/pkg/cli/snapshot_local.go
+++ b/pkg/cli/snapshot_local.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/loft-sh/log"
+	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/lifecycle"
+	"github.com/loft-sh/vcluster/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/snapshot/container"
+	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
+	"github.com/loft-sh/vcluster/pkg/util/podhelper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+)
+
+// dataMountPath is where the vCluster data PVC is mounted in the syncer container.
+const dataMountPath = "/data"
+
+func snapshotToLocalFile(ctx context.Context, vCluster *find.VCluster,
+	kubeClient *kubernetes.Clientset, restConfig *rest.Config,
+	snapshotOpts *snapshot.Options, log log.Logger, vClusterConfig *vclusterconfig.VirtualClusterConfig) error {
+
+	localPath := snapshotOpts.LocalPath
+	tempPath := fmt.Sprintf("%s/vcluster-snapshot-%d.tar.gz", dataMountPath, time.Now().Unix())
+
+	// Translate to container:// for the in-cluster controller.
+	containerOpts := *snapshotOpts
+	containerOpts.Type = "container"
+	containerOpts.Container = container.Options{Path: tempPath}
+
+	log.Infof("Creating snapshot request...")
+	snapshotRequest, err := snapshot.CreateSnapshotRequestResources(
+		ctx, vCluster.Namespace, vClusterConfig.Name, vClusterConfig, &containerOpts, kubeClient)
+	if err != nil {
+		return fmt.Errorf("create snapshot request: %w", err)
+	}
+
+	log.Infof("Waiting for snapshot to complete...")
+	if err := waitForSnapshotRequest(ctx, kubeClient, vCluster.Namespace, snapshotRequest.Name); err != nil {
+		return err
+	}
+
+	if vCluster.IsStandalone {
+		// The file backend writes with 0600 already; chmod is a no-op but kept for safety.
+		_ = os.Chmod(localPath, 0600)
+		log.Infof("Snapshot saved to %s", localPath)
+		return nil
+	}
+
+	targetPod, err := findVClusterPod(vCluster)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("create local file %s: %w", localPath, err)
+	}
+	defer f.Close()
+
+	log.Infof("Downloading snapshot from pod %s to %s...", targetPod.Name, localPath)
+	if err := podhelper.ExecStream(ctx, restConfig, &podhelper.ExecStreamOptions{
+		Pod:       targetPod.Name,
+		Namespace: vCluster.Namespace,
+		Container: "syncer",
+		Command:   []string{"cat", tempPath},
+		Stdout:    f,
+		Stderr:    os.Stderr,
+	}); err != nil {
+		_ = os.Remove(localPath)
+		return fmt.Errorf("download snapshot from pod: %w", err)
+	}
+
+	if _, _, err := podhelper.ExecBuffered(ctx, restConfig, vCluster.Namespace,
+		targetPod.Name, "syncer", []string{"rm", "-f", tempPath}, nil); err != nil {
+		log.Warnf("Failed to remove temp snapshot file %s from pod: %v", tempPath, err)
+	}
+
+	log.Infof("Snapshot saved to %s", localPath)
+	return nil
+}
+
+func restoreFromLocalFile(ctx context.Context, vCluster *find.VCluster,
+	kubeClient *kubernetes.Clientset, restConfig *rest.Config,
+	snapshotOpts *snapshot.Options, podOpts *pod.Options,
+	restoreVolumes bool, log log.Logger) error {
+
+	localPath := snapshotOpts.LocalPath
+	if _, err := os.Stat(localPath); os.IsNotExist(err) {
+		return fmt.Errorf("snapshot file not found: %s", localPath)
+	}
+
+	containerOpts := *snapshotOpts
+	containerOpts.Type = "container"
+
+	cmdArgs := []string{"restore"}
+	if restoreVolumes {
+		cmdArgs = append(cmdArgs, "--restore-volumes")
+	}
+
+	if vCluster.IsStandalone {
+		containerOpts.Container = container.Options{Path: localPath}
+		return restoreStandaloneVCluster(ctx, vCluster, &containerOpts, cmdArgs, log)
+	}
+
+	// For non-standalone, we need to upload the local file into the syncer container first, then point the restore command at it.
+	tempPath := fmt.Sprintf("%s/vcluster-restore-%d.tar.gz", dataMountPath, time.Now().Unix())
+	containerOpts.Container = container.Options{Path: tempPath}
+
+	// Stream the local file into the syncer PVC via exec before pausing.
+	// The PVC (and the staged file) persist through scale-to-zero.
+	targetPod, err := findVClusterPod(vCluster)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("open local snapshot %s: %w", localPath, err)
+	}
+	defer f.Close()
+
+	log.Infof("Uploading %s to pod %s at %s...", localPath, targetPod.Name, tempPath)
+	if err := podhelper.ExecStream(ctx, restConfig, &podhelper.ExecStreamOptions{
+		Pod:       targetPod.Name,
+		Namespace: vCluster.Namespace,
+		Container: "syncer",
+		Command:   []string{"/bin/sh", "-c", "cat > " + tempPath},
+		Stdin:     f,
+		Stdout:    os.Stdout,
+		Stderr:    os.Stderr,
+	}); err != nil {
+		return fmt.Errorf("upload snapshot to pod: %w", err)
+	}
+
+	log.Infof("Pausing vCluster %s", vCluster.Name)
+	if err := pauseVCluster(ctx, kubeClient, vCluster, log); err != nil {
+		return fmt.Errorf("pause vCluster %s: %w", vCluster.Name, err)
+	}
+	defer func() {
+		log.Infof("Resuming vCluster %s", vCluster.Name)
+		if err := lifecycle.ResumeVCluster(ctx, kubeClient, vCluster.Name, vCluster.Namespace, true, log); err != nil {
+			log.Warnf("Error resuming vCluster %s: %v", vCluster.Name, err)
+		}
+	}()
+
+	command := append([]string{"/vcluster"}, cmdArgs...)
+	return pod.RunSnapshotPod(ctx, restConfig, kubeClient, command, vCluster, podOpts, &containerOpts, log)
+}
+
+func waitForSnapshotRequest(ctx context.Context, kubeClient *kubernetes.Clientset,
+	namespace, name string) error {
+
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			cm, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("get snapshot request ConfigMap: %w", err)
+			}
+			req, err := snapshot.UnmarshalSnapshotRequest(cm)
+			if err != nil {
+				return false, fmt.Errorf("unmarshal snapshot request: %w", err)
+			}
+			if req.Done() {
+				if req.Status.Phase == snapshot.RequestPhaseCompleted {
+					return true, nil
+				}
+				return false, fmt.Errorf("snapshot %s: %s", req.Status.Phase, req.Status.Error.Message)
+			}
+			return false, nil
+		})
+}
+
+func findVClusterPod(vCluster *find.VCluster) (*corev1.Pod, error) {
+	for i := range vCluster.Pods {
+		p := &vCluster.Pods[i]
+		if (vCluster.StatefulSet != nil || vCluster.Deployment != nil) && len(p.Name) > 0 {
+			return p, nil
+		}
+	}
+	return nil, fmt.Errorf("no running pod found for vCluster %s", vCluster.Name)
+}

--- a/pkg/cli/snapshot_local.go
+++ b/pkg/cli/snapshot_local.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
 	"github.com/loft-sh/log"
 	vclusterconfig "github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
@@ -25,7 +26,7 @@ const dataMountPath = "/data"
 
 func snapshotToLocalFile(ctx context.Context, vCluster *find.VCluster,
 	kubeClient *kubernetes.Clientset, restConfig *rest.Config,
-	snapshotOpts *snapshot.Options, log log.Logger, vClusterConfig *vclusterconfig.VirtualClusterConfig) error {
+	snapshotOpts *snapshotapi.Options, log log.Logger, vClusterConfig *vclusterconfig.VirtualClusterConfig) error {
 	tempPath := fmt.Sprintf("%s/vcluster-snapshot-%d.tar.gz", dataMountPath, time.Now().Unix())
 	localPath := snapshotOpts.File.Path
 	if !vCluster.IsStandalone {
@@ -87,7 +88,7 @@ func snapshotToLocalFile(ctx context.Context, vCluster *find.VCluster,
 
 func restoreFromLocalFile(ctx context.Context, vCluster *find.VCluster,
 	kubeClient *kubernetes.Clientset, restConfig *rest.Config,
-	snapshotOpts *snapshot.Options, podOpts *pod.Options,
+	snapshotOpts *snapshotapi.Options, podOpts *pod.Options,
 	log log.Logger, cmdArgs []string) error {
 	tempPath := fmt.Sprintf("%s/vcluster-restore-%d.tar.gz", dataMountPath, time.Now().Unix())
 	localPath := snapshotOpts.File.Path
@@ -121,7 +122,7 @@ func restoreFromLocalFile(ctx context.Context, vCluster *find.VCluster,
 		Pod:       targetPod.Name,
 		Namespace: vCluster.Namespace,
 		Container: "syncer",
-		Command:   []string{"/bin/sh", "-c", "cat > " + tempPath},
+		Command:   []string{"sh", "-c", "cat > \"$1\"", "--", tempPath},
 		Stdin:     f,
 		Stdout:    os.Stdout,
 		Stderr:    os.Stderr,
@@ -140,12 +141,12 @@ func waitForSnapshotRequest(ctx context.Context, kubeClient *kubernetes.Clientse
 			if err != nil {
 				return false, fmt.Errorf("get snapshot request ConfigMap: %w", err)
 			}
-			req, err := snapshot.UnmarshalSnapshotRequest(cm)
+			req, err := snapshotapi.UnmarshalRequest(cm)
 			if err != nil {
 				return false, fmt.Errorf("unmarshal snapshot request: %w", err)
 			}
 			if req.Done() {
-				if req.Status.Phase == snapshot.RequestPhaseCompleted {
+				if req.Status.Phase == snapshotapi.RequestPhaseCompleted {
 					return true, nil
 				}
 				return false, fmt.Errorf("snapshot %s: %s", req.Status.Phase, req.Status.Error.Message)
@@ -155,8 +156,8 @@ func waitForSnapshotRequest(ctx context.Context, kubeClient *kubernetes.Clientse
 }
 
 func findVClusterPod(vCluster *find.VCluster) (*corev1.Pod, error) {
-	for i := range vCluster.Pods {
-		p := &vCluster.Pods[i]
+	for _, pod := range vCluster.Pods {
+		p := &pod
 		if (vCluster.StatefulSet != nil || vCluster.Deployment != nil) && len(p.Name) > 0 {
 			return p, nil
 		}

--- a/pkg/cli/snapshot_local.go
+++ b/pkg/cli/snapshot_local.go
@@ -12,7 +12,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/snapshot"
 	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -53,7 +52,7 @@ func snapshotToLocalFile(ctx context.Context, vCluster *find.VCluster,
 		return nil
 	}
 
-	targetPod, err := findVClusterPod(vCluster)
+	targetPod, err := pod.FindVClusterPod(vCluster)
 	if err != nil {
 		return err
 	}
@@ -106,7 +105,7 @@ func restoreFromLocalFile(ctx context.Context, vCluster *find.VCluster,
 
 	// Stream the local file into the syncer PVC via exec before pausing.
 	// The PVC (and the staged file) persist through scale-to-zero.
-	targetPod, err := findVClusterPod(vCluster)
+	targetPod, err := pod.FindVClusterPod(vCluster)
 	if err != nil {
 		return err
 	}
@@ -153,14 +152,4 @@ func waitForSnapshotRequest(ctx context.Context, kubeClient *kubernetes.Clientse
 			}
 			return false, nil
 		})
-}
-
-func findVClusterPod(vCluster *find.VCluster) (*corev1.Pod, error) {
-	for _, pod := range vCluster.Pods {
-		p := &pod
-		if (vCluster.StatefulSet != nil || vCluster.Deployment != nil) && len(p.Name) > 0 {
-			return p, nil
-		}
-	}
-	return nil, fmt.Errorf("no running pod found for vCluster %s", vCluster.Name)
 }

--- a/pkg/snapshot/file/store.go
+++ b/pkg/snapshot/file/store.go
@@ -9,14 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/loft-sh/vcluster/pkg/snapshot/types"
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
 )
 
 type Options struct {
 	Path string `json:"path,omitempty"`
 }
 
-func NewStore(options *Options) *Store {
+func NewStore(options *snapshotapi.FileOptions) *Store {
 	return &Store{path: options.Path}
 }
 
@@ -45,7 +45,7 @@ func (s *Store) PutObject(_ context.Context, body io.Reader) error {
 	return err
 }
 
-func (s *Store) List(_ context.Context) ([]types.Snapshot, error) {
+func (s *Store) List(_ context.Context) ([]snapshotapi.Snapshot, error) {
 	path := s.path
 	fi, err := os.Stat(path)
 	if err != nil {
@@ -60,7 +60,7 @@ func (s *Store) List(_ context.Context) ([]types.Snapshot, error) {
 		return nil, err
 	}
 
-	var snapshots []types.Snapshot
+	var snapshots []snapshotapi.Snapshot
 	for _, entry := range entries {
 		info, err := entry.Info()
 		if err != nil {
@@ -72,7 +72,7 @@ func (s *Store) List(_ context.Context) ([]types.Snapshot, error) {
 		if info.IsDir() || !strings.HasSuffix(entry.Name(), ".tar.gz") {
 			continue
 		}
-		snapshots = append(snapshots, types.Snapshot{
+		snapshots = append(snapshots, snapshotapi.Snapshot{
 			ID:        entry.Name(),
 			URL:       "file://" + path + "/" + entry.Name(),
 			Timestamp: info.ModTime(),

--- a/pkg/snapshot/file/store.go
+++ b/pkg/snapshot/file/store.go
@@ -1,0 +1,96 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/snapshot/types"
+)
+
+type Options struct {
+	Path string `json:"path,omitempty"`
+}
+
+func NewStore(options *Options) *Store {
+	return &Store{path: options.Path}
+}
+
+type Store struct {
+	path string
+}
+
+func (s *Store) Target() string {
+	return "file://" + s.path
+}
+
+func (s *Store) GetObject(_ context.Context) (io.ReadCloser, error) {
+	return os.Open(s.path)
+}
+
+func (s *Store) PutObject(_ context.Context, body io.Reader) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, body)
+	return err
+}
+
+func (s *Store) List(_ context.Context) ([]types.Snapshot, error) {
+	path := s.path
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.IsDir() {
+		path = filepath.Dir(path)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshots []types.Snapshot
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		if info.IsDir() || !strings.HasSuffix(entry.Name(), ".tar.gz") {
+			continue
+		}
+		snapshots = append(snapshots, types.Snapshot{
+			ID:        entry.Name(),
+			URL:       "file://" + path + "/" + entry.Name(),
+			Timestamp: info.ModTime(),
+		})
+	}
+	return snapshots, nil
+}
+
+func (s *Store) Delete(_ context.Context) error {
+	fi, err := os.Stat(s.path)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		return fmt.Errorf("not a snapshot file")
+	}
+	if !strings.HasSuffix(s.path, ".tar.gz") {
+		return fmt.Errorf("not a snapshot file")
+	}
+	return os.Remove(s.path)
+}

--- a/pkg/snapshot/options.go
+++ b/pkg/snapshot/options.go
@@ -49,7 +49,7 @@ func Parse(snapshotURL string, snapshotOptions *snapshotapi.Options) error {
 		return fmt.Errorf("error parsing snapshotURL %s: %w", snapshotURL, err)
 	}
 
-	supportedSchemes := []string{"oci", "s3", "container", "https"}
+	supportedSchemes := []string{"oci", "s3", "container", "file", "https"}
 	if !slices.Contains(supportedSchemes, parsedURL.Scheme) {
 		return fmt.Errorf("scheme needs to be one of %s", strings.Join(supportedSchemes, ", "))
 	}
@@ -99,6 +99,12 @@ func Parse(snapshotURL string, snapshotOptions *snapshotapi.Options) error {
 		// Azure blob storage support
 		snapshotOptions.Type = "azure"
 		snapshotOptions.Azure.BlobURL = snapshotURL
+	case "file":
+		// file:///absolute/path — host is empty for absolute paths
+		if parsedURL.Path == "" {
+			return fmt.Errorf("path must be specified via file:///PATH")
+		}
+		snapshotOptions.File.Path = parsedURL.Path
 	}
 
 	return nil
@@ -145,8 +151,12 @@ func Validate(options *snapshotapi.Options, isList bool) error {
 		if options.Azure.BlobURL == "" {
 			return fmt.Errorf("blob URL must be specified")
 		}
+	} else if options.Type == "file" {
+		if options.File.Path == "" {
+			return fmt.Errorf("path must be specified via file:///PATH")
+		}
 	} else {
-		return fmt.Errorf("type must be either 'container', 'oci', 's3', or 'azure'")
+		return fmt.Errorf("type must be either 'container', 'file', 'oci', 's3', or 'azure'")
 	}
 
 	return nil

--- a/pkg/snapshot/pod/pod.go
+++ b/pkg/snapshot/pod/pod.go
@@ -62,17 +62,9 @@ func SnapshotExec(
 ) error {
 	// get target pod
 	var targetPod *corev1.Pod
-	for _, pod := range vCluster.Pods {
-		if vCluster.StatefulSet != nil && strings.HasSuffix(pod.Name, "-0") {
-			targetPod = &pod
-			break
-		} else if vCluster.Deployment != nil {
-			targetPod = &pod
-			break
-		}
-	}
-	if targetPod == nil {
-		return fmt.Errorf("couldn't find a running pod for vCluster %s", vCluster.Name)
+	targetPod, err := FindVClusterPod(vCluster)
+	if err != nil {
+		return err
 	}
 
 	// build env variables
@@ -606,4 +598,16 @@ func WaitForCompletedPod(ctx context.Context, kubeClient *kubernetes.Clientset, 
 	}
 
 	return exitCode, nil
+}
+
+func FindVClusterPod(vCluster *find.VCluster) (*corev1.Pod, error) {
+	for _, pod := range vCluster.Pods {
+		p := &pod
+		if vCluster.StatefulSet != nil && strings.HasSuffix(p.Name, "-0") {
+			return p, nil
+		} else if vCluster.Deployment != nil {
+			return p, nil
+		}
+	}
+	return nil, fmt.Errorf("couldn't find a running pod for vCluster %s", vCluster.Name)
 }

--- a/pkg/snapshot/storagefactory.go
+++ b/pkg/snapshot/storagefactory.go
@@ -7,6 +7,7 @@ import (
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
 	"github.com/loft-sh/vcluster/pkg/snapshot/azure"
 	"github.com/loft-sh/vcluster/pkg/snapshot/container"
+	"github.com/loft-sh/vcluster/pkg/snapshot/file"
 	"github.com/loft-sh/vcluster/pkg/snapshot/oci"
 	"github.com/loft-sh/vcluster/pkg/snapshot/s3"
 	"github.com/loft-sh/vcluster/pkg/snapshot/types"
@@ -24,6 +25,8 @@ func CreateStore(ctx context.Context, options *snapshotapi.Options) (types.Stora
 		return objectStore, nil
 	} else if options.Type == "container" {
 		return container.NewStore(&options.Container), nil
+	} else if options.Type == "file" {
+		return file.NewStore(&options.File), nil
 	} else if options.Type == "oci" {
 		return oci.NewStore(&options.OCI), nil
 	} else if options.Type == "azure" {

--- a/vendor/github.com/loft-sh/api/v4/pkg/snapshot/options.go
+++ b/vendor/github.com/loft-sh/api/v4/pkg/snapshot/options.go
@@ -7,6 +7,7 @@ type Options struct {
 	Container ContainerOptions `json:"container"`
 	OCI       OCIOptions       `json:"oci"`
 	Azure     AzureOptions     `json:"azure"`
+	File      FileOptions      `json:"file"`
 
 	Release        *HelmRelease `json:"release,omitempty"`
 	IncludeVolumes bool         `json:"include-volumes,omitempty"`
@@ -30,6 +31,8 @@ func (o *Options) GetURL() string {
 		return "oci://" + o.OCI.Repository
 	case "azure":
 		return o.Azure.BlobURL
+	case "file":
+		return "file://" + o.File.Path
 	default:
 		return ""
 	}
@@ -114,4 +117,8 @@ type AzureOptions struct {
 
 	// ClientSecret is the client secret for service principal auth.
 	ClientSecret string `json:"client-secret,omitempty"`
+}
+
+type FileOptions struct {
+	Path string `json:"path,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -689,7 +689,11 @@ github.com/loft-sh/agentapi/v4/pkg/clientset/versioned/typed/storage/v1
 # github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 ## explicit; go 1.21
 github.com/loft-sh/analytics-client/client
+<<<<<<< HEAD
 # github.com/loft-sh/api/v4 v4.10.0-alpha.2
+=======
+# github.com/loft-sh/api/v4 v4.10.0-alpha.1 => /Users/josesilva/Development/loft/github/loft-enterprise/staging/src/github.com/loft-sh/api/v4
+>>>>>>> 4b9730b10 (adds: file protocol for snapshot and restore)
 ## explicit; go 1.26.0
 github.com/loft-sh/api/v4/pkg/apis/audit/v1
 github.com/loft-sh/api/v4/pkg/apis/management
@@ -2708,3 +2712,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/kyaml
+# github.com/loft-sh/api/v4 => /Users/josesilva/Development/loft/github/loft-enterprise/staging/src/github.com/loft-sh/api/v4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -677,7 +677,7 @@ github.com/lithammer/dedent
 # github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0
 ## explicit; go 1.24.11
 github.com/loft-sh/admin-apis/pkg/licenseapi
-# github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2
+# github.com/loft-sh/agentapi/v4 v4.10.0-alpha.3
 ## explicit; go 1.26.0
 github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster
 github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1
@@ -689,11 +689,7 @@ github.com/loft-sh/agentapi/v4/pkg/clientset/versioned/typed/storage/v1
 # github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 ## explicit; go 1.21
 github.com/loft-sh/analytics-client/client
-<<<<<<< HEAD
-# github.com/loft-sh/api/v4 v4.10.0-alpha.2
-=======
-# github.com/loft-sh/api/v4 v4.10.0-alpha.1 => /Users/josesilva/Development/loft/github/loft-enterprise/staging/src/github.com/loft-sh/api/v4
->>>>>>> 4b9730b10 (adds: file protocol for snapshot and restore)
+# github.com/loft-sh/api/v4 v4.10.0-alpha.3
 ## explicit; go 1.26.0
 github.com/loft-sh/api/v4/pkg/apis/audit/v1
 github.com/loft-sh/api/v4/pkg/apis/management
@@ -2712,4 +2708,3 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/kyaml
-# github.com/loft-sh/api/v4 => /Users/josesilva/Development/loft/github/loft-enterprise/staging/src/github.com/loft-sh/api/v4


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-427


**Please provide a short message that should be published in the vcluster release notes**
Adds a file protocol for snapshot and restore feature to enable users to use the filesystem as a backing storage


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
