### PR TITLE
docs(claude.md): point at loft-sh/github-actions and the developer skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,10 @@
 When doing test-driven development, ALWAYS follow the workflow in
 [.claude/e2e-tdd-workflow.md](.claude/e2e-tdd-workflow.md).
 Use the AGENT_SESSION env var to isolate your commands per session.
+
+## CI / GitHub Actions
+
+Shared CI logic lives in [`loft-sh/github-actions`](https://github.com/loft-sh/github-actions);
+production repos reuse those actions rather than inlining shell. The
+`github-actions-developer` skill (from `vcluster-skills-engineering`) auto-loads
+when you touch `.github/` and carries the full convention.


### PR DESCRIPTION
## Summary

Add a short pointer in root `CLAUDE.md` to `loft-sh/github-actions` and the `github-actions-developer` skill, so agents working on CI in this repo pick up the reuse-not-inline convention without having to open a workflow file first.

## Key Changes

- `CLAUDE.md`: new `## CI / GitHub Actions` section (4 lines) linking the shared-actions repo and naming the skill that auto-loads on `.github/` paths.

## Dependencies

None. Parallel PRs in `vcluster-pro` and `loft-enterprise` will land the same one-liner.

## TODO

- [ ] CI green

Closes DEVOPS-876