### PR TITLE
fix(snapshot): update CLI error message examples to include .tar.gz filename

### DIFF
--- a/pkg/cli/snapshot_helm.go
+++ b/pkg/cli/snapshot_helm.go
@@ -196,13 +196,13 @@ func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeCli
 func resolveSnapshotArgs(args []string, standalone bool) (string, string, error) {
 	if standalone {
 		if len(args) != 1 {
-			return "", "", fmt.Errorf("unexpected amount of arguments: %d, need exactly 1 argument. E.g. vcluster [snapshot|restore] s3://my-bucket/my-key --standalone", len(args))
+			return "", "", fmt.Errorf("unexpected amount of arguments: %d, need exactly 1 argument. E.g. vcluster [snapshot|restore] s3://my-bucket/my-key/snapshot1.tar.gz --standalone", len(args))
 		}
 		return "", args[0], nil
 	}
 
 	if len(args) != 2 {
-		return "", "", fmt.Errorf("unexpected amount of arguments: %d, need exactly 2 arguments. E.g. vcluster [snapshot|restore] my-vcluster s3://my-bucket/my-key", len(args))
+		return "", "", fmt.Errorf("unexpected amount of arguments: %d, need exactly 2 arguments. E.g. vcluster [snapshot|restore] my-vcluster s3://my-bucket/my-key/snapshot1.tar.gz", len(args))
 	}
 
 	return args[0], args[1], nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Updates the CLI error message examples in `vcluster snapshot` / `vcluster restore` to include a `.tar.gz` filename in the S3 URL. Previously the example showed `s3://my-bucket/my-key`, which led users to omit the filename and receive a confusing "No snapshot found" response. The corrected example is `s3://my-bucket/my-key/snapshot1.tar.gz`.

resolves ENGCP-533

**Please provide a short message that should be published in the vcluster release notes**
Fix an issue where the `vcluster snapshot` / `vcluster restore` error message showed an incomplete S3 URL example that omitted the required `.tar.gz` filename, causing users to receive a misleading "No snapshot found" error.

**What else do we need to know?** 
The S3 store skips any object that does not end with `tar.gz` during listing (`pkg/snapshot/s3/store.go`), so omitting the filename from the URL will always result in "No snapshot found" even when a snapshot exists.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
