### PR TITLE
fix(snapshot): fail early when restore snapshot is inaccessible

### DIFF
--- a/pkg/cli/create_helm.go
+++ b/pkg/cli/create_helm.go
@@ -403,7 +403,7 @@ func buildExtraValues(ctx context.Context, cmd *CreateOptions, log log.Logger) (
 	if len(cmd.Values) == 0 && len(cmd.SetValues) == 0 {
 		restoreValuesFile, err := getVClusterConfigFromSnapshot(ctx, cmd)
 		if err != nil {
-			log.Warnf("get vCluster config from snapshot: %w", err)
+			return nil, fmt.Errorf("get vCluster config from snapshot: %w", err)
 		} else if restoreValuesFile != "" {
 			filesToRemove = append(filesToRemove, restoreValuesFile)
 			log.Info("Using vCluster config from snapshot")
@@ -873,13 +873,16 @@ func getVClusterConfigFromSnapshot(ctx context.Context, cmd *CreateOptions) (str
 	// read the vCluster config
 	header, err := tarReader.Next()
 	if err != nil {
-		return "", err
+		if errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("snapshot archive is empty or truncated")
+		}
+		return "", fmt.Errorf("read snapshot archive: %w", err)
 	}
 
 	buf := &bytes.Buffer{}
 	_, err = io.Copy(buf, tarReader)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("read snapshot entry: %w", err)
 	}
 
 	// no vCluster config in the snapshot

--- a/pkg/cli/create_helm_test.go
+++ b/pkg/cli/create_helm_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	"github.com/loft-sh/log"
+	"gotest.tools/v3/assert"
+)
+
+// snapshotEntry is a single tar entry for makeContainerSnapshot.
+// An ordered slice is used instead of a map so tar entry order is deterministic;
+// getVClusterConfigFromSnapshot reads only the first entry, so ordering matters.
+type snapshotEntry struct {
+	name string
+	data []byte
+}
+
+// makeContainerSnapshot writes a minimal .tar.gz to a temp file and returns its path.
+func makeContainerSnapshot(t *testing.T, entries []snapshotEntry) string {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "snapshot-*.tar.gz")
+	assert.NilError(t, err)
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Size: int64(len(e.data)), Mode: 0644}
+		assert.NilError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write(e.data)
+		assert.NilError(t, err)
+	}
+
+	assert.NilError(t, tw.Close())
+	assert.NilError(t, gw.Close())
+	return f.Name()
+}
+
+// TestBuildExtraValuesErrorsOnInaccessibleSnapshot verifies that when --restore is
+// set and the snapshot cannot be fetched, buildExtraValues returns an error instead
+// of silently continuing.
+func TestBuildExtraValuesErrorsOnInaccessibleSnapshot(t *testing.T) {
+	cmd := &CreateOptions{
+		Restore: "container:///nonexistent/snapshot.tar.gz",
+	}
+
+	_, err := buildExtraValues(context.Background(), cmd, log.Discard)
+	assert.ErrorContains(t, err, "get vCluster config from snapshot")
+}
+
+// TestBuildExtraValuesSkipsSnapshotWhenValuesProvided verifies that when the caller
+// already provides --values or --set, buildExtraValues skips the snapshot fetch
+// entirely (so an inaccessible snapshot does not cause an error).
+func TestBuildExtraValuesSkipsSnapshotWhenValuesProvided(t *testing.T) {
+	// Use a string with characters that are invalid base64 so it is passed
+	// through as a raw path, and that is clearly not a real filesystem path
+	// to avoid any accidental base64 decode of an existing file.
+	const sentinel = "not!base64/values"
+
+	cmd := &CreateOptions{
+		Restore: "container:///nonexistent/snapshot.tar.gz",
+		Values:  []string{sentinel},
+	}
+
+	filesToRemove, err := buildExtraValues(context.Background(), cmd, log.Discard)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(filesToRemove))
+	assert.Equal(t, 1, len(cmd.Values))
+	assert.Equal(t, sentinel, cmd.Values[0])
+}
+
+// TestBuildExtraValuesSkipsSnapshotWhenSetValuesProvided mirrors the Values case
+// for --set, covering the other half of the `len == 0 && len == 0` gate.
+func TestBuildExtraValuesSkipsSnapshotWhenSetValuesProvided(t *testing.T) {
+	cmd := &CreateOptions{
+		Restore:   "container:///nonexistent/snapshot.tar.gz",
+		SetValues: []string{"key=value"},
+	}
+
+	_, err := buildExtraValues(context.Background(), cmd, log.Discard)
+	assert.NilError(t, err)
+	// SetValues must not be modified: buildExtraValues only reads it.
+	assert.Equal(t, 1, len(cmd.SetValues))
+	assert.Equal(t, "key=value", cmd.SetValues[0])
+}
+
+// TestBuildExtraValuesExtractsConfigFromSnapshot verifies that when --restore points
+// to an accessible snapshot that contains a Helm release entry, buildExtraValues
+// extracts the values and writes them to a temp file.
+func TestBuildExtraValuesExtractsConfigFromSnapshot(t *testing.T) {
+	release := snapshotapi.HelmRelease{
+		ChartVersion: "v0.33.0",
+		Values:       []byte("controlPlane:\n  distro:\n    k8s: {}\n"),
+	}
+	releaseJSON, err := json.Marshal(release)
+	assert.NilError(t, err)
+
+	snapshotPath := makeContainerSnapshot(t, []snapshotEntry{
+		{name: snapshotapi.SnapshotReleaseKey, data: releaseJSON},
+	})
+
+	cmd := &CreateOptions{
+		Restore: "container://" + snapshotPath,
+	}
+
+	filesToRemove, err := buildExtraValues(context.Background(), cmd, log.Discard)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(filesToRemove))
+	t.Cleanup(func() {
+		for _, f := range filesToRemove {
+			os.Remove(f)
+		}
+	})
+
+	data, err := os.ReadFile(filesToRemove[0])
+	assert.NilError(t, err)
+	assert.Equal(t, string(release.Values), string(data))
+	assert.Equal(t, "v0.33.0", cmd.ChartVersion)
+}
+
+// TestBuildExtraValuesNoRestoreIsNoop verifies that without --restore, the function
+// is a no-op and returns no files to clean up.
+func TestBuildExtraValuesNoRestoreIsNoop(t *testing.T) {
+	cmd := &CreateOptions{}
+
+	filesToRemove, err := buildExtraValues(context.Background(), cmd, log.Discard)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(filesToRemove))
+}

