### PR TITLE
feat: add --snapshot-temp-dir for snapshot create/restore commands

### DIFF
--- a/cmd/vclusterctl/cmd/create.go
+++ b/cmd/vclusterctl/cmd/create.go
@@ -122,7 +122,7 @@ func (cmd *CreateCmd) Run(cobraCmd *cobra.Command, args []string) error {
 			if !cobraCmd.Flag("chart-version").Changed {
 				cmd.ChartVersion = ""
 			}
-			return cli.RestoreDocker(ctx, cmd.GlobalFlags, cmd.Restore, args[0], &cmd.CreateOptions, cmd.log)
+			return cli.RestoreDocker(ctx, cmd.GlobalFlags, cmd.Restore, args[0], &cmd.CreateOptions, cmd.CreateOptions.SnapshotTempDir, cmd.log)
 		}
 		return cli.CreateDocker(ctx, &cmd.CreateOptions, cmd.GlobalFlags, args[0], cmd.log)
 	}

--- a/cmd/vclusterctl/cmd/restore.go
+++ b/cmd/vclusterctl/cmd/restore.go
@@ -81,7 +81,7 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 				if len(args) < 2 {
 					return fmt.Errorf("usage: vcluster restore VCLUSTER_NAME SNAPSHOT_FILE --driver docker")
 				}
-				return cli.RestoreDocker(cobraCmd.Context(), cmd.GlobalFlags, args[1], args[0], nil, cmd.Log)
+				return cli.RestoreDocker(cobraCmd.Context(), cmd.GlobalFlags, args[1], args[0], nil, cmd.Snapshot.SnapshotTempDir, cmd.Log)
 			}
 			return cli.Restore(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, &cmd.Pod, false, cmd.RestoreVolumes, cmd.Standalone, cmd.Log)
 		},

--- a/cmd/vclusterctl/cmd/restore.go
+++ b/cmd/vclusterctl/cmd/restore.go
@@ -92,6 +92,7 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 	pod.AddFlags(cobraCmd.Flags(), &cmd.Pod, true)
 	cobraCmd.Flags().BoolVar(&cmd.RestoreVolumes, "restore-volumes", false, "Restore volumes from volume snapshots")
 	cobraCmd.Flags().BoolVar(&cmd.Standalone, "standalone", false, "Target the local standalone vCluster on this host")
+	cobraCmd.Flags().StringVarP(&cmd.Snapshot.SnapshotTempDir, "snapshot-temp-dir", "", "", "Temporary directory for snapshot operations. If set to empty string, the OS default directory for temporary files will be used")
 	snapshotazure.AddFlags(cobraCmd.Flags(), &cmd.Snapshot.Azure)
 	return cobraCmd
 }

--- a/cmd/vclusterctl/cmd/snapshot/create.go
+++ b/cmd/vclusterctl/cmd/snapshot/create.go
@@ -82,7 +82,7 @@ vcluster snapshot create my-vcluster --driver docker
 				} else {
 					outputPath = fmt.Sprintf("%s-snapshot-%s.tar.gz", vClusterName, time.Now().Format("2006-01-02T15-04-05"))
 				}
-				return cli.SnapshotDocker(cobraCmd.Context(), cmd.GlobalFlags, vClusterName, outputPath, cmd.Log)
+				return cli.SnapshotDocker(cobraCmd.Context(), cmd.GlobalFlags, &cmd.Snapshot, vClusterName, outputPath, cmd.Log)
 			}
 			return cli.CreateSnapshot(cobraCmd.Context(), args, cmd.GlobalFlags, &cmd.Snapshot, nil, cmd.Log, true, cmd.Standalone)
 		},

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0
-	github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2
+	github.com/loft-sh/agentapi/v4 v4.10.0-alpha.4
 	github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
-	github.com/loft-sh/api/v4 v4.10.0-alpha.2
+	github.com/loft-sh/api/v4 v4.10.0-alpha.4
 	github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979
 	github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364
 	github.com/loft-sh/utils v0.0.29

