### PR TITLE
feat: add networking.advanced.overrideDNS config field

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3570,6 +3570,10 @@
           "type": "boolean",
           "description": "FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without\nany other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace"
         },
+        "overrideDNS": {
+          "type": "string",
+          "description": "OverrideDNS overrides the DNS server address that vCluster sets on synced pods. Accepts either\nan IP address (e.g. \"10.96.0.10\") or a hostname (e.g. \"my-dns.example.com\"). When a hostname\nis given it is resolved once at startup and an error is returned if resolution fails."
+        },
         "proxyKubelets": {
           "$ref": "#/$defs/NetworkProxyKubelets",
           "description": "ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to \"fake\" this for applications such as\nprometheus or other node exporters."

--- a/config/config.go
+++ b/config/config.go
@@ -1693,6 +1693,11 @@ type NetworkingAdvanced struct {
 	// any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
 	FallbackHostCluster bool `json:"fallbackHostCluster,omitempty"`
 
+	// OverrideDNS overrides the DNS server address that vCluster sets on synced pods. Accepts either
+	// an IP address (e.g. "10.96.0.10") or a hostname (e.g. "my-dns.example.com"). When a hostname
+	// is given it is resolved once at startup and an error is returned if resolution fails.
+	OverrideDNS string `json:"overrideDNS,omitempty"`
+
 	// ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 	// prometheus or other node exporters.
 	ProxyKubelets NetworkProxyKubelets `json:"proxyKubelets,omitempty"`

--- a/pkg/controllers/resources/pods/syncer.go
+++ b/pkg/controllers/resources/pods/syncer.go
@@ -104,6 +104,11 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		return nil, fmt.Errorf("failed to parse host cluster version : %w", err)
 	}
 
+	overrideDNSIP, err := resolveDNSOverride(ctx.Config.Networking.Advanced.OverrideDNS)
+	if err != nil {
+		return nil, err
+	}
+
 	return &podSyncer{
 		GenericTranslator: genericTranslator,
 		Importer:          pro.NewImporter(podsMapper),
@@ -111,6 +116,7 @@ func New(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 		serviceName:      ctx.Config.Name,
 		schedulingConfig: schedulingConfig,
 		fakeKubeletIPs:   ctx.Config.Networking.Advanced.ProxyKubelets.ByIP,
+		overrideDNSIP:    overrideDNSIP,
 
 		virtualClusterClient:  virtualClusterClient,
 		physicalClusterClient: physicalClusterClient,
@@ -131,6 +137,7 @@ type podSyncer struct {
 	serviceName      string
 	schedulingConfig scheduling.Config
 	fakeKubeletIPs   bool
+	overrideDNSIP    string
 
 	podTranslator         translatepods.Translator
 	virtualClusterClient  kubernetes.Interface

--- a/pkg/controllers/resources/pods/syncer_test.go
+++ b/pkg/controllers/resources/pods/syncer_test.go
@@ -691,7 +691,93 @@ func TestSync(t *testing.T) {
 				assert.NilError(t, err)
 			},
 		},
+		{
+			// DNS IP is resolved from the kube-dns service in the host cluster.
+			Name: "SyncToHost uses DNS service IP for ClusterFirst pods",
+			InitialVirtualState: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: vObjectMeta,
+					Spec:       corev1.PodSpec{DNSPolicy: corev1.DNSClusterFirst},
+				},
+				vNamespace.DeepCopy(),
+			},
+			InitialPhysicalState: []runtime.Object{pVclusterService.DeepCopy(), pDNSService.DeepCopy()},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {
+					func() *corev1.Pod {
+						p := pPodBase.DeepCopy()
+						p.Spec.DNSPolicy = corev1.DNSNone
+						p.Spec.DNSConfig = &corev1.PodDNSConfig{
+							Nameservers: []string{pDNSService.Spec.ClusterIP},
+							Searches:    []string{"testns.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+							Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: ptr.To("5")}},
+						}
+						return p
+					}(),
+				},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncContext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).SyncToHost(syncContext, synccontext.NewSyncToHostEvent(&corev1.Pod{
+					ObjectMeta: vObjectMeta,
+					Spec:       corev1.PodSpec{DNSPolicy: corev1.DNSClusterFirst},
+				}))
+				assert.NilError(t, err)
+			},
+		},
+		{
+			// When networking.advanced.overrideDNS is set to an IP, that IP is used directly and
+			// the kube-dns service is never consulted (it is absent from InitialPhysicalState).
+			Name: "SyncToHost uses overrideDNS IP for ClusterFirst pods",
+			InitialVirtualState: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: vObjectMeta,
+					Spec:       corev1.PodSpec{DNSPolicy: corev1.DNSClusterFirst},
+				},
+				vNamespace.DeepCopy(),
+			},
+			// pDNSService intentionally absent — override must not fall back to service lookup.
+			InitialPhysicalState: []runtime.Object{pVclusterService.DeepCopy()},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("Pod"): {
+					func() *corev1.Pod {
+						p := pPodBase.DeepCopy()
+						p.Spec.DNSPolicy = corev1.DNSNone
+						p.Spec.DNSConfig = &corev1.PodDNSConfig{
+							Nameservers: []string{"9.9.9.9"},
+							Searches:    []string{"testns.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+							Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: ptr.To("5")}},
+						}
+						return p
+					}(),
+				},
+			},
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Networking.Advanced.OverrideDNS = "9.9.9.9"
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncContext, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+				_, err := syncer.(*podSyncer).SyncToHost(syncContext, synccontext.NewSyncToHostEvent(&corev1.Pod{
+					ObjectMeta: vObjectMeta,
+					Spec:       corev1.PodSpec{DNSPolicy: corev1.DNSClusterFirst},
+				}))
+				assert.NilError(t, err)
+			},
+		},
 	})
