### PR TITLE
chore(e2e-next): Fix csi setup

### DIFF
--- a/e2e-next/setup/csi.go
+++ b/e2e-next/setup/csi.go
@@ -5,7 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+)
+
+const (
+	csiDriverHostPathVersion   = "v1.17.0"
+	externalSnapshotterVersion = "v8.4.0"
 )
 
 // InstallCSIHostpath returns a PreSetupFunc that installs the CSI hostpath
@@ -23,17 +29,18 @@ func InstallCSIHostpath(kubeContext string) func(ctx context.Context) error {
 		}
 
 		// Install snapshot CRDs
+		snapshotterBase := "https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/" + externalSnapshotterVersion
 		if err := kubectlApply(ctx, kubeContext,
-			"https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml",
-			"https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml",
-			"https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml",
+			snapshotterBase+"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml",
+			snapshotterBase+"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml",
+			snapshotterBase+"/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml",
 		); err != nil {
 			return fmt.Errorf("install snapshot CRDs: %w", err)
 		}
 
 		// Install snapshot-controller
 		if err := kubectlApplyKustomize(ctx, kubeContext,
-			"https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller"); err != nil {
+			"https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref="+externalSnapshotterVersion); err != nil {
 			return fmt.Errorf("install snapshot-controller: %w", err)
 		}
 
@@ -44,11 +51,15 @@ func InstallCSIHostpath(kubeContext string) func(ctx context.Context) error {
 		}
 		defer os.RemoveAll(tmpDir)
 
-		cloneCmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1",
+		cloneCmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--branch", csiDriverHostPathVersion,
 			"https://github.com/kubernetes-csi/csi-driver-host-path.git", tmpDir)
 		if out, err := cloneCmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("clone csi-driver-host-path: %s: %w", string(out), err)
+			return fmt.Errorf("clone csi-driver-host-path@%s: %s: %w", csiDriverHostPathVersion, string(out), err)
 		}
+
+		// Remove the testing manifest (socat proxy) - it is only needed for
+		// csi-sanity/csc testing and its StatefulSet is flaky on Kind.
+		_ = os.Remove(filepath.Join(tmpDir, "deploy", "kubernetes-latest", "hostpath", "csi-hostpath-testing.yaml"))
 
 		// Set the kubectl context before running deploy.sh so the CSI driver
 		// is installed into the correct cluster even when multiple contexts exist.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshot
```