--- a/go.sum
+++ b/go.sum
@@ -320,12 +320,12 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0 h1:12fy1LhhyuQ46ls272yWn6HpAMLNUClsBYqRvu+qTC0=
 github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0/go.mod h1:pp+2PgOsRCTb1DXnEev/HCc0gvj5t0nHuTIMU8C8b90=
-github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2 h1:xWQUCRnORLKVeAW5r6l/NeKwN3k6LtzwPiyPL6P8ip4=
-github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2/go.mod h1:3bAQUMI7xhTSlODdKXXQgRePg1TifgRd1sBSnMX5OvM=
+github.com/loft-sh/agentapi/v4 v4.10.0-alpha.4 h1:VO2H45VeS5eTNgwoDSZsGDXycoy5mqs1lgnJL45Bz20=
+github.com/loft-sh/agentapi/v4 v4.10.0-alpha.4/go.mod h1:3bAQUMI7xhTSlODdKXXQgRePg1TifgRd1sBSnMX5OvM=
 github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e h1:JcPnMaoczikvpasi8OJ47dCkWZjfgFubWa4V2SZo7h0=
 github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e/go.mod h1:FFWcGASyM2QlWTDTCG/WBVM/XYr8btqYt335TFNRCFg=
-github.com/loft-sh/api/v4 v4.10.0-alpha.2 h1:an0xLCdlbwnJLD0kVzckpN3T+I0L1W0EzTAE9zm9/0g=
-github.com/loft-sh/api/v4 v4.10.0-alpha.2/go.mod h1:iRNMIrbfQ3j3nIQ+bszoubOUxGtHKVB64UQvpk1JdYU=
+github.com/loft-sh/api/v4 v4.10.0-alpha.4 h1:gqxBfP4tvmbcf8owApL8NYWXAh2UlP+7hvEPXvxqiEQ=
+github.com/loft-sh/api/v4 v4.10.0-alpha.4/go.mod h1:NY19EqkvOM4IaLnCyGHT7kLgIfIInwwK1wFUDDHYNQw=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530 h1:2B4XhZ30FVt17PbWj2iRKcqys8a+3DoPLabvxGswPmU=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530/go.mod h1:YfIUirXHfVcUb3bVtj7yzIAVT6etrHj9wkOkMgnEuz0=
 github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979 h1:5nhHRJIGlxkvJappR0SdBEsuM/ziBke+Z2dVI+A4G3I=

