### PR TITLE
feat: add snapshot post server hook

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -258,6 +258,10 @@ func (s *Server) ServeOnListenerTLS(ctx *synccontext.ControllerContext) error {
 			Path: "/vcluster/features",
 			Verb: "*",
 		},
+		delegatingauthorizer.PathVerb{
+			Path: "/vcluster/snapshots*",
+			Verb: "*",
+		},
 	)
 	redirectAuthNonResources = append(
 		redirectAuthNonResources,

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/plugin"
 	"github.com/loft-sh/vcluster/pkg/pro"
 	"github.com/loft-sh/vcluster/pkg/scheme"
+	snapshotapi "github.com/loft-sh/vcluster/pkg/snapshot/api"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/telemetry"
 	"github.com/loft-sh/vcluster/pkg/util/blockingcacheclient"
@@ -101,6 +102,9 @@ func NewControllerContext(ctx context.Context, options *config.VirtualClusterCon
 	if err != nil {
 		return nil, fmt.Errorf("init controller context: %w", err)
 	}
+
+	// register snapshot handler
+	snapshotapi.Register(controllerContext)
 
 	// init pro controller context
 	err = pro.InitProControllerContext(controllerContext)

--- a/pkg/snapshot/api/handler.go
+++ b/pkg/snapshot/api/handler.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/constants"
+	"github.com/loft-sh/vcluster/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	utilrequest "github.com/loft-sh/vcluster/pkg/util/request"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	maxRequestBytes = 1 << 20 // 1MB
+)
+
+type snapshotRouteHandler func(*synccontext.ControllerContext, http.ResponseWriter, *http.Request)
+
+// WithSnapshots returns an http.Handler that intercepts vCluster snapshot API
+// requests and delegates everything else to next.
+func WithSnapshots(next http.Handler, ctx *synccontext.ControllerContext) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isSnapshotPath(r.URL.Path) {
+			if next != nil {
+				next.ServeHTTP(w, r)
+			}
+			return
+		}
+		if ctx == nil {
+			fail(w, r, http.StatusInternalServerError, errors.New("controller context is nil"))
+			return
+		}
+
+		newSnapshotMux(ctx).ServeHTTP(w, r)
+	})
+}
+
+func newSnapshotMux(ctx *synccontext.ControllerContext) *http.ServeMux {
+	mux := http.NewServeMux()
+	handle := func(pattern string, handler snapshotRouteHandler) {
+		mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+			handler(ctx, w, r)
+		})
+	}
+
+	handle("HEAD /vcluster/snapshots", handleProbe)
+	handle("POST /vcluster/snapshots", handleCreate)
+	handle("POST /vcluster/snapshots/list", handleList)
+	handle("POST /vcluster/snapshots/request", handleCreateRequest)
+	handle("POST /vcluster/snapshots/request/delete", handleDeleteRequest)
+	handle("GET /vcluster/snapshots/request/{name}", handleGetRequest)
+
+	return mux
+}
+
+func handleProbe(_ *synccontext.ControllerContext, w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleCreate(ctx *synccontext.ControllerContext, w http.ResponseWriter, r *http.Request) {
+	client, err := snapshotClient(r, false)
+	if err != nil {
+		fail(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if ctx.Config == nil {
+		fail(w, r, http.StatusInternalServerError, fmt.Errorf("snapshot config is nil"))
+		return
+	}
+	config := *ctx.Config
+	if err := client.Run(r.Context(), &config); err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	utilrequest.SucceedWithStatus(w)
+}
+
+func handleList(_ *synccontext.ControllerContext, w http.ResponseWriter, r *http.Request) {
+	client, err := snapshotClient(r, true)
+	if err != nil {
+		fail(w, r, http.StatusBadRequest, err)
+		return
+	}
+	snapshots, err := client.List(r.Context())
+	if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	utilrequest.SucceedWithObject(w, snapshots)
+}
+
+func handleCreateRequest(ctx *synccontext.ControllerContext, w http.ResponseWriter, r *http.Request) {
+	options, err := snapshotOptions(r, false)
+	if err != nil {
+		fail(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	kubeClient, requestNamespace, err := snapshotRequestResourcesClient(ctx)
+	if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	request, err := snapshot.CreateSnapshotRequestResources(r.Context(), requestNamespace, ctx.Config.Name, ctx.Config, options, kubeClient)
+	if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	utilrequest.SucceedWithObject(w, request)
+}
+
+func handleGetRequest(ctx *synccontext.ControllerContext, w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		fail(w, r, http.StatusBadRequest, fmt.Errorf("snapshot request name is required"))
+		return
+	}
+
+	kubeClient, requestNamespace, err := snapshotRequestResourcesClient(ctx)
+	if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	configMap, err := kubeClient.CoreV1().ConfigMaps(requestNamespace).Get(r.Context(), name, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		fail(w, r, http.StatusNotFound, fmt.Errorf("snapshot request %s not found", name))
+		return
+	} else if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	request, err := snapshot.UnmarshalSnapshotRequest(configMap)
+	if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	utilrequest.SucceedWithObject(w, request)
+}
+
+func handleDeleteRequest(ctx *synccontext.ControllerContext, w http.ResponseWriter, r *http.Request) {
+	options, err := snapshotOptions(r, false)
+	if err != nil {
+		fail(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	kubeClient, requestNamespace, err := snapshotRequestResourcesClient(ctx)
+	if err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := snapshot.DeleteSnapshotRequestResources(r.Context(), requestNamespace, ctx.Config.Name, ctx.Config, options, kubeClient); err != nil {
+		fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+
+	utilrequest.SucceedWithStatus(w)
+}
+
+func snapshotRequestResourcesClient(ctx *synccontext.ControllerContext) (*kubernetes.Clientset, string, error) {
+	isHostMode, err := snapshot.IsSnapshotRequestCreatedInHostCluster(ctx.Config)
+	if err != nil {
+		return nil, "", err
+	}
+
+	requestNamespace := constants.VClusterStandaloneSnapshotNamespace
+	requestManager := ctx.VirtualManager
+	if isHostMode {
+		requestNamespace = ctx.Config.HostNamespace
+		requestManager = ctx.HostManager
+	}
+	if requestManager == nil {
+		return nil, "", fmt.Errorf("snapshot request manager is nil")
+	}
+
+	kubeClient, err := kubeClientFromManager(requestManager)
+	if err != nil {
+		return nil, "", err
+	}
+	return kubeClient, requestNamespace, nil
+}
+
+func kubeClientFromManager(m manager.Manager) (*kubernetes.Clientset, error) {
+	kubeClient, err := kubernetes.NewForConfig(m.GetConfig())
+	if err != nil {
+		return nil, fmt.Errorf("create kube client: %w", err)
+	}
+	return kubeClient, nil
+}
+
+func snapshotClient(r *http.Request, isList bool) (*snapshot.Client, error) {
+	options, err := snapshotOptions(r, isList)
+	if err != nil {
+		return nil, err
+	}
+
+	return &snapshot.Client{Options: *options}, nil
+}
+
+func snapshotOptions(r *http.Request, isList bool) (*snapshot.Options, error) {
+	if r.Body == nil {
+		return nil, fmt.Errorf("request body is required")
+	}
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read request body: %w", err)
+	}
+	if len(body) > maxRequestBytes {
+		return nil, fmt.Errorf("request body is too large")
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("request body is required")
+	}
+
+	var request OptionsRequest
+	if err := json.Unmarshal(body, &request); err == nil && request.Options != nil {
+		if err := snapshot.Validate(request.Options, isList); err != nil {
+			return nil, err
+		}
+		return request.Options, nil
+	}
+
+	var options snapshot.Options
+	if err := json.Unmarshal(body, &options); err != nil {
+		return nil, fmt.Errorf("decode snapshot options: %w", err)
+	}
+	if err := snapshot.Validate(&options, isList); err != nil {
+		return nil, err
+	}
+	return &options, nil
+}
+
+func fail(w http.ResponseWriter, r *http.Request, code int, err error) {
+	utilrequest.FailWithStatus(w, r, int32(code), err)
+}
+
+func isSnapshotPath(path string) bool {
+	return path == "/vcluster/snapshots" || strings.HasPrefix(path, "/vcluster/snapshots/")
+}

--- a/pkg/snapshot/api/handler_test.go
+++ b/pkg/snapshot/api/handler_test.go
@@ -1,0 +1,226 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+)
+
+func TestWithSnapshotsDelegatesOtherPaths(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	handler := WithSnapshots(next, &synccontext.ControllerContext{})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil))
+
+	if !called {
+		t.Fatal("expected next handler to be called")
+	}
+	if recorder.Code != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, recorder.Code)
+	}
+}
+
+func TestWithSnapshotsDelegatesSimilarPrefixPaths(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	handler := WithSnapshots(next, &synccontext.ControllerContext{})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/vcluster/snapshots-extra", nil))
+
+	if !called {
+		t.Fatal("expected next handler to be called")
+	}
+	if recorder.Code != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, recorder.Code)
+	}
+}
+
+func TestWithSnapshotsProbe(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	handler := WithSnapshots(next, &synccontext.ControllerContext{Config: &config.VirtualClusterConfig{}})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodHead, "/vcluster/snapshots", nil))
+
+	if called {
+		t.Fatal("expected snapshot handler to handle probe")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("expected empty response body, got %q", recorder.Body.String())
+	}
+}
+
+func TestWithSnapshotsRejectsUnknownSnapshotPath(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	handler := WithSnapshots(next, &synccontext.ControllerContext{Config: &config.VirtualClusterConfig{}})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/vcluster/snapshots/unknown/path", nil))
+
+	if called {
+		t.Fatal("expected snapshot handler to handle snapshot path")
+	}
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, recorder.Code)
+	}
+}
+
+func TestWithSnapshotsRejectsMissingBody(t *testing.T) {
+	handler := WithSnapshots(nil, &synccontext.ControllerContext{Config: &config.VirtualClusterConfig{}})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/vcluster/snapshots/list", nil))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+}
+
+func TestWithSnapshotsRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "create",
+			path: "/vcluster/snapshots",
+			body: `{"type":"s3","s3":{"bucket":"bucket"}}`,
+		},
+		{
+			name: "list",
+			path: "/vcluster/snapshots/list",
+			body: `{"type":"s3"}`,
+		},
+		{
+			name: "create request",
+			path: "/vcluster/snapshots/request",
+			body: `{"type":"s3","s3":{"bucket":"bucket"}}`,
+		},
+		{
+			name: "delete request",
+			path: "/vcluster/snapshots/request/delete",
+			body: `{"type":"s3","s3":{"bucket":"bucket"}}`,
+		},
+	}
+
+	handler := WithSnapshots(nil, &synccontext.ControllerContext{Config: &config.VirtualClusterConfig{}})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(test.body)))
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+			}
+		})
+	}
+}
+
+func TestWithSnapshotsRejectsUnsupportedDeleteRequestMethod(t *testing.T) {
+	handler := WithSnapshots(nil, &synccontext.ControllerContext{Config: &config.VirtualClusterConfig{}})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPut, "/vcluster/snapshots/request/delete", nil))
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, recorder.Code)
+	}
+}
+
+func TestWithSnapshotsRoutesSnapshotRequestName(t *testing.T) {
+	handler := WithSnapshots(nil, &synccontext.ControllerContext{Config: &config.VirtualClusterConfig{}})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/vcluster/snapshots/request/test-snapshot", nil))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, recorder.Code)
+	}
+	if strings.Contains(recorder.Body.String(), "404") {
+		t.Fatalf("expected request name route to match, got body %q", recorder.Body.String())
+	}
+}
+
+func TestDecodeOptionsAcceptsWrappedAndRawOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "wrapped",
+			body: `{"options":{"type":"container","container":{"path":"/tmp/snapshot.tar.gz"}}}`,
+		},
+		{
+			name: "raw",
+			body: `{"type":"container","container":{"path":"/tmp/snapshot.tar.gz"}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/vcluster/snapshots", strings.NewReader(test.body))
+			options, err := snapshotOptions(request, false)
+			if err != nil {
+				t.Fatalf("decode options: %v", err)
+			}
+			if options.Type != "container" {
+				t.Fatalf("expected type container, got %q", options.Type)
+			}
+			if options.Container.Path != "/tmp/snapshot.tar.gz" {
+				t.Fatalf("expected container path to be decoded, got %q", options.Container.Path)
+			}
+		})
+	}
+}
+
+func TestDecodeOptionsRejectsOversizedBody(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/vcluster/snapshots", strings.NewReader(strings.Repeat("x", maxRequestBytes+1)))
+
+	_, err := snapshotOptions(request, false)
+	if err == nil {
+		t.Fatal("expected oversized request body error")
+	}
+	if !strings.Contains(err.Error(), "request body is too large") {
+		t.Fatalf("expected oversized request body error, got %v", err)
+	}
+}
+
+func TestIsSnapshotPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{path: "/vcluster/snapshots", expected: true},
+		{path: "/vcluster/snapshots/list", expected: true},
+		{path: "/vcluster/snapshots-extra", expected: false},
+		{path: "/api/v1/pods", expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			if got := isSnapshotPath(test.path); got != test.expected {
+				t.Fatalf("expected %t, got %t", test.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/snapshot/api/register.go
+++ b/pkg/snapshot/api/register.go
@@ -1,0 +1,12 @@
+package api
+
+import "github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+
+// Register adds the snapshot HTTP API to the vCluster server handler chain.
+func Register(ctx *synccontext.ControllerContext) {
+	if ctx == nil {
+		return
+	}
+
+	ctx.PostServerHooks = append(ctx.PostServerHooks, WithSnapshots)
+}

--- a/pkg/snapshot/api/types.go
+++ b/pkg/snapshot/api/types.go
@@ -1,0 +1,7 @@
+package api
+
+import "github.com/loft-sh/vcluster/pkg/snapshot"
+
+type OptionsRequest struct {
+	Options *snapshot.Options `json:"options,omitempty"`
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 
Implemented a vCluster snapshot HTTP hook that exposes snapshot operations without requiring command exec.
The API now uses a single `/vcluster/snapshots*` prefix:
- HEAD `/vcluster/snaphots` - probe
- POST `/vcluster/snapshots` - snapshot create
- POST `/vcluster/snapshots/list` - snapshot list
- POST `/vcluster/snapshots/request` - snapshot request create (async snapshot creation)
- POST `/vcluster/snapshots/request/delete` - snapshot delete (async snapshot deletion)
- GET  `/vcluster/snapshots/request/{name}` - snapshot request get

Direct snapshot routes operate on storage immediately, while request routes create/read k8s request resources that are reconciled asynchronously by the snapshot controller.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
