### PR TITLE
fix(snapshot): suppress misleading etcd client warnings during restore

### DIFF
--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/constants"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap"
 )
 
 type Value struct {
@@ -101,7 +100,7 @@ func New(ctx context.Context, certificates *Certificates, endpoints ...string) (
 		return nil, err
 	}
 
-	etcdClient, err := GetEtcdClient(ctx, zap.L().Named("etcd-client"), certificates, endpoints...)
+	etcdClient, err := GetEtcdClient(ctx, certificates, endpoints...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/etcd/util.go
+++ b/pkg/etcd/util.go
@@ -25,19 +25,10 @@ type Certificates struct {
 }
 
 func WaitForEtcd(parentCtx context.Context, certificates *Certificates, endpoints ...string) error {
-	// This polls etcd before it is necessarily reachable, so transient dial
-	// failures are expected. Silence the etcd client logger (we log our own
-	// retry message below) unless verbose logging is enabled, so we don't print
-	// misleading "retrying of unary invoker failed" warnings.
-	log := zap.NewNop()
-	if klog.V(1).Enabled() {
-		log = zap.L().Named("wait-for-etcd")
-	}
-
 	var err error
 	waitErr := wait.PollUntilContextTimeout(parentCtx, time.Second, waitForClientTimeout, true, func(ctx context.Context) (bool, error) {
 		var etcdClient *clientv3.Client
-		etcdClient, err = GetEtcdClient(ctx, log, certificates, endpoints...)
+		etcdClient, err = GetEtcdClient(ctx, certificates, endpoints...)
 		if err == nil {
 			defer func() {
 				_ = etcdClient.Close()
@@ -64,7 +55,16 @@ func WaitForEtcd(parentCtx context.Context, certificates *Certificates, endpoint
 // If the runtime config does not list any endpoints, the default endpoint is used.
 // The returned client should be closed when no longer needed, in order to avoid leaking GRPC
 // client goroutines.
-func GetEtcdClient(ctx context.Context, log *zap.Logger, certificates *Certificates, endpoints ...string) (*clientv3.Client, error) {
+func GetEtcdClient(ctx context.Context, certificates *Certificates, endpoints ...string) (*clientv3.Client, error) {
+	// etcd clients frequently connect before etcd is reachable (reachability
+	// probes, restore, startup), so the clientv3 retry interceptor logs
+	// misleading "retrying of unary invoker failed" warnings. Silence the client
+	// logger unless verbose logging is enabled.
+	log := zap.NewNop()
+	if klog.V(1).Enabled() {
+		log = zap.L().Named("etcd-client")
+	}
+
 	cfg, err := getClientConfig(ctx, log, certificates, endpoints...)
 	if err != nil {
 		return nil, err

--- a/pkg/etcd/util.go
+++ b/pkg/etcd/util.go
@@ -25,10 +25,19 @@ type Certificates struct {
 }
 
 func WaitForEtcd(parentCtx context.Context, certificates *Certificates, endpoints ...string) error {
+	// This polls etcd before it is necessarily reachable, so transient dial
+	// failures are expected. Silence the etcd client logger (we log our own
+	// retry message below) unless verbose logging is enabled, so we don't print
+	// misleading "retrying of unary invoker failed" warnings.
+	log := zap.NewNop()
+	if klog.V(1).Enabled() {
+		log = zap.L().Named("wait-for-etcd")
+	}
+
 	var err error
 	waitErr := wait.PollUntilContextTimeout(parentCtx, time.Second, waitForClientTimeout, true, func(ctx context.Context) (bool, error) {
 		var etcdClient *clientv3.Client
-		etcdClient, err = GetEtcdClient(ctx, zap.L().Named("wait-for-etcd"), certificates, endpoints...)
+		etcdClient, err = GetEtcdClient(ctx, log, certificates, endpoints...)
 		if err == nil {
 			defer func() {
 				_ = etcdClient.Close()

--- a/pkg/etcd/util_test.go
+++ b/pkg/etcd/util_test.go
@@ -1,0 +1,70 @@
+package etcd
+
+import (
+	"context"
+	"flag"
+	"io"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/grpclog"
+	"gotest.tools/v3/assert"
+	"k8s.io/klog/v2"
+)
+
+// TestGetEtcdClientLoggerVerbosity verifies that GetEtcdClient silences the
+// clientv3 logger by default, so restore and startup don't print misleading
+// "retrying of unary invoker failed" warnings, and only wires up the real
+// logger when verbose logging (-v=1) is enabled.
+//
+// Regression test for ENGCP-428: before the fix every etcd client was created
+// with the global logger, so the clientv3 retry interceptor logged warnings to
+// the console whenever it connected before the backing store was reachable.
+func TestGetEtcdClientLoggerVerbosity(t *testing.T) {
+	// The lazily-dialed client logs a transport error via grpclog when it is
+	// closed; discard it so it doesn't pollute the test output.
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
+
+	// Install a real global logger that is enabled at all levels but discards
+	// its output, so that "the client would log" is observable without writing
+	// noise to the test output.
+	enabled := zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(io.Discard),
+		zapcore.DebugLevel,
+	))
+	defer zap.ReplaceGlobals(enabled)()
+
+	t.Run("silenced by default", func(t *testing.T) {
+		setKlogVerbosity(t, "0")
+
+		cli, err := GetEtcdClient(context.Background(), nil, "127.0.0.1:2379")
+		assert.NilError(t, err)
+		t.Cleanup(func() { _ = cli.Close() })
+
+		assert.Assert(t, !cli.GetLogger().Core().Enabled(zapcore.WarnLevel),
+			"etcd client logger should be silenced when verbose logging is off")
+	})
+
+	t.Run("enabled with verbose logging", func(t *testing.T) {
+		setKlogVerbosity(t, "1")
+
+		cli, err := GetEtcdClient(context.Background(), nil, "127.0.0.1:2379")
+		assert.NilError(t, err)
+		t.Cleanup(func() { _ = cli.Close() })
+
+		assert.Assert(t, cli.GetLogger().Core().Enabled(zapcore.WarnLevel),
+			"etcd client logger should emit warnings when verbose logging is on")
+	})
+}
+
+// setKlogVerbosity sets the global klog verbosity for the duration of the test
+// and restores it afterwards.
+func setKlogVerbosity(t *testing.T, level string) {
+	t.Helper()
+	var fs flag.FlagSet
+	klog.InitFlags(&fs)
+	assert.NilError(t, fs.Set("v", level))
+	t.Cleanup(func() { _ = fs.Set("v", "0") })
+}

--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -359,7 +359,7 @@ func (o *RestoreClient) postRestoreSnapshotDataMutation(ctx context.Context, vCo
 		return fmt.Errorf("failed to wait for embedded etcd: %w", err)
 	}
 
-	etcdClient, err := etcd.GetEtcdClient(ctx, zap.L().Named("etcd-client"), etcdCertificates, etcdEndpoint)
+	etcdClient, err := etcd.GetEtcdClient(ctx, etcdCertificates, etcdEndpoint)
 	if err != nil {
 		return fmt.Errorf("failed to get etcd client: %w", err)
 	}

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -15,7 +15,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/pro"
 	setupconfig "github.com/loft-sh/vcluster/pkg/setup/config"
 	"github.com/loft-sh/vcluster/pkg/util/servicecidr"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/grpclog"
 	"k8s.io/klog/v2"
 )
@@ -64,18 +63,11 @@ func isEtcdReachable(ctx context.Context, endpoint string, certificates *etcd.Ce
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	// This probe runs before the backing store is started, so connection
-	// failures are expected and handled by the caller. Silence the etcd client
-	// logger unless verbose logging is enabled, so restore doesn't print
-	// misleading "retrying of unary invoker failed" warnings.
-	log := zap.NewNop()
-	if klog.V(1).Enabled() {
-		log = zap.L().Named("etcd-client")
-	} else {
+	if !klog.V(1).Enabled() {
 		// prevent etcd client messages from showing
 		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 	}
-	etcdClient, err := etcd.GetEtcdClient(ctx, log, certificates, endpoint)
+	etcdClient, err := etcd.GetEtcdClient(ctx, certificates, endpoint)
 	if err == nil {
 		defer func() {
 			_ = etcdClient.Close()

--- a/pkg/snapshot/store.go
+++ b/pkg/snapshot/store.go
@@ -64,11 +64,18 @@ func isEtcdReachable(ctx context.Context, endpoint string, certificates *etcd.Ce
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if !klog.V(1).Enabled() {
+	// This probe runs before the backing store is started, so connection
+	// failures are expected and handled by the caller. Silence the etcd client
+	// logger unless verbose logging is enabled, so restore doesn't print
+	// misleading "retrying of unary invoker failed" warnings.
+	log := zap.NewNop()
+	if klog.V(1).Enabled() {
+		log = zap.L().Named("etcd-client")
+	} else {
 		// prevent etcd client messages from showing
 		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 	}
-	etcdClient, err := etcd.GetEtcdClient(ctx, zap.L().Named("etcd-client"), certificates, endpoint)
+	etcdClient, err := etcd.GetEtcdClient(ctx, log, certificates, endpoint)
 	if err == nil {
 		defer func() {
 			_ = etcdClient.Close()


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
Resolves ENGCP-428.

When restoring a snapshot, the key-value restore path probes and connects to a backing store that has not been started yet:
- `isEtcdReachable` runs a `MemberList` probe before kine is started (embedded/external database)
- `WaitForEtcd` polls while the store boots (deployed/external etcd)

Because vcluster installs a real global zap logger (`WithGlobalZap(true)` → `zap.ReplaceGlobals`) and every restore etcd client was created with `zap.L().Named("etcd-client")`, the etcd `clientv3` retry interceptor logged `retrying of unary invoker failed` warnings straight to the console. These retries are expected and ultimately succeed, but they look like the user did something wrong. The existing mitigation in `isEtcdReachable` only discarded grpclog output, not the clientv3 zap logger, so the warning still leaked.

This passes a no-op logger to the clientv3 client in both probe paths (still using the named logger under `-v=1` for debugging), so the expected retries no longer print false warnings. Real errors continue to propagate as returned errors. Embedded etcd restored with the new snapshot format was already unaffected, since it only talks to etcd after `WaitForEtcd` confirms readiness.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster printed misleading etcd client warnings ("retrying of unary invoker failed") while restoring a snapshot.

**What else do we need to know?**
Affects database, deployed etcd and external etcd backing stores. No functional change to restore behavior; logging only.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically.

```label-filter
snapshots
```