--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -77,6 +77,7 @@ type CreateOptions struct {
 	Expose               bool
 	ExposeLocal          bool
 	Restore              string
+	SnapshotTempDir      string
 	Connect              bool
 	Upgrade              bool
 
@@ -182,7 +183,7 @@ func CreateHelm(ctx context.Context, options *CreateOptions, globalFlags *flags.
 				}
 
 				log.Infof("Restore vCluster %s...", vClusterName)
-				err = Restore(ctx, []string{vClusterName, cmd.Restore}, globalFlags, &snapshotapi.Options{}, &pod.Options{}, false, false, false, log)
+				err = Restore(ctx, []string{vClusterName, cmd.Restore}, globalFlags, &snapshotapi.Options{SnapshotTempDir: cmd.SnapshotTempDir}, &pod.Options{}, false, false, false, log)
 				if err != nil {
 					return fmt.Errorf("restore vCluster %s: %w", vClusterName, err)
 				}
@@ -649,7 +650,7 @@ func (cmd *createHelm) deployChart(ctx context.Context, vClusterName, chartValue
 	// now restore if wanted
 	if cmd.Restore != "" {
 		cmd.log.Infof("Restore vCluster %s...", vClusterName)
-		err = Restore(ctx, []string{vClusterName, cmd.Restore}, cmd.GlobalFlags, &snapshotapi.Options{}, &pod.Options{}, true, false, false, cmd.log)
+		err = Restore(ctx, []string{vClusterName, cmd.Restore}, cmd.GlobalFlags, &snapshotapi.Options{SnapshotTempDir: cmd.SnapshotTempDir}, &pod.Options{}, true, false, false, cmd.log)
 		if err != nil {
 			// delete the vcluster if the restore failed
 			deleteErr := helmClient.Delete(vClusterName, cmd.Namespace)
@@ -844,7 +845,7 @@ func getVClusterConfigFromSnapshot(ctx context.Context, cmd *CreateOptions) (str
 		return "", nil
 	}
 
-	snapshotOptions := &snapshotapi.Options{}
+	snapshotOptions := &snapshotapi.Options{SnapshotTempDir: cmd.SnapshotTempDir}
 	err := snapshot.Parse(cmd.Restore, snapshotOptions)
 	if err != nil {
 		return "", fmt.Errorf("parse snapshot: %w", err)

--- a/pkg/cli/flags/create/create.go
+++ b/pkg/cli/flags/create/create.go
@@ -57,6 +57,7 @@ func AddHelmFlags(cmd *cobra.Command, options *cli.CreateOptions) {
 	cmd.Flags().BoolVar(&options.CreateNamespace, "create-namespace", true, "If true the namespace will be created if it does not exist")
 	cmd.Flags().StringVar(&options.LocalChartDir, "local-chart-dir", "", "The virtual cluster local chart dir to use")
 	cmd.Flags().StringVar(&options.Restore, "restore", "", "Restore the virtual cluster from a backup. E.g. --restore oci://ghcr.io/my-user/my-repo:my-tag")
+	cmd.Flags().StringVarP(&options.SnapshotTempDir, "snapshot-temp-dir", "", "", "Temporary directory for snapshot operations. If set to empty string, the OS default directory for temporary files will be used")
 	cmd.Flags().BoolVar(&options.ExposeLocal, "expose-local", true, "If true and a local Kubernetes distro is detected, will deploy vcluster with a NodePort service. Will be set to false and the passed value will be ignored if --expose is set to true.")
 	cmd.Flags().BoolVar(&options.BackgroundProxy, "background-proxy", true, "Try to use a background-proxy to access the vCluster. Only works if docker is installed and reachable")
 	cmd.Flags().StringVar(&options.BackgroundProxyImage, "background-proxy-image", constants.DefaultBackgroundProxyImage(upgrade.GetVersion()), "The image to use for the background proxy. Only used if --background-proxy is enabled.")

--- a/pkg/cli/restore_docker.go
+++ b/pkg/cli/restore_docker.go
@@ -24,12 +24,12 @@ import (
 // into memory. Tar entries are handled as they arrive: metadata is parsed first, volume
 // entries are piped directly to Docker, and config files are written directly to disk.
 // callerOpts may be nil (standalone restore) or the user's CreateOptions (create --restore).
-func RestoreDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotPath, targetName string, callerOpts *CreateOptions, log log.Logger) error {
+func RestoreDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotPath, targetName string, callerOpts *CreateOptions, tempDir string, log log.Logger) error {
 	// If the snapshot path is a remote URL, pull it to a temp file first.
 	localPath := snapshotPath
 	if isRemoteSnapshotURL(snapshotPath) {
 		log.Infof("Pulling snapshot from %s...", snapshotPath)
-		tmpFile, err := os.CreateTemp("", "vcluster-docker-restore-*.tar.gz")
+		tmpFile, err := os.CreateTemp(tempDir, "vcluster-docker-restore-*.tar.gz")
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
@@ -199,7 +199,7 @@ func RestoreDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshot
 	// If the snapshot contains a vcluster.yaml, pass it as a values file so that
 	// any custom configuration (including multi-node definitions) is preserved.
 	if metadata.VClusterYAML != "" {
-		tmpFile, err := os.CreateTemp("", "vcluster-restore-*.yaml")
+		tmpFile, err := os.CreateTemp(tempDir, "vcluster-restore-*.yaml")
 		if err != nil {
 			return fmt.Errorf("failed to create temp values file: %w", err)
 		}

--- a/pkg/cli/snapshot_docker.go
+++ b/pkg/cli/snapshot_docker.go
@@ -50,7 +50,7 @@ type SnapshotVolume struct {
 
 // SnapshotDocker creates a snapshot of a Docker-based vCluster by exporting its Docker volumes
 // and configuration directory into a single gzipped tar archive.
-func SnapshotDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName, outputPath string, log log.Logger) error {
+func SnapshotDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, vClusterName, outputPath string, log log.Logger) error {
 	cpContainer := getControlPlaneContainerName(vClusterName)
 
 	// Verify the vCluster exists.
@@ -132,7 +132,7 @@ func SnapshotDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vCluste
 	isRemote := isRemoteSnapshotURL(outputPath)
 	localPath := outputPath
 	if isRemote {
-		tmpFile, err := os.CreateTemp("", "vcluster-docker-snapshot-*.tar.gz")
+		tmpFile, err := os.CreateTemp(snapshotOpts.SnapshotTempDir, "vcluster-docker-snapshot-*.tar.gz")
 		if err != nil {
 			return fmt.Errorf("failed to create temp file: %w", err)
 		}
@@ -167,7 +167,7 @@ func SnapshotDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vCluste
 	for _, vol := range volumes {
 		dockerVolumeName := resolveDockerVolumeName(vClusterName, vol.LogicalName)
 		log.Infof("Exporting volume %s...", vol.LogicalName)
-		if err := exportDockerVolumeToTar(ctx, tw, vol.ArchivePath, dockerVolumeName); err != nil {
+		if err := exportDockerVolumeToTar(ctx, tw, vol.ArchivePath, dockerVolumeName, snapshotOpts.SnapshotTempDir); err != nil {
 			return fmt.Errorf("failed to export volume %s: %w", vol.LogicalName, err)
 		}
 	}
@@ -251,9 +251,9 @@ func resolveDockerVolumeName(vClusterName, logicalName string) string {
 
 // exportDockerVolumeToTar exports a Docker volume directly into a tar writer by streaming
 // through a temporary file. This avoids holding multi-GB volume data in memory.
-func exportDockerVolumeToTar(ctx context.Context, tw *tar.Writer, archivePath, volumeName string) error {
+func exportDockerVolumeToTar(ctx context.Context, tw *tar.Writer, archivePath, volumeName string, tempDir string) error {
 	// Write docker output to a temp file (uses disk, not RAM).
-	tmpFile, err := os.CreateTemp("", "vcluster-vol-export-*.tar")
+	tmpFile, err := os.CreateTemp(tempDir, "vcluster-vol-export-*.tar")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -141,14 +141,14 @@ func (c *Client) writeEtcdSnapshot(ctx context.Context, etcdClient etcd.Client, 
 	}
 	defer res.Snapshot.Close()
 
-	dbPath, err := writeTempFile(res.Snapshot)
+	dbPath, err := writeTempFile(c.Options.SnapshotTempDir, res.Snapshot)
 	if err != nil {
 		return fmt.Errorf("failed to write snapshot to temp file: %w", err)
 	}
 	defer os.Remove(dbPath)
 
 	log.Info("Creating snapshot archive")
-	snapshotFileWrite, err := os.CreateTemp("", "snapshot-")
+	snapshotFileWrite, err := os.CreateTemp(c.Options.SnapshotTempDir, "snapshot-")
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/pkg/snapshot/options.go
+++ b/pkg/snapshot/options.go
@@ -158,5 +158,6 @@ func AddFlags(flags *pflag.FlagSet, options *snapshotapi.Options) {
 	flags.StringVarP(&options.S3.CustomerKeyEncryptionFile, "customer-key-encryption-file", "", "", "AWS customer key encryption file used for SSE-C. Mutually exclusive with kms-key-id")
 	flags.StringVarP(&options.S3.ServerSideEncryption, "server-side-encryption", "", "", "AWS Server-Side encryption algorithm")
 	flags.BoolVarP(&options.IncludeVolumes, "include-volumes", "", false, "Create CSI volume snapshots (shared and private nodes only)")
+	flags.StringVarP(&options.SnapshotTempDir, "snapshot-temp-dir", "", "", "Temporary directory for snapshot operations. If set to empty string, the OS default directory for temporary files will be used")
 	azure.AddFlags(flags, &options.Azure)
 }

--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -189,7 +189,7 @@ func (o *RestoreClient) Run(ctx context.Context, vConfig *config.VirtualClusterC
 	}
 	defer snapshotReader.Close()
 
-	snapshotPath, err := writeTempFile(snapshotReader)
+	snapshotPath, err := writeTempFile(o.Snapshot.SnapshotTempDir, snapshotReader)
 	if err != nil {
 		return fmt.Errorf("failed to write snapshot to temp file: %w", err)
 	}
@@ -264,7 +264,7 @@ func (o *RestoreClient) restoreEtcdSnapshot(ctx context.Context, vConfig *config
 		}
 
 		if header.Name == DBStoreKey {
-			dbPath, err = writeTempFile(tarReader)
+			dbPath, err = writeTempFile(o.Snapshot.SnapshotTempDir, tarReader)
 			if err != nil {
 				return fmt.Errorf("failed to write snapshot to temp file: %w", err)
 			}
@@ -1132,8 +1132,8 @@ func getTranslatedPVCName(pvcName string) string {
 	return hostName.Namespace + "/" + hostName.Name
 }
 
-func writeTempFile(reader io.Reader) (string, error) {
-	f, err := os.CreateTemp("", "snapshot-")
+func writeTempFile(dir string, reader io.Reader) (string, error) {
+	f, err := os.CreateTemp(dir, "snapshot-")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}

--- a/vendor/github.com/loft-sh/api/v4/pkg/snapshot/options.go
+++ b/vendor/github.com/loft-sh/api/v4/pkg/snapshot/options.go
@@ -7,6 +7,7 @@ type Options struct {
 	Container ContainerOptions `json:"container"`
 	OCI       OCIOptions       `json:"oci"`
 	Azure     AzureOptions     `json:"azure"`
+	File      FileOptions      `json:"file"`
 
 	Release        *HelmRelease `json:"release,omitempty"`
 	IncludeVolumes bool         `json:"include-volumes,omitempty"`
@@ -14,6 +15,10 @@ type Options struct {
 	// DelegateFromCLIToCluster indicates that the snapshot options are saved in a Kubernetes Secret because the
 	// snapshot/restore operation will be executed in a Kubernetes cluster.
 	DelegateFromCLIToCluster bool `json:"delegateFromCLIToCluster,omitempty"`
+
+	// SnapshotTempDir is the temporary directory used for snapshot operations.
+	// If set to empty string, the default directory for temporary files will be used, as returned by os.TempDir().
+	SnapshotTempDir string `json:"snapshotTempDir,omitempty"`
 }
 
 func (o *Options) GetURL() string {
@@ -30,6 +35,8 @@ func (o *Options) GetURL() string {
 		return "oci://" + o.OCI.Repository
 	case "azure":
 		return o.Azure.BlobURL
+	case "file":
+		return "file://" + o.File.Path
 	default:
 		return ""
 	}
@@ -114,4 +121,8 @@ type AzureOptions struct {
 
 	// ClientSecret is the client secret for service principal auth.
 	ClientSecret string `json:"client-secret,omitempty"`
+}
+
+type FileOptions struct {
+	Path string `json:"path,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -677,7 +677,7 @@ github.com/lithammer/dedent
 # github.com/loft-sh/admin-apis v0.0.0-20260311181619-506013b79ba0
 ## explicit; go 1.24.11
 github.com/loft-sh/admin-apis/pkg/licenseapi
-# github.com/loft-sh/agentapi/v4 v4.10.0-alpha.2
+# github.com/loft-sh/agentapi/v4 v4.10.0-alpha.4
 ## explicit; go 1.26.0
 github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster
 github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1
@@ -689,7 +689,7 @@ github.com/loft-sh/agentapi/v4/pkg/clientset/versioned/typed/storage/v1
 # github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 ## explicit; go 1.21
 github.com/loft-sh/analytics-client/client
-# github.com/loft-sh/api/v4 v4.10.0-alpha.2
+# github.com/loft-sh/api/v4 v4.10.0-alpha.4
 ## explicit; go 1.26.0
 github.com/loft-sh/api/v4/pkg/apis/audit/v1
 github.com/loft-sh/api/v4/pkg/apis/management


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGCP-851



**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [x] **Add labels** to the test suite
- [x] **Update label-filter section** below to execute the new test suite
- [x] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