+}
+
+func TestNewPodSyncerOverrideDNSError(t *testing.T) {
+	translate.Default = translate.NewSingleNamespaceTranslator(testingutil.DefaultTestTargetNamespace)
+	specialservices.Default = specialservices.NewDefaultServiceSyncer()
+
+	test := syncertesting.SyncTest{}
+	pClient, vClient, vConfig := test.Setup()
+	registerContext := syncertesting.NewFakeRegisterContext(vConfig, pClient, vClient)
+	registerContext.Config.Networking.Advanced.OverrideDNS = "this.hostname.does.not.exist.invalid"
+
+	_, err := New(registerContext)
+	assert.Assert(t, err != nil, "expected New() to return an error for an unresolvable overrideDNS hostname")
 }
 
 func TestBuildResizePatch(t *testing.T) {

--- a/pkg/controllers/resources/pods/translate.go
+++ b/pkg/controllers/resources/pods/translate.go
@@ -3,6 +3,7 @@ package pods
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/specialservices"
@@ -67,6 +68,10 @@ func (s *podSyncer) findKubernetesIP(ctx *synccontext.SyncContext) (string, erro
 }
 
 func (s *podSyncer) findKubernetesDNSIP(ctx *synccontext.SyncContext) (string, error) {
+	if s.overrideDNSIP != "" {
+		return s.overrideDNSIP, nil
+	}
+
 	if specialservices.Default == nil {
 		return "", errors.New("specialservices default not initialized")
 	}
@@ -87,6 +92,26 @@ func (s *podSyncer) findKubernetesDNSIP(ctx *synccontext.SyncContext) (string, e
 	}
 
 	return ip, nil
+}
+
+// resolveDNSOverride resolves value to an IP address suitable for use as the DNS nameserver on
+// synced pods. If value is empty, "" is returned. If value is already a valid IP address it is
+// returned unchanged. Otherwise value is treated as a hostname: it is resolved via the system
+// resolver once at startup, the resolved IP is logged, and an error is returned if resolution
+// fails.
+func resolveDNSOverride(value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	if net.ParseIP(value) != nil {
+		return value, nil
+	}
+	addrs, err := net.LookupHost(value)
+	if err != nil {
+		return "", fmt.Errorf("networking.advanced.overrideDNS: failed to resolve hostname %q: %w", value, err)
+	}
+	klog.Infof("networking.advanced.overrideDNS: resolved hostname %q to %s", value, addrs[0])
+	return addrs[0], nil
 }
 
 func (s *podSyncer) translateAndFindDNSService(ctx *synccontext.SyncContext, kubeClient client.Client, namespace, name string) string {

--- a/pkg/controllers/resources/pods/translate_dns_test.go
+++ b/pkg/controllers/resources/pods/translate_dns_test.go
@@ -1,0 +1,70 @@
+package pods
+
+import (
+	"net"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestResolveDNSOverride(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		checkAddr func(t *testing.T, got string)
+	}{
+		{
+			name:    "empty value returns empty without error",
+			input:   "",
+			wantErr: false,
+			checkAddr: func(t *testing.T, got string) {
+				assert.Equal(t, "", got)
+			},
+		},
+		{
+			name:    "valid IPv4 is returned as-is",
+			input:   "10.96.0.10",
+			wantErr: false,
+			checkAddr: func(t *testing.T, got string) {
+				assert.Equal(t, "10.96.0.10", got)
+			},
+		},
+		{
+			name:    "valid IPv6 is returned as-is",
+			input:   "fd00::1",
+			wantErr: false,
+			checkAddr: func(t *testing.T, got string) {
+				assert.Equal(t, "fd00::1", got)
+			},
+		},
+		{
+			name:    "resolvable hostname returns a valid IP",
+			input:   "localhost",
+			wantErr: false,
+			checkAddr: func(t *testing.T, got string) {
+				if net.ParseIP(got) == nil {
+					t.Fatalf("expected a valid IP for hostname 'localhost', got %q", got)
+				}
+			},
+		},
+		{
+			name:      "unresolvable hostname returns error",
+			input:     "this.hostname.does.not.exist.invalid",
+			wantErr:   true,
+			checkAddr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveDNSOverride(tc.input)
+			if tc.wantErr {
+				assert.Assert(t, err != nil, "expected an error for input %q", tc.input)
+				return
+			}
+			assert.NilError(t, err)
+			tc.checkAddr(t, got)
+		})
+	}
+}


### PR DESCRIPTION


**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
feat: add networking.advanced.overrideDNS config field

**What else do we need to know?** 
New field allows users to override the dns server address set on synced pods.                                                                                                 Accepts an ip address or a hostname; hostnames are resolved once at startup and an error is returned if resolution fails.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
