### PR TITLE
fix: k3s to k8s cert migration

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5493,11 +5493,15 @@
         },
         "serverCACert": {
           "type": "string",
-          "description": "ServerCAKey is the server ca cert path."
+          "description": "ServerCACert is the server ca cert path."
         },
         "clientCACert": {
           "type": "string",
-          "description": "ServerCAKey is the client ca cert path."
+          "description": "ClientCACert is the client ca cert path."
+        },
+        "clientCAKey": {
+          "type": "string",
+          "description": "ClientCAKey is the client ca key path."
         },
         "requestHeaderCACert": {
           "type": "string",

--- a/config/config.go
+++ b/config/config.go
@@ -2061,11 +2061,14 @@ type VirtualClusterKubeConfig struct {
 	// ServerCAKey is the server ca key path.
 	ServerCAKey string `json:"serverCAKey,omitempty"`
 
-	// ServerCAKey is the server ca cert path.
+	// ServerCACert is the server ca cert path.
 	ServerCACert string `json:"serverCACert,omitempty"`
 
-	// ServerCAKey is the client ca cert path.
+	// ClientCACert is the client ca cert path.
 	ClientCACert string `json:"clientCACert,omitempty"`
+
+	// ClientCAKey is the client ca key path.
+	ClientCAKey string `json:"clientCAKey,omitempty"`
 
 	// RequestHeaderCACert is the request header ca cert path.
 	RequestHeaderCACert string `json:"requestHeaderCACert,omitempty"`

--- a/e2e-next/README.md
+++ b/e2e-next/README.md
@@ -139,6 +139,7 @@ Each suite file maps to one vCluster. One file, one vCluster, one function.
 | `suite_plugin_test.go` | `plugin-vcluster` | no |
 | `suite_lifecycle_test.go` | `cli-vcluster` | no |
 | `suite_export_kubeconfig_test.go` | `export-kubeconfig-vcluster` | no |
+| `suite_migration_test.go` | `migration-vcluster` | no |
 | `suite_vind_test.go` | (self-managed) | no |
 
 ## Labels
@@ -161,6 +162,7 @@ Labels are defined in `labels/labels.go`. `labels.PR` goes on suites that should
 | `exportkubeconfig` | `export-kubeconfig-vcluster` |
 | `isolation` | `isolation-mode-vcluster` |
 | `metricsproxy` | `metricsproxy-vcluster` |
+| `migration` | `migration-vcluster` |
 | `nodesync` | `node-sync-vcluster` |
 | `plugin` | `plugin-vcluster` |
 | `rootless` | `rootless-vcluster` |

--- a/e2e-next/labels/labels.go
+++ b/e2e-next/labels/labels.go
@@ -44,4 +44,5 @@ var (
 	Plugin           = Label("plugin")
 	CLI              = Label("cli")
 	ExportKubeConfig = Label("exportkubeconfig")
+	Migration        = Label("migration")
 )

--- a/e2e-next/suite_migration_test.go
+++ b/e2e-next/suite_migration_test.go
@@ -1,0 +1,28 @@
+// Suite: migration-vcluster
+// Tests upgrade and migration flows that need to start from an older released
+// vCluster chart before upgrading to the current local chart.
+// Run: just run-e2e 'migration'
+package e2e_next
+
+import (
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	testmigration "github.com/loft-sh/vcluster/e2e-next/test_migration"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func init() {
+	suiteMigrationVCluster()
+}
+
+func suiteMigrationVCluster() {
+	Describe("migration-vcluster",
+		labels.Migration,
+		Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			testmigration.K3SToK8SMigrationSpec()
+		},
+	)
+}

--- a/e2e-next/test_migration/k3s_to_k8s.go
+++ b/e2e-next/test_migration/k3s_to_k8s.go
@@ -1,0 +1,305 @@
+// Package testmigration contains vCluster upgrade and migration tests.
+package testmigration
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/certs"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	k3sBaseChartVersion       = "0.32.2"
+	migratedFromK3sAnnotation = "vcluster.loft.sh/migrated-from-k3s"
+)
+
+// K3SToK8SMigrationSpec verifies that k3s-era CA material is migrated into a
+// k8s distro vCluster in a way that survives later kubeadm leaf regeneration.
+func K3SToK8SMigrationSpec() {
+	Describe("k3s to k8s migration",
+		labels.Migration,
+		Ordered,
+		func() {
+			var (
+				clusterName   string
+				namespace     string
+				hostClient    kubernetes.Interface
+				initialRootCA []byte
+			)
+
+			BeforeAll(func(ctx context.Context) {
+				clusterName = "migration-k3s-" + random.String(6)
+				namespace = clusterName
+				hostClient = cluster.KubeClientFrom(ctx, constants.GetHostClusterName())
+				Expect(hostClient).NotTo(BeNil())
+			})
+
+			AfterAll(func(ctx context.Context) {
+				_, err := runVClusterCmd(ctx, "delete", clusterName, "-n", namespace, "--delete-namespace", "--ignore-not-found")
+				Expect(err).To(Succeed())
+			})
+
+			It("creates a k3s vCluster from the last k3s-capable chart", func(ctx context.Context) {
+				_, err := runHelmCmd(ctx, createK3SHelmArgs(clusterName, namespace)...)
+				Expect(err).To(Succeed())
+
+				waitForVClusterPodsReady(ctx, hostClient, namespace, clusterName)
+
+				secret := getCertSecret(ctx, hostClient, namespace, clusterName)
+				initialRootCA = append([]byte(nil), secret.Data[certs.CACertName]...)
+				Expect(initialRootCA).NotTo(BeEmpty())
+				Expect(secret.Data[certs.ClientCACertName]).To(Equal(initialRootCA))
+				Expect(secret.Data[certs.ServerCACertName]).To(Equal(initialRootCA))
+			})
+
+			It("migrates k3s CA aliases when upgraded to the local k8s chart", func(ctx context.Context) {
+				_, err := runHelmCmd(ctx, upgradeToLocalK8SHelmArgs(clusterName, namespace)...)
+				Expect(err).To(Succeed())
+
+				waitForVClusterPodsReady(ctx, hostClient, namespace, clusterName)
+
+				Eventually(func(g Gomega, ctx context.Context) {
+					secret := getCertSecret(ctx, hostClient, namespace, clusterName)
+					g.Expect(secret.Annotations).To(HaveKeyWithValue(migratedFromK3sAnnotation, "true"))
+
+					ca := secret.Data[certs.CACertName]
+					clientCA := secret.Data[certs.ClientCACertName]
+					serverCA := secret.Data[certs.ServerCACertName]
+
+					g.Expect(ca).NotTo(BeEmpty())
+					g.Expect(clientCA).NotTo(BeEmpty())
+					g.Expect(serverCA).NotTo(BeEmpty())
+					g.Expect(ca).To(Equal(clientCA), "ca.crt must follow the migrated k3s client CA")
+					g.Expect(secret.Data[certs.CAKeyName]).To(Equal(secret.Data[certs.ClientCAKeyName]))
+					g.Expect(ca).NotTo(Equal(initialRootCA), "ca.crt should not remain the pre-migration kubeadm CA")
+					g.Expect(serverCA).NotTo(Equal(clientCA), "k3s server CA should stay split until kubeadm regenerates leaves")
+				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
+			})
+
+			It("regenerates leaf certs without breaking client authentication", func(ctx context.Context) {
+				deleteCertSecretKey(ctx, hostClient, namespace, clusterName, certs.APIServerCertName)
+				restartVClusterPods(ctx, hostClient, namespace, clusterName)
+				waitForVClusterPodsReady(ctx, hostClient, namespace, clusterName)
+
+				Eventually(func(g Gomega, ctx context.Context) {
+					secret := getCertSecret(ctx, hostClient, namespace, clusterName)
+					ca := secret.Data[certs.CACertName]
+					clientCA := secret.Data[certs.ClientCACertName]
+					serverCA := secret.Data[certs.ServerCACertName]
+
+					g.Expect(ca).To(Equal(clientCA))
+					g.Expect(serverCA).NotTo(Equal(clientCA), "leaf renewal should preserve the migrated k3s server CA")
+					g.Expect(secret.Data[certs.CAKeyName]).To(Equal(secret.Data[certs.ClientCAKeyName]))
+					g.Expect(secret.Data[certs.ServerCAKeyName]).NotTo(Equal(secret.Data[certs.ClientCAKeyName]))
+					expectCertSignedBy(g, secret.Data[certs.APIServerKubeletClientCertName], ca)
+					expectCertSignedBy(g, secret.Data[certs.APIServerCertName], serverCA)
+					expectKubeConfigTrustsCA(g, secret.Data[certs.AdminKubeConfigFileName], serverCA)
+					expectKubeConfigTrustsCA(g, secret.Data[certs.ControllerManagerKubeConfigFileName], serverCA)
+					expectKubeConfigTrustsCA(g, secret.Data[certs.SchedulerKubeConfigFileName], serverCA)
+				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
+
+				expectVClusterAPIReachable(ctx, namespace, clusterName)
+			})
+		},
+	)
+}
+
+func createK3SHelmArgs(name, namespace string) []string {
+	return []string{
+		"upgrade", "--install", name,
+		oldChartURL(),
+		"-n", namespace,
+		"--create-namespace",
+		"--set", "controlPlane.distro.k3s.enabled=true",
+		"--set", "controlPlane.distro.k8s.enabled=false",
+		"--set", "controlPlane.statefulSet.image.registry=ghcr.io",
+		"--set", "controlPlane.statefulSet.image.repository=loft-sh/vcluster-oss",
+		"--set", "controlPlane.statefulSet.image.tag=" + k3sBaseChartVersion,
+	}
+}
+
+func upgradeToLocalK8SHelmArgs(name, namespace string) []string {
+	return []string{
+		"upgrade", "--install", name,
+		filepath.Join("..", "chart"),
+		"-n", namespace,
+		"--reset-values",
+		"--set", "controlPlane.distro.k8s.enabled=true",
+		"--set", "controlPlane.distro.k8s.image.tag=v1.35.0",
+		"--set", "controlPlane.statefulSet.image.registry=",
+		"--set", "controlPlane.statefulSet.image.repository=" + constants.GetRepository(),
+		"--set", "controlPlane.statefulSet.image.tag=" + constants.GetTag(),
+	}
+}
+
+func oldChartURL() string {
+	return "https://charts.loft.sh/charts/vcluster-" + k3sBaseChartVersion + ".tgz"
+}
+
+func runHelmCmd(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "helm", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("helm %s failed: %w\noutput: %s", strings.Join(args, " "), err, string(out))
+	}
+	return string(out), nil
+}
+
+func runVClusterCmd(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, filepath.Join(os.Getenv("GOBIN"), "vcluster"), args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("vcluster %s failed: %w\noutput: %s", strings.Join(args, " "), err, string(out))
+	}
+	return string(out), nil
+}
+
+func getCertSecret(ctx context.Context, hostClient kubernetes.Interface, namespace, vClusterName string) *corev1.Secret {
+	GinkgoHelper()
+	secret, err := hostClient.CoreV1().Secrets(namespace).Get(ctx, certs.CertSecretName(vClusterName), metav1.GetOptions{})
+	Expect(err).To(Succeed())
+	return secret
+}
+
+func waitForVClusterPodsReady(ctx context.Context, hostClient kubernetes.Interface, namespace, vClusterName string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega, ctx context.Context) {
+		pods, err := hostClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=vcluster,release=" + vClusterName,
+		})
+		g.Expect(err).To(Succeed())
+		g.Expect(pods.Items).NotTo(BeEmpty(), "no vCluster pods found")
+		for _, pod := range pods.Items {
+			g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning),
+				"pod %s phase is %s, expected Running", pod.Name, pod.Status.Phase)
+			g.Expect(pod.Status.ContainerStatuses).NotTo(BeEmpty(),
+				"pod %s has no container statuses", pod.Name)
+			for _, container := range pod.Status.ContainerStatuses {
+				g.Expect(container.Ready).To(BeTrue(),
+					"container %s in pod %s is not ready", container.Name, pod.Name)
+			}
+		}
+	}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
+}
+
+func deleteCertSecretKey(ctx context.Context, hostClient kubernetes.Interface, namespace, vClusterName, key string) {
+	GinkgoHelper()
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		secret, err := hostClient.CoreV1().Secrets(namespace).Get(ctx, certs.CertSecretName(vClusterName), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		delete(secret.Data, key)
+		_, err = hostClient.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+		return err
+	})
+	Expect(err).To(Succeed())
+}
+
+func restartVClusterPods(ctx context.Context, hostClient kubernetes.Interface, namespace, vClusterName string) {
+	GinkgoHelper()
+	pods, err := hostClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app=vcluster,release=" + vClusterName,
+	})
+	Expect(err).To(Succeed())
+	Expect(pods.Items).NotTo(BeEmpty())
+
+	oldUIDs := map[string]struct{}{}
+	for _, pod := range pods.Items {
+		oldUIDs[string(pod.UID)] = struct{}{}
+		err := hostClient.CoreV1().Pods(namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		Expect(err).To(Succeed())
+	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		pods, err := hostClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=vcluster,release=" + vClusterName,
+		})
+		g.Expect(err).To(Succeed())
+		g.Expect(pods.Items).NotTo(BeEmpty())
+		for _, pod := range pods.Items {
+			_, old := oldUIDs[string(pod.UID)]
+			g.Expect(old).To(BeFalse(), "pod %s still has pre-restart UID", pod.Name)
+		}
+	}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
+}
+
+func expectCertSignedBy(g Gomega, certPEM, caPEM []byte) {
+	GinkgoHelper()
+	cert := parseCertificate(g, certPEM)
+	ca := parseCertificate(g, caPEM)
+	g.Expect(cert.CheckSignatureFrom(ca)).To(Succeed(),
+		"certificate issuer %q should be signed by CA subject %q", cert.Issuer.String(), ca.Subject.String())
+}
+
+func expectKubeConfigTrustsCA(g Gomega, kubeConfigBytes, caPEM []byte) {
+	GinkgoHelper()
+	kubeConfig, err := clientcmd.Load(kubeConfigBytes)
+	g.Expect(err).To(Succeed())
+	for _, cluster := range kubeConfig.Clusters {
+		g.Expect(cluster.CertificateAuthority).To(BeEmpty())
+		g.Expect(cluster.CertificateAuthorityData).To(Equal(caPEM))
+	}
+}
+
+func parseCertificate(g Gomega, certPEM []byte) *x509.Certificate {
+	GinkgoHelper()
+	block, _ := pem.Decode(certPEM)
+	g.Expect(block).NotTo(BeNil(), "failed to decode certificate PEM")
+	g.Expect(block.Type).To(Equal("CERTIFICATE"))
+	cert, err := x509.ParseCertificate(block.Bytes)
+	g.Expect(err).To(Succeed())
+	return cert
+}
+
+func expectVClusterAPIReachable(ctx context.Context, namespace, vClusterName string) {
+	GinkgoHelper()
+	tmpFile, err := os.CreateTemp("", "vcluster-migration-kubeconfig-*")
+	Expect(err).To(Succeed())
+	Expect(tmpFile.Close()).To(Succeed())
+	DeferCleanup(func() { _ = os.Remove(tmpFile.Name()) })
+
+	_, err = runVClusterCmd(ctx,
+		"connect", vClusterName,
+		"-n", namespace,
+		"--driver", "helm",
+		"--kube-config", tmpFile.Name(),
+		"--update-current=false",
+		"--background-proxy=true",
+		"--background-proxy-image", constants.GetVClusterImage(),
+	)
+	Expect(err).To(Succeed())
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		data, err := os.ReadFile(tmpFile.Name())
+		g.Expect(err).To(Succeed())
+		g.Expect(bytes.TrimSpace(data)).NotTo(BeEmpty(), "kubeconfig file is still empty after connect")
+
+		restConfig, err := clientcmd.RESTConfigFromKubeConfig(data)
+		g.Expect(err).To(Succeed())
+
+		client, err := kubernetes.NewForConfig(restConfig)
+		g.Expect(err).To(Succeed())
+
+		_, err = client.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+		g.Expect(err).To(Succeed())
+	}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+}

