### PR TITLE
fix(snapshot): move etcd snapshot archive entry after release and request entries

### DIFF
--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -179,14 +179,6 @@ func (c *Client) writeEtcdSnapshot(ctx context.Context, etcdClient etcd.Client, 
 		}
 	}
 
-	// DBStoreKey as the second entry (or first, if no release) marks this archive
-	// as an EtcdSnapshot; otherwise it is treated as a KeyValueSnapshot.
-	// Keep getSnapshotArchiveKind in sync with any structure changes.
-	log.Info("Adding etcd snapshot to snapshot archive")
-	if err := writeArchiveFileEntry(tarWriter, DBStoreKey, dbPath); err != nil {
-		return fmt.Errorf("failed to write etcd snapshot to tar archive: %w", err)
-	}
-
 	if c.Request != nil {
 		log.Info("Adding snapshot request to snapshot archive")
 		requestBytes, err := json.Marshal(c.Request)
@@ -198,6 +190,14 @@ func (c *Client) writeEtcdSnapshot(ctx context.Context, etcdClient etcd.Client, 
 		if err != nil {
 			return fmt.Errorf("failed to snapshot request: %w", err)
 		}
+	}
+
+	// DBStoreKey as the third entry (or first, if no release or snapshot request) marks this archive
+	// as an EtcdSnapshot; otherwise it is treated as a KeyValueSnapshot.
+	// Keep getSnapshotArchiveKind in sync with any structure changes.
+	log.Info("Adding etcd snapshot to snapshot archive")
+	if err := writeArchiveFileEntry(tarWriter, DBStoreKey, dbPath); err != nil {
+		return fmt.Errorf("failed to write etcd snapshot to tar archive: %w", err)
 	}
 
 	if c.skipKeys != nil {

--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -1182,6 +1182,17 @@ func getSnapshotArchiveKind(fileName string) (SnapshotKind, error) {
 		}
 	}
 
+	// found request store key, reading the next entry header
+	if strings.HasPrefix(header.Name, RequestStoreKey) {
+		header, err = tarReader.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return KeyValueSnapshotKind, nil
+			}
+			return UnknownSnapshotKind, fmt.Errorf("failed to read tar header: %w", err)
+		}
+	}
+
 	// found the DBStoreKey, return EtcdSnapshotKind.
 	if header.Name == DBStoreKey {
 		return EtcdSnapshotKind, nil

--- a/pkg/snapshot/restoreclient_test.go
+++ b/pkg/snapshot/restoreclient_test.go
@@ -95,6 +95,27 @@ func TestGetSnapshotArchiveKind(t *testing.T) {
 			wantKind: EtcdSnapshotKind,
 		},
 		{
+			name: "etcd snapshot - release, request then DBStoreKey",
+			setup: func(t *testing.T) string {
+				return newTestArchive(t,
+					archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: []byte("{}")},
+					archiveEntry{key: RequestStoreKey + "/v1", value: []byte("{}")},
+					archiveEntry{key: DBStoreKey, value: []byte("db-bytes")},
+				)
+			},
+			wantKind: EtcdSnapshotKind,
+		},
+		{
+			name: "etcd snapshot - request then DBStoreKey (no release)",
+			setup: func(t *testing.T) string {
+				return newTestArchive(t,
+					archiveEntry{key: RequestStoreKey + "/v1", value: []byte("{}")},
+					archiveEntry{key: DBStoreKey, value: []byte("db-bytes")},
+				)
+			},
+			wantKind: EtcdSnapshotKind,
+		},
+		{
 			name: "kv snapshot - registry key first",
 			setup: func(t *testing.T) string {
 				return newTestArchive(t,
@@ -118,6 +139,45 @@ func TestGetSnapshotArchiveKind(t *testing.T) {
 			setup: func(t *testing.T) string {
 				return newTestArchive(t,
 					archiveEntry{key: RequestStoreKey + "/v1", value: []byte("{}")},
+				)
+			},
+			wantKind: KeyValueSnapshotKind,
+		},
+		{
+			name: "kv snapshot - only request key, EOF after",
+			setup: func(t *testing.T) string {
+				return newTestArchive(t,
+					archiveEntry{key: RequestStoreKey + "/v1", value: []byte("{}")},
+				)
+			},
+			wantKind: KeyValueSnapshotKind,
+		},
+		{
+			name: "kv snapshot - release then request key, EOF after",
+			setup: func(t *testing.T) string {
+				return newTestArchive(t,
+					archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: []byte("{}")},
+					archiveEntry{key: RequestStoreKey + "/v1", value: []byte("{}")},
+				)
+			},
+			wantKind: KeyValueSnapshotKind,
+		},
+		{
+			name: "kv snapshot - release, request then non-DB key",
+			setup: func(t *testing.T) string {
+				return newTestArchive(t,
+					archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: []byte("{}")},
+					archiveEntry{key: RequestStoreKey + "/v1", value: []byte("{}")},
+					archiveEntry{key: "/registry/pods/default/foo", value: []byte("v")},
+				)
+			},
+			wantKind: KeyValueSnapshotKind,
+		},
+		{
+			name: "kv snapshot - exact RequestStoreKey (no suffix)",
+			setup: func(t *testing.T) string {
+				return newTestArchive(t,
+					archiveEntry{key: RequestStoreKey, value: []byte("{}")},
 				)
 			},
 			wantKind: KeyValueSnapshotKind,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-874


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [x] **Add labels** to the test suite
- [x] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
