### PR TITLE
Add RBAC permissions required for Kubernetes v1.36+ DRA granular   status authorization (DRAResourceClaimGranularStatusAuthorization)

### DIFF
--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -104,6 +104,12 @@ rules:
   - apiGroups: ["resource.k8s.io"]
     resources: ["resourceclaims/status"]
     verbs: ["patch", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims/binding"]
+    verbs: ["patch", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims/driver"]
+    verbs: ["arbitrary-node:patch", "arbitrary-node:update"]
   {{- end }}
   {{ if .Values.sync.toHost.resourceClaimTemplates.enabled}}
   - apiGroups: ["resource.k8s.io"]


### PR DESCRIPTION
  ## Summary

  Add RBAC permissions required for Kubernetes v1.36+ DRA granular
  status authorization (DRAResourceClaimGranularStatusAuthorization).

  vCluster syncs ResourceClaim status fields to the host cluster, which
  requires:
  - `resourceclaims/binding`: to update status.allocation and status.reservedFor
  - `resourceclaims/driver`: to update status.devices

  These permissions are inert in Kubernetes versions prior to v1.36.

  Ref:kubernetes/kubernetes#138149