--- a/pkg/certs/ensure.go
+++ b/pkg/certs/ensure.go
@@ -1,6 +1,7 @@
 package certs
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -25,6 +26,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
@@ -348,6 +350,22 @@ func generateCertificates(
 		return fmt.Errorf("split ca cert: %w", err)
 	}
 
+	// k3s can use split client/server CAs. In that case StartK8S switches the
+	// controller-manager to per-signer args, so make sure kubeadm-generated
+	// serving certs and kubeconfigs keep using server-ca for apiserver TLS.
+	err = ensureAPIServerServingCertSignedByServerCA(certificateDir, kubeadmConfig)
+	if err != nil {
+		return fmt.Errorf("ensure apiserver cert: %w", err)
+	}
+
+	// For split k3s CAs, kubeconfigs must trust server-ca because they connect
+	// to the apiserver serving cert. This keeps regenerated kubeconfigs aligned
+	// with the per-signer controller-manager args and server-ca-signed leafs.
+	err = ensureKubeConfigsTrustServerCA(certificateDir)
+	if err != nil {
+		return fmt.Errorf("ensure kube configs trust server ca: %w", err)
+	}
+
 	return nil
 }
 
@@ -443,6 +461,120 @@ func splitCACert(certificateDir string) error {
 	}
 
 	return nil