--- a/pkg/cli/restore_docker.go
+++ b/pkg/cli/restore_docker.go
@@ -165,12 +165,24 @@ func RestoreDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshot
 
 	// Use caller's CreateOptions if provided (from vcluster create --restore),
 	// otherwise build minimal options from snapshot metadata.
-	createOpts := callerOpts
-	if createOpts == nil {
+	var createOpts *CreateOptions
+	if callerOpts == nil {
 		createOpts = &CreateOptions{
 			Connect:       true,
 			UpdateCurrent: true,
 		}
+	} else {
+		// Copy so we don't mutate the caller's struct. Deep-copy Values to
+		// avoid sharing the backing array with the caller's slice on append.
+		// SetValues is intentionally left as a shallow copy: buildExtraValues
+		// and mergeAllValues only read it, never append to it.
+		// Clear Restore: the archive is already extracted; clearing it also
+		// prevents buildExtraValues from making a redundant (potentially
+		// failing) second fetch of the snapshot URL inside CreateDocker.
+		opts := *callerOpts
+		opts.Restore = ""
+		opts.Values = append([]string(nil), callerOpts.Values...)
+		createOpts = &opts
 	}
 	if createOpts.ChartVersion == "" || createOpts.ChartVersion == upgrade.DevelopmentVersion {
 		createOpts.ChartVersion = chartVersion


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
When `vcluster create --restore <url>` is used and the storage backend (e.g. S3) returns an error — expired credentials, missing object, permission denied — the CLI was only logging a warning and continuing. It would install the helm chart, create a resource quota, pause the vCluster, and launch the restore pod before the failure was surfaced.

The fix turns the warning in `buildExtraValues` into a hard error so the command stops before any cluster state is mutated.

resolves ENGCP-417

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where `vcluster create --restore` would proceed with creating and pausing the vCluster even when the snapshot was inaccessible (e.g. expired S3 credentials).

**What else do we need to know?** 
The change is a one-liner: `log.Warnf(...)` → `return nil, fmt.Errorf(...)` in `buildExtraValues`. The function `getVClusterConfigFromSnapshot` already returns `("", nil)` immediately when no `--restore` flag is set, so any error it returns implies the snapshot URL was provided and the backend rejected the access attempt.

The separate code path for restoring an already-existing vCluster (line ~177 in `create_helm.go`) does not call `buildExtraValues` and is a separate concern.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```