### PR TITLE
Adds: deprecate volume snapshot and restore

### DIFF
--- a/cmd/vcluster/cmd/snapshot/restore.go
+++ b/cmd/vcluster/cmd/snapshot/restore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/snapshot"
 	"github.com/spf13/cobra"
@@ -20,6 +21,9 @@ func NewRestoreCommand() *cobra.Command {
 		Short: "Restore a vCluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if restoreVolumes {
+				log.GetInstance().Warnf("WARNING: --restore-volumes is deprecated and will be removed in an upcoming release.")
+			}
 			vConfig, err := config.LoadConfig(os.Getenv("VCLUSTER_NAME"))
 			if err != nil {
 				return err
@@ -35,6 +39,6 @@ func NewRestoreCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&newVCluster, "new-vcluster", false, "Restore a new vCluster from snapshot instead of restoring into an existing vCluster")
-	cmd.Flags().BoolVar(&restoreVolumes, "restore-volumes", false, "Restore volumes from volume snapshots")
+	cmd.Flags().BoolVar(&restoreVolumes, "restore-volumes", false, "Restore volumes from volume snapshots. Deprecated: volume snapshot and restore will be removed in an upcoming release.")
 	return cmd
 }

--- a/cmd/vclusterctl/cmd/restore.go
+++ b/cmd/vclusterctl/cmd/restore.go
@@ -69,6 +69,9 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 		},
 		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if cmd.RestoreVolumes {
+				cmd.Log.Warnf("WARNING: --restore-volumes is deprecated and will be removed in an upcoming release.")
+			}
 			cfg := cmd.LoadedConfig(cmd.Log)
 			driverType, err := config.ParseDriverType(cmp.Or(cmd.Driver, string(cfg.Driver.Type)))
 			if err != nil {
@@ -90,7 +93,7 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 	cobraCmd.Flags().StringVar(&cmd.Driver, "driver", "", "The driver to use for managing the virtual cluster, can be either helm, platform, or docker.")
 	// add storage flags
 	pod.AddFlags(cobraCmd.Flags(), &cmd.Pod, true)
-	cobraCmd.Flags().BoolVar(&cmd.RestoreVolumes, "restore-volumes", false, "Restore volumes from volume snapshots")
+	cobraCmd.Flags().BoolVar(&cmd.RestoreVolumes, "restore-volumes", false, "Restore volumes from volume snapshots. Deprecated: volume snapshot and restore will be removed in an upcoming release.")
 	cobraCmd.Flags().BoolVar(&cmd.Standalone, "standalone", false, "Target the local standalone vCluster on this host")
 	cobraCmd.Flags().StringVarP(&cmd.Snapshot.SnapshotTempDir, "snapshot-temp-dir", "", "", "Temporary directory for snapshot operations. If set to empty string, the OS default directory for temporary files will be used")
 	snapshotazure.AddFlags(cobraCmd.Flags(), &cmd.Snapshot.Azure)

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -30,6 +30,9 @@ const (
 )
 
 func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, podOpts *pod.Options, newVCluster, restoreVolumes, standalone bool, log log.Logger) error {
+	if restoreVolumes {
+		log.Warnf("WARNING: --restore-volumes is deprecated and will be removed in an upcoming release.")
+	}
 	// init kube client and vCluster
 	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, true, standalone)
 	if err != nil {

--- a/pkg/controllers/register.go
+++ b/pkg/controllers/register.go
@@ -271,6 +271,7 @@ func registerSnapshotController(registerContext *synccontext.RegisterContext) er
 
 	config := registerContext.Config
 	if config.PrivateNodes.Enabled && config.Deploy.VolumeSnapshotController.Enabled {
+		klog.Warning("WARNING: volume snapshot and restore is deprecated and will be removed in an upcoming release.")
 		err = csiVolumeSnapshots.Deploy(registerContext)
 		if err != nil {
 			return fmt.Errorf("unable to deploy required CSI volume snapshot compoments: %w", err)

--- a/pkg/snapshot/options.go
+++ b/pkg/snapshot/options.go
@@ -157,7 +157,7 @@ func AddFlags(flags *pflag.FlagSet, options *snapshotapi.Options) {
 	flags.StringVarP(&options.S3.KmsKeyID, "kms-key-id", "", "", "AWS KMS key ID that is configured for given S3 bucket. If set, aws-kms SSE will be used")
 	flags.StringVarP(&options.S3.CustomerKeyEncryptionFile, "customer-key-encryption-file", "", "", "AWS customer key encryption file used for SSE-C. Mutually exclusive with kms-key-id")
 	flags.StringVarP(&options.S3.ServerSideEncryption, "server-side-encryption", "", "", "AWS Server-Side encryption algorithm")
-	flags.BoolVarP(&options.IncludeVolumes, "include-volumes", "", false, "Create CSI volume snapshots (shared and private nodes only)")
+	flags.BoolVarP(&options.IncludeVolumes, "include-volumes", "", false, "Create CSI volume snapshots (shared and private nodes only). Deprecated: volume snapshot and restore will be removed in an upcoming release.")
 	flags.StringVarP(&options.SnapshotTempDir, "snapshot-temp-dir", "", "", "Temporary directory for snapshot operations. If set to empty string, the OS default directory for temporary files will be used")
 	azure.AddFlags(flags, &options.Azure)
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-827


**Please provide a short message that should be published in the vcluster release notes**
Adds a warning message stating that volume snapshot and restore will be deprecated


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
