### PR TITLE
fix(release): make goreleaser retry asset upload on 422 already_exists

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,7 +237,7 @@ jobs:
       - sync_linear
     permissions:
       contents: read
-    uses: loft-sh/github-actions/.github/workflows/notify-release.yaml@55d5b751b3c096231e7fc1e291c152a3d2449b9c # release-notification/v2
+    uses: loft-sh/github-actions/.github/workflows/notify-release.yaml@release-notification/v2
     with:
       release_version: ${{ github.event.release.tag_name }}
       target_repo: ${{ github.repository }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,6 +124,11 @@ changelog:
 release:
   prerelease: auto
   make_latest: false
+  # Re-runs of this workflow against the same tag re-upload assets to an
+  # already-populated GitHub Release and 422 with `already_exists`. This
+  # tells goreleaser to fetch+delete the conflicting asset and retry the
+  # upload only when it sees that 422, so first-run cost is unchanged.
+  replace_existing_artifacts: true
 
   extra_files:
     - glob: ./chart/values.schema.json


### PR DESCRIPTION
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

Closes DEVOPS-923.

## Summary

Two related fixes for the vcluster release pipeline that surfaced together on run [25905886661](https://github.com/loft-sh/vcluster/actions/runs/25905886661):

1. **goreleaser idempotency** — re-running a failed release uploaded asset names that already existed on the GitHub Release and hit 422 `already_exists` on seven assets (mix of binaries and SBOMs). `--clean` only clears the local `release/` dir, not remote assets, so the re-run path was unrecoverable without manual cleanup. `release.replace_existing_artifacts: true` makes goreleaser fetch+delete the conflicting asset and retry — only on 422, so first-run cost is unchanged.
2. **notify-release pin** — switch the SHA pin on the `notify-release.yaml` reusable workflow to the floating `@release-notification/v2` tag. Matches vcluster-pro and loft-enterprise convention so future composite-action fixes propagate without per-repo SHA bumps. (The composite-pin drift behind DEVOPS-923's silent `notify_failure` was fixed in [loft-sh/github-actions#145](https://github.com/loft-sh/github-actions/pull/145); the v2 tag has been force-moved onto that merge commit.)

## Key Changes

- `.goreleaser.yaml`: set `release.replace_existing_artifacts: true`.
- `.github/workflows/release.yaml`: switch notify-release pin from SHA → `@release-notification/v2`.

## Dependencies

- [loft-sh/github-actions#145](https://github.com/loft-sh/github-actions/pull/145) — merged. The v2 tag has been moved forward.
- [loft-sh/vcluster-pro#1802](https://github.com/loft-sh/vcluster-pro/pull/1802) — mirror of the goreleaser one-liner.
- [loft-sh/loft-enterprise#6855](https://github.com/loft-sh/loft-enterprise/pull/6855) — mirror of the goreleaser one-liner.

**Please provide a short message that should be published in the vcluster release notes**

Fixed an issue where re-running a stuck release workflow would 422 on every asset upload to GitHub Releases. goreleaser now deletes and re-uploads conflicting assets automatically. Failure notifications now fire reliably via the updated release-notification/v2 reusable workflow.

**What else do we need to know?**

The stuck v0.35.0-alpha.5 release has already been unblocked by deleting its assets and rerunning the failed jobs — that path is independent of this PR.

## E2E Tests

```label-filter
none
```