### PR TITLE
fix(snapshot): only send x-amz-tagging header when tagging is configured

### DIFF
--- a/pkg/snapshot/s3/store.go
+++ b/pkg/snapshot/s3/store.go
@@ -216,10 +216,12 @@ func (o *ObjectStore) Target() string {
 
 func (o *ObjectStore) PutObject(ctx context.Context, body io.Reader) error {
 	input := &s3.PutObjectInput{
-		Bucket:  aws.String(o.bucket),
-		Key:     aws.String(o.key),
-		Body:    &wrapper{body},
-		Tagging: aws.String(o.tagging),
+		Bucket: aws.String(o.bucket),
+		Key:    aws.String(o.key),
+		Body:   &wrapper{body},
+	}
+	if o.tagging != "" {
+		input.Tagging = aws.String(o.tagging)
 	}
 
 	switch {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
Guards the `Tagging` field on `s3.PutObjectInput` so it is only set when the user has actually configured a tagging value. Without this guard, the AWS SDK v2 serializer emits an `x-amz-tagging:` header with an empty value, which Cloudflare R2 and some other S3-compatible backends reject with `HTTP 501 NotImplemented` — regardless of value — because they do not implement object tagging at all.

resolves #3882 
resolves ENGCP-641


**Please provide a short message that should be published in the vcluster release notes**
Fixed `vcluster snapshot create` failing against Cloudflare R2 and other S3-compatible backends with `StatusCode: 501, api error NotImplemented: Header 'x-amz-tagging' with value '' not implemented`. The empty `x-amz-tagging` header is no longer sent when no tagging value is configured.


**What else do we need to know?**
- `pkg/snapshot/s3/store.go` is forked from Velero's `velero-plugin-for-aws` object store. The upstream still has the same unconditional `Tagging` assignment on `main`, `v1.13.x`, and `v1.14.x` ([object_store.go#L341](https://github.com/velero-io/velero-plugin-for-aws/blob/main/velero-plugin-for-aws/object_store.go#L341)), so this is an original fix, not an upstream sync.
- Reproduction: configure a vcluster snapshot to an R2 bucket via `s3://my-bucket/path/snap.tar.gz?force-path-style=true&region=auto&url=<base64 https://<acct>.r2.cloudflarestorage.com>&access-key-id=<base64>&secret-access-key=<base64>` and run `vcluster snapshot create`. The snapshot-request ConfigMap reports `phase: Failed` with the 501 error. Setting a non-empty `tagging` query param does not help — R2 rejects the header regardless of value.
- Follow-up PR (stacked on this one): tagging validation in `Init()` and unit tests covering this behavior.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
