### PR TITLE
ci(codeowners): route control-plane e2e suites to eng-control-plane

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,8 @@
 
 /test/ @loft-sh/eng-qa @loft-sh/eng-dev-vcluster-platform
 /e2e-next/ @loft-sh/eng-qa
+/e2e-next/test_core/lifecycle/   @loft-sh/eng-control-plane
+/e2e-next/test_storage/snapshot/ @loft-sh/eng-control-plane
 
 /hack/email/ @zerbitx
 


### PR DESCRIPTION
## Summary

Carve two product-feature e2e-next subtrees out from the blanket `/e2e-next/ @loft-sh/eng-qa` rule and assign them to `@loft-sh/eng-control-plane`:

- `/e2e-next/test_core/lifecycle/` — exercises `vcluster connect` / pause / resume CLI behavior
- `/e2e-next/test_storage/snapshot/` — exercises snapshot/restore behavior

QA retains ownership of the framework layer (`clusters/`, `setup/`, `labels/`, `init/`) and every other test directory under `/e2e-next/`. CODEOWNERS uses last-match-wins, so the existing `/e2e-next/` line stays in place.

## Why

Bugs in those two suites are almost always bugs in the corresponding control-plane code paths (CLI lifecycle, snapshot/restore subprocesses). Routing reviews to the team that owns the underlying product is faster than going through QA only to bounce to control-plane.

Motivating example: #3931 fixes a `KUBECONFIG` race in `vcluster connect` and snapshot/restore test helpers. With today's CODEOWNERS it routed to QA; with this change it would route to control-plane.

## Notes

- `.github/CODEOWNERS` itself is owned by `@loft-sh/eng-tech-leads` (line 7), so this PR needs tech-leads approval to merge.
- After this lands, an empty commit / rebase on #3931 will re-trigger CODEOWNERS evaluation and request control-plane review.

## Test plan

- [ ] Verify CI is green
- [ ] After merge, rebase #3931 on main and confirm GitHub auto-requests `@loft-sh/eng-control-plane` (not `@loft-sh/eng-qa`)