### PR TITLE
fix(e2e-next): isolate cli shell-outs from the shared ambient kubeconfig

### DIFF
--- a/e2e-next/test_core/lifecycle/test_connect.go
+++ b/e2e-next/test_core/lifecycle/test_connect.go
@@ -60,12 +60,14 @@ func ConnectSpec() {
 			defer cancel()
 
 			By("running vcluster connect --print and capturing kubeconfig", func() {
+				hostKubeconfig := cluster.From(ctx, constants.GetHostClusterName()).GetKubeconfig()
 				cmd := exec.CommandContext(cmdCtx, vclusterBin(), "connect",
 					"-n", vClusterNamespace,
 					"--print",
 					"--background-proxy=false",
 					"--server", proxyServer,
 					vClusterName)
+				cmd.Env = append(os.Environ(), "KUBECONFIG="+hostKubeconfig)
 				kubeConfigBytes, err := cmd.Output()
 				Expect(err).To(Succeed(),
 					"vcluster connect --print failed for %s", vClusterName)
@@ -87,6 +89,7 @@ func ConnectSpec() {
 
 		It("should fail to connect to a vCluster with an invalid name", func(ctx context.Context) {
 			By("running vcluster connect --print with a non-existent vcluster name", func() {
+				hostKubeconfig := cluster.From(ctx, constants.GetHostClusterName()).GetKubeconfig()
 				cmdCtx, cancel := context.WithTimeout(ctx, constants.PollingTimeoutShort)
 				defer cancel()
 				cmd := exec.CommandContext(cmdCtx, vclusterBin(), "connect",
@@ -94,6 +97,7 @@ func ConnectSpec() {
 					"--print",
 					"--background-proxy=false",
 					"INVALID")
+				cmd.Env = append(os.Environ(), "KUBECONFIG="+hostKubeconfig)
 				out, err := cmd.CombinedOutput()
 				Expect(err).To(HaveOccurred(),
 					"expected vcluster connect to fail for non-existent vcluster INVALID, output: %s", string(out))
@@ -104,6 +108,7 @@ func ConnectSpec() {
 
 		It("should connect to a vCluster and execute a command inline", func(ctx context.Context) {
 			By("running vcluster connect with an inline kubectl command", func() {
+				hostKubeconfig := cluster.From(ctx, constants.GetHostClusterName()).GetKubeconfig()
 				// Retry the whole command because port-forwarding can fail
 				// transiently in CI (e.g. containerd closing the pod network
 				// namespace mid-forward).
@@ -115,6 +120,7 @@ func ConnectSpec() {
 						"--background-proxy=false",
 						vClusterName,
 						"--", "kubectl", "get", "ns")
+					cmd.Env = append(os.Environ(), "KUBECONFIG="+hostKubeconfig)
 					out, err := cmd.CombinedOutput()
 					g.Expect(err).To(Succeed(),
 						"vcluster connect -- kubectl get ns failed for %s, output: %s", vClusterName, string(out))

--- a/e2e-next/test_storage/snapshot/helpers.go
+++ b/e2e-next/test_storage/snapshot/helpers.go
@@ -4,6 +4,7 @@ package snapshot
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"time"
 
@@ -18,16 +19,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func runVClusterCmd(args ...string) {
+func runVClusterCmd(kubeconfig string, args ...string) {
 	GinkgoHelper()
 	cmd := exec.Command("vcluster", args...)
+	cmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfig)
 	cmd.Stdout = GinkgoWriter
 	cmd.Stderr = GinkgoWriter
 	err := cmd.Run()
 	Expect(err).NotTo(HaveOccurred(), "vcluster command failed: vcluster %v", args)
 }
 
-func createSnapshot(vClusterName, vClusterNamespace string, useNewCommand bool, snapshotPath string, includeVolumes bool) {
+func createSnapshot(vClusterName, vClusterNamespace, kubeconfig string, useNewCommand bool, snapshotPath string, includeVolumes bool) {
 	GinkgoHelper()
 	By("Creating a snapshot", func() {
 		if useNewCommand {
@@ -35,15 +37,15 @@ func createSnapshot(vClusterName, vClusterNamespace string, useNewCommand bool, 
 			if includeVolumes {
 				args = append(args, "--include-volumes")
 			}
-			runVClusterCmd(args...)
+			runVClusterCmd(kubeconfig, args...)
 		} else {
-			runVClusterCmd("snapshot", vClusterName, snapshotPath, "-n", vClusterNamespace,
+			runVClusterCmd(kubeconfig, "snapshot", vClusterName, snapshotPath, "-n", vClusterNamespace,
 				"--pod-mount", "pvc:snapshot-pvc:/snapshot-pvc")
 		}
 	})
 }
 
-func restoreVCluster(ctx context.Context, hostClient kubernetes.Interface, vClusterName, vClusterNamespace, snapshotPath string, controllerBased, restoreVolumes bool) {
+func restoreVCluster(ctx context.Context, hostClient kubernetes.Interface, vClusterName, vClusterNamespace, snapshotPath, kubeconfig string, controllerBased, restoreVolumes bool) {
 	GinkgoHelper()
 	By("Restoring the vCluster", func() {
 		args := []string{"restore", vClusterName, snapshotPath, "-n", vClusterNamespace}
@@ -53,7 +55,7 @@ func restoreVCluster(ctx context.Context, hostClient kubernetes.Interface, vClus
 		if restoreVolumes {
 			args = append(args, "--restore-volumes")
 		}
-		runVClusterCmd(args...)
+		runVClusterCmd(kubeconfig, args...)
 	})
 
 	By("Waiting for vCluster pods to be running and ready after restore", func() {

--- a/e2e-next/test_storage/snapshot/test_snapshot.go
+++ b/e2e-next/test_storage/snapshot/test_snapshot.go
@@ -43,6 +43,7 @@ type snapshotCtx struct {
 	vClusterClient kubernetes.Interface
 	vClusterName   string
 	vClusterNS     string
+	kubeconfig     string
 }
 
 func newSnapshotCtx(ctx context.Context) *snapshotCtx {
@@ -64,6 +65,7 @@ func newSnapshotCtx(ctx context.Context) *snapshotCtx {
 	Expect(s.vClusterClient).NotTo(BeNil())
 	s.vClusterName = cluster.CurrentClusterNameFrom(ctx)
 	s.vClusterNS = "vcluster-" + s.vClusterName
+	s.kubeconfig = cluster.From(ctx, hostName).GetKubeconfig()
 	return s
 }
 
@@ -89,6 +91,19 @@ func (s *snapshotCtx) refreshClient(ctx context.Context) {
 				BackgroundProxyImage: constants.GetVClusterImage(),
 			},
 		}
+		// connectCmd internally builds a client from the ambient KUBECONFIG to
+		// locate the host cluster. Parallel ginkgo workers share ~/.kube/config
+		// and kind create cluster rewrites it, so override the env with the
+		// per-cluster temp kubeconfig for this call only.
+		prevKubeconfig, hadKubeconfig := os.LookupEnv("KUBECONFIG")
+		Expect(os.Setenv("KUBECONFIG", s.kubeconfig)).To(Succeed())
+		defer func() {
+			if hadKubeconfig {
+				_ = os.Setenv("KUBECONFIG", prevKubeconfig)
+			} else {
+				_ = os.Unsetenv("KUBECONFIG")
+			}
+		}()
 		err = connectCmd.Run(ctx, []string{s.vClusterName})
 		Expect(err).To(Succeed(), "vcluster connect failed after restore")
 
@@ -220,7 +235,7 @@ func describeSnapshotRestore(s *snapshotCtx) {
 		})
 
 		It("Creates the snapshot", func(ctx context.Context) {
-			createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, false)
+			createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, false)
 			waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
 		})
 
@@ -248,7 +263,7 @@ func describeSnapshotRestore(s *snapshotCtx) {
 			})
 
 			By("Restoring the vCluster from snapshot", func() {
-				restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, true, false)
+				restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, s.kubeconfig, true, false)
 				s.refreshClient(ctx)
 			})
 
@@ -336,7 +351,7 @@ func describeSnapshotRestore(s *snapshotCtx) {
 
 		It("Creates the snapshot and verifies VolumeSnapshots are cleaned up", func(ctx context.Context) {
 			By("Creating the snapshot with volumes", func() {
-				createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
+				createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, true)
 				waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
 			})
 
@@ -381,7 +396,7 @@ func describeSnapshotRestore(s *snapshotCtx) {
 			deletePVC(ctx, s.vClusterClient, s.hostClient, s.vClusterName, s.vClusterNS, testNS, pvcToRestoreName)
 			// PVC restored without data in previous specs; delete again for proper restore
 			deletePVC(ctx, s.vClusterClient, s.hostClient, s.vClusterName, s.vClusterNS, testNS, pvcToRestoreName)
-			restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, true, true)
+			restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, s.kubeconfig, true, true)
 			s.refreshClient(ctx)
 
 			Eventually(func(g Gomega) {
@@ -436,7 +451,7 @@ func describeSnapshotRestore(s *snapshotCtx) {
 			})
 
 			By("Creating the snapshot", func() {
-				createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, false)
+				createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, false)
 				waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
 			})
 		})
@@ -447,7 +462,7 @@ func describeSnapshotRestore(s *snapshotCtx) {
 			})
 
 			By("Restoring the tenant cluster from snapshot", func() {
-				restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, true, false)
+				restoreVCluster(ctx, s.hostClient, s.vClusterName, s.vClusterNS, snapshotPath, s.kubeconfig, true, false)
 				s.refreshClient(ctx)
 			})
 		})
@@ -502,12 +517,12 @@ func describeSnapshotCanceling(s *snapshotCtx) {
 				}
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 
-			createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
+			createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, true)
 			// Brief pause to ensure the first snapshot request is registered before
 			// the second one arrives - tests the cancellation path where a new
 			// snapshot supersedes an in-progress one.
 			time.Sleep(2 * time.Second)
-			createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
+			createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, true)
 		})
 
 		It("Has 2 snapshot requests", func(ctx context.Context) {
@@ -613,7 +628,7 @@ func describeSnapshotDeletion(s *snapshotCtx) {
 				}
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 
-			createSnapshot(s.vClusterName, s.vClusterNS, true, snapshotPath, true)
+			createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath, true)
 		})
 
 		It("Creates snapshot deletion request", func(ctx context.Context) {


### PR DESCRIPTION
## Summary

Parallel ginkgo workers share the filesystem, and any helper that runs the `vcluster` CLI as a child process inherits `KUBECONFIG` from the OS env (or defaults to `~/.kube/config`). When two suites concurrently create kind clusters, that shared file is rewritten and the current context flips, so a `vcluster` CLI call may not find its host cluster at all.

Tests then fail with one of:
- `couldn't find vcluster X` (after restore)
- `no configuration has been provided`

depending on which write wins the race.

## Changes

- `test_core/lifecycle/test_connect.go`: all three `vcluster connect` invocations now set `cmd.Env`'s `KUBECONFIG` to the per-cluster temp kubeconfig the framework already manages.
- `test_storage/snapshot/helpers.go`: `runVClusterCmd`, `createSnapshot`, and `restoreVCluster` take a `kubeconfig` argument and set it on the child cmd's env, so the snapshot/restore subprocesses talk to the right cluster.
- `test_storage/snapshot/test_snapshot.go`: `snapshotCtx` carries the host kubeconfig discovered in `newSnapshotCtx`. The programmatic `connectcmd.Run` in `refreshClient` reads the same ambient env, so override and restore `KUBECONFIG` around that call.

## Background

Surfaced in `vcluster-pro` when running multiple kind clusters in parallel for Istio-per-version coverage. The same fixes ship to `vcluster-pro`'s non-vendored test paths in [`loft-sh/vcluster-pro#1791`](https://github.com/loft-sh/vcluster-pro/pull/1791); this PR moves the vendor-side fixes to the right home.

## Test plan

- [x] `go build ./e2e-next/...` clean
- [x] `go vet ./e2e-next/...` clean