+}
+
+// ensureKubeConfigsTrustServerCA keeps generated kubeconfigs trusting server-ca
+// when a migrated k3s cluster has split server/client CAs. Kubeconfigs connect
+// to the apiserver, so they must trust the CA that signs apiserver.crt, not the
+// client CA exposed as ca.crt in this mode.
+func ensureKubeConfigsTrustServerCA(certificateDir string) error {
+	caCert, err := os.ReadFile(filepath.Join(certificateDir, CACertName))
+	if err != nil {
+		return fmt.Errorf("read %s: %w", CACertName, err)
+	}
+
+	serverCACert, err := os.ReadFile(filepath.Join(certificateDir, ServerCACertName))
+	if err != nil {
+		return fmt.Errorf("read %s: %w", ServerCACertName, err)
+	}
+
+	if equalFirstPEMCertificate(caCert, serverCACert) {
+		return nil
+	}
+
+	for _, kubeConfigName := range []string{
+		AdminKubeConfigFileName,
+		ControllerManagerKubeConfigFileName,
+		SchedulerKubeConfigFileName,
+	} {
+		err := ensureKubeConfigTrustsCA(filepath.Join(certificateDir, kubeConfigName), serverCACert)
+		if err != nil {
+			return fmt.Errorf("update %s: %w", kubeConfigName, err)
+		}
+	}
+
+	return nil
+}
+
+func ensureKubeConfigTrustsCA(path string, caCert []byte) error {
+	kubeConfig, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return fmt.Errorf("load kube config: %w", err)
+	}
+
+	for _, cluster := range kubeConfig.Clusters {
+		cluster.CertificateAuthority = ""
+		cluster.CertificateAuthorityData = caCert
+	}
+
+	err = clientcmd.WriteToFile(*kubeConfig, path)
+	if err != nil {
+		return fmt.Errorf("write kube config: %w", err)
+	}
+
+	return nil
+}
+
+// ensureAPIServerServingCertSignedByServerCA keeps the apiserver serving leaf on
+// server-ca when a migrated k3s cluster has split server/client CAs. Existing
+// migrated certs are already signed correctly, but kubeadm would sign a future
+// regenerated apiserver.crt with ca.crt, which points at client-ca in this mode.
+func ensureAPIServerServingCertSignedByServerCA(certificateDir string, kubeadmConfig *kubeadmapi.InitConfiguration) error {
+	caCert, err := os.ReadFile(filepath.Join(certificateDir, CACertName))
+	if err != nil {
+		return fmt.Errorf("read %s: %w", CACertName, err)
+	}
+
+	serverCACert, err := os.ReadFile(filepath.Join(certificateDir, ServerCACertName))
+	if err != nil {
+		return fmt.Errorf("read %s: %w", ServerCACertName, err)
+	}
+
+	if equalFirstPEMCertificate(caCert, serverCACert) {
+		return nil
+	}
+
+	serverCA, serverCAKey, err := pkiutil.TryLoadCertAndKeyFromDisk(certificateDir, strings.TrimSuffix(ServerCACertName, ".crt"))
+	if err != nil {
+		return fmt.Errorf("load %s: %w", ServerCACertName, err)
+	}
+
+	if err := os.Remove(filepath.Join(certificateDir, APIServerCertName)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", APIServerCertName, err)
+	}
+	if err := os.Remove(filepath.Join(certificateDir, APIServerKeyName)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", APIServerKeyName, err)
+	}
+
+	if err := certs.KubeadmCertAPIServer().CreateFromCA(kubeadmConfig, serverCA, serverCAKey); err != nil {
+		return fmt.Errorf("create %s from %s: %w", APIServerCertName, ServerCACertName, err)
+	}
+
+	return nil
+}
+
+func HasSplitClusterSigningCA(serverCACertPath, clientCACertPath string) (bool, error) {
+	serverCACert, err := os.ReadFile(serverCACertPath)
+	if err != nil {
+		return false, fmt.Errorf("read server ca cert: %w", err)
+	}
+
+	clientCACert, err := os.ReadFile(clientCACertPath)
+	if err != nil {
+		return false, fmt.Errorf("read client ca cert: %w", err)
+	}
+
+	return !equalFirstPEMCertificate(serverCACert, clientCACert), nil
+}
+
+func equalFirstPEMCertificate(a, b []byte) bool {
+	aBlock, _ := pem.Decode(a)
+	bBlock, _ := pem.Decode(b)
+	if aBlock == nil || bBlock == nil || aBlock.Type != "CERTIFICATE" || bBlock.Type != "CERTIFICATE" {
+		return bytes.Equal(a, b)
+	}
+
+	return bytes.Equal(aBlock.Bytes, bBlock.Bytes)
 }
 
 func copyFileIfNotExists(src, dst string) error {

--- a/pkg/certs/ensure_test.go
+++ b/pkg/certs/ensure_test.go
@@ -1,18 +1,28 @@
 package certs
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"math/big"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/loft-sh/vcluster/pkg/util/certhelper"
 	"gotest.tools/assert"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmcerts "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 )
 
 // newSelfSignedCertPEM creates a self-signed certificate PEM that expires at the given time.
@@ -197,4 +207,239 @@ func TestWarnIfCAExpiring(t *testing.T) {
 
 	delete(data, CACertName)
 	warnIfCAExpiring(data)
+}
+
+func TestSplitCACertPreservesExistingAliases(t *testing.T) {
+	dir := t.TempDir()
+	caPEM := newSelfSignedCertPEM(t, "ca", time.Now().Add(365*24*time.Hour))
+	serverPEM := newSelfSignedCertPEM(t, "server-ca", time.Now().Add(365*24*time.Hour))
+	clientPEM := newSelfSignedCertPEM(t, "client-ca", time.Now().Add(365*24*time.Hour))
+
+	writeTestCertFile(t, dir, CACertName, caPEM)
+	writeTestCertFile(t, dir, CAKeyName, []byte("ca-key"))
+	writeTestCertFile(t, dir, ServerCACertName, serverPEM)
+	writeTestCertFile(t, dir, ServerCAKeyName, []byte("server-key"))
+	writeTestCertFile(t, dir, ClientCACertName, clientPEM)
+	writeTestCertFile(t, dir, ClientCAKeyName, []byte("client-key"))
+
+	err := splitCACert(dir)
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(readTestCertFile(t, dir, ServerCACertName)), string(serverPEM))
+	assert.Equal(t, string(readTestCertFile(t, dir, ServerCAKeyName)), "server-key")
+	assert.Equal(t, string(readTestCertFile(t, dir, ClientCACertName)), string(clientPEM))
+	assert.Equal(t, string(readTestCertFile(t, dir, ClientCAKeyName)), "client-key")
+}
+
+func TestSplitCACertCreatesMissingAliases(t *testing.T) {
+	dir := t.TempDir()
+	caPEM := newSelfSignedCertPEM(t, "ca", time.Now().Add(365*24*time.Hour))
+
+	writeTestCertFile(t, dir, CACertName, caPEM)
+	writeTestCertFile(t, dir, CAKeyName, []byte("ca-key"))
+
+	err := splitCACert(dir)
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(readTestCertFile(t, dir, ServerCACertName)), string(caPEM))
+	assert.Equal(t, string(readTestCertFile(t, dir, ServerCAKeyName)), "ca-key")
+	assert.Equal(t, string(readTestCertFile(t, dir, ClientCACertName)), string(caPEM))
+	assert.Equal(t, string(readTestCertFile(t, dir, ClientCAKeyName)), "ca-key")
+}
+
+func TestEnsureAPIServerServingCertSignedByServerCA(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := writeTestCA(t, dir, CACertAndKeyBaseName, "kubernetes")
+	serverCACert, _ := writeTestCA(t, dir, strings.TrimSuffix(ServerCACertName, ".crt"), "k3s-server-ca")
+	kubeadmConfig := testKubeadmConfig(dir)
+
+	err := kubeadmcerts.KubeadmCertAPIServer().CreateFromCA(kubeadmConfig, caCert, caKey)
+	assert.NilError(t, err)
+	apiServerCert := readTestCertificate(t, dir, APIServerCertName)
+	assert.NilError(t, apiServerCert.CheckSignatureFrom(caCert))
+	assert.Assert(t, apiServerCert.CheckSignatureFrom(serverCACert) != nil)
+
+	err = ensureAPIServerServingCertSignedByServerCA(dir, kubeadmConfig)
+	assert.NilError(t, err)
+
+	apiServerCert = readTestCertificate(t, dir, APIServerCertName)
+	assert.NilError(t, apiServerCert.CheckSignatureFrom(serverCACert))
+	assert.Assert(t, apiServerCert.CheckSignatureFrom(caCert) != nil)
+}
+
+func TestGenerateCertificatesPreservesSplitCA(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := writeTestCA(t, dir, CACertAndKeyBaseName, "k3s-client-ca")
+	serverCACert, _ := writeTestCA(t, dir, strings.TrimSuffix(ServerCACertName, ".crt"), "k3s-server-ca")
+	err := pkiutil.WriteCertAndKey(dir, strings.TrimSuffix(ClientCACertName, ".crt"), caCert, caKey)
+	assert.NilError(t, err)
+
+	err = generateCertificates(dir, testKubeadmConfig(dir))
+	assert.NilError(t, err)
+
+	apiServerCert := readTestCertificate(t, dir, APIServerCertName)
+	assert.NilError(t, apiServerCert.CheckSignatureFrom(serverCACert))
+	assert.Assert(t, apiServerCert.CheckSignatureFrom(caCert) != nil)
+
+	apiServerKubeletClientCert := readTestCertificate(t, dir, APIServerKubeletClientCertName)
+	assert.NilError(t, apiServerKubeletClientCert.CheckSignatureFrom(caCert))
+	assert.Assert(t, apiServerKubeletClientCert.CheckSignatureFrom(serverCACert) != nil)
+
+	for _, kubeConfigName := range []string{
+		AdminKubeConfigFileName,
+		ControllerManagerKubeConfigFileName,
+		SchedulerKubeConfigFileName,
+	} {
+		assertKubeConfigTrustsCA(t, filepath.Join(dir, kubeConfigName), readTestCertFile(t, dir, ServerCACertName))
+		assertKubeConfigClientCertSignedBy(t, filepath.Join(dir, kubeConfigName), caCert)
+	}
+}
+
+func TestHasSplitClusterSigningCA(t *testing.T) {
+	dir := t.TempDir()
+	serverCA := newSelfSignedCertPEM(t, "server-ca", time.Now().Add(365*24*time.Hour))
+	clientCA := newSelfSignedCertPEM(t, "client-ca", time.Now().Add(365*24*time.Hour))
+
+	serverCAPath := filepath.Join(dir, "server-ca.crt")
+	clientCAPath := filepath.Join(dir, "client-ca.crt")
+	writeTestCertFile(t, dir, "server-ca.crt", serverCA)
+	writeTestCertFile(t, dir, "client-ca.crt", serverCA)
+
+	split, err := HasSplitClusterSigningCA(serverCAPath, clientCAPath)
+	assert.NilError(t, err)
+	assert.Equal(t, split, false)
+
+	writeTestCertFile(t, dir, "client-ca.crt", clientCA)
+	split, err = HasSplitClusterSigningCA(serverCAPath, clientCAPath)
+	assert.NilError(t, err)
+	assert.Equal(t, split, true)
+}
+
+func TestEnsureKubeConfigTrustsCAClearsCAPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "admin.conf")
+	serverCA := []byte("server-ca")
+
+	err := clientcmd.WriteToFile(clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster": {
+				Server:                   "https://127.0.0.1:6443",
+				CertificateAuthority:     "/old/ca.crt",
+				CertificateAuthorityData: []byte("old-ca"),
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"admin": {},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"context": {
+				Cluster:  "cluster",
+				AuthInfo: "admin",
+			},
+		},
+		CurrentContext: "context",
+	}, path)
+	assert.NilError(t, err)
+
+	err = ensureKubeConfigTrustsCA(path, serverCA)
+	assert.NilError(t, err)
+
+	assertKubeConfigTrustsCA(t, path, serverCA)
+}
+
+func writeTestCA(t *testing.T, dir, baseName, commonName string) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+
+	cert, key, err := pkiutil.NewCertificateAuthority(&pkiutil.CertConfig{
+		Config: certutil.Config{
+			CommonName: commonName,
+		},
+		NotAfter:            time.Now().Add(365 * 24 * time.Hour),
+		EncryptionAlgorithm: kubeadmapi.EncryptionAlgorithmRSA2048,
+	})
+	assert.NilError(t, err)
+
+	err = pkiutil.WriteCertAndKey(dir, baseName, cert, key)
+	assert.NilError(t, err)
+
+	return cert, key
+}
+
+func assertKubeConfigTrustsCA(t *testing.T, path string, caPEM []byte) {
+	t.Helper()
+
+	kubeConfig, err := clientcmd.LoadFromFile(path)
+	assert.NilError(t, err)
+	for _, cluster := range kubeConfig.Clusters {
+		assert.DeepEqual(t, cluster.CertificateAuthorityData, caPEM)
+		assert.Equal(t, cluster.CertificateAuthority, "")
+	}
+}
+
+func assertKubeConfigClientCertSignedBy(t *testing.T, path string, caCert *x509.Certificate) {
+	t.Helper()
+
+	kubeConfig, err := clientcmd.LoadFromFile(path)
+	assert.NilError(t, err)
+	for _, authInfo := range kubeConfig.AuthInfos {
+		clientCert := parseTestCertificate(t, authInfo.ClientCertificateData)
+		assert.NilError(t, clientCert.CheckSignatureFrom(caCert))
+	}
+}
+
+func testKubeadmConfig(dir string) *kubeadmapi.InitConfiguration {
+	return &kubeadmapi.InitConfiguration{
+		ClusterConfiguration: kubeadmapi.ClusterConfiguration{
+			CertificatesDir:     dir,
+			EncryptionAlgorithm: kubeadmapi.EncryptionAlgorithmRSA2048,
+			Networking: kubeadmapi.Networking{
+				ServiceSubnet: "10.96.0.0/12",
+				DNSDomain:     "cluster.local",
+			},
+		},
+		NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+			Name: "test-node",
+		},
+		LocalAPIEndpoint: kubeadmapi.APIEndpoint{
+			AdvertiseAddress: "127.0.0.1",
+			BindPort:         6443,
+		},
+	}
+}
+
+func writeTestCertFile(t *testing.T, dir, name string, data []byte) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	err := os.MkdirAll(filepath.Dir(path), 0777)
+	assert.NilError(t, err)
+
+	err = os.WriteFile(path, data, 0666)
+	assert.NilError(t, err)
+}
+
+func readTestCertFile(t *testing.T, dir, name string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	assert.NilError(t, err)
+	return data
+}
+
+func readTestCertificate(t *testing.T, dir, name string) *x509.Certificate {
+	t.Helper()
+
+	return parseTestCertificate(t, readTestCertFile(t, dir, name))
+}
+
+func parseTestCertificate(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+
+	block, _ := pem.Decode(certPEM)
+	assert.Assert(t, block != nil)
+	assert.Equal(t, block.Type, "CERTIFICATE")
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	assert.NilError(t, err)
+	return cert
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,7 @@ func (v VirtualClusterConfig) VirtualClusterKubeConfig() config.VirtualClusterKu
 		ServerCAKey:         constants.ServerCAKey,
 		ServerCACert:        constants.ServerCACert,
 		ClientCACert:        constants.ClientCACert,
+		ClientCAKey:         constants.ClientCAKey,
 		RequestHeaderCACert: constants.RequestHeaderCACert,
 	}
 
