### PR TITLE
feat(pods): add sync.toHost.pods.dns.nameservers

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1121,7 +1121,7 @@
       "properties": {
         "scope": {
           "type": "string",
-          "description": "Scope chooses which cluster to look up the Service in.\n\n+kubebuilder:validation:Enum=host;tenant"
+          "description": "Scope chooses which cluster to look up the Service in.\n\n+kubebuilder:validation:Enum=control-plane-host;tenant-cluster"
         },
         "namespace": {
           "type": "string",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1106,6 +1106,36 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "DNSNameserverEntry": {
+      "properties": {
+        "service": {
+          "$ref": "#/$defs/DNSNameserverService",
+          "description": "Service selects the Service whose ClusterIP becomes one nameserver."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DNSNameserverEntry is one element of the nameservers list."
+    },
+    "DNSNameserverService": {
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Scope chooses which cluster to look up the Service in.\n\n+kubebuilder:validation:Enum=host;tenant"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace containing the Service."
+        },
+        "labelSelector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "LabelSelector must match exactly one Service in Namespace. If zero or\nmore than one Service matches, a Warning event is emitted for this entry\nand the entry is skipped (other entries are still resolved)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DNSNameserverService describes the Service lookup for a single nameserver."
+    },
     "Database": {
       "properties": {
         "embedded": {
@@ -5011,10 +5041,28 @@
         "hybridScheduling": {
           "$ref": "#/$defs/HybridScheduling",
           "description": "HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster."
+        },
+        "dns": {
+          "$ref": "#/$defs/SyncPodsDNS",
+          "description": "DNS controls DNS-related behavior for synced pods."
         }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "SyncPodsDNS": {
+      "properties": {
+        "nameservers": {
+          "items": {
+            "$ref": "#/$defs/DNSNameserverEntry"
+          },
+          "type": "array",
+          "description": "Nameservers is a list of Service-based nameserver sources. Each entry\nresolves independently to a Service ClusterIP which is written to\ndnsConfig.nameservers on every synced pod, in configuration order.\n\nEntries that fail to resolve emit a Warning event but do not block\nthe remaining entries. If ALL entries fail, pod sync returns an error\nand requeues -- the pod is not created until at least one Service is found.\n\nPods with spec.hostNetwork=true and pods that already pin\nspec.dnsConfig.nameservers are skipped entirely."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SyncPodsDNS controls DNS-related behavior for synced pods."
     },
     "SyncRewriteHosts": {
       "properties": {

--- a/config/config.go
+++ b/config/config.go
@@ -1547,7 +1547,58 @@ type SyncPods struct {
 
 	// HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 	HybridScheduling HybridScheduling `json:"hybridScheduling,omitempty"`
+
+	// DNS controls DNS-related behavior for synced pods.
+	DNS SyncPodsDNS `json:"dns,omitempty"`
 }
+
+// SyncPodsDNS controls DNS-related behavior for synced pods.
+type SyncPodsDNS struct {
+	// Nameservers is a list of Service-based nameserver sources. Each entry
+	// resolves independently to a Service ClusterIP which is written to
+	// dnsConfig.nameservers on every synced pod, in configuration order.
+	//
+	// Entries that fail to resolve emit a Warning event but do not block
+	// the remaining entries. If ALL entries fail, pod sync returns an error
+	// and requeues -- the pod is not created until at least one Service is found.
+	//
+	// Pods with spec.hostNetwork=true and pods that already pin
+	// spec.dnsConfig.nameservers are skipped entirely.
+	Nameservers []DNSNameserverEntry `json:"nameservers,omitempty"`
+}
+
+// DNSNameserverEntry is one element of the nameservers list.
+type DNSNameserverEntry struct {
+	// Service selects the Service whose ClusterIP becomes one nameserver.
+	Service DNSNameserverService `json:"service,omitempty"`
+}
+
+// DNSNameserverService describes the Service lookup for a single nameserver.
+type DNSNameserverService struct {
+	// Scope chooses which cluster to look up the Service in.
+	//
+	// +kubebuilder:validation:Enum=host;tenant
+	Scope DNSNameserverScope `json:"scope,omitempty"`
+
+	// Namespace containing the Service.
+	Namespace string `json:"namespace,omitempty"`
+
+	// LabelSelector must match exactly one Service in Namespace. If zero or
+	// more than one Service matches, a Warning event is emitted for this entry
+	// and the entry is skipped (other entries are still resolved).
+	LabelSelector *StandardLabelSelector `json:"labelSelector,omitempty"`
+}
+
+// DNSNameserverScope chooses where the nameserver Service is looked up.
+type DNSNameserverScope string
+
+const (
+	// DNSNameserverScopeHost looks the Service up in the Control Plane Cluster (host).
+	DNSNameserverScopeHost DNSNameserverScope = "host"
+
+	// DNSNameserverScopeTenant looks the Service up inside the tenant cluster.
+	DNSNameserverScopeTenant DNSNameserverScope = "tenant"
+)
 
 type SyncRewriteHosts struct {
 	// Enabled specifies if rewriting stateful set pods should be enabled.

--- a/config/config.go
+++ b/config/config.go
@@ -1577,7 +1577,7 @@ type DNSNameserverEntry struct {
 type DNSNameserverService struct {
 	// Scope chooses which cluster to look up the Service in.
 	//
-	// +kubebuilder:validation:Enum=host;tenant
+	// +kubebuilder:validation:Enum=control-plane-host;tenant-cluster
 	Scope DNSNameserverScope `json:"scope,omitempty"`
 
 	// Namespace containing the Service.
@@ -1594,10 +1594,10 @@ type DNSNameserverScope string
 
 const (
 	// DNSNameserverScopeHost looks the Service up in the Control Plane Cluster (host).
-	DNSNameserverScopeHost DNSNameserverScope = "host"
+	DNSNameserverScopeHost DNSNameserverScope = "control-plane-host"
 
 	// DNSNameserverScopeTenant looks the Service up inside the tenant cluster.
-	DNSNameserverScopeTenant DNSNameserverScope = "tenant"
+	DNSNameserverScopeTenant DNSNameserverScope = "tenant-cluster"
 )
 
 type SyncRewriteHosts struct {

--- a/e2e-next/suite_pods_dns_nameservers_test.go
+++ b/e2e-next/suite_pods_dns_nameservers_test.go
@@ -53,8 +53,9 @@ const podsDNSNameserversVClusterName = "pods-dns-nameservers-vcluster"
 func init() { suitePodsDNSNameserversVCluster() }
 
 func suitePodsDNSNameserversVCluster() {
-	// Ordered: BeforeAll must complete (vCluster + host namespace created)
-	// before any spec runs; specs share the lazily-created vCluster.
+	// Ordered: BeforeAll must complete before any spec runs so the vCluster
+	// and host namespace exist. Specs themselves are independent — each
+	// recreates its own pods via BeforeEach and shares no sequential state.
 	Describe("pods-dns-nameservers-vcluster", labels.PR, labels.Sync, Ordered,
 		cluster.Use(clusters.HostCluster),
 		func() {

--- a/e2e-next/suite_pods_dns_nameservers_test.go
+++ b/e2e-next/suite_pods_dns_nameservers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/clusters"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
 	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
 	test_core "github.com/loft-sh/vcluster/e2e-next/test_core/sync"
 	. "github.com/onsi/ginkgo/v2"
@@ -52,13 +53,12 @@ const podsDNSNameserversVClusterName = "pods-dns-nameservers-vcluster"
 func init() { suitePodsDNSNameserversVCluster() }
 
 func suitePodsDNSNameserversVCluster() {
-	// Serial: every spec re-creates the same-named vCluster and host
-	// namespace in BeforeEach, so parallel processes would collide on the
-	// Helm release and the shared dns-test namespace.
-	Describe("pods-dns-nameservers-vcluster", Serial,
+	// Ordered: BeforeAll must complete (vCluster + host namespace created)
+	// before any spec runs; specs share the lazily-created vCluster.
+	Describe("pods-dns-nameservers-vcluster", labels.PR, labels.Sync, Ordered,
 		cluster.Use(clusters.HostCluster),
 		func() {
-			BeforeEach(func(ctx context.Context) context.Context {
+			BeforeAll(func(ctx context.Context) context.Context {
 				DeferCleanup(podsDNSNameserversCleanup)
 				return lazyvcluster.LazyVCluster(ctx,
 					podsDNSNameserversVClusterName,

--- a/e2e-next/suite_pods_dns_nameservers_test.go
+++ b/e2e-next/suite_pods_dns_nameservers_test.go
@@ -43,6 +43,8 @@ const podsDNSNameserversVClusterName = "pods-dns-nameservers-vcluster"
 
 func init() { suitePodsDNSNameserversVCluster() }
 
+// Ordered because all It specs depend on the vCluster started by BeforeAll;
+// BeforeAll must complete before any spec runs.
 func suitePodsDNSNameserversVCluster() {
 	Describe("pods-dns-nameservers-vcluster", labels.PR, labels.Sync, Ordered,
 		cluster.Use(clusters.HostCluster),

--- a/e2e-next/suite_pods_dns_nameservers_test.go
+++ b/e2e-next/suite_pods_dns_nameservers_test.go
@@ -1,8 +1,10 @@
 // Suite: pods-dns-nameservers-vcluster
 // vCluster: sync.toHost.pods.dns.nameservers with two host-scoped Service
-// references. PreSetup creates the shared host namespace + DNS Services
-// before the vCluster starts so the syncer can resolve them on first
-// reconcile. Lifecycle owned by this Describe's BeforeAll + DeferCleanup.
+// references. PreSetup creates the shared host namespace, two CoreDNS
+// instances (Deployment + ConfigMap), and the two label-selected
+// Services that front them so the syncer can resolve them on first
+// reconcile and pods can actually verify DNS resolution against unique
+// records served only by these instances.
 // Run:      just run-e2e 'pr && sync'
 package e2e_next
 
@@ -10,19 +12,21 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"time"
 
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/clusters"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
-	"github.com/loft-sh/vcluster/e2e-next/labels"
 	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
 	test_core "github.com/loft-sh/vcluster/e2e-next/test_core/sync"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -36,6 +40,10 @@ const podsDNSNameserversSyncerNamespace = "vcluster-" + podsDNSNameserversVClust
 // ServiceAccount, named vc-<vcluster-name>.
 const podsDNSNameserversSyncerServiceAccount = "vc-" + podsDNSNameserversVClusterName
 
+// podsDNSNameserversCoreDNSImage is the official CoreDNS image used by
+// both DNS instances. Pinned so behavior does not drift with upstream.
+const podsDNSNameserversCoreDNSImage = "coredns/coredns:1.11.3"
+
 //go:embed vcluster-pods-dns-nameservers.yaml
 var podsDNSNameserversVClusterYAML string
 
@@ -43,13 +51,14 @@ const podsDNSNameserversVClusterName = "pods-dns-nameservers-vcluster"
 
 func init() { suitePodsDNSNameserversVCluster() }
 
-// Ordered because all It specs depend on the vCluster started by BeforeAll;
-// BeforeAll must complete before any spec runs.
 func suitePodsDNSNameserversVCluster() {
-	Describe("pods-dns-nameservers-vcluster", labels.PR, labels.Sync, Ordered,
+	// Serial: every spec re-creates the same-named vCluster and host
+	// namespace in BeforeEach, so parallel processes would collide on the
+	// Helm release and the shared dns-test namespace.
+	Describe("pods-dns-nameservers-vcluster", Serial,
 		cluster.Use(clusters.HostCluster),
 		func() {
-			BeforeAll(func(ctx context.Context) context.Context {
+			BeforeEach(func(ctx context.Context) context.Context {
 				DeferCleanup(podsDNSNameserversCleanup)
 				return lazyvcluster.LazyVCluster(ctx,
 					podsDNSNameserversVClusterName,
@@ -63,10 +72,11 @@ func suitePodsDNSNameserversVCluster() {
 	)
 }
 
-// podsDNSNameserversPreSetup provisions the host namespace and the two
-// label-selected ClusterIP Services that the vCluster's
-// sync.toHost.pods.dns.nameservers entries resolve to. Runs before the
-// vCluster starts so the syncer sees both Services on first reconcile.
+// podsDNSNameserversPreSetup provisions the host namespace, two CoreDNS
+// instances (one per DNS service), and the two label-selected ClusterIP
+// Services that front them. Runs before the vCluster starts so the
+// syncer sees both Services on first reconcile and pods can verify DNS
+// resolution against the per-instance custom records.
 func podsDNSNameserversPreSetup(ctx context.Context) error {
 	hostCluster := cluster.From(ctx, constants.GetHostClusterName())
 	if hostCluster == nil {
@@ -84,11 +94,17 @@ func podsDNSNameserversPreSetup(ctx context.Context) error {
 		return fmt.Errorf("create namespace %s: %w", test_core.PodDNSNameserversNamespace, err)
 	}
 
-	for _, svc := range podsDNSNameserversServices() {
-		_, err = hostClient.CoreV1().Services(test_core.PodDNSNameserversNamespace).Create(ctx, svc, metav1.CreateOptions{})
-		if err != nil && !kerrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create service %s: %w", svc.Name, err)
+	for _, inst := range podsDNSNameserversInstances() {
+		if err := podsDNSNameserversCreateInstance(ctx, hostClient, inst); err != nil {
+			return err
 		}
+	}
+
+	// Wait for both CoreDNS Deployments to be Available before the
+	// vCluster starts: the syncer resolves the Services at sync time and
+	// pods later exec nslookup against the resolved IPs.
+	if err := podsDNSNameserversWaitForDeployments(ctx, hostClient); err != nil {
+		return err
 	}
 
 	// The host-scoped DNS resolver runs an informer cache against the
@@ -135,8 +151,10 @@ func podsDNSNameserversPreSetup(ctx context.Context) error {
 }
 
 // podsDNSNameserversCleanup removes the shared host namespace created by
-// the pre-setup. Registered in BeforeAll so it runs after all specs and
-// after the vCluster itself is torn down.
+// the pre-setup and waits for termination. The next spec's BeforeEach
+// re-creates the namespace immediately, so leaving it in Terminating state
+// would race the next pre-setup with "forbidden: namespace is being
+// terminated".
 func podsDNSNameserversCleanup(ctx context.Context) {
 	hostCluster := cluster.From(ctx, constants.GetHostClusterName())
 	if hostCluster == nil {
@@ -146,38 +164,178 @@ func podsDNSNameserversCleanup(ctx context.Context) {
 	Expect(err).To(Succeed())
 
 	err = hostClient.CoreV1().Namespaces().Delete(ctx, test_core.PodDNSNameserversNamespace, metav1.DeleteOptions{})
-	if !kerrors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		Expect(err).To(Succeed())
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, constants.PollingTimeoutLong)
+	defer cancel()
+	for {
+		_, err := hostClient.CoreV1().Namespaces().Get(pollCtx, test_core.PodDNSNameserversNamespace, metav1.GetOptions{})
+		if kerrors.IsNotFound(err) {
+			return
+		}
+		select {
+		case <-pollCtx.Done():
+			Expect(pollCtx.Err()).To(Succeed(), "namespace %s did not finish terminating", test_core.PodDNSNameserversNamespace)
+			return
+		case <-time.After(constants.PollingInterval):
+		}
 	}
 }
 
-// podsDNSNameserversServices returns the two ClusterIP Services that
-// sync.toHost.pods.dns.nameservers resolves via label selector.
-func podsDNSNameserversServices() []*corev1.Service {
-	return []*corev1.Service{
+// podsDNSNameserversInstance describes one CoreDNS instance: a
+// ConfigMap with a Corefile answering a unique A-record, a Deployment
+// running CoreDNS with that Corefile, and a Service that selects the
+// Deployment's pods. The Service carries the label the syncer
+// configuration selects on.
+type podsDNSNameserversInstance struct {
+	serviceName string
+	selectorVal string
+	corefile    string
+}
+
+func podsDNSNameserversInstances() []podsDNSNameserversInstance {
+	return []podsDNSNameserversInstance{
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   test_core.PodDNSNameserversPrimaryService,
-				Labels: map[string]string{test_core.PodDNSNameserversLabelKey: "primary"},
-			},
-			Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeClusterIP,
-				Ports: []corev1.ServicePort{
-					{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
-				},
-			},
+			serviceName: test_core.PodDNSNameserversPrimaryService,
+			selectorVal: "primary",
+			corefile: `. {
+    hosts {
+        ` + test_core.PodDNSNameserversPrimaryExpectedIP + ` ` + test_core.PodDNSNameserversPrimaryExpectedName + `
+    }
+    log
+    errors
+    forward . /etc/resolv.conf
+}
+`,
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   test_core.PodDNSNameserversSecondaryService,
-				Labels: map[string]string{test_core.PodDNSNameserversLabelKey: "secondary"},
-			},
-			Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeClusterIP,
-				Ports: []corev1.ServicePort{
-					{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
+			serviceName: test_core.PodDNSNameserversSecondaryService,
+			selectorVal: "secondary",
+			corefile: `. {
+    hosts {
+        ` + test_core.PodDNSNameserversSecondaryExpectedIP + ` ` + test_core.PodDNSNameserversSecondaryExpectedName + `
+    }
+    log
+    errors
+    forward . /etc/resolv.conf
+}
+`,
+		},
+	}
+}
+
+func podsDNSNameserversCreateInstance(ctx context.Context, hostClient kubernetes.Interface, inst podsDNSNameserversInstance) error {
+	ns := test_core.PodDNSNameserversNamespace
+	podLabels := map[string]string{"app": inst.serviceName}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      inst.serviceName,
+			Namespace: ns,
+		},
+		Data: map[string]string{"Corefile": inst.corefile},
+	}
+	if _, err := hostClient.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create ConfigMap %s: %w", cm.Name, err)
+	}
+
+	replicas := int32(1)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      inst.serviceName,
+			Namespace: ns,
+			Labels:    podLabels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "coredns",
+						Image: podsDNSNameserversCoreDNSImage,
+						Args:  []string{"-conf", "/etc/coredns/Corefile"},
+						Ports: []corev1.ContainerPort{
+							{Name: "dns", ContainerPort: 53, Protocol: corev1.ProtocolUDP},
+							{Name: "dns-tcp", ContainerPort: 53, Protocol: corev1.ProtocolTCP},
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "config",
+							MountPath: "/etc/coredns",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "config",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: inst.serviceName},
+							},
+						},
+					}},
 				},
 			},
 		},
 	}
+	if _, err := hostClient.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create Deployment %s: %w", dep.Name, err)
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      inst.serviceName,
+			Namespace: ns,
+			Labels:    map[string]string{test_core.PodDNSNameserversLabelKey: inst.selectorVal},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: podLabels,
+			Ports: []corev1.ServicePort{
+				{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt(53)},
+				{Name: "dns-tcp", Port: 53, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(53)},
+			},
+		},
+	}
+	if _, err := hostClient.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create service %s: %w", svc.Name, err)
+	}
+
+	return nil
+}
+
+// podsDNSNameserversWaitForDeployments polls until both CoreDNS
+// Deployments report Available. Returning before that risks the
+// resolver picking up Services with no backing pods, so the e2e
+// nslookup verification would race the rollout.
+func podsDNSNameserversWaitForDeployments(ctx context.Context, hostClient kubernetes.Interface) error {
+	deadline := constants.PollingTimeoutLong
+	pollCtx, cancel := context.WithTimeout(ctx, deadline)
+	defer cancel()
+
+	for _, inst := range podsDNSNameserversInstances() {
+		name := inst.serviceName
+		for {
+			dep, err := hostClient.AppsV1().Deployments(test_core.PodDNSNameserversNamespace).Get(pollCtx, name, metav1.GetOptions{})
+			if err == nil {
+				available := false
+				for _, c := range dep.Status.Conditions {
+					if c.Type == appsv1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+						available = true
+						break
+					}
+				}
+				if available && dep.Status.ReadyReplicas >= 1 {
+					break
+				}
+			}
+			select {
+			case <-pollCtx.Done():
+				return fmt.Errorf("timed out waiting for Deployment %s to become Available: %w", name, pollCtx.Err())
+			case <-time.After(constants.PollingInterval):
+			}
+		}
+	}
+	return nil
 }

--- a/e2e-next/suite_pods_dns_nameservers_test.go
+++ b/e2e-next/suite_pods_dns_nameservers_test.go
@@ -156,6 +156,7 @@ func podsDNSNameserversPreSetup(ctx context.Context) error {
 // would race the next pre-setup with "forbidden: namespace is being
 // terminated".
 func podsDNSNameserversCleanup(ctx context.Context) {
+	GinkgoHelper()
 	hostCluster := cluster.From(ctx, constants.GetHostClusterName())
 	if hostCluster == nil {
 		return

--- a/e2e-next/suite_pods_dns_nameservers_test.go
+++ b/e2e-next/suite_pods_dns_nameservers_test.go
@@ -1,0 +1,181 @@
+// Suite: pods-dns-nameservers-vcluster
+// vCluster: sync.toHost.pods.dns.nameservers with two host-scoped Service
+// references. PreSetup creates the shared host namespace + DNS Services
+// before the vCluster starts so the syncer can resolve them on first
+// reconcile. Lifecycle owned by this Describe's BeforeAll + DeferCleanup.
+// Run:      just run-e2e 'pr && sync'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	test_core "github.com/loft-sh/vcluster/e2e-next/test_core/sync"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// podsDNSNameserversSyncerNamespace is the host namespace the vCluster
+// CLI installs the StatefulSet into (vcluster-<name>). The syncer
+// ServiceAccount living there is what needs Service read access in the
+// target namespace.
+const podsDNSNameserversSyncerNamespace = "vcluster-" + podsDNSNameserversVClusterName
+
+// podsDNSNameserversSyncerServiceAccount is the syncer Pod's
+// ServiceAccount, named vc-<vcluster-name>.
+const podsDNSNameserversSyncerServiceAccount = "vc-" + podsDNSNameserversVClusterName
+
+//go:embed vcluster-pods-dns-nameservers.yaml
+var podsDNSNameserversVClusterYAML string
+
+const podsDNSNameserversVClusterName = "pods-dns-nameservers-vcluster"
+
+func init() { suitePodsDNSNameserversVCluster() }
+
+func suitePodsDNSNameserversVCluster() {
+	Describe("pods-dns-nameservers-vcluster", labels.PR, labels.Sync, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				DeferCleanup(podsDNSNameserversCleanup)
+				return lazyvcluster.LazyVCluster(ctx,
+					podsDNSNameserversVClusterName,
+					podsDNSNameserversVClusterYAML,
+					lazyvcluster.WithPreSetup(podsDNSNameserversPreSetup),
+				)
+			})
+
+			test_core.PodDNSNameserversSpec()
+		},
+	)
+}
+
+// podsDNSNameserversPreSetup provisions the host namespace and the two
+// label-selected ClusterIP Services that the vCluster's
+// sync.toHost.pods.dns.nameservers entries resolve to. Runs before the
+// vCluster starts so the syncer sees both Services on first reconcile.
+func podsDNSNameserversPreSetup(ctx context.Context) error {
+	hostCluster := cluster.From(ctx, constants.GetHostClusterName())
+	if hostCluster == nil {
+		return fmt.Errorf("host cluster %s not found in context", constants.GetHostClusterName())
+	}
+	hostClient, err := kubernetes.NewForConfig(hostCluster.KubernetesRestConfig())
+	if err != nil {
+		return fmt.Errorf("create host client: %w", err)
+	}
+
+	_, err = hostClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: test_core.PodDNSNameserversNamespace},
+	}, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create namespace %s: %w", test_core.PodDNSNameserversNamespace, err)
+	}
+
+	for _, svc := range podsDNSNameserversServices() {
+		_, err = hostClient.CoreV1().Services(test_core.PodDNSNameserversNamespace).Create(ctx, svc, metav1.CreateOptions{})
+		if err != nil && !kerrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create service %s: %w", svc.Name, err)
+		}
+	}
+
+	// The host-scoped DNS resolver runs an informer cache against the
+	// target namespace from inside the syncer Pod, so its ServiceAccount
+	// needs Service read access there. The Role + RoleBinding may
+	// reference an SA that does not yet exist; once the StatefulSet
+	// creates it, the binding starts authorizing immediately.
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vcluster-dns-test-svc-reader",
+			Namespace: test_core.PodDNSNameserversNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"get", "list", "watch"},
+		}},
+	}
+	if _, err := hostClient.RbacV1().Roles(test_core.PodDNSNameserversNamespace).Create(ctx, role, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create Role %s: %w", role.Name, err)
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vcluster-dns-test-svc-reader",
+			Namespace: test_core.PodDNSNameserversNamespace,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      podsDNSNameserversSyncerServiceAccount,
+			Namespace: podsDNSNameserversSyncerNamespace,
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     role.Name,
+		},
+	}
+	if _, err := hostClient.RbacV1().RoleBindings(test_core.PodDNSNameserversNamespace).Create(ctx, binding, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create RoleBinding %s: %w", binding.Name, err)
+	}
+
+	return nil
+}
+
+// podsDNSNameserversCleanup removes the shared host namespace created by
+// the pre-setup. Registered in BeforeAll so it runs after all specs and
+// after the vCluster itself is torn down.
+func podsDNSNameserversCleanup(ctx context.Context) {
+	hostCluster := cluster.From(ctx, constants.GetHostClusterName())
+	if hostCluster == nil {
+		return
+	}
+	hostClient, err := kubernetes.NewForConfig(hostCluster.KubernetesRestConfig())
+	Expect(err).To(Succeed())
+
+	err = hostClient.CoreV1().Namespaces().Delete(ctx, test_core.PodDNSNameserversNamespace, metav1.DeleteOptions{})
+	if !kerrors.IsNotFound(err) {
+		Expect(err).To(Succeed())
+	}
+}
+
+// podsDNSNameserversServices returns the two ClusterIP Services that
+// sync.toHost.pods.dns.nameservers resolves via label selector.
+func podsDNSNameserversServices() []*corev1.Service {
+	return []*corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   test_core.PodDNSNameserversPrimaryService,
+				Labels: map[string]string{test_core.PodDNSNameserversLabelKey: "primary"},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   test_core.PodDNSNameserversSecondaryService,
+				Labels: map[string]string{test_core.PodDNSNameserversLabelKey: "secondary"},
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
+				},
+			},
+		},
+	}
+}

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -7,10 +7,11 @@ import (
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
 	"github.com/loft-sh/vcluster/e2e-next/labels"
-	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/podhelper"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,9 +32,30 @@ const (
 	// DNS Service resolved by the second nameservers entry.
 	PodDNSNameserversSecondaryService = "secondary-dns"
 
+	// PodDNSNameserversAltPrimaryService is an alternate Service that can
+	// take over the "primary" selector value at runtime to exercise the
+	// reschedule-on-selector-rebind path.
+	PodDNSNameserversAltPrimaryService = "primary-dns-alt"
+
 	// PodDNSNameserversLabelKey is the label key the nameservers entries
 	// select on. Values: "primary" or "secondary".
-	PodDNSNameserversLabelKey = "vcluster.loft.sh/dns-ns"
+	PodDNSNameserversLabelKey = "vcluster.com/dns-ns"
+
+	// PodDNSNameserversPrimaryExpectedName is the unique A-record the
+	// primary CoreDNS instance answers.
+	PodDNSNameserversPrimaryExpectedName = "primary.dns-test.vcluster.com"
+
+	// PodDNSNameserversPrimaryExpectedIP is the IP returned by the primary
+	// CoreDNS instance for PodDNSNameserversPrimaryExpectedName.
+	PodDNSNameserversPrimaryExpectedIP = "1.2.3.4"
+
+	// PodDNSNameserversSecondaryExpectedName is the unique A-record the
+	// secondary CoreDNS instance answers.
+	PodDNSNameserversSecondaryExpectedName = "secondary.dns-test.vcluster.com"
+
+	// PodDNSNameserversSecondaryExpectedIP is the IP returned by the
+	// secondary CoreDNS instance for PodDNSNameserversSecondaryExpectedName.
+	PodDNSNameserversSecondaryExpectedIP = "5.6.7.8"
 )
 
 // PodDNSNameserversSpec exercises sync.toHost.pods.dns.nameservers: pods
@@ -74,29 +96,35 @@ func PodDNSNameserversSpec() {
 				Expect(secondaryIP).NotTo(BeEmpty(), "secondary DNS Service has no ClusterIP")
 			})
 
-			// createVPod creates a pod in the vCluster default namespace and
-			// registers cleanup. Returns the pod's name.
-			createVPod := func(ctx context.Context, name string, mutate func(*corev1.Pod)) {
+			// createVPod creates a pod in the vCluster default namespace
+			// with a generated name, registers cleanup, and returns the
+			// created pod (whose Name is populated by the API server).
+			createVPod := func(ctx context.Context, mutate func(*corev1.Pod)) *corev1.Pod {
 				GinkgoHelper()
 				pod := &corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "dns-pod-", Namespace: "default"},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "main", Image: "nginxinc/nginx-unprivileged:stable-alpine3.20-slim"},
+							{
+								Name:    "main",
+								Image:   "busybox:1.28",
+								Command: []string{"sh", "-c", "sleep 3600"},
+							},
 						},
 					},
 				}
 				if mutate != nil {
 					mutate(pod)
 				}
-				_, err := vClusterClient.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
+				created, err := vClusterClient.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
 				DeferCleanup(func(ctx context.Context) {
-					err := vClusterClient.CoreV1().Pods("default").Delete(ctx, name, metav1.DeleteOptions{})
+					err := vClusterClient.CoreV1().Pods("default").Delete(ctx, created.Name, metav1.DeleteOptions{})
 					if !kerrors.IsNotFound(err) {
 						Expect(err).To(Succeed())
 					}
 				})
+				return created
 			}
 
 			// getHostPod fetches the host-side pod corresponding to a virtual
@@ -130,17 +158,17 @@ func PodDNSNameserversSpec() {
 				Expect(err).To(Succeed())
 			}
 
-			It("writes all resolved ClusterIPs to synced pods", func(ctx context.Context) {
-				podName := "dns-pod-default-" + random.String(6)
+			It("writes all resolved ClusterIPs to synced pods", labels.PR, func(ctx context.Context) {
+				var pod *corev1.Pod
 
 				By("Creating a simple pod in the vCluster", func() {
-					createVPod(ctx, podName, nil)
+					pod = createVPod(ctx, nil)
 				})
 
 				By("Waiting for the host pod to receive both resolved nameservers", func() {
 					Eventually(func(g Gomega) {
-						hostPod, err := getHostPod(ctx, podName)
-						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
 						g.Expect(hostPod.Spec.DNSPolicy).To(Equal(corev1.DNSNone),
 							"host pod dnsPolicy is %s, expected None", hostPod.Spec.DNSPolicy)
 						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
@@ -149,21 +177,54 @@ func PodDNSNameserversSpec() {
 							hostPod.Spec.DNSConfig.Nameservers, primaryIP, secondaryIP)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
+
+				By("Waiting for the virtual pod to be Running", func() {
+					Eventually(func(g Gomega) {
+						p, err := vClusterClient.CoreV1().Pods("default").Get(ctx, pod.Name, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(p.Status.Phase).To(Equal(corev1.PodRunning),
+							"pod not yet running, phase=%s reason=%s message=%s",
+							p.Status.Phase, p.Status.Reason, p.Status.Message)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Verifying DNS resolution via the injected nameservers", func() {
+					vClusterRestConfig := cluster.CurrentClusterFrom(ctx).KubernetesRestConfig()
+					Expect(vClusterRestConfig).NotTo(BeNil())
+
+					Eventually(func(g Gomega) {
+						stdout, stderr, err := podhelper.ExecBuffered(
+							ctx, vClusterRestConfig, "default", pod.Name, "main",
+							[]string{"nslookup", PodDNSNameserversPrimaryExpectedName}, nil,
+						)
+						g.Expect(err).NotTo(HaveOccurred(),
+							"nslookup primary failed: stdout=%s stderr=%s", string(stdout), string(stderr))
+						g.Expect(string(stdout)).To(ContainSubstring(PodDNSNameserversPrimaryExpectedIP),
+							"primary nslookup output missing expected IP: %s", string(stdout))
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+
+					Eventually(func(g Gomega) {
+						stdout, stderr, err := podhelper.ExecBuffered(
+							ctx, vClusterRestConfig, "default", pod.Name, "main",
+							[]string{"nslookup", PodDNSNameserversSecondaryExpectedName}, nil,
+						)
+						g.Expect(err).NotTo(HaveOccurred(),
+							"nslookup secondary failed: stdout=%s stderr=%s", string(stdout), string(stderr))
+						g.Expect(string(stdout)).To(ContainSubstring(PodDNSNameserversSecondaryExpectedIP),
+							"secondary nslookup output missing expected IP: %s", string(stdout))
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
 			})
 
 			It("skips hostNetwork pods", func(ctx context.Context) {
-				podName := "dns-pod-hostnet-" + random.String(6)
-
-				By("Creating a hostNetwork pod in the vCluster", func() {
-					createVPod(ctx, podName, func(p *corev1.Pod) {
-						p.Spec.HostNetwork = true
-					})
+				pod := createVPod(ctx, func(p *corev1.Pod) {
+					p.Spec.HostNetwork = true
 				})
 
 				By("Waiting for the host pod to appear without injected nameservers", func() {
 					Eventually(func(g Gomega) {
-						hostPod, err := getHostPod(ctx, podName)
-						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
 						if hostPod.Spec.DNSConfig != nil {
 							g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(BeEmpty(),
 								"hostNetwork pod should not have injected nameservers, got %v",
@@ -171,35 +232,52 @@ func PodDNSNameserversSpec() {
 						}
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
+
+				By("Asserting the host pod's nameservers stay empty over the polling window", func() {
+					Consistently(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s vanished", pod.Name)
+						if hostPod.Spec.DNSConfig != nil {
+							g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(BeEmpty(),
+								"hostNetwork pod gained injected nameservers, got %v",
+								hostPod.Spec.DNSConfig.Nameservers)
+						}
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
 			})
 
 			It("respects user-defined dnsConfig.nameservers", func(ctx context.Context) {
-				podName := "dns-pod-userdns-" + random.String(6)
 				userIP := "8.8.8.8"
 
-				By("Creating a pod with user-supplied dnsConfig in the vCluster", func() {
-					createVPod(ctx, podName, func(p *corev1.Pod) {
-						p.Spec.DNSPolicy = corev1.DNSNone
-						p.Spec.DNSConfig = &corev1.PodDNSConfig{
-							Nameservers: []string{userIP},
-						}
-					})
+				pod := createVPod(ctx, func(p *corev1.Pod) {
+					p.Spec.DNSPolicy = corev1.DNSNone
+					p.Spec.DNSConfig = &corev1.PodDNSConfig{
+						Nameservers: []string{userIP},
+					}
 				})
 
 				By("Waiting for the host pod and verifying the user nameservers are preserved", func() {
 					Eventually(func(g Gomega) {
-						hostPod, err := getHostPod(ctx, podName)
-						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
 						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
 						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{userIP}),
 							"user-supplied nameservers were modified, got %v", hostPod.Spec.DNSConfig.Nameservers)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
+
+				By("Asserting user-supplied nameservers remain stable over the polling window", func() {
+					Consistently(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s vanished", pod.Name)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{userIP}),
+							"user-supplied nameservers were overwritten, got %v", hostPod.Spec.DNSConfig.Nameservers)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
 			})
 
 			It("resolves partial list when one Service is missing", func(ctx context.Context) {
-				podName := "dns-pod-partial-" + random.String(6)
-
 				By("Removing the dns-ns label from the secondary Service", func() {
 					setServiceLabel(ctx, PodDNSNameserversSecondaryService, "")
 					DeferCleanup(func(ctx context.Context) {
@@ -207,14 +285,12 @@ func PodDNSNameserversSpec() {
 					})
 				})
 
-				By("Creating a pod in the vCluster", func() {
-					createVPod(ctx, podName, nil)
-				})
+				pod := createVPod(ctx, nil)
 
 				By("Waiting for the host pod to receive only the primary nameserver", func() {
 					Eventually(func(g Gomega) {
-						hostPod, err := getHostPod(ctx, podName)
-						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
 						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
 						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP}),
 							"expected only primary nameserver, got %v", hostPod.Spec.DNSConfig.Nameservers)
@@ -224,9 +300,9 @@ func PodDNSNameserversSpec() {
 				By("Waiting for a warning event on the virtual pod about the unresolved nameserver", func() {
 					Eventually(func(g Gomega) {
 						events, err := vClusterClient.CoreV1().Events("default").List(ctx, metav1.ListOptions{
-							FieldSelector: "involvedObject.name=" + podName,
+							FieldSelector: "involvedObject.name=" + pod.Name,
 						})
-						g.Expect(err).To(Succeed(), "failed to list events for pod %s", podName)
+						g.Expect(err).To(Succeed(), "failed to list events for pod %s", pod.Name)
 						var found bool
 						for _, ev := range events.Items {
 							if ev.Type == corev1.EventTypeWarning &&
@@ -237,14 +313,12 @@ func PodDNSNameserversSpec() {
 						}
 						g.Expect(found).To(BeTrue(),
 							"no DNS nameserver warning event found for pod %s, events: %d",
-							podName, len(events.Items))
+							pod.Name, len(events.Items))
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 			})
 
 			It("blocks pod creation when all Services are missing", func(ctx context.Context) {
-				podName := "dns-pod-blocked-" + random.String(6)
-
 				By("Removing the dns-ns label from both Services", func() {
 					setServiceLabel(ctx, PodDNSNameserversPrimaryService, "")
 					DeferCleanup(func(ctx context.Context) {
@@ -256,25 +330,221 @@ func PodDNSNameserversSpec() {
 					})
 				})
 
-				By("Creating a pod in the vCluster", func() {
-					createVPod(ctx, podName, nil)
-				})
+				pod := createVPod(ctx, nil)
 
 				By("Verifying the host pod is not created", func() {
 					Consistently(func(g Gomega) {
-						_, err := getHostPod(ctx, podName)
+						_, err := getHostPod(ctx, pod.Name)
 						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
-							"host pod for %s should not exist, got err=%v", podName, err)
+							"host pod for %s should not exist, got err=%v", pod.Name, err)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 				})
 			})
 
-			// The embedded CoreDNS variant exercises the same nameservers
-			// override but with controlPlane.coredns.embedded=true; it
-			// requires its own vcluster-pods-dns-nameservers-embedded.yaml
-			// and a dedicated suite_pods_dns_nameservers_embedded_test.go
-			// so the lifecycle stays parallelisable. Tracked separately.
-			PIt("works with embedded CoreDNS variant", Label("todo"), func(ctx context.Context) {})
+			It("re-resolves nameservers when a selected Service's ClusterIP changes", func(ctx context.Context) {
+				// Use a Deployment so a ReplicaSet replaces the pod after the
+				// syncer deletes it. Standalone pods would not be recreated
+				// because the syncer treats a missing host pod with a
+				// non-empty StartTime as terminal and deletes the virtual pod.
+				deployName := "dns-dep-rebind-ip"
+				selector := map[string]string{"app": deployName}
+				replicas := int32(1)
+
+				By("Creating a single-replica Deployment in the vCluster", func() {
+					_, err := vClusterClient.AppsV1().Deployments("default").Create(ctx, &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{Name: deployName, Namespace: "default"},
+						Spec: appsv1.DeploymentSpec{
+							Replicas: &replicas,
+							Selector: &metav1.LabelSelector{MatchLabels: selector},
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{Labels: selector},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:    "main",
+										Image:   "busybox:1.28",
+										Command: []string{"sh", "-c", "sleep 3600"},
+									}},
+								},
+							},
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.AppsV1().Deployments("default").Delete(ctx, deployName, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				findDeploymentPod := func(ctx context.Context) (*corev1.Pod, error) {
+					pods, err := vClusterClient.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+						LabelSelector: "app=" + deployName,
+					})
+					if err != nil {
+						return nil, err
+					}
+					for i := range pods.Items {
+						if pods.Items[i].DeletionTimestamp == nil {
+							return &pods.Items[i], nil
+						}
+					}
+					return nil, kerrors.NewNotFound(corev1.Resource("pods"), deployName)
+				}
+
+				var oldPodName, oldHostPodUID string
+				By("Waiting for the Deployment's pod to receive the original primary ClusterIP", func() {
+					Eventually(func(g Gomega) {
+						vPod, err := findDeploymentPod(ctx)
+						g.Expect(err).To(Succeed())
+						hostPod, err := getHostPod(ctx, vPod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", vPod.Name)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(ContainElement(primaryIP),
+							"host pod nameservers %v missing original primary IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, primaryIP)
+						oldPodName = vPod.Name
+						oldHostPodUID = string(hostPod.UID)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				var newPrimaryIP string
+				By("Deleting and recreating primary-dns to force a new ClusterIP", func() {
+					origSvc, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, PodDNSNameserversPrimaryService, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+
+					err = hostClient.CoreV1().Services(PodDNSNameserversNamespace).Delete(ctx, PodDNSNameserversPrimaryService, metav1.DeleteOptions{})
+					Expect(err).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						_, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, PodDNSNameserversPrimaryService, metav1.GetOptions{})
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"primary-dns not yet deleted, err=%v", err)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+					recreated := &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      PodDNSNameserversPrimaryService,
+							Namespace: PodDNSNameserversNamespace,
+							Labels:    origSvc.Labels,
+						},
+						Spec: corev1.ServiceSpec{
+							Type:     corev1.ServiceTypeClusterIP,
+							Selector: origSvc.Spec.Selector,
+							Ports:    stripPortNodePort(origSvc.Spec.Ports),
+						},
+					}
+
+					var created *corev1.Service
+					Eventually(func(g Gomega) {
+						var err error
+						created, err = hostClient.CoreV1().Services(PodDNSNameserversNamespace).Create(ctx, recreated, metav1.CreateOptions{})
+						g.Expect(err).To(Succeed(), "recreate primary-dns failed: %v", err)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+					Expect(created.Spec.ClusterIP).NotTo(BeEmpty(), "recreated primary-dns has no ClusterIP")
+					Expect(created.Spec.ClusterIP).NotTo(Equal(primaryIP),
+						"recreated primary-dns reused old ClusterIP %s", primaryIP)
+					newPrimaryIP = created.Spec.ClusterIP
+				})
+
+				By("Waiting for the Deployment's pod to be replaced with the new primary IP", func() {
+					Eventually(func(g Gomega) {
+						vPod, err := findDeploymentPod(ctx)
+						g.Expect(err).To(Succeed())
+						g.Expect(vPod.Name).NotTo(Equal(oldPodName),
+							"Deployment pod %s was not replaced", oldPodName)
+						hostPod, err := getHostPod(ctx, vPod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", vPod.Name)
+						g.Expect(string(hostPod.UID)).NotTo(Equal(oldHostPodUID),
+							"host pod was not recreated, UID %s unchanged", oldHostPodUID)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(ContainElement(newPrimaryIP),
+							"host pod nameservers %v missing new primary IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, newPrimaryIP)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Asserting the new primary IP remains stable over the polling window", func() {
+					Consistently(func(g Gomega) {
+						vPod, err := findDeploymentPod(ctx)
+						g.Expect(err).To(Succeed())
+						hostPod, err := getHostPod(ctx, vPod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s vanished", vPod.Name)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(ContainElement(newPrimaryIP),
+							"host pod nameservers %v lost new primary IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, newPrimaryIP)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
+			})
+
+			It("re-resolves nameservers when the label selector matches a different Service", func(ctx context.Context) {
+				By("Creating an alternate primary Service without the selector label", func() {
+					altSvc := &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      PodDNSNameserversAltPrimaryService,
+							Namespace: PodDNSNameserversNamespace,
+						},
+						Spec: corev1.ServiceSpec{
+							Type: corev1.ServiceTypeClusterIP,
+							Ports: []corev1.ServicePort{
+								{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
+								{Name: "dns-tcp", Port: 53, Protocol: corev1.ProtocolTCP},
+							},
+						},
+					}
+					_, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Create(ctx, altSvc, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Delete(ctx, PodDNSNameserversAltPrimaryService, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				By("Moving the primary selector value from primary-dns to primary-dns-alt", func() {
+					setServiceLabel(ctx, PodDNSNameserversPrimaryService, "")
+					DeferCleanup(func(ctx context.Context) {
+						setServiceLabel(ctx, PodDNSNameserversPrimaryService, "primary")
+					})
+					setServiceLabel(ctx, PodDNSNameserversAltPrimaryService, "primary")
+				})
+
+				altSvc, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, PodDNSNameserversAltPrimaryService, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				altIP := altSvc.Spec.ClusterIP
+				Expect(altIP).NotTo(BeEmpty(), "primary-dns-alt has no ClusterIP")
+				Expect(altIP).NotTo(Equal(primaryIP), "primary-dns-alt reused primary-dns ClusterIP")
+
+				pod := createVPod(ctx, nil)
+
+				By("Waiting for the host pod to be created with the alternate primary IP", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(ContainElement(altIP),
+							"host pod nameservers %v missing alt primary IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, altIP)
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).NotTo(ContainElement(primaryIP),
+							"host pod nameservers %v still contains original primary IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, primaryIP)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Asserting the alt primary IP remains stable over the polling window", func() {
+					Consistently(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s vanished", pod.Name)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(ContainElement(altIP),
+							"host pod nameservers %v lost alt primary IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, altIP)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
+			})
 		},
 	)
 }
@@ -290,4 +560,20 @@ func containsAny(s string, subs ...string) bool {
 		}
 	}
 	return false
+}
+
+// stripPortNodePort clears NodePort and TargetPort.IntVal on each port so
+// a recreated Service does not collide on NodePort allocation while
+// preserving Port and Protocol.
+func stripPortNodePort(ports []corev1.ServicePort) []corev1.ServicePort {
+	out := make([]corev1.ServicePort, len(ports))
+	for i, p := range ports {
+		out[i] = corev1.ServicePort{
+			Name:       p.Name,
+			Port:       p.Port,
+			Protocol:   p.Protocol,
+			TargetPort: p.TargetPort,
+		}
+	}
+	return out
 }

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loft-sh/vcluster/e2e-next/constants"
 	"github.com/loft-sh/vcluster/e2e-next/labels"
 	"github.com/loft-sh/vcluster/pkg/util/podhelper"
+	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,6 +56,30 @@ const (
 	// PodDNSNameserversSecondaryExpectedIP is the IP returned by the
 	// secondary CoreDNS instance for PodDNSNameserversSecondaryExpectedName.
 	PodDNSNameserversSecondaryExpectedIP = "5.6.7.8"
+
+	// PodDNSNameserversTenantDNSNamespace is the namespace of the
+	// tenant-cluster kube-dns Service that the third nameservers entry
+	// targets.
+	PodDNSNameserversTenantDNSNamespace = "kube-system"
+
+	// PodDNSNameserversTenantDNSService is the name of the tenant-cluster
+	// kube-dns Service that the third nameservers entry targets.
+	PodDNSNameserversTenantDNSService = "kube-dns"
+
+	// PodDNSNameserversTenantDNSLabelKey is the label key the
+	// tenant-cluster entry selects on. The vCluster syncer labels the
+	// in-tenant kube-dns Service with this key.
+	PodDNSNameserversTenantDNSLabelKey = "k8s-app"
+
+	// PodDNSNameserversTenantDNSLabelValue is the label value the
+	// tenant-cluster entry selects on. Matches the value vCluster uses to
+	// label its in-tenant kube-dns Service.
+	PodDNSNameserversTenantDNSLabelValue = "vcluster-kube-dns"
+
+	// PodDNSNameserversAltTenantDNSService is an alternate tenant-side
+	// Service that takes the tenant-cluster selector value at runtime to
+	// exercise re-resolution on tenant Service events.
+	PodDNSNameserversAltTenantDNSService = "kube-dns-alt"
 )
 
 // PodDNSNameserversSpec exercises sync.toHost.pods.dns.nameservers: pods
@@ -74,6 +99,7 @@ func PodDNSNameserversSpec() {
 				hostNS         string
 				primaryIP      string
 				secondaryIP    string
+				tenantDNSIP    string
 			)
 
 			BeforeEach(func(ctx context.Context) {
@@ -93,6 +119,13 @@ func PodDNSNameserversSpec() {
 				Expect(err).To(Succeed())
 				secondaryIP = secondarySvc.Spec.ClusterIP
 				Expect(secondaryIP).NotTo(BeEmpty(), "secondary DNS Service has no ClusterIP")
+
+				// Resolve the tenant-scope kube-dns Service so specs can
+				// assert the IP that the tenant-cluster entry injects.
+				tenantDNSSvc, err := vClusterClient.CoreV1().Services(PodDNSNameserversTenantDNSNamespace).Get(ctx, PodDNSNameserversTenantDNSService, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				tenantDNSIP = tenantDNSSvc.Spec.ClusterIP
+				Expect(tenantDNSIP).NotTo(BeEmpty(), "tenant kube-dns Service has no ClusterIP")
 			})
 
 			// createVPod creates a pod in the vCluster default namespace
@@ -164,16 +197,16 @@ func PodDNSNameserversSpec() {
 					pod = createVPod(ctx, nil)
 				})
 
-				By("Waiting for the host pod to receive both resolved nameservers", func() {
+				By("Waiting for the host pod to receive all three resolved nameservers", func() {
 					Eventually(func(g Gomega) {
 						hostPod, err := getHostPod(ctx, pod.Name)
 						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
 						g.Expect(hostPod.Spec.DNSPolicy).To(Equal(corev1.DNSNone),
 							"host pod dnsPolicy is %s, expected None", hostPod.Spec.DNSPolicy)
 						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
-						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP, secondaryIP}),
-							"host pod nameservers %v != expected [%s %s]",
-							hostPod.Spec.DNSConfig.Nameservers, primaryIP, secondaryIP)
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP, secondaryIP, tenantDNSIP}),
+							"host pod nameservers %v != expected [%s %s %s]",
+							hostPod.Spec.DNSConfig.Nameservers, primaryIP, secondaryIP, tenantDNSIP)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 
@@ -295,8 +328,8 @@ func PodDNSNameserversSpec() {
 				})
 			})
 
-			It("blocks pod creation when all Services are missing", func(ctx context.Context) {
-				By("Removing the dns-ns label from both Services", func() {
+			It("blocks pod creation when all host-scoped Services are missing", func(ctx context.Context) {
+				By("Removing the dns-ns label from both host Services", func() {
 					setServiceLabel(ctx, PodDNSNameserversPrimaryService, "")
 					DeferCleanup(func(ctx context.Context) {
 						setServiceLabel(ctx, PodDNSNameserversPrimaryService, "primary")
@@ -323,7 +356,7 @@ func PodDNSNameserversSpec() {
 				// syncer deletes it. Standalone pods would not be recreated
 				// because the syncer treats a missing host pod with a
 				// non-empty StartTime as terminal and deletes the virtual pod.
-				deployName := "dns-dep-rebind-ip"
+				deployName := "dns-dep-rebind-ip-" + random.String(6)
 				selector := map[string]string{"app": deployName}
 				replicas := int32(1)
 
@@ -453,6 +486,77 @@ func PodDNSNameserversSpec() {
 							"host pod nameservers %v lost new primary IP %s",
 							hostPod.Spec.DNSConfig.Nameservers, newPrimaryIP)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+				})
+			})
+
+			It("re-reconciles on tenant-scope Service events", func(ctx context.Context) {
+				// The tenant watch's job is to enqueue virtual pods when a
+				// Service event fires inside a configured tenant namespace.
+				// Adding an alternate Service with the same selector forces
+				// the resolver to return a different IP set, and the syncer
+				// reacts by deleting the host pod whose injected
+				// nameservers no longer match. The host pod deletion is the
+				// signal that the watch fired -- without it the syncer
+				// never sees the new Service and the host pod stays put.
+				//
+				// The pod cannot be recreated with the new IP set because
+				// Kubernetes caps dnsConfig.nameservers at 3 entries; the
+				// recreation failure is unrelated to the watch and is the
+				// reason this spec asserts on the deletion rather than the
+				// recreation.
+				pod := createVPod(ctx, nil)
+
+				var oldHostPodUID string
+				By("Waiting for the host pod to receive the original tenant kube-dns IP", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, pod.Name)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(ContainElement(tenantDNSIP),
+							"host pod nameservers %v missing tenant kube-dns IP %s",
+							hostPod.Spec.DNSConfig.Nameservers, tenantDNSIP)
+						oldHostPodUID = string(hostPod.UID)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Creating an alternate tenant Service with the same k8s-app=vcluster-kube-dns label", func() {
+					altSvc := &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      PodDNSNameserversAltTenantDNSService,
+							Namespace: PodDNSNameserversTenantDNSNamespace,
+							Labels: map[string]string{
+								PodDNSNameserversTenantDNSLabelKey: PodDNSNameserversTenantDNSLabelValue,
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							Type: corev1.ServiceTypeClusterIP,
+							Ports: []corev1.ServicePort{
+								{Name: "dns", Port: 53, Protocol: corev1.ProtocolUDP},
+								{Name: "dns-tcp", Port: 53, Protocol: corev1.ProtocolTCP},
+							},
+						},
+					}
+					_, err := vClusterClient.CoreV1().Services(PodDNSNameserversTenantDNSNamespace).Create(ctx, altSvc, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						err := vClusterClient.CoreV1().Services(PodDNSNameserversTenantDNSNamespace).Delete(ctx, PodDNSNameserversAltTenantDNSService, metav1.DeleteOptions{})
+						if !kerrors.IsNotFound(err) {
+							Expect(err).To(Succeed())
+						}
+					})
+				})
+
+				By("Verifying the host pod was deleted because the tenant watch fired", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, pod.Name)
+						if kerrors.IsNotFound(err) {
+							return
+						}
+						g.Expect(err).To(Succeed())
+						g.Expect(string(hostPod.UID)).NotTo(Equal(oldHostPodUID),
+							"host pod UID %s unchanged -- tenant Service event did not enqueue the pod for reconcile",
+							oldHostPodUID)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 			})
 

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -158,7 +158,7 @@ func PodDNSNameserversSpec() {
 				Expect(err).To(Succeed())
 			}
 
-			It("writes all resolved ClusterIPs to synced pods", labels.PR, func(ctx context.Context) {
+			It("writes all resolved ClusterIPs to synced pods", func(ctx context.Context) {
 				var pod *corev1.Pod
 
 				By("Creating a simple pod in the vCluster", func() {

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -89,7 +89,6 @@ const (
 func PodDNSNameserversSpec() {
 	Describe("Pod DNS nameservers override",
 		labels.Core,
-		labels.Sync,
 		labels.Pods,
 		func() {
 			var (

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -2,7 +2,6 @@ package test_core
 
 import (
 	"context"
-	"strings"
 
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
@@ -277,7 +276,7 @@ func PodDNSNameserversSpec() {
 				})
 			})
 
-			It("resolves partial list when one Service is missing", func(ctx context.Context) {
+			It("blocks pod creation when one Service is missing", func(ctx context.Context) {
 				By("Removing the dns-ns label from the secondary Service", func() {
 					setServiceLabel(ctx, PodDNSNameserversSecondaryService, "")
 					DeferCleanup(func(ctx context.Context) {
@@ -287,34 +286,12 @@ func PodDNSNameserversSpec() {
 
 				pod := createVPod(ctx, nil)
 
-				By("Waiting for the host pod to receive only the primary nameserver", func() {
-					Eventually(func(g Gomega) {
-						hostPod, err := getHostPod(ctx, pod.Name)
-						g.Expect(err).To(Succeed(), "host pod for %s not yet present", pod.Name)
-						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
-						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP}),
-							"expected only primary nameserver, got %v", hostPod.Spec.DNSConfig.Nameservers)
-					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
-				})
-
-				By("Waiting for a warning event on the virtual pod about the unresolved nameserver", func() {
-					Eventually(func(g Gomega) {
-						events, err := vClusterClient.CoreV1().Events("default").List(ctx, metav1.ListOptions{
-							FieldSelector: "involvedObject.name=" + pod.Name,
-						})
-						g.Expect(err).To(Succeed(), "failed to list events for pod %s", pod.Name)
-						var found bool
-						for _, ev := range events.Items {
-							if ev.Type == corev1.EventTypeWarning &&
-								(containsAny(ev.Message, "nameserver", "DNS") || containsAny(ev.Reason, "DNS", "Nameserver")) {
-								found = true
-								break
-							}
-						}
-						g.Expect(found).To(BeTrue(),
-							"no DNS nameserver warning event found for pod %s, events: %d",
-							pod.Name, len(events.Items))
-					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				By("Verifying the host pod is not created while one selector fails to resolve", func() {
+					Consistently(func(g Gomega) {
+						_, err := getHostPod(ctx, pod.Name)
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"host pod for %s should not exist, got err=%v", pod.Name, err)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 				})
 			})
 
@@ -547,19 +524,6 @@ func PodDNSNameserversSpec() {
 			})
 		},
 	)
-}
-
-// containsAny reports whether s contains any of the given substrings.
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		if sub == "" {
-			continue
-		}
-		if strings.Contains(s, sub) {
-			return true
-		}
-	}
-	return false
 }
 
 // stripPortNodePort clears NodePort and TargetPort.IntVal on each port so

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -253,7 +253,7 @@ func PodDNSNameserversSpec() {
 							ctx, vClusterRestConfig, "default", pod.Name, "main",
 							[]string{"nslookup", PodDNSNameserversPrimaryExpectedName}, nil,
 						)
-						g.Expect(err).NotTo(HaveOccurred(),
+						g.Expect(err).To(Succeed(),
 							"nslookup primary failed: stdout=%s stderr=%s", string(stdout), string(stderr))
 						g.Expect(string(stdout)).To(ContainSubstring(PodDNSNameserversPrimaryExpectedIP),
 							"primary nslookup output missing expected IP: %s", string(stdout))
@@ -264,7 +264,7 @@ func PodDNSNameserversSpec() {
 							ctx, vClusterRestConfig, "default", pod.Name, "main",
 							[]string{"nslookup", PodDNSNameserversSecondaryExpectedName}, nil,
 						)
-						g.Expect(err).NotTo(HaveOccurred(),
+						g.Expect(err).To(Succeed(),
 							"nslookup secondary failed: stdout=%s stderr=%s", string(stdout), string(stderr))
 						g.Expect(string(stdout)).To(ContainSubstring(PodDNSNameserversSecondaryExpectedIP),
 							"secondary nslookup output missing expected IP: %s", string(stdout))

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -457,6 +457,29 @@ func PodDNSNameserversSpec() {
 
 					err = hostClient.CoreV1().Services(PodDNSNameserversNamespace).Delete(ctx, PodDNSNameserversPrimaryService, metav1.DeleteOptions{})
 					Expect(err).To(Succeed())
+					DeferCleanup(func(ctx context.Context) {
+						_, existErr := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(
+							ctx, PodDNSNameserversPrimaryService, metav1.GetOptions{})
+						if kerrors.IsNotFound(existErr) {
+							restored := &corev1.Service{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      PodDNSNameserversPrimaryService,
+									Namespace: PodDNSNameserversNamespace,
+									Labels:    origSvc.Labels,
+								},
+								Spec: corev1.ServiceSpec{
+									Type:     corev1.ServiceTypeClusterIP,
+									Selector: origSvc.Spec.Selector,
+									Ports:    stripPortNodePort(origSvc.Spec.Ports),
+								},
+							}
+							_, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Create(
+								ctx, restored, metav1.CreateOptions{})
+							Expect(err).To(Succeed())
+							return
+						}
+						Expect(existErr).To(Succeed())
+					})
 
 					Eventually(func(g Gomega) {
 						_, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, PodDNSNameserversPrimaryService, metav1.GetOptions{})

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -1,0 +1,301 @@
+package test_core
+
+import (
+	"context"
+	"strings"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	// PodDNSNameserversNamespace is the host-side namespace that holds the
+	// DNS Services referenced by sync.toHost.pods.dns.nameservers.
+	PodDNSNameserversNamespace = "vcluster-dns-test"
+
+	// PodDNSNameserversPrimaryService is the name of the primary host DNS
+	// Service resolved by the first nameservers entry.
+	PodDNSNameserversPrimaryService = "primary-dns"
+
+	// PodDNSNameserversSecondaryService is the name of the secondary host
+	// DNS Service resolved by the second nameservers entry.
+	PodDNSNameserversSecondaryService = "secondary-dns"
+
+	// PodDNSNameserversLabelKey is the label key the nameservers entries
+	// select on. Values: "primary" or "secondary".
+	PodDNSNameserversLabelKey = "vcluster.loft.sh/dns-ns"
+
+	// podDNSNameserversTenantHostLabel is the label written by the syncer
+	// onto host pods carrying the resolved nameservers.
+	podDNSNameserversTenantHostLabel = "vcluster.loft.sh/tenant-host-namespace"
+)
+
+// PodDNSNameserversSpec exercises sync.toHost.pods.dns.nameservers: pods
+// synced to the host receive dnsConfig.nameservers built from the resolved
+// host Services' ClusterIPs unless they opt out (hostNetwork) or override
+// (user-supplied dnsConfig.nameservers).
+func PodDNSNameserversSpec() {
+	Describe("Pod DNS nameservers override",
+		labels.Core,
+		labels.Sync,
+		labels.Pods,
+		func() {
+			var (
+				hostClient     kubernetes.Interface
+				vClusterClient kubernetes.Interface
+				vClusterName   string
+				hostNS         string
+				primaryIP      string
+				secondaryIP    string
+			)
+
+			BeforeEach(func(ctx context.Context) {
+				hostClient = cluster.KubeClientFrom(ctx, constants.GetHostClusterName())
+				Expect(hostClient).NotTo(BeNil())
+				vClusterClient = cluster.CurrentKubeClientFrom(ctx)
+				Expect(vClusterClient).NotTo(BeNil())
+				vClusterName = cluster.CurrentClusterNameFrom(ctx)
+				hostNS = "vcluster-" + vClusterName
+
+				primarySvc, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, PodDNSNameserversPrimaryService, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				primaryIP = primarySvc.Spec.ClusterIP
+				Expect(primaryIP).NotTo(BeEmpty(), "primary DNS Service has no ClusterIP")
+
+				secondarySvc, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, PodDNSNameserversSecondaryService, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				secondaryIP = secondarySvc.Spec.ClusterIP
+				Expect(secondaryIP).NotTo(BeEmpty(), "secondary DNS Service has no ClusterIP")
+			})
+
+			// createVPod creates a pod in the vCluster default namespace and
+			// registers cleanup. Returns the pod's name.
+			createVPod := func(ctx context.Context, name string, mutate func(*corev1.Pod)) {
+				GinkgoHelper()
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "main", Image: "nginxinc/nginx-unprivileged:stable-alpine3.20-slim"},
+						},
+					},
+				}
+				if mutate != nil {
+					mutate(pod)
+				}
+				_, err := vClusterClient.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().Pods("default").Delete(ctx, name, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+			}
+
+			// getHostPod fetches the host-side pod corresponding to a virtual
+			// pod by its translated name.
+			getHostPod := func(ctx context.Context, vPodName string) (*corev1.Pod, error) {
+				hostName := translate.SingleNamespaceHostName(vPodName, "default", vClusterName)
+				return hostClient.CoreV1().Pods(hostNS).Get(ctx, hostName, metav1.GetOptions{})
+			}
+
+			// setServiceLabel patches the named host Service's label value or
+			// removes the label entirely when value is empty. Uses retry on
+			// conflict so concurrent reconcilers do not race the test.
+			setServiceLabel := func(ctx context.Context, svcName, value string) {
+				GinkgoHelper()
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					svc, err := hostClient.CoreV1().Services(PodDNSNameserversNamespace).Get(ctx, svcName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if svc.Labels == nil {
+						svc.Labels = map[string]string{}
+					}
+					if value == "" {
+						delete(svc.Labels, PodDNSNameserversLabelKey)
+					} else {
+						svc.Labels[PodDNSNameserversLabelKey] = value
+					}
+					_, err = hostClient.CoreV1().Services(PodDNSNameserversNamespace).Update(ctx, svc, metav1.UpdateOptions{})
+					return err
+				})
+				Expect(err).To(Succeed())
+			}
+
+			It("writes all resolved ClusterIPs and tenant-identity label to synced pods", func(ctx context.Context) {
+				podName := "dns-pod-default-" + random.String(6)
+
+				By("Creating a simple pod in the vCluster", func() {
+					createVPod(ctx, podName, nil)
+				})
+
+				By("Waiting for the host pod to receive both resolved nameservers and the tenant label", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, podName)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						g.Expect(hostPod.Spec.DNSPolicy).To(Equal(corev1.DNSNone),
+							"host pod dnsPolicy is %s, expected None", hostPod.Spec.DNSPolicy)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP, secondaryIP}),
+							"host pod nameservers %v != expected [%s %s]",
+							hostPod.Spec.DNSConfig.Nameservers, primaryIP, secondaryIP)
+						g.Expect(hostPod.Labels).To(HaveKey(podDNSNameserversTenantHostLabel),
+							"tenant-host-namespace label missing, labels: %v", hostPod.Labels)
+						g.Expect(hostPod.Labels[podDNSNameserversTenantHostLabel]).NotTo(BeEmpty(),
+							"tenant-host-namespace label value is empty")
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+			})
+
+			It("skips hostNetwork pods", func(ctx context.Context) {
+				podName := "dns-pod-hostnet-" + random.String(6)
+
+				By("Creating a hostNetwork pod in the vCluster", func() {
+					createVPod(ctx, podName, func(p *corev1.Pod) {
+						p.Spec.HostNetwork = true
+					})
+				})
+
+				By("Waiting for the host pod to appear without injected nameservers", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, podName)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						if hostPod.Spec.DNSConfig != nil {
+							g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(BeEmpty(),
+								"hostNetwork pod should not have injected nameservers, got %v",
+								hostPod.Spec.DNSConfig.Nameservers)
+						}
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+			})
+
+			It("respects user-defined dnsConfig.nameservers", func(ctx context.Context) {
+				podName := "dns-pod-userdns-" + random.String(6)
+				userIP := "8.8.8.8"
+
+				By("Creating a pod with user-supplied dnsConfig in the vCluster", func() {
+					createVPod(ctx, podName, func(p *corev1.Pod) {
+						p.Spec.DNSPolicy = corev1.DNSNone
+						p.Spec.DNSConfig = &corev1.PodDNSConfig{
+							Nameservers: []string{userIP},
+						}
+					})
+				})
+
+				By("Waiting for the host pod and verifying the user nameservers are preserved", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, podName)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{userIP}),
+							"user-supplied nameservers were modified, got %v", hostPod.Spec.DNSConfig.Nameservers)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+			})
+
+			It("resolves partial list when one Service is missing", func(ctx context.Context) {
+				podName := "dns-pod-partial-" + random.String(6)
+
+				By("Removing the dns-ns label from the secondary Service", func() {
+					setServiceLabel(ctx, PodDNSNameserversSecondaryService, "")
+					DeferCleanup(func(ctx context.Context) {
+						setServiceLabel(ctx, PodDNSNameserversSecondaryService, "secondary")
+					})
+				})
+
+				By("Creating a pod in the vCluster", func() {
+					createVPod(ctx, podName, nil)
+				})
+
+				By("Waiting for the host pod to receive only the primary nameserver", func() {
+					Eventually(func(g Gomega) {
+						hostPod, err := getHostPod(ctx, podName)
+						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
+						g.Expect(hostPod.Spec.DNSConfig).NotTo(BeNil(), "host pod dnsConfig is nil")
+						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP}),
+							"expected only primary nameserver, got %v", hostPod.Spec.DNSConfig.Nameservers)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Waiting for a warning event on the virtual pod about the unresolved nameserver", func() {
+					Eventually(func(g Gomega) {
+						events, err := vClusterClient.CoreV1().Events("default").List(ctx, metav1.ListOptions{
+							FieldSelector: "involvedObject.name=" + podName,
+						})
+						g.Expect(err).To(Succeed(), "failed to list events for pod %s", podName)
+						var found bool
+						for _, ev := range events.Items {
+							if ev.Type == corev1.EventTypeWarning &&
+								(containsAny(ev.Message, "nameserver", "DNS") || containsAny(ev.Reason, "DNS", "Nameserver")) {
+								found = true
+								break
+							}
+						}
+						g.Expect(found).To(BeTrue(),
+							"no DNS nameserver warning event found for pod %s, events: %d",
+							podName, len(events.Items))
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+			})
+
+			It("blocks pod creation when all Services are missing", func(ctx context.Context) {
+				podName := "dns-pod-blocked-" + random.String(6)
+
+				By("Removing the dns-ns label from both Services", func() {
+					setServiceLabel(ctx, PodDNSNameserversPrimaryService, "")
+					DeferCleanup(func(ctx context.Context) {
+						setServiceLabel(ctx, PodDNSNameserversPrimaryService, "primary")
+					})
+					setServiceLabel(ctx, PodDNSNameserversSecondaryService, "")
+					DeferCleanup(func(ctx context.Context) {
+						setServiceLabel(ctx, PodDNSNameserversSecondaryService, "secondary")
+					})
+				})
+
+				By("Creating a pod in the vCluster", func() {
+					createVPod(ctx, podName, nil)
+				})
+
+				By("Verifying the host pod is not created", func() {
+					Consistently(func(g Gomega) {
+						_, err := getHostPod(ctx, podName)
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"host pod for %s should not exist, got err=%v", podName, err)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+				})
+			})
+
+			// The embedded CoreDNS variant exercises the same nameservers
+			// override but with controlPlane.coredns.embedded=true; it
+			// requires its own vcluster-pods-dns-nameservers-embedded.yaml
+			// and a dedicated suite_pods_dns_nameservers_embedded_test.go
+			// so the lifecycle stays parallelisable. Tracked separately.
+			PIt("works with embedded CoreDNS variant", Label("todo"), func(ctx context.Context) {})
+		},
+	)
+}
+
+// containsAny reports whether s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if sub == "" {
+			continue
+		}
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -34,10 +34,6 @@ const (
 	// PodDNSNameserversLabelKey is the label key the nameservers entries
 	// select on. Values: "primary" or "secondary".
 	PodDNSNameserversLabelKey = "vcluster.loft.sh/dns-ns"
-
-	// podDNSNameserversTenantHostLabel is the label written by the syncer
-	// onto host pods carrying the resolved nameservers.
-	podDNSNameserversTenantHostLabel = "vcluster.loft.sh/tenant-host-namespace"
 )
 
 // PodDNSNameserversSpec exercises sync.toHost.pods.dns.nameservers: pods
@@ -134,14 +130,14 @@ func PodDNSNameserversSpec() {
 				Expect(err).To(Succeed())
 			}
 
-			It("writes all resolved ClusterIPs and tenant-identity label to synced pods", func(ctx context.Context) {
+			It("writes all resolved ClusterIPs to synced pods", func(ctx context.Context) {
 				podName := "dns-pod-default-" + random.String(6)
 
 				By("Creating a simple pod in the vCluster", func() {
 					createVPod(ctx, podName, nil)
 				})
 
-				By("Waiting for the host pod to receive both resolved nameservers and the tenant label", func() {
+				By("Waiting for the host pod to receive both resolved nameservers", func() {
 					Eventually(func(g Gomega) {
 						hostPod, err := getHostPod(ctx, podName)
 						g.Expect(err).To(Succeed(), "host pod for %s not yet present", podName)
@@ -151,10 +147,6 @@ func PodDNSNameserversSpec() {
 						g.Expect(hostPod.Spec.DNSConfig.Nameservers).To(Equal([]string{primaryIP, secondaryIP}),
 							"host pod nameservers %v != expected [%s %s]",
 							hostPod.Spec.DNSConfig.Nameservers, primaryIP, secondaryIP)
-						g.Expect(hostPod.Labels).To(HaveKey(podDNSNameserversTenantHostLabel),
-							"tenant-host-namespace label missing, labels: %v", hostPod.Labels)
-						g.Expect(hostPod.Labels[podDNSNameserversTenantHostLabel]).NotTo(BeEmpty(),
-							"tenant-host-namespace label value is empty")
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 			})

--- a/e2e-next/test_core/sync/test_pods_dns_nameservers.go
+++ b/e2e-next/test_core/sync/test_pods_dns_nameservers.go
@@ -190,6 +190,30 @@ func PodDNSNameserversSpec() {
 				Expect(err).To(Succeed())
 			}
 
+			// expectDNSNameserversWarning polls events on the virtual pod
+			// until at least one Warning event with Reason=DNSNameservers
+			// appears. The syncer emits this event for each failed selector,
+			// so it is the only user-visible signal that the pod is blocked
+			// because of nameserver resolution.
+			expectDNSNameserversWarning := func(ctx context.Context, podName string) {
+				GinkgoHelper()
+				Eventually(func(g Gomega) {
+					events, err := vClusterClient.CoreV1().Events("default").List(ctx, metav1.ListOptions{
+						FieldSelector: "involvedObject.name=" + podName + ",involvedObject.kind=Pod",
+					})
+					g.Expect(err).To(Succeed())
+					found := false
+					for _, e := range events.Items {
+						if e.Type == corev1.EventTypeWarning && e.Reason == "DNSNameservers" {
+							found = true
+							break
+						}
+					}
+					g.Expect(found).To(BeTrue(),
+						"no Warning DNSNameservers event on pod %s, events=%+v", podName, events.Items)
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+			}
+
 			It("writes all resolved ClusterIPs to synced pods", func(ctx context.Context) {
 				var pod *corev1.Pod
 
@@ -326,6 +350,10 @@ func PodDNSNameserversSpec() {
 							"host pod for %s should not exist, got err=%v", pod.Name, err)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 				})
+
+				By("Verifying a Warning DNSNameservers event was emitted on the virtual pod", func() {
+					expectDNSNameserversWarning(ctx, pod.Name)
+				})
 			})
 
 			It("blocks pod creation when all host-scoped Services are missing", func(ctx context.Context) {
@@ -348,6 +376,10 @@ func PodDNSNameserversSpec() {
 						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
 							"host pod for %s should not exist, got err=%v", pod.Name, err)
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+				})
+
+				By("Verifying a Warning DNSNameservers event was emitted on the virtual pod", func() {
+					expectDNSNameserversWarning(ctx, pod.Name)
 				})
 			})
 

--- a/e2e-next/vcluster-pods-dns-nameservers.yaml
+++ b/e2e-next/vcluster-pods-dns-nameservers.yaml
@@ -1,0 +1,24 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  toHost:
+    pods:
+      enabled: true
+      dns:
+        nameservers:
+          - service:
+              scope: host
+              namespace: vcluster-dns-test
+              labelSelector:
+                matchLabels:
+                  vcluster.loft.sh/dns-ns: primary
+          - service:
+              scope: host
+              namespace: vcluster-dns-test
+              labelSelector:
+                matchLabels:
+                  vcluster.loft.sh/dns-ns: secondary

--- a/e2e-next/vcluster-pods-dns-nameservers.yaml
+++ b/e2e-next/vcluster-pods-dns-nameservers.yaml
@@ -15,10 +15,10 @@ sync:
               namespace: vcluster-dns-test
               labelSelector:
                 matchLabels:
-                  vcluster.loft.sh/dns-ns: primary
+                  vcluster.com/dns-ns: primary
           - service:
               scope: host
               namespace: vcluster-dns-test
               labelSelector:
                 matchLabels:
-                  vcluster.loft.sh/dns-ns: secondary
+                  vcluster.com/dns-ns: secondary

--- a/e2e-next/vcluster-pods-dns-nameservers.yaml
+++ b/e2e-next/vcluster-pods-dns-nameservers.yaml
@@ -11,14 +11,20 @@ sync:
       dns:
         nameservers:
           - service:
-              scope: host
+              scope: control-plane-host
               namespace: vcluster-dns-test
               labelSelector:
                 matchLabels:
                   vcluster.com/dns-ns: primary
           - service:
-              scope: host
+              scope: control-plane-host
               namespace: vcluster-dns-test
               labelSelector:
                 matchLabels:
                   vcluster.com/dns-ns: secondary
+          - service:
+              scope: tenant-cluster
+              namespace: kube-system
+              labelSelector:
+                matchLabels:
+                  k8s-app: vcluster-kube-dns

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -54,6 +54,10 @@ func ValidateConfigAndSetDefaults(vConfig *VirtualClusterConfig) error {
 		}
 	}
 
+	if err := validateDNSNameservers(vConfig.Sync.ToHost.Pods.DNS.Nameservers); err != nil {
+		return err
+	}
+
 	// check if enable scheduler works correctly
 	if vConfig.SchedulingInVirtualClusterEnabled() && !vConfig.Sync.FromHost.Nodes.Selector.All && len(vConfig.Sync.FromHost.Nodes.Selector.Labels) == 0 {
 		vConfig.Sync.FromHost.Nodes.Selector.All = true
@@ -995,7 +999,7 @@ func ValidateExperimentalProxyCustomResourcesConfig(cfg map[string]config.Custom
 		}
 	}
 
-	// All entries sharing a group/version must agree on target vCluster and access mode —
+	// All entries sharing a group/version must agree on target vCluster and access mode --
 	// APIService aggregation routes the whole group/version to one proxy, so mismatched
 	// settings are ambiguous and would otherwise be silently dropped.
 	for _, group := range lo.GroupBy(entries, func(e entry) string { return e.gvKey }) {
@@ -1014,5 +1018,29 @@ func ValidateExperimentalProxyCustomResourcesConfig(cfg map[string]config.Custom
 }
 
 var ProValidateConfig = func(_ *VirtualClusterConfig) error {
+	return nil
+}
+
+// validateDNSNameservers validates entries in sync.toHost.pods.dns.nameservers.
+func validateDNSNameservers(entries []config.DNSNameserverEntry) error {
+	for i, entry := range entries {
+		svc := entry.Service
+		if svc.Scope != config.DNSNameserverScopeHost && svc.Scope != config.DNSNameserverScopeTenant {
+			return fmt.Errorf(
+				"sync.toHost.pods.dns.nameservers[%d].service.scope must be %q or %q, got %q",
+				i, config.DNSNameserverScopeHost, config.DNSNameserverScopeTenant, svc.Scope,
+			)
+		}
+		if svc.Namespace == "" {
+			return fmt.Errorf("sync.toHost.pods.dns.nameservers[%d].service.namespace must be set", i)
+		}
+		if svc.LabelSelector == nil ||
+			(len(svc.LabelSelector.MatchLabels) == 0 && len(svc.LabelSelector.MatchExpressions) == 0) {
+			return fmt.Errorf("sync.toHost.pods.dns.nameservers[%d].service.labelSelector must be set and non-empty", i)
+		}
+		if _, err := svc.LabelSelector.ToSelector(); err != nil {
+			return fmt.Errorf("sync.toHost.pods.dns.nameservers[%d].service.labelSelector is invalid: %w", i, err)
+		}
+	}
 	return nil
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/util/namespaces"
 )
@@ -2341,6 +2343,196 @@ func TestValidateAutoUpgradeSecurityContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validatePrivatedNodesMode(tc.vclusterConfig)
 			tc.checkErr(t, err)
+		})
+	}
+}
+
+func TestDNSNameserversValidation(t *testing.T) {
+	type testCase struct {
+		name    string
+		entries []config.DNSNameserverEntry
+		wantErr bool
+	}
+
+	validSelector := &config.StandardLabelSelector{
+		MatchLabels: map[string]string{"app": "coredns"},
+	}
+	validSelectorExpr := &config.StandardLabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "app",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"coredns"},
+			},
+		},
+	}
+	badOpSelector := &config.StandardLabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "app",
+				Operator: metav1.LabelSelectorOperator("NotARealOperator"),
+				Values:   []string{"coredns"},
+			},
+		},
+	}
+
+	cases := []testCase{
+		{
+			name:    "empty list is valid",
+			entries: nil,
+			wantErr: false,
+		},
+		{
+			name: "valid host scope",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeHost,
+						Namespace:     "kube-system",
+						LabelSelector: validSelector,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid tenant scope",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeTenant,
+						Namespace:     "kube-system",
+						LabelSelector: validSelectorExpr,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing scope",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Namespace:     "kube-system",
+						LabelSelector: validSelector,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad scope value",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         "cluster",
+						Namespace:     "kube-system",
+						LabelSelector: validSelector,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing namespace",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeHost,
+						LabelSelector: validSelector,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil labelSelector",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:     config.DNSNameserverScopeHost,
+						Namespace: "kube-system",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty labelSelector",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeHost,
+						Namespace:     "kube-system",
+						LabelSelector: &config.StandardLabelSelector{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed labelSelector with bad operator",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeHost,
+						Namespace:     "kube-system",
+						LabelSelector: badOpSelector,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multi-entry: first valid, second invalid",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeHost,
+						Namespace:     "kube-system",
+						LabelSelector: validSelector,
+					},
+				},
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeTenant,
+						LabelSelector: validSelector,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multi-entry: both valid",
+			entries: []config.DNSNameserverEntry{
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeHost,
+						Namespace:     "kube-system",
+						LabelSelector: validSelector,
+					},
+				},
+				{
+					Service: config.DNSNameserverService{
+						Scope:         config.DNSNameserverScopeTenant,
+						Namespace:     "kube-system",
+						LabelSelector: validSelectorExpr,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDNSNameservers(tc.entries)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 		})
 	}
 }

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -84,8 +84,10 @@ func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserv
 
 	for i, ce := range cfgEntries {
 		svc := ce.Service
-		// selector validity is guaranteed by validateDNSNameservers at startup
-		selector, _ := svc.LabelSelector.ToSelector()
+		selector, err := svc.LabelSelector.ToSelector()
+		if err != nil {
+			return nil, fmt.Errorf("nameservers[%d]: invalid label selector: %w", i, err)
+		}
 
 		entry := dnsNameserverEntry{
 			namespace: svc.Namespace,

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -28,7 +28,7 @@ func (r *dnsNameserversResolver) Enabled() bool {
 	return r != nil && len(r.entries) > 0
 }
 
-func (r *dnsNameserversResolver) Resolve(ctx *synccontext.SyncContext) ([]string, []error) {
+func (r *dnsNameserversResolver) Resolve(ctx context.Context) ([]string, []error) {
 	if !r.Enabled() {
 		return nil, nil
 	}
@@ -81,19 +81,12 @@ func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserv
 	}
 
 	res := &dnsNameserversResolver{}
+	hostCaches := map[string]client.Reader{}
 
 	for i, ce := range cfgEntries {
 		svc := ce.Service
-		if svc.LabelSelector == nil {
-			return nil, fmt.Errorf("nameservers[%d]: selector is nil", i)
-		}
-		selector, err := svc.LabelSelector.ToSelector()
-		if err != nil {
-			return nil, fmt.Errorf("nameservers[%d]: invalid selector: %w", i, err)
-		}
-		if selector.Empty() {
-			return nil, fmt.Errorf("nameservers[%d]: selector is empty", i)
-		}
+		// selector validity is guaranteed by validateDNSNameservers at startup
+		selector, _ := svc.LabelSelector.ToSelector()
 
 		entry := dnsNameserverEntry{
 			namespace: svc.Namespace,
@@ -102,20 +95,25 @@ func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserv
 
 		switch svc.Scope {
 		case vclusterconfig.DNSNameserverScopeHost:
-			c, err := cache.New(ctx.HostManager.GetConfig(), cache.Options{
-				Scheme: ctx.HostManager.GetScheme(),
-				Mapper: ctx.HostManager.GetRESTMapper(),
-				DefaultNamespaces: map[string]cache.Config{
-					svc.Namespace: {},
-				},
-			})
-			if err != nil {
-				return nil, fmt.Errorf("nameservers[%d]: build host cache: %w", i, err)
+			if r, ok := hostCaches[svc.Namespace]; ok {
+				entry.reader = r
+			} else {
+				c, err := cache.New(ctx.HostManager.GetConfig(), cache.Options{
+					Scheme: ctx.HostManager.GetScheme(),
+					Mapper: ctx.HostManager.GetRESTMapper(),
+					DefaultNamespaces: map[string]cache.Config{
+						svc.Namespace: {},
+					},
+				})
+				if err != nil {
+					return nil, fmt.Errorf("nameservers[%d]: build host cache: %w", i, err)
+				}
+				if err := ctx.HostManager.Add(c); err != nil {
+					return nil, fmt.Errorf("nameservers[%d]: attach host cache: %w", i, err)
+				}
+				hostCaches[svc.Namespace] = c
+				entry.reader = c
 			}
-			if err := ctx.HostManager.Add(c); err != nil {
-				return nil, fmt.Errorf("nameservers[%d]: attach host cache: %w", i, err)
-			}
-			entry.reader = c
 
 		case vclusterconfig.DNSNameserverScopeTenant:
 			entry.reader = ctx.VirtualManager.GetClient()

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -1,0 +1,133 @@
+package pods
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vclusterconfig "github.com/loft-sh/vcluster/config"
+	podstranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+)
+
+type dnsNameserversResolver struct {
+	entries []dnsNameserverEntry
+}
+
+type dnsNameserverEntry struct {
+	namespace string
+	selector  labels.Selector
+	reader    client.Reader
+}
+
+func (r *dnsNameserversResolver) Enabled() bool {
+	return r != nil && len(r.entries) > 0
+}
+
+func (r *dnsNameserversResolver) Resolve(ctx *synccontext.SyncContext) ([]string, []error) {
+	if !r.Enabled() {
+		return nil, nil
+	}
+	var ips []string
+	var errs []error
+	for _, e := range r.entries {
+		ip, err := resolveEntryIP(ctx, e)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			ips = append(ips, ip)
+		}
+	}
+	return ips, errs
+}
+
+func resolveEntryIP(ctx context.Context, e dnsNameserverEntry) (string, error) {
+	var svcList corev1.ServiceList
+	if err := e.reader.List(ctx, &svcList,
+		client.InNamespace(e.namespace),
+		client.MatchingLabelsSelector{Selector: e.selector},
+	); err != nil {
+		return "", fmt.Errorf("list Services in %q: %w", e.namespace, err)
+	}
+	switch len(svcList.Items) {
+	case 0:
+		return "", fmt.Errorf("no Service matches selector %q in namespace %q", e.selector, e.namespace)
+	case 1:
+		ip := svcList.Items[0].Spec.ClusterIP
+		if ip == "" || ip == corev1.ClusterIPNone {
+			return "", fmt.Errorf("Service %s/%s has no ClusterIP", svcList.Items[0].Namespace, svcList.Items[0].Name)
+		}
+		return ip, nil
+	default:
+		names := make([]string, 0, len(svcList.Items))
+		for _, s := range svcList.Items {
+			names = append(names, s.Name)
+		}
+		return "", fmt.Errorf("expected exactly one Service, got %d: %v", len(svcList.Items), names)
+	}
+}
+
+// buildDNSNameserversResolver constructs the resolver and starts a dedicated
+// informer cache for each host-scoped entry. Tenant-scoped entries reuse the
+// virtual manager's cache. Returns (nil, nil) when no nameservers are configured.
+func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserversResolver, error) {
+	cfgEntries := ctx.Config.Sync.ToHost.Pods.DNS.Nameservers
+	if len(cfgEntries) == 0 {
+		return nil, nil
+	}
+
+	res := &dnsNameserversResolver{}
+
+	for i, ce := range cfgEntries {
+		svc := ce.Service
+		if svc.LabelSelector == nil {
+			return nil, fmt.Errorf("nameservers[%d]: selector is nil", i)
+		}
+		selector, err := svc.LabelSelector.ToSelector()
+		if err != nil {
+			return nil, fmt.Errorf("nameservers[%d]: invalid selector: %w", i, err)
+		}
+		if selector.Empty() {
+			return nil, fmt.Errorf("nameservers[%d]: selector is empty", i)
+		}
+
+		entry := dnsNameserverEntry{
+			namespace: svc.Namespace,
+			selector:  selector,
+		}
+
+		switch svc.Scope {
+		case vclusterconfig.DNSNameserverScopeHost:
+			c, err := cache.New(ctx.HostManager.GetConfig(), cache.Options{
+				Scheme: ctx.HostManager.GetScheme(),
+				Mapper: ctx.HostManager.GetRESTMapper(),
+				DefaultNamespaces: map[string]cache.Config{
+					svc.Namespace: {},
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("nameservers[%d]: build host cache: %w", i, err)
+			}
+			if err := ctx.HostManager.Add(c); err != nil {
+				return nil, fmt.Errorf("nameservers[%d]: attach host cache: %w", i, err)
+			}
+			entry.reader = c
+
+		case vclusterconfig.DNSNameserverScopeTenant:
+			entry.reader = ctx.VirtualManager.GetClient()
+
+		default:
+			return nil, fmt.Errorf("nameservers[%d]: unknown scope %q", i, svc.Scope)
+		}
+
+		res.entries = append(res.entries, entry)
+	}
+
+	return res, nil
+}
+
+var _ podstranslate.DNSNameserversResolver = (*dnsNameserversResolver)(nil)

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -42,43 +42,45 @@ func (r *dnsNameserversResolver) Resolve(ctx context.Context) ([]string, []error
 	var ips []string
 	var errs []error
 	for _, e := range r.entries {
-		ip, err := resolveEntryIP(ctx, e)
+		entryIPs, err := resolveEntryIPs(ctx, e)
 		if err != nil {
 			errs = append(errs, err)
-		} else {
-			ips = append(ips, ip)
+			continue
 		}
+		ips = append(ips, entryIPs...)
 	}
 	return ips, errs
 }
 
-func resolveEntryIP(ctx context.Context, e dnsNameserverEntry) (string, error) {
+func resolveEntryIPs(ctx context.Context, e dnsNameserverEntry) ([]string, error) {
 	if e.selector == nil {
-		return "", fmt.Errorf("nil label selector for namespace %q", e.namespace)
+		return nil, fmt.Errorf("nil label selector for namespace %q", e.namespace)
 	}
 	var svcList corev1.ServiceList
 	if err := e.reader.List(ctx, &svcList,
 		client.InNamespace(e.namespace),
 		client.MatchingLabelsSelector{Selector: e.selector},
 	); err != nil {
-		return "", fmt.Errorf("list Services in %q: %w", e.namespace, err)
+		return nil, fmt.Errorf("list Services in %q: %w", e.namespace, err)
 	}
-	switch len(svcList.Items) {
-	case 0:
-		return "", fmt.Errorf("no Service matches selector %q in namespace %q", e.selector, e.namespace)
-	case 1:
-		ip := svcList.Items[0].Spec.ClusterIP
+	if len(svcList.Items) == 0 {
+		return nil, fmt.Errorf("no Service matches selector %q in namespace %q", e.selector, e.namespace)
+	}
+
+	ips := make([]string, 0, len(svcList.Items))
+	skipped := make([]string, 0, len(svcList.Items))
+	for _, svc := range svcList.Items {
+		ip := svc.Spec.ClusterIP
 		if ip == "" || ip == corev1.ClusterIPNone {
-			return "", fmt.Errorf("service %s/%s has no ClusterIP", svcList.Items[0].Namespace, svcList.Items[0].Name)
+			skipped = append(skipped, fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
+			continue
 		}
-		return ip, nil
-	default:
-		names := make([]string, 0, len(svcList.Items))
-		for _, s := range svcList.Items {
-			names = append(names, s.Name)
-		}
-		return "", fmt.Errorf("expected exactly one Service, got %d: %v", len(svcList.Items), names)
+		ips = append(ips, ip)
 	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no Service with a ClusterIP matches selector %q in namespace %q (headless or unassigned: %v)", e.selector, e.namespace, skipped)
+	}
+	return ips, nil
 }
 
 // buildDNSNameserversResolver constructs the resolver and starts a dedicated

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -16,6 +16,13 @@ import (
 
 type dnsNameserversResolver struct {
 	entries []dnsNameserverEntry
+
+	// hostCaches maps host namespace to the cache.Cache backing the
+	// resolver's reads from that namespace. The pod syncer reuses these
+	// caches to install Service watches that re-enqueue virtual pods when
+	// the selected Service's ClusterIP changes or when the label selector
+	// suddenly matches a different Service.
+	hostCaches map[string]cache.Cache
 }
 
 type dnsNameserverEntry struct {
@@ -46,6 +53,9 @@ func (r *dnsNameserversResolver) Resolve(ctx context.Context) ([]string, []error
 }
 
 func resolveEntryIP(ctx context.Context, e dnsNameserverEntry) (string, error) {
+	if e.selector == nil {
+		return "", fmt.Errorf("nil label selector for namespace %q", e.namespace)
+	}
 	var svcList corev1.ServiceList
 	if err := e.reader.List(ctx, &svcList,
 		client.InNamespace(e.namespace),
@@ -76,11 +86,12 @@ func resolveEntryIP(ctx context.Context, e dnsNameserverEntry) (string, error) {
 // virtual manager's cache. Returns (nil, nil) when no nameservers are configured.
 func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserversResolver, error) {
 	cfgEntries := ctx.Config.Sync.ToHost.Pods.DNS.Nameservers
-	res := &dnsNameserversResolver{}
+	res := &dnsNameserversResolver{
+		hostCaches: map[string]cache.Cache{},
+	}
 	if len(cfgEntries) == 0 {
 		return res, nil
 	}
-	hostCaches := map[string]client.Reader{}
 
 	for i, ce := range cfgEntries {
 		svc := ce.Service
@@ -96,8 +107,8 @@ func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserv
 
 		switch svc.Scope {
 		case vclusterconfig.DNSNameserverScopeHost:
-			if r, ok := hostCaches[svc.Namespace]; ok {
-				entry.reader = r
+			if c, ok := res.hostCaches[svc.Namespace]; ok {
+				entry.reader = c
 			} else {
 				c, err := cache.New(ctx.HostManager.GetConfig(), cache.Options{
 					Scheme: ctx.HostManager.GetScheme(),
@@ -112,7 +123,7 @@ func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserv
 				if err := ctx.HostManager.Add(c); err != nil {
 					return nil, fmt.Errorf("nameservers[%d]: attach host cache: %w", i, err)
 				}
-				hostCaches[svc.Namespace] = c
+				res.hostCaches[svc.Namespace] = c
 				entry.reader = c
 			}
 

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -59,7 +59,7 @@ func resolveEntryIP(ctx context.Context, e dnsNameserverEntry) (string, error) {
 	case 1:
 		ip := svcList.Items[0].Spec.ClusterIP
 		if ip == "" || ip == corev1.ClusterIPNone {
-			return "", fmt.Errorf("Service %s/%s has no ClusterIP", svcList.Items[0].Namespace, svcList.Items[0].Name)
+			return "", fmt.Errorf("service %s/%s has no ClusterIP", svcList.Items[0].Namespace, svcList.Items[0].Name)
 		}
 		return ip, nil
 	default:
@@ -76,11 +76,10 @@ func resolveEntryIP(ctx context.Context, e dnsNameserverEntry) (string, error) {
 // virtual manager's cache. Returns (nil, nil) when no nameservers are configured.
 func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserversResolver, error) {
 	cfgEntries := ctx.Config.Sync.ToHost.Pods.DNS.Nameservers
-	if len(cfgEntries) == 0 {
-		return nil, nil
-	}
-
 	res := &dnsNameserversResolver{}
+	if len(cfgEntries) == 0 {
+		return res, nil
+	}
 	hostCaches := map[string]client.Reader{}
 
 	for i, ce := range cfgEntries {

--- a/pkg/controllers/resources/pods/dns_override.go
+++ b/pkg/controllers/resources/pods/dns_override.go
@@ -23,6 +23,12 @@ type dnsNameserversResolver struct {
 	// the selected Service's ClusterIP changes or when the label selector
 	// suddenly matches a different Service.
 	hostCaches map[string]cache.Cache
+
+	// tenantNamespaces is the set of tenant-cluster namespaces referenced
+	// by tenant-scoped entries. The pod syncer uses it to filter Service
+	// events from the virtual cache so re-resolution also runs when a
+	// tenant Service's ClusterIP or selector match changes.
+	tenantNamespaces map[string]struct{}
 }
 
 type dnsNameserverEntry struct {
@@ -89,7 +95,8 @@ func resolveEntryIPs(ctx context.Context, e dnsNameserverEntry) ([]string, error
 func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserversResolver, error) {
 	cfgEntries := ctx.Config.Sync.ToHost.Pods.DNS.Nameservers
 	res := &dnsNameserversResolver{
-		hostCaches: map[string]cache.Cache{},
+		hostCaches:       map[string]cache.Cache{},
+		tenantNamespaces: map[string]struct{}{},
 	}
 	if len(cfgEntries) == 0 {
 		return res, nil
@@ -131,6 +138,7 @@ func buildDNSNameserversResolver(ctx *synccontext.RegisterContext) (*dnsNameserv
 
 		case vclusterconfig.DNSNameserverScopeTenant:
 			entry.reader = ctx.VirtualManager.GetClient()
+			res.tenantNamespaces[svc.Namespace] = struct{}{}
 
 		default:
 			return nil, fmt.Errorf("nameservers[%d]: unknown scope %q", i, svc.Scope)

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -85,6 +85,11 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		return nil, errors.Wrap(err, "create pod translator")
 	}
 
+	dnsNameservers, err := buildDNSNameserversResolver(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build dns nameservers resolver: %w", err)
+	}
+
 	schedulingConfig, err := scheduling.NewConfig(
 		ctx.Config.IsVirtualSchedulerEnabled(),
 		ctx.Config.Sync.ToHost.Pods.HybridScheduling.Enabled,
@@ -116,6 +121,7 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		physicalClusterClient: physicalClusterClient,
 		physicalClusterConfig: ctx.HostManager.GetConfig(),
 		podTranslator:         podTranslator,
+		dnsNameservers:        dnsNameservers,
 		nodeSelector:          nodeSelector,
 
 		hostClusterVersion: hostClusterVersion,
@@ -133,6 +139,7 @@ type podSyncer struct {
 	fakeKubeletIPs   bool
 
 	podTranslator         translatepods.Translator
+	dnsNameservers        *dnsNameserversResolver
 	virtualClusterClient  kubernetes.Interface
 	physicalClusterClient kubernetes.Interface
 	physicalClusterConfig *rest.Config

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -187,30 +187,48 @@ func (s *podSyncer) ModifyController(registerContext *synccontext.RegisterContex
 
 	builder = builder.Watches(&corev1.Namespace{}, eventHandler)
 
-	// When sync.toHost.pods.dns.nameservers is configured, watch the host
+	// When sync.toHost.pods.dns.nameservers is configured, watch the
 	// Services that back each entry. A Service's ClusterIP can change (delete
 	// + recreate), or the label selector can suddenly match a different
 	// Service. Either case means every virtual pod's injected nameservers
 	// must be recomputed, so we enqueue every virtual pod whenever a watched
-	// host namespace sees a Service event.
+	// namespace sees a Service event. Both host-scoped and tenant-scoped
+	// entries are watched -- without the tenant watch, ClusterIP/selector
+	// changes in tenant Services would not trigger reconciles and existing
+	// pods would keep stale injected nameservers until an unrelated event.
 	if s.dnsNameservers != nil {
+		enqueueAllVirtualPods := func(ctx context.Context, watchedNS string) []reconcile.Request {
+			pods := &corev1.PodList{}
+			if err := registerContext.VirtualManager.GetClient().List(ctx, pods); err != nil {
+				klog.FromContext(ctx).Info("failed to list virtual pods on dns nameserver Service event", "namespace", watchedNS, "error", err)
+				return nil
+			}
+			requests := make([]reconcile.Request, 0, len(pods.Items))
+			for _, pod := range pods.Items {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+					Name:      pod.GetName(),
+					Namespace: pod.GetNamespace(),
+				}})
+			}
+			return requests
+		}
+
 		for ns, hostCache := range s.dnsNameservers.hostCaches {
 			watchedNS := ns
 			builder = builder.WatchesRawSource(source.Kind(hostCache, &corev1.Service{},
 				handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, _ *corev1.Service) []reconcile.Request {
-					pods := &corev1.PodList{}
-					if err := registerContext.VirtualManager.GetClient().List(ctx, pods); err != nil {
-						klog.FromContext(ctx).Info("failed to list virtual pods on dns nameserver Service event", "namespace", watchedNS, "error", err)
+					return enqueueAllVirtualPods(ctx, watchedNS)
+				})))
+		}
+
+		if len(s.dnsNameservers.tenantNamespaces) > 0 {
+			tenantNamespaces := s.dnsNameservers.tenantNamespaces
+			builder = builder.WatchesRawSource(source.Kind(registerContext.VirtualManager.GetCache(), &corev1.Service{},
+				handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, svc *corev1.Service) []reconcile.Request {
+					if _, watched := tenantNamespaces[svc.GetNamespace()]; !watched {
 						return nil
 					}
-					requests := make([]reconcile.Request, 0, len(pods.Items))
-					for _, pod := range pods.Items {
-						requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
-							Name:      pod.GetName(),
-							Namespace: pod.GetNamespace(),
-						}})
-					}
-					return requests
+					return enqueueAllVirtualPods(ctx, svc.GetNamespace())
 				})))
 		}
 	}

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	translatepods "github.com/loft-sh/vcluster/pkg/controllers/resources/pods/translate"
 )
@@ -184,7 +185,37 @@ func (s *podSyncer) ModifyController(registerContext *synccontext.RegisterContex
 		},
 	}
 
-	return builder.Watches(&corev1.Namespace{}, eventHandler), nil
+	builder = builder.Watches(&corev1.Namespace{}, eventHandler)
+
+	// When sync.toHost.pods.dns.nameservers is configured, watch the host
+	// Services that back each entry. A Service's ClusterIP can change (delete
+	// + recreate), or the label selector can suddenly match a different
+	// Service. Either case means every virtual pod's injected nameservers
+	// must be recomputed, so we enqueue every virtual pod whenever a watched
+	// host namespace sees a Service event.
+	if s.dnsNameservers != nil {
+		for ns, hostCache := range s.dnsNameservers.hostCaches {
+			watchedNS := ns
+			builder = builder.WatchesRawSource(source.Kind(hostCache, &corev1.Service{},
+				handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, _ *corev1.Service) []reconcile.Request {
+					pods := &corev1.PodList{}
+					if err := registerContext.VirtualManager.GetClient().List(ctx, pods); err != nil {
+						klog.FromContext(ctx).Info("failed to list virtual pods on dns nameserver Service event", "namespace", watchedNS, "error", err)
+						return nil
+					}
+					requests := make([]reconcile.Request, 0, len(pods.Items))
+					for _, pod := range pods.Items {
+						requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+							Name:      pod.GetName(),
+							Namespace: pod.GetNamespace(),
+						}})
+					}
+					return requests
+				})))
+		}
+	}
+
+	return builder, nil
 }
 
 var _ syncertypes.Syncer = &podSyncer{}
@@ -351,6 +382,16 @@ func (s *podSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEv
 	} else if event.Virtual.Spec.NodeName != "" && event.Host.Spec.NodeName != event.Virtual.Spec.NodeName {
 		// if physical pod nodeName is different from virtual pod nodeName, we delete the virtual one
 		return patcher.DeleteVirtualObjectWithOptions(ctx, event.Virtual, event.Host, "node name is different between the two", &client.DeleteOptions{GracePeriodSeconds: &minimumGracePeriodInSeconds})
+	}
+
+	// dnsConfig.nameservers is immutable on a running pod, so when the
+	// resolved Service ClusterIPs change (Service was recreated or the
+	// label selector now matches a different Service) we delete the host
+	// pod and let SyncToHost recreate it with the new nameservers.
+	if shouldRecreate, reason := s.dnsNameserversDrift(ctx, event.Virtual, event.Host); shouldRecreate {
+		return patcher.DeleteHostObjectWithOptions(ctx, event.Host, event.Virtual, reason, &client.DeleteOptions{
+			GracePeriodSeconds: &zero,
+		})
 	}
 
 	// validate virtual pod before syncing it to the host cluster
@@ -626,6 +667,39 @@ func (s *podSyncer) assignNodeToPod(ctx *synccontext.SyncContext, pObj *corev1.P
 	}
 
 	return nil
+}
+
+// dnsNameserversDrift reports whether the host pod's injected
+// dnsConfig.nameservers no longer match what the resolver would write
+// today. Pods that opted out (hostNetwork) or pinned their own
+// nameservers are never recreated. Resolver errors are ignored here
+// because dropping the host pod on a transient resolver hiccup would be
+// worse than leaving slightly stale nameservers; the next event-driven
+// reconcile retries.
+func (s *podSyncer) dnsNameserversDrift(ctx *synccontext.SyncContext, vPod, pPod *corev1.Pod) (bool, string) {
+	if s.dnsNameservers == nil || !s.dnsNameservers.Enabled() {
+		return false, ""
+	}
+	if pPod.Spec.HostNetwork {
+		return false, ""
+	}
+	if vPod.Spec.DNSConfig != nil && len(vPod.Spec.DNSConfig.Nameservers) > 0 {
+		return false, ""
+	}
+
+	ips, errs := s.dnsNameservers.Resolve(ctx)
+	if len(ips) == 0 || len(errs) > 0 {
+		return false, ""
+	}
+
+	var current []string
+	if pPod.Spec.DNSConfig != nil {
+		current = pPod.Spec.DNSConfig.Nameservers
+	}
+	if slices.Equal(current, ips) {
+		return false, ""
+	}
+	return true, fmt.Sprintf("dns nameservers changed from %v to %v", current, ips)
 }
 
 func (s *podSyncer) applyLimitByClasses(ctx *synccontext.SyncContext, virtual *corev1.Pod) bool {

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -77,9 +77,8 @@ func TestSyncTable(t *testing.T) {
 			podtranslate.UIDAnnotation:                string(vObjectMeta.UID),
 		},
 		Labels: map[string]string{
-			translate.NamespaceLabel:                     vObjectMeta.Namespace,
-			translate.MarkerLabel:                        translate.VClusterName,
-			podtranslate.TenantClusterHostNamespaceLabel: testingutil.DefaultTestCurrentNamespace,
+			translate.NamespaceLabel: vObjectMeta.Namespace,
+			translate.MarkerLabel:    translate.VClusterName,
 		},
 	}
 	virtualNode := corev1.Node{
@@ -384,9 +383,8 @@ func TestSync(t *testing.T) {
 			podtranslate.UIDAnnotation:                string(vObjectMeta.UID),
 		},
 		Labels: map[string]string{
-			translate.NamespaceLabel:                     vObjectMeta.Namespace,
-			translate.MarkerLabel:                        translate.VClusterName,
-			podtranslate.TenantClusterHostNamespaceLabel: testingutil.DefaultTestCurrentNamespace,
+			translate.NamespaceLabel: vObjectMeta.Namespace,
+			translate.MarkerLabel:    translate.VClusterName,
 		},
 	}
 	pPodBase := &corev1.Pod{
@@ -489,9 +487,8 @@ func TestSync(t *testing.T) {
 				podtranslate.UIDAnnotation:                string(vHostPathPod.UID),
 			},
 			Labels: map[string]string{
-				translate.NamespaceLabel:                     vHostPathPod.Namespace,
-				translate.MarkerLabel:                        translate.VClusterName,
-				podtranslate.TenantClusterHostNamespaceLabel: testingutil.DefaultTestCurrentNamespace,
+				translate.NamespaceLabel: vHostPathPod.Namespace,
+				translate.MarkerLabel:    translate.VClusterName,
 			},
 			// CreationTimestamp: metav1.Time{},
 			// ResourceVersion:   "999",

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -77,8 +77,9 @@ func TestSyncTable(t *testing.T) {
 			podtranslate.UIDAnnotation:                string(vObjectMeta.UID),
 		},
 		Labels: map[string]string{
-			translate.NamespaceLabel: vObjectMeta.Namespace,
-			translate.MarkerLabel:    translate.VClusterName,
+			translate.NamespaceLabel:                     vObjectMeta.Namespace,
+			translate.MarkerLabel:                        translate.VClusterName,
+			podtranslate.TenantClusterHostNamespaceLabel: testingutil.DefaultTestCurrentNamespace,
 		},
 	}
 	virtualNode := corev1.Node{
@@ -383,8 +384,9 @@ func TestSync(t *testing.T) {
 			podtranslate.UIDAnnotation:                string(vObjectMeta.UID),
 		},
 		Labels: map[string]string{
-			translate.NamespaceLabel: vObjectMeta.Namespace,
-			translate.MarkerLabel:    translate.VClusterName,
+			translate.NamespaceLabel:                     vObjectMeta.Namespace,
+			translate.MarkerLabel:                        translate.VClusterName,
+			podtranslate.TenantClusterHostNamespaceLabel: testingutil.DefaultTestCurrentNamespace,
 		},
 	}
 	pPodBase := &corev1.Pod{
@@ -487,8 +489,9 @@ func TestSync(t *testing.T) {
 				podtranslate.UIDAnnotation:                string(vHostPathPod.UID),
 			},
 			Labels: map[string]string{
-				translate.NamespaceLabel: vHostPathPod.Namespace,
-				translate.MarkerLabel:    translate.VClusterName,
+				translate.NamespaceLabel:                     vHostPathPod.Namespace,
+				translate.MarkerLabel:                        translate.VClusterName,
+				podtranslate.TenantClusterHostNamespaceLabel: testingutil.DefaultTestCurrentNamespace,
 			},
 			// CreationTimestamp: metav1.Time{},
 			// ResourceVersion:   "999",

--- a/pkg/controllers/resources/pods/translate.go
+++ b/pkg/controllers/resources/pods/translate.go
@@ -19,7 +19,7 @@ func (s *podSyncer) translate(ctx *synccontext.SyncContext, vPod *corev1.Pod) (*
 		return nil, err
 	}
 
-	pPod, err := s.podTranslator.Translate(ctx, vPod, ptrServiceList, dnsIP, kubeIP)
+	pPod, err := s.podTranslator.Translate(ctx, vPod, ptrServiceList, dnsIP, kubeIP, s.dnsNameservers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/resources/pods/translate/diff.go
+++ b/pkg/controllers/resources/pods/translate/diff.go
@@ -83,7 +83,6 @@ func (t *translator) Diff(ctx *synccontext.SyncContext, event *synccontext.SyncE
 	for k, v := range vNamespace.GetLabels() {
 		event.Host.Labels[translate.HostLabelNamespace(k)] = v
 	}
-
 	// update pod annotations
 	event.Host.Annotations[VClusterLabelsAnnotation] = LabelsAnnotation(vPod)
 	if len(vPod.OwnerReferences) > 0 {

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -799,8 +799,11 @@ func (t *translator) applyDNSNameservers(
 			"could not resolve nameserver Service entry: %v", err,
 		)
 	}
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more nameserver Service entries failed to resolve, requeuing: %v", errs)
+	}
 	if len(ips) == 0 {
-		return fmt.Errorf("all nameserver Service entries failed to resolve, requeuing: %v", errs)
+		return fmt.Errorf("nameserver Service entries returned no ClusterIPs, requeuing")
 	}
 
 	if vPod.Spec.DNSPolicy == corev1.DNSDefault {

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -2,6 +2,7 @@ package translate
 
 import (
 	"cmp"
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -46,11 +47,6 @@ const (
 	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
 	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
 	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
-
-	// TenantClusterHostNamespaceLabel is stamped on every synced pod to carry
-	// the Control Plane Cluster namespace of the vCluster instance. Used by
-	// Candy and NetworkPolicy selectors to identify pods from a specific vCluster.
-	TenantClusterHostNamespaceLabel = "vcluster.loft.sh/tenant-host-namespace"
 )
 
 var (
@@ -79,7 +75,7 @@ type DNSNameserversResolver interface {
 	// a non-fatal error is appended to errs -- the caller emits a Warning
 	// event per error. If ips is empty, the caller must return an error
 	// and requeue rather than creating the pod with default DNS.
-	Resolve(ctx *synccontext.SyncContext) (ips []string, errs []error)
+	Resolve(ctx context.Context) (ips []string, errs []error)
 }
 
 func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder events.EventRecorder) (Translator, error) {
@@ -314,9 +310,6 @@ func (t *translator) Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, s
 	for k, v := range vNamespace.GetLabels() {
 		updatedLabels[translate.HostLabelNamespace(k)] = v
 	}
-	// Stamp tenant-identity label unconditionally so Candy and NetworkPolicy
-	// selectors can always identify pods from this vCluster instance.
-	updatedLabels[TenantClusterHostNamespaceLabel] = ctx.CurrentNamespace
 	pPod.SetLabels(updatedLabels)
 
 	// translate services to environment variables

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -803,6 +803,13 @@ func (t *translator) applyDNSNameservers(
 		return fmt.Errorf("all nameserver Service entries failed to resolve, requeuing: %v", errs)
 	}
 
+	if vPod.Spec.DNSPolicy == corev1.DNSDefault {
+		t.eventRecorder.Eventf(
+			vPod, nil, "Warning", "DNSNameservers", "PodDNSNameservers",
+			"pod uses dnsPolicy=Default; nameserver override converts it to DNSNone, node resolv.conf search domains and options are not preserved",
+		)
+	}
+
 	existing := pPod.Spec.DNSConfig
 	newCfg := &corev1.PodDNSConfig{
 		Nameservers: ips,

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -46,6 +46,11 @@ const (
 	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
 	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
 	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
+
+	// TenantClusterHostNamespaceLabel is stamped on every synced pod to carry
+	// the Control Plane Cluster namespace of the vCluster instance. Used by
+	// Candy and NetworkPolicy selectors to identify pods from a specific vCluster.
+	TenantClusterHostNamespaceLabel = "vcluster.loft.sh/tenant-host-namespace"
 )
 
 var (
@@ -56,9 +61,25 @@ var (
 )
 
 type Translator interface {
-	Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string) (*corev1.Pod, error)
+	Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string, dnsNameservers DNSNameserversResolver) (*corev1.Pod, error)
 	Diff(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*corev1.Pod]) error
 	TranslateContainerEnv(ctx *synccontext.SyncContext, envVar []corev1.EnvVar, envFrom []corev1.EnvFromSource, vPod *corev1.Pod, serviceEnvMap map[string]string) ([]corev1.EnvVar, []corev1.EnvFromSource, error)
+}
+
+// DNSNameserversResolver resolves the list of Service ClusterIPs to write to
+// dnsConfig.nameservers on synced pods. Implementations must be safe for
+// concurrent use and must read from informer caches (no API-server calls on
+// the hot path).
+type DNSNameserversResolver interface {
+	// Enabled reports whether any nameservers are configured.
+	Enabled() bool
+
+	// Resolve returns one ClusterIP per successfully resolved entry, in
+	// configuration order. For each entry that fails (missing / >1 match),
+	// a non-fatal error is appended to errs -- the caller emits a Warning
+	// event per error. If ips is empty, the caller must return an error
+	// and requeue rather than creating the pod with default DNS.
+	Resolve(ctx *synccontext.SyncContext) (ips []string, errs []error)
 }
 
 func NewTranslator(ctx *synccontext.RegisterContext, eventRecorder events.EventRecorder) (Translator, error) {
@@ -179,7 +200,7 @@ type translator struct {
 	enforcedTolerations []corev1.Toleration
 }
 
-func (t *translator) Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string) (*corev1.Pod, error) {
+func (t *translator) Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, services []*corev1.Service, dnsIP string, kubeIP string, dnsNameservers DNSNameserversResolver) (*corev1.Pod, error) {
 	// get Namespace resource in order to have access to its labels
 	vNamespace := &corev1.Namespace{}
 	err := t.vClient.Get(ctx, client.ObjectKey{Name: vPod.ObjectMeta.GetNamespace()}, vNamespace)
@@ -293,6 +314,9 @@ func (t *translator) Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, s
 	for k, v := range vNamespace.GetLabels() {
 		updatedLabels[translate.HostLabelNamespace(k)] = v
 	}
+	// Stamp tenant-identity label unconditionally so Candy and NetworkPolicy
+	// selectors can always identify pods from this vCluster instance.
+	updatedLabels[TenantClusterHostNamespaceLabel] = ctx.CurrentNamespace
 	pPod.SetLabels(updatedLabels)
 
 	// translate services to environment variables
@@ -311,6 +335,9 @@ func (t *translator) Translate(ctx *synccontext.SyncContext, vPod *corev1.Pod, s
 
 	// translate the dns config
 	t.translateDNSConfig(pPod, vPod, dnsIP)
+	if err := t.applyDNSNameservers(ctx, pPod, vPod, dnsNameservers); err != nil {
+		return nil, err
+	}
 
 	// truncate hostname if needed
 	if pPod.Spec.Hostname == "" {
@@ -750,6 +777,50 @@ func (t *translator) translateDNSConfig(pPod *corev1.Pod, vPod *corev1.Pod, name
 	case corev1.DNSDefault:
 		return
 	}
+}
+
+func (t *translator) applyDNSNameservers(
+	ctx *synccontext.SyncContext,
+	pPod *corev1.Pod,
+	vPod *corev1.Pod,
+	resolver DNSNameserversResolver,
+) error {
+	if resolver == nil || !resolver.Enabled() {
+		return nil
+	}
+	if pPod.Spec.HostNetwork {
+		return nil
+	}
+	if vPod.Spec.DNSConfig != nil && len(vPod.Spec.DNSConfig.Nameservers) > 0 {
+		t.eventRecorder.Eventf(
+			vPod, nil, "Warning", "DNSNameservers", "PodDNSNameservers",
+			"pod already pins dnsConfig.nameservers; skipping nameserver override",
+		)
+		return nil
+	}
+
+	ips, errs := resolver.Resolve(ctx)
+	for _, err := range errs {
+		t.eventRecorder.Eventf(
+			vPod, nil, "Warning", "DNSNameservers", "PodDNSNameservers",
+			"could not resolve nameserver Service entry: %v", err,
+		)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("all nameserver Service entries failed to resolve, requeuing: %v", errs)
+	}
+
+	existing := pPod.Spec.DNSConfig
+	newCfg := &corev1.PodDNSConfig{
+		Nameservers: ips,
+	}
+	if existing != nil {
+		newCfg.Searches = existing.Searches
+		newCfg.Options = existing.Options
+	}
+	pPod.Spec.DNSPolicy = corev1.DNSNone
+	pPod.Spec.DNSConfig = newCfg
+	return nil
 }
 
 func translateDNSClusterFirstConfig(pPod *corev1.Pod, vPod *corev1.Pod, clusterDomain, nameServer string) {

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -570,7 +570,7 @@ func TestPodResourcesTranslation(t *testing.T) {
 			err := vClient.Create(syncCtx.Context, vNamespace)
 			assert.NilError(t, err)
 
-			pPod, err := tr.Translate(syncCtx, &tc.vPod, nil, "", "")
+			pPod, err := tr.Translate(syncCtx, &tc.vPod, nil, "", "", nil)
 			assert.NilError(t, err)
 
 			if tc.shouldTranslate {
@@ -1036,7 +1036,7 @@ func TestTranslateEnforcedTolerationDedup(t *testing.T) {
 		},
 	}
 
-	pPod, err := tr.Translate(syncCtx, vPod, nil, "", "")
+	pPod, err := tr.Translate(syncCtx, vPod, nil, "", "", nil)
 	assert.NilError(t, err)
 
 	// Count how many times the enforced toleration appears on the physical pod.
@@ -1047,4 +1047,203 @@ func TestTranslateEnforcedTolerationDedup(t *testing.T) {
 		}
 	}
 	assert.Equal(t, count, 1, "enforced toleration must appear exactly once on the physical pod, got %d", count)
+}
+
+type fakeNameserversResolver struct {
+	enabled bool
+	ips     []string
+	errs    []error
+}
+
+func (f *fakeNameserversResolver) Enabled() bool { return f.enabled }
+func (f *fakeNameserversResolver) Resolve(_ *synccontext.SyncContext) ([]string, []error) {
+	return f.ips, f.errs
+}
+
+func newDNSNameserversTranslator(t *testing.T, recorder events.EventRecorder) (*translator, *synccontext.SyncContext) {
+	t.Helper()
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	imageTranslator, _ := NewImageTranslator(map[string]string{})
+
+	tr := &translator{
+		eventRecorder:   recorder,
+		log:             loghelper.New("pods-syncer-translator-test"),
+		vClient:         vClient,
+		pClient:         pClient,
+		imageTranslator: imageTranslator,
+	}
+
+	registerCtx := generictesting.NewFakeRegisterContext(testingutil.NewFakeConfig(), pClient, vClient)
+	syncCtx := registerCtx.ToSyncContext("test")
+	return tr, syncCtx
+}
+
+func basePodPair() (*corev1.Pod, *corev1.Pod) {
+	vPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
+		},
+	}
+	pPod := vPod.DeepCopy()
+	return vPod, pPod
+}
+
+func drainEvents(ch <-chan string) []string {
+	out := []string{}
+	for {
+		select {
+		case e := <-ch:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+func TestApplyDNSNameservers(t *testing.T) {
+	t.Run("nil resolver does not mutate", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, nil)
+		assert.NilError(t, err)
+		assert.Assert(t, pPod.Spec.DNSConfig == nil)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
+		assert.Equal(t, len(drainEvents(recorder.Events)), 0)
+	})
+
+	t.Run("disabled resolver does not mutate", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		resolver := &fakeNameserversResolver{enabled: false}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Assert(t, pPod.Spec.DNSConfig == nil)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
+		assert.Equal(t, len(drainEvents(recorder.Events)), 0)
+	})
+
+	t.Run("single entry happy path preserves searches and options", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		pPod.Spec.DNSConfig = &corev1.PodDNSConfig{
+			Searches: []string{"default.svc.cluster.local"},
+			Options: []corev1.PodDNSConfigOption{
+				{Name: "ndots", Value: ptr.To("5")},
+			},
+		}
+		resolver := &fakeNameserversResolver{enabled: true, ips: []string{"10.0.0.99"}}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSNone)
+		assert.Assert(t, pPod.Spec.DNSConfig != nil)
+		assert.DeepEqual(t, pPod.Spec.DNSConfig.Nameservers, []string{"10.0.0.99"})
+		assert.DeepEqual(t, pPod.Spec.DNSConfig.Searches, []string{"default.svc.cluster.local"})
+		assert.Equal(t, len(pPod.Spec.DNSConfig.Options), 1)
+		assert.Equal(t, len(drainEvents(recorder.Events)), 0)
+	})
+
+	t.Run("two entries both resolve", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		resolver := &fakeNameserversResolver{enabled: true, ips: []string{"10.0.0.1", "10.0.0.2"}}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSNone)
+		assert.DeepEqual(t, pPod.Spec.DNSConfig.Nameservers, []string{"10.0.0.1", "10.0.0.2"})
+		assert.Equal(t, len(drainEvents(recorder.Events)), 0)
+	})
+
+	t.Run("partial failure: one of two resolves", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		resolver := &fakeNameserversResolver{
+			enabled: true,
+			ips:     []string{"10.0.0.1"},
+			errs:    []error{fmt.Errorf("svc not found")},
+		}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSNone)
+		assert.DeepEqual(t, pPod.Spec.DNSConfig.Nameservers, []string{"10.0.0.1"})
+		assert.Equal(t, len(drainEvents(recorder.Events)), 1)
+	})
+
+	t.Run("all entries fail returns error and emits events", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		resolver := &fakeNameserversResolver{
+			enabled: true,
+			ips:     nil,
+			errs: []error{
+				fmt.Errorf("err1"),
+				fmt.Errorf("err2"),
+			},
+		}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.Assert(t, err != nil)
+		assert.Assert(t, pPod.Spec.DNSConfig == nil)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
+		assert.Equal(t, len(drainEvents(recorder.Events)), 2)
+	})
+
+	t.Run("hostNetwork pod is skipped", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		pPod.Spec.HostNetwork = true
+		resolver := &fakeNameserversResolver{enabled: true, ips: []string{"10.0.0.99"}}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Assert(t, pPod.Spec.DNSConfig == nil)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
+		assert.Equal(t, len(drainEvents(recorder.Events)), 0)
+	})
+
+	t.Run("pod with existing dnsConfig.nameservers is skipped", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		vPod.Spec.DNSConfig = &corev1.PodDNSConfig{
+			Nameservers: []string{"8.8.8.8"},
+		}
+		resolver := &fakeNameserversResolver{enabled: true, ips: []string{"10.0.0.99"}}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Assert(t, pPod.Spec.DNSConfig == nil)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
+		assert.Equal(t, len(drainEvents(recorder.Events)), 1)
+	})
+}
+
+func TestTranslateStampsTenantHostNamespaceLabel(t *testing.T) {
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	registerCtx := generictesting.NewFakeRegisterContext(testingutil.NewFakeConfig(), pClient, vClient)
+	fakeRecorder := events.NewFakeRecorder(10)
+
+	tr, err := NewTranslator(registerCtx, fakeRecorder)
+	assert.NilError(t, err)
+	syncCtx := registerCtx.ToSyncContext("tenant-label-test")
+
+	vNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+	assert.NilError(t, vClient.Create(syncCtx.Context, vNamespace))
+
+	vPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
+		},
+	}
+
+	pPod, err := tr.Translate(syncCtx, vPod, nil, "", "", nil)
+	assert.NilError(t, err)
+	assert.Equal(t, pPod.Labels[TenantClusterHostNamespaceLabel], syncCtx.CurrentNamespace)
 }

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -1,6 +1,7 @@
 package translate
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -1056,7 +1057,7 @@ type fakeNameserversResolver struct {
 }
 
 func (f *fakeNameserversResolver) Enabled() bool { return f.enabled }
-func (f *fakeNameserversResolver) Resolve(_ *synccontext.SyncContext) ([]string, []error) {
+func (f *fakeNameserversResolver) Resolve(_ context.Context) ([]string, []error) {
 	return f.ips, f.errs
 }
 
@@ -1221,29 +1222,4 @@ func TestApplyDNSNameservers(t *testing.T) {
 		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
 		assert.Equal(t, len(drainEvents(recorder.Events)), 1)
 	})
-}
-
-func TestTranslateStampsTenantHostNamespaceLabel(t *testing.T) {
-	pClient := testingutil.NewFakeClient(scheme.Scheme)
-	vClient := testingutil.NewFakeClient(scheme.Scheme)
-	registerCtx := generictesting.NewFakeRegisterContext(testingutil.NewFakeConfig(), pClient, vClient)
-	fakeRecorder := events.NewFakeRecorder(10)
-
-	tr, err := NewTranslator(registerCtx, fakeRecorder)
-	assert.NilError(t, err)
-	syncCtx := registerCtx.ToSyncContext("tenant-label-test")
-
-	vNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
-	assert.NilError(t, vClient.Create(syncCtx.Context, vNamespace))
-
-	vPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
-		},
-	}
-
-	pPod, err := tr.Translate(syncCtx, vPod, nil, "", "", nil)
-	assert.NilError(t, err)
-	assert.Equal(t, pPod.Labels[TenantClusterHostNamespaceLabel], syncCtx.CurrentNamespace)
 }

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -1160,7 +1160,7 @@ func TestApplyDNSNameservers(t *testing.T) {
 		assert.Equal(t, len(drainEvents(recorder.Events)), 0)
 	})
 
-	t.Run("partial failure: one of two resolves", func(t *testing.T) {
+	t.Run("partial failure blocks pod: one of two resolves", func(t *testing.T) {
 		recorder := events.NewFakeRecorder(10)
 		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
 		vPod, pPod := basePodPair()
@@ -1170,9 +1170,9 @@ func TestApplyDNSNameservers(t *testing.T) {
 			errs:    []error{fmt.Errorf("svc not found")},
 		}
 		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
-		assert.NilError(t, err)
-		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSNone)
-		assert.DeepEqual(t, pPod.Spec.DNSConfig.Nameservers, []string{"10.0.0.1"})
+		assert.Assert(t, err != nil)
+		assert.Assert(t, pPod.Spec.DNSConfig == nil)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
 		assert.Equal(t, len(drainEvents(recorder.Events)), 1)
 	})
 

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
@@ -1221,5 +1222,20 @@ func TestApplyDNSNameservers(t *testing.T) {
 		assert.Assert(t, pPod.Spec.DNSConfig == nil)
 		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSPolicy(""))
 		assert.Equal(t, len(drainEvents(recorder.Events)), 1)
+	})
+
+	t.Run("DNSPolicy=Default emits a Warning about lost resolv.conf options", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		tr, syncCtx := newDNSNameserversTranslator(t, recorder)
+		vPod, pPod := basePodPair()
+		vPod.Spec.DNSPolicy = corev1.DNSDefault
+		resolver := &fakeNameserversResolver{enabled: true, ips: []string{"10.0.0.99"}}
+		err := tr.applyDNSNameservers(syncCtx, pPod, vPod, resolver)
+		assert.NilError(t, err)
+		assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSNone)
+		assert.DeepEqual(t, pPod.Spec.DNSConfig.Nameservers, []string{"10.0.0.99"})
+		evts := drainEvents(recorder.Events)
+		assert.Equal(t, len(evts), 1)
+		assert.Assert(t, strings.Contains(evts[0], "resolv.conf"), "got %q", evts[0])
 	})
 }


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind feature

**What does this pull request do? Which issues does it resolve?**
Closes ENGCP-861

Adds a new `sync.toHost.pods.dns.nameservers` list field. Each entry resolves a Service ClusterIP by namespace + label selector (scoped to either the host cluster or the tenant cluster). The resolved IPs are written into `dnsConfig.nameservers` on every synced pod and `dnsPolicy` is forced to `None`. Failing entries emit a Warning event per pod; an all-fail resolution blocks pod creation. Pods with user-supplied `dnsConfig.nameservers` or `hostNetwork: true` are left untouched.

This is the vCluster syncer portion of the Calico FQDN design: Calico's per-node FQDN cache only works when the DNS request originates from the same node as the workload, so synced pods need to be pointed at a node-local DNS endpoint via Service ClusterIPs configured by the operator.

**Please provide a short message that should be published in the vcluster release notes**
Added `sync.toHost.pods.dns.nameservers`: a list of Service references (host or tenant scope) whose ClusterIPs are written into the `dnsConfig.nameservers` of every synced pod.

**What else do we need to know?**
- New host-scoped resolver entries require the syncer ServiceAccount to have `get/list/watch` on Services in the target namespace; without it the controller blocks waiting for the informer cache to sync.
- Unit tests cover the validator, the translator, and the resolver fallback paths.
- E2E suite `pods-dns-nameservers-vcluster` covers happy path, hostNetwork opt-out, user-defined nameservers override, partial-failure with Warning events, and all-fail blocking pod creation.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [x] **Add labels** to the test suite (`labels.PR`, `labels.Sync`, `labels.Core`, `labels.Pods`)
- [x] **Update label-filter section** below to execute the new test suite (carries `pr` so default mandatory suite picks it up)
- [x] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```