### PR TITLE
fix(chart): grant lease verbs when embedded etcd is enabled

### DIFF
--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -67,7 +67,7 @@ rules:
     resources: [ "endpointslices" ]
     verbs: [ "create", "list", "get", "delete", "patch", "update", "watch" ]
   {{- end }}
-  {{- if or .Values.privateNodes.enabled (gt (int .Values.controlPlane.statefulSet.highAvailability.replicas) 1) }}
+  {{- if or .Values.privateNodes.enabled (gt (int .Values.controlPlane.statefulSet.highAvailability.replicas) 1) .Values.controlPlane.backingStore.etcd.embedded.enabled }}
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]

--- a/chart/tests/role_test.yaml
+++ b/chart/tests/role_test.yaml
@@ -429,6 +429,45 @@ tests:
             verbs:
               ["create", "delete", "patch", "update", "get", "list", "watch"]
 
+  - it: embedded etcd grants lease verbs
+    # Embedded etcd uses a host-namespace Lease for the health-checker leader
+    # election. Without this rule, single-replica embedded-etcd deployments
+    # spin in lease-acquire retries.
+    set:
+      controlPlane:
+        backingStore:
+          etcd:
+            embedded:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs:
+              ["create", "delete", "patch", "update", "get", "list", "watch"]
+
+  - it: default config does not grant lease verbs
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Role
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs:
+              ["create", "delete", "patch", "update", "get", "list", "watch"]
+
   - it: volume snapshot rules
     set:
       rbac:


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

The vCluster Pro embedded-etcd health checker (introduced in loft-sh/vcluster-pro#1815) uses a host-namespace `Lease` to leader-elect the polling replica, so health reporting survives an outage of any single pod including pod-0.

The current `Role` conditional in `chart/templates/role.yaml`:

```yaml
{{- if or .Values.privateNodes.enabled (gt (int .Values.controlPlane.statefulSet.highAvailability.replicas) 1) }}
- apiGroups: ["coordination.k8s.io"]
  resources: ["leases"]
  verbs: ["create", "delete", "patch", "update", "get", "list", "watch"]
{{- end }}
```

only grants `coordination.k8s.io/leases` verbs when `privateNodes.enabled` OR `replicas > 1`. A single-replica embedded-etcd deployment without `privateNodes` is left with no lease RBAC, and `leaderelection.RunOrDie` silently spins forever logging 403s.

This PR extends the conditional to also include `controlPlane.backingStore.etcd.embedded.enabled`, so any embedded-etcd deployment gets the lease verbs regardless of replica count.

**Please provide a short message that should be published in the vcluster release notes**

Embedded etcd: ensure the host-namespace `Role` always grants `coordination.k8s.io/leases` verbs so the health checker can leader-elect on single-replica deployments without `privateNodes`.

**What else do we need to know?**

- Companion change in vCluster Pro is loft-sh/vcluster-pro#1815, which uses the Lease for the new etcd health-checker leader election.
- Related Linear issue: ENGCP-882 (Standalone vCluster: add etcd health reporting).
- Chart test was extended with two cases: one verifying the rule is present when embedded etcd is enabled, and a counter-test verifying the rule is absent under default values. All 21 role tests pass locally via `helm unittest chart`.