@@ -54,6 +55,9 @@ func (v VirtualClusterConfig) VirtualClusterKubeConfig() config.VirtualClusterKu
 	}
 	if retConfig.ClientCACert == "" {
 		retConfig.ClientCACert = distroConfig.ClientCACert
+	}
+	if retConfig.ClientCAKey == "" {
+		retConfig.ClientCAKey = distroConfig.ClientCAKey
 	}
 	if retConfig.ServerCAKey == "" {
 		retConfig.ServerCAKey = distroConfig.ServerCAKey

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,7 @@ var (
 	ServerCAKey         = filepath.Join(PKIDir, "server-ca.key")
 	ServerCACert        = filepath.Join(PKIDir, "server-ca.crt")
 	ClientCACert        = filepath.Join(PKIDir, "client-ca.crt")
+	ClientCAKey         = filepath.Join(PKIDir, "client-ca.key")
 	RequestHeaderCACert = filepath.Join(PKIDir, "front-proxy-ca.crt")
 
 	FrontProxyClientCert = filepath.Join(PKIDir, "front-proxy-client.crt")

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/certs"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/etcd"
@@ -150,14 +151,25 @@ func StartK8S(ctx context.Context, serviceCIDR string, vConfig *config.VirtualCl
 				args = append(args, "--bind-address=127.0.0.1")
 				args = append(args, "--client-ca-file="+vConfig.VirtualClusterKubeConfig().ClientCACert)
 				args = append(args, "--cluster-name=kubernetes")
-				args = append(args, "--cluster-signing-cert-file="+vConfig.VirtualClusterKubeConfig().ServerCACert)
-				args = append(args, "--cluster-signing-key-file="+vConfig.VirtualClusterKubeConfig().ServerCAKey)
 				args = append(args, "--kubeconfig="+constants.ControllerManagerConf)
 				args = append(args, "--requestheader-client-ca-file="+vConfig.VirtualClusterKubeConfig().RequestHeaderCACert)
 				args = append(args, "--root-ca-file="+vConfig.VirtualClusterKubeConfig().ServerCACert)
 				args = append(args, "--service-account-private-key-file="+constants.SAKey)
 				args = append(args, "--use-service-account-credentials=true")
 				args = append(args, "--leader-elect=true")
+
+				if !hasClusterSigningFileArgs(controllerManager.ExtraArgs) {
+					splitClusterSigningCA, err := certs.HasSplitClusterSigningCA(
+						vConfig.VirtualClusterKubeConfig().ServerCACert,
+						vConfig.VirtualClusterKubeConfig().ClientCACert,
+					)
+					if err != nil {
+						klog.Errorf("error configuring cluster signing args: %s", err.Error())
+						osutil.Exit(1)
+						return
+					}
+					args = appendClusterSigningArgs(args, vConfig.VirtualClusterKubeConfig(), splitClusterSigningCA)
+				}
 
 				if vConfig.PrivateNodes.Enabled {
 					controllers := "--controllers=*,bootstrapsigner,tokencleaner"
@@ -380,6 +392,45 @@ func ExecTemplate(templateContents string, name, namespace string, values *vclus
 	}
 
 	return b.Bytes(), nil
+}
+
+func appendClusterSigningArgs(args []string, kubeConfig vclusterconfig.VirtualClusterKubeConfig, splitCA bool) []string {
+	if !splitCA {
+		args = append(args, "--cluster-signing-cert-file="+kubeConfig.ServerCACert)
+		args = append(args, "--cluster-signing-key-file="+kubeConfig.ServerCAKey)
+		return args
+	}
+
+	args = append(args, "--cluster-signing-kube-apiserver-client-cert-file="+kubeConfig.ClientCACert)
+	args = append(args, "--cluster-signing-kube-apiserver-client-key-file="+kubeConfig.ClientCAKey)
+	args = append(args, "--cluster-signing-kubelet-client-cert-file="+kubeConfig.ClientCACert)
+	args = append(args, "--cluster-signing-kubelet-client-key-file="+kubeConfig.ClientCAKey)
+	args = append(args, "--cluster-signing-kubelet-serving-cert-file="+kubeConfig.ServerCACert)
+	args = append(args, "--cluster-signing-kubelet-serving-key-file="+kubeConfig.ServerCAKey)
+	args = append(args, "--cluster-signing-legacy-unknown-cert-file="+kubeConfig.ServerCACert)
+	args = append(args, "--cluster-signing-legacy-unknown-key-file="+kubeConfig.ServerCAKey)
+	return args
+}
+
+func hasClusterSigningFileArgs(args []string) bool {
+	for _, flag := range []string{
+		"--cluster-signing-cert-file",
+		"--cluster-signing-key-file",
+		"--cluster-signing-kube-apiserver-client-cert-file",
+		"--cluster-signing-kube-apiserver-client-key-file",
+		"--cluster-signing-kubelet-client-cert-file",
+		"--cluster-signing-kubelet-client-key-file",
+		"--cluster-signing-kubelet-serving-cert-file",
+		"--cluster-signing-kubelet-serving-key-file",
+		"--cluster-signing-legacy-unknown-cert-file",
+		"--cluster-signing-legacy-unknown-key-file",
+	} {
+		if command.ContainsFlag(args, flag) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // waits for the api to be up, ignoring certs and calling it

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -1,0 +1,176 @@
+package k8s
+
+import (
+	"testing"
+
+	vclusterconfig "github.com/loft-sh/vcluster/config"
+	"github.com/loft-sh/vcluster/pkg/util/command"
+	"gotest.tools/assert"
+)
+
+func TestAppendClusterSigningArgsUsesGenericSignerForNonSplitCA(t *testing.T) {
+	kubeConfig := vclusterconfig.VirtualClusterKubeConfig{
+		ServerCACert: "/custom/ca.crt",
+		ServerCAKey:  "/custom/ca.key",
+		ClientCACert: "/custom/ca.crt",
+	}
+
+	args := appendClusterSigningArgs(nil, kubeConfig, false)
+
+	assertHasArgs(t, args,
+		"--cluster-signing-cert-file=/custom/ca.crt",
+		"--cluster-signing-key-file=/custom/ca.key",
+	)
+	assertMissingFlags(t, args, perSignerClusterSigningFlags...)
+}
+
+func TestAppendClusterSigningArgsUsesSplitCASigners(t *testing.T) {
+	kubeConfig := vclusterconfig.VirtualClusterKubeConfig{
+		ServerCACert: "/data/pki/server-ca.crt",
+		ServerCAKey:  "/data/pki/server-ca.key",
+		ClientCACert: "/data/pki/client-ca.crt",
+		ClientCAKey:  "/data/pki/client-ca.key",
+	}
+
+	args := appendClusterSigningArgs(nil, kubeConfig, true)
+
+	assertMissingFlags(t, args, genericClusterSigningFlags...)
+	assertHasArgs(t, args,
+		"--cluster-signing-kube-apiserver-client-cert-file=/data/pki/client-ca.crt",
+		"--cluster-signing-kube-apiserver-client-key-file=/data/pki/client-ca.key",
+		"--cluster-signing-kubelet-client-cert-file=/data/pki/client-ca.crt",
+		"--cluster-signing-kubelet-client-key-file=/data/pki/client-ca.key",
+		"--cluster-signing-kubelet-serving-cert-file=/data/pki/server-ca.crt",
+		"--cluster-signing-kubelet-serving-key-file=/data/pki/server-ca.key",
+		"--cluster-signing-legacy-unknown-cert-file=/data/pki/server-ca.crt",
+		"--cluster-signing-legacy-unknown-key-file=/data/pki/server-ca.key",
+	)
+}
+
+func TestAppendClusterSigningArgsUsesCustomClientCAKeyForCustomSplitCA(t *testing.T) {
+	kubeConfig := vclusterconfig.VirtualClusterKubeConfig{
+		ServerCACert: "/custom/server-ca.crt",
+		ServerCAKey:  "/custom/server-ca.key",
+		ClientCACert: "/custom/client-ca.crt",
+		ClientCAKey:  "/custom/client-ca.key",
+	}
+
+	args := appendClusterSigningArgs(nil, kubeConfig, true)
+
+	assertMissingFlags(t, args, genericClusterSigningFlags...)
+	assertHasArgs(t, args,
+		"--cluster-signing-kube-apiserver-client-cert-file=/custom/client-ca.crt",
+		"--cluster-signing-kube-apiserver-client-key-file=/custom/client-ca.key",
+		"--cluster-signing-kubelet-client-cert-file=/custom/client-ca.crt",
+		"--cluster-signing-kubelet-client-key-file=/custom/client-ca.key",
+		"--cluster-signing-kubelet-serving-cert-file=/custom/server-ca.crt",
+		"--cluster-signing-kubelet-serving-key-file=/custom/server-ca.key",
+		"--cluster-signing-legacy-unknown-cert-file=/custom/server-ca.crt",
+		"--cluster-signing-legacy-unknown-key-file=/custom/server-ca.key",
+	)
+}
+
+func TestHasClusterSigningFileArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "generic cert file",
+			args:     []string{"--cluster-signing-cert-file=/custom/ca.crt"},
+			expected: true,
+		},
+		{
+			name:     "generic key file with split value",
+			args:     []string{"--cluster-signing-key-file", "/custom/ca.key"},
+			expected: true,
+		},
+		{
+			name:     "per-signer cert file",
+			args:     []string{"--cluster-signing-kube-apiserver-client-cert-file=/custom/client-ca.crt"},
+			expected: true,
+		},
+		{
+			name:     "per-signer key file",
+			args:     []string{"--cluster-signing-kubelet-serving-key-file=/custom/server-ca.key"},
+			expected: true,
+		},
+		{
+			name:     "duration does not override signing files",
+			args:     []string{"--cluster-signing-duration=24h", "--profiling=true"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, hasClusterSigningFileArgs(test.args), test.expected)
+		})
+	}
+}
+
+func TestGenericClusterSigningExtraArgsSkipGeneratedSigningArgs(t *testing.T) {
+	kubeConfig := vclusterconfig.VirtualClusterKubeConfig{
+		ServerCACert: "/data/pki/server-ca.crt",
+		ServerCAKey:  "/data/pki/server-ca.key",
+		ClientCACert: "/data/pki/client-ca.crt",
+		ClientCAKey:  "/data/pki/client-ca.key",
+	}
+	extraArgs := []string{
+		"--cluster-signing-cert-file=/custom/ca.crt",
+		"--cluster-signing-key-file=/custom/ca.key",
+	}
+
+	args := []string{}
+	if !hasClusterSigningFileArgs(extraArgs) {
+		args = appendClusterSigningArgs(args, kubeConfig, true)
+	}
+	args = command.MergeArgs(args, extraArgs)
+
+	assertMissingFlags(t, args, perSignerClusterSigningFlags...)
+	assertHasArgs(t, args,
+		"--cluster-signing-cert-file=/custom/ca.crt",
+		"--cluster-signing-key-file=/custom/ca.key",
+	)
+}
+
+var genericClusterSigningFlags = []string{
+	"--cluster-signing-cert-file",
+	"--cluster-signing-key-file",
+}
+
+var perSignerClusterSigningFlags = []string{
+	"--cluster-signing-kube-apiserver-client-cert-file",
+	"--cluster-signing-kube-apiserver-client-key-file",
+	"--cluster-signing-kubelet-client-cert-file",
+	"--cluster-signing-kubelet-client-key-file",
+	"--cluster-signing-kubelet-serving-cert-file",
+	"--cluster-signing-kubelet-serving-key-file",
+	"--cluster-signing-legacy-unknown-cert-file",
+	"--cluster-signing-legacy-unknown-key-file",
+}
+
+func assertHasArgs(t *testing.T, args []string, expected ...string) {
+	t.Helper()
+	for _, expectedArg := range expected {
+		assert.Assert(t, hasArg(args, expectedArg), "missing arg %s", expectedArg)
+	}
+}
+
+func assertMissingFlags(t *testing.T, args []string, flags ...string) {
+	t.Helper()
+	for _, flag := range flags {
+		assert.Assert(t, !command.ContainsFlag(args, flag), "unexpected flag %s", flag)
+	}
+}
+
+func hasArg(args []string, expected string) bool {
+	for _, arg := range args {
+		if arg == expected {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/k8s/migrate.go
+++ b/pkg/k8s/migrate.go
@@ -21,6 +21,9 @@ import (
 var (
 	migratedFromK3sAnnotation = "vcluster.loft.sh/migrated-from-k3s"
 
+	k3sClientCACertPath = "/data/server/tls/client-ca.crt"
+	k3sClientCAKeyPath  = "/data/server/tls/client-ca.key"
+
 	k3sKubeConfig = map[string]string{
 		certs.AdminKubeConfigFileName:             "/data/server/cred/admin.kubeconfig",
 		certs.ControllerManagerKubeConfigFileName: "/data/server/cred/controller.kubeconfig",
@@ -34,8 +37,12 @@ var (
 		certs.ServerCACertName: "/data/server/tls/server-ca.crt",
 		certs.ServerCAKeyName:  "/data/server/tls/server-ca.key",
 
-		certs.ClientCACertName: "/data/server/tls/client-ca.crt",
-		certs.ClientCAKeyName:  "/data/server/tls/client-ca.key",
+		// Kubernetes cert renewal signs component client certificates with ca.*,
+		// while the migrated apiserver authenticates clients with client-ca.*.
+		certs.CACertName:       k3sClientCACertPath,
+		certs.CAKeyName:        k3sClientCAKeyPath,
+		certs.ClientCACertName: k3sClientCACertPath,
+		certs.ClientCAKeyName:  k3sClientCAKeyPath,
 
 		certs.FrontProxyCACertName: "/data/server/tls/request-header-ca.crt",
 		certs.FrontProxyCAKeyName:  "/data/server/tls/request-header-ca.key",

--- a/pkg/util/command/command.go
+++ b/pkg/util/command/command.go
@@ -23,7 +23,7 @@ const VClusterManaged = "_VCLUSTER_MANAGED=yes"
 func MergeArgs(baseArgs []string, extraArgs []string) []string {
 	newArgs := []string{}
 	for _, arg := range baseArgs {
-		if containsFlag(extraArgs, arg) {
+		if ContainsFlag(extraArgs, arg) {
 			continue
 		}
 
@@ -33,7 +33,7 @@ func MergeArgs(baseArgs []string, extraArgs []string) []string {
 	return newArgs
 }
 
-func containsFlag(args []string, flag string) bool {
+func ContainsFlag(args []string, flag string) bool {
 	for _, arg := range args {
 		if !strings.HasPrefix(arg, "--") || !strings.HasPrefix(flag, "--") {
 			continue

--- a/pkg/util/command/command_test.go
+++ b/pkg/util/command/command_test.go
@@ -65,3 +65,46 @@ func TestMergeArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flag     string
+		expected bool
+	}{
+		{
+			name:     "same flag with inline value",
+			args:     []string{"--foo=bar"},
+			flag:     "--foo",
+			expected: true,
+		},
+		{
+			name:     "same flag with split value",
+			args:     []string{"--foo", "bar"},
+			flag:     "--foo",
+			expected: true,
+		},
+		{
+			name:     "different flag",
+			args:     []string{"--foobar=baz"},
+			flag:     "--foo",
+			expected: false,
+		},
+		{
+			name:     "non flag args are ignored",
+			args:     []string{"foo"},
+			flag:     "--foo",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := ContainsFlag(test.args, test.flag)
+			if result != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-859


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [x] **Add labels** to the test suite
- [x] **Update label-filter section** below to execute the new test suite
- [x] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
migration
```
