### PR TITLE
feat: Add types for argocd v2 integration support

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -32,6 +32,76 @@
       "type": "object",
       "description": "APIServiceService holds the service name and namespace of the host apiservice."
     },
+    "ArgoCDApplication": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name specifies the stable identifier of the argo cd application. It is used to derive generated\nArgoCDApplication resource names and the final Argo CD application name.\n+optional"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "DisplayName specifies the display name of the argo cd application.\n+optional"
+        },
+        "target": {
+          "type": "string",
+          "description": "Target specifies the target of the argo cd application. This can be \"vCluster\" or \"host\". Defaults to \"vCluster\".\n+optional"
+        },
+        "inline": {
+          "type": "object",
+          "description": "Inline specifies the inline argo cd application definition. This requires the argo cd integration to be enabled.\n+optional"
+        },
+        "template": {
+          "$ref": "#/$defs/ArgoCDApplicationTemplate",
+          "description": "Template specifies the argo cd application template to use. This requires the argo cd integration to be enabled.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ArgoCDApplication holds argo cd application configuration."
+    },
+    "ArgoCDApplicationTemplate": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name specifies the name of the argo cd application template\n+optional"
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Parameters specifies the parameters to pass to the argo cd application template.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ArgoCDDeploy": {
+      "properties": {
+        "applications": {
+          "items": {
+            "$ref": "#/$defs/ArgoCDApplication"
+          },
+          "type": "array",
+          "description": "Applications specifies the applications to deploy. This requires the argo cd integration to be enabled.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ArgoCDDeploy holds argo cd deploy configuration."
+    },
+    "ArgoCDIntegration": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if argo cd integration is enabled\n+optional"
+        },
+        "connector": {
+          "type": "string",
+          "description": "Connector specifies the argo cd connector name\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ArgoCDIntegration holds argo cd integration configuration."
+    },
     "AutoUpgrade": {
       "properties": {
         "enabled": {
@@ -1243,6 +1313,10 @@
         "volumeSnapshotController": {
           "$ref": "#/$defs/VolumeSnapshotController",
           "description": "VolumeSnapshotController holds dedicated CSI snapshot-controller configuration."
+        },
+        "argoCD": {
+          "$ref": "#/$defs/ArgoCDDeploy",
+          "description": "ArgoCD holds dedicated configuration for argoCD Apps to deploy"
         }
       },
       "additionalProperties": false,
@@ -2583,6 +2657,10 @@
         "netris": {
           "$ref": "#/$defs/NetrisIntegration",
           "description": "Netris integration helps configuring netris networking for vCluster."
+        },
+        "argoCD": {
+          "$ref": "#/$defs/ArgoCDIntegration",
+          "description": "ArgoCD integration helps configuring ArgoCD for vCluster."
         }
       },
       "additionalProperties": false,

--- a/config/config.go
+++ b/config/config.go
@@ -340,6 +340,9 @@ type Deploy struct {
 
 	// VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
 	VolumeSnapshotController VolumeSnapshotController `json:"volumeSnapshotController,omitempty"`
+
+	// ArgoCD holds dedicated configuration for argoCD Apps to deploy
+	ArgoCD vclusterconfig.ArgoCDDeploy `json:"argoCD,omitempty"`
 }
 
 type DeployMetricsServer struct {
@@ -726,6 +729,9 @@ type Integrations struct {
 
 	// Netris integration helps configuring netris networking for vCluster.
 	Netris vclusterconfig.NetrisIntegration `json:"netris,omitempty"`
+
+	// ArgoCD integration helps configuring ArgoCD for vCluster.
+	ArgoCD vclusterconfig.ArgoCDIntegration `json:"argoCD,omitempty"`
 }
 
 // CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0
-	github.com/loft-sh/agentapi/v4 v4.10.0-alpha.1
+	github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2
 	github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
-	github.com/loft-sh/api/v4 v4.10.0-alpha.1
+	github.com/loft-sh/api/v4 v4.10.0-alpha.2
 	github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979
 	github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364
 	github.com/loft-sh/utils v0.0.29

--- a/go.sum
+++ b/go.sum
@@ -320,12 +320,12 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0 h1:12fy1LhhyuQ46ls272yWn6HpAMLNUClsBYqRvu+qTC0=
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0/go.mod h1:pp+2PgOsRCTb1DXnEev/HCc0gvj5t0nHuTIMU8C8b90=
-github.com/loft-sh/agentapi/v4 v4.10.0-alpha.1 h1:Jg3c+oLw0xNn1TpM4q4BxmN7neavsFZXIyU8zv00p+I=
-github.com/loft-sh/agentapi/v4 v4.10.0-alpha.1/go.mod h1:3bAQUMI7xhTSlODdKXXQgRePg1TifgRd1sBSnMX5OvM=
+github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2 h1:xWQUCRnORLKVeAW5r6l/NeKwN3k6LtzwPiyPL6P8ip4=
+github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2/go.mod h1:3bAQUMI7xhTSlODdKXXQgRePg1TifgRd1sBSnMX5OvM=
 github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e h1:JcPnMaoczikvpasi8OJ47dCkWZjfgFubWa4V2SZo7h0=
 github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e/go.mod h1:FFWcGASyM2QlWTDTCG/WBVM/XYr8btqYt335TFNRCFg=
-github.com/loft-sh/api/v4 v4.10.0-alpha.1 h1:wGwDAm/gnm3cufGaQqUI843vNrwReg9BhnqLu6GEyAQ=
-github.com/loft-sh/api/v4 v4.10.0-alpha.1/go.mod h1:+Rb6rF3E9hfEjXHNei/o6Xn9VMkg2xfgu9a/cTs4Yzs=
+github.com/loft-sh/api/v4 v4.10.0-alpha.2 h1:an0xLCdlbwnJLD0kVzckpN3T+I0L1W0EzTAE9zm9/0g=
+github.com/loft-sh/api/v4 v4.10.0-alpha.2/go.mod h1:iRNMIrbfQ3j3nIQ+bszoubOUxGtHKVB64UQvpk1JdYU=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530 h1:2B4XhZ30FVt17PbWj2iRKcqys8a+3DoPLabvxGswPmU=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530/go.mod h1:YfIUirXHfVcUb3bVtj7yzIAVT6etrHj9wkOkMgnEuz0=
 github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979 h1:5nhHRJIGlxkvJappR0SdBEsuM/ziBke+Z2dVI+A4G3I=

--- a/vendor/github.com/loft-sh/api/v4/pkg/apis/storage/v1/nodeprovider_types.go
+++ b/vendor/github.com/loft-sh/api/v4/pkg/apis/storage/v1/nodeprovider_types.go
@@ -339,6 +339,18 @@ type Metal3Deployment struct {
 	// Enabled controls whether Metal3 and Ironic are deployed into the cluster.
 	Enabled bool `json:"enabled"`
 
+	// ChartRepo overrides the Helm chart repository used to install Metal3.
+	// +optional
+	ChartRepo string `json:"chartRepo,omitempty"`
+
+	// Chart overrides the Helm chart name used to install Metal3.
+	// +optional
+	Chart string `json:"chart,omitempty"`
+
+	// Version overrides the Helm chart version used to install Metal3.
+	// +optional
+	Version string `json:"version,omitempty"`
+
 	// HelmValues is raw YAML that will be passed as values to the Metal3 Helm chart.
 	// +optional
 	HelmValues string `json:"helmValues,omitempty"`

--- a/vendor/github.com/loft-sh/api/v4/pkg/vclusterconfig/types.go
+++ b/vendor/github.com/loft-sh/api/v4/pkg/vclusterconfig/types.go
@@ -387,10 +387,6 @@ type ArgoCDApplication struct {
 	// +optional
 	Target string `json:"target,omitempty"`
 
-	// DestinationNamespace specifies the namespace of the destination.
-	// +optional
-	DestinationNamespace string `json:"destinationNamespace,omitempty"`
-
 	// Inline specifies the inline argo cd application definition. This requires the argo cd integration to be enabled.
 	// +optional
 	Inline map[string]interface{} `json:"inline,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -677,7 +677,7 @@ github.com/lithammer/dedent
 # github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0
 ## explicit; go 1.24.11
 github.com/loft-sh/admin-apis/pkg/licenseapi
-# github.com/loft-sh/agentapi/v4 v4.10.0-alpha.1
+# github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2
 ## explicit; go 1.26.0
 github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster
 github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1
@@ -689,7 +689,7 @@ github.com/loft-sh/agentapi/v4/pkg/clientset/versioned/typed/storage/v1
 # github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 ## explicit; go 1.21
 github.com/loft-sh/analytics-client/client
-# github.com/loft-sh/api/v4 v4.10.0-alpha.1
+# github.com/loft-sh/api/v4 v4.10.0-alpha.2
 ## explicit; go 1.26.0
 github.com/loft-sh/api/v4/pkg/apis/audit/v1
 github.com/loft-sh/api/v4/pkg/apis/management


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
