### PR TITLE
fix(coredns): fully-qualify default CoreDNS image (ENGCP-588)

### DIFF
--- a/e2e-next/test_core/coredns/test_coredns.go
+++ b/e2e-next/test_core/coredns/test_coredns.go
@@ -215,8 +215,6 @@ func CoreDNSSpec() {
 					coreDNSDeployment, err := vClusterClient.AppsV1().Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					Expect(coreDNSDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-					// The default image is fully qualified with docker.io so it pulls on
-					// clusters that don't expand short (registry-less) image names.
 					expectedImage := coredns.DefaultImageRegistry + "/" + coredns.DefaultImage
 					Expect(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal(expectedImage),
 						"CoreDNS image should match the pinned default image")

--- a/e2e-next/test_core/coredns/test_coredns.go
+++ b/e2e-next/test_core/coredns/test_coredns.go
@@ -215,7 +215,10 @@ func CoreDNSSpec() {
 					coreDNSDeployment, err := vClusterClient.AppsV1().Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					Expect(coreDNSDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-					Expect(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal(coredns.DefaultImage),
+					// The default image is fully qualified with docker.io so it pulls on
+					// clusters that don't expand short (registry-less) image names.
+					expectedImage := coredns.DefaultImageRegistry + "/" + coredns.DefaultImage
+					Expect(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal(expectedImage),
 						"CoreDNS image should match the pinned default image")
 					// Ensure we are not using images with known security vulnerabilities
 					Expect(coreDNSDeployment.Spec.Template.Spec.Containers[0].Image).NotTo(ContainSubstring("1.11.1"))

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -18,15 +18,19 @@ import (
 )
 
 const (
-	DefaultImage    = "coredns/coredns:1.14.2"
-	VarImage        = "IMAGE"
-	VarHostDNS      = "HOST_CLUSTER_DNS"
-	VarRunAsUser    = "RUN_AS_USER"
-	VarRunAsNonRoot = "RUN_AS_NON_ROOT"
-	VarRunAsGroup   = "RUN_AS_GROUP"
-	VarLogInDebug   = "LOG_IN_DEBUG"
-	defaultUID      = int64(1001)
-	defaultGID      = int64(1001)
+	DefaultImage = "coredns/coredns:1.14.2"
+	// DefaultImageRegistry is prepended to the CoreDNS image when no custom
+	// image registry is configured, so the rendered image is always fully
+	// qualified (registry-less names are not reliably resolved on all runtimes).
+	DefaultImageRegistry = "docker.io"
+	VarImage             = "IMAGE"
+	VarHostDNS           = "HOST_CLUSTER_DNS"
+	VarRunAsUser         = "RUN_AS_USER"
+	VarRunAsNonRoot      = "RUN_AS_NON_ROOT"
+	VarRunAsGroup        = "RUN_AS_GROUP"
+	VarLogInDebug        = "LOG_IN_DEBUG"
+	defaultUID           = int64(1001)
+	defaultGID           = int64(1001)
 )
 
 var ErrNoCoreDNSManifests = fmt.Errorf("no coredns manifests found")
@@ -48,15 +52,22 @@ func ApplyManifest(ctx context.Context, config *config.Config, defaultImageRegis
 	return applier.ApplyManifest(ctx, inClusterConfig, output)
 }
 
-func getManifestVariables(defaultImageRegistry string, serverVersion *version.Info) map[string]interface{} {
+func getManifestVariables(defaultImageRegistry string, serverVersion *version.Info) map[string]any {
 	var found bool
-	vars := make(map[string]interface{})
+	vars := make(map[string]any)
 	vars[VarImage], found = constants.CoreDNSVersionMap[fmt.Sprintf("%s.%s", serverVersion.Major, serverVersion.Minor)]
 	if !found {
 		vars[VarImage] = DefaultImage
 	}
 	if defaultImageRegistry != "" {
 		vars[VarImage] = strings.TrimSuffix(defaultImageRegistry, "/") + "/" + vars[VarImage].(string)
+	} else {
+		// Fully-qualify the image with the default registry so CoreDNS pulls
+		// work on clusters that don't expand short (registry-less) image names,
+		// e.g. Kubernetes v1.34+ with strict CRI/registry short-name resolution.
+		// This keeps the image identical to the previously short-named default
+		// (which container runtimes used to expand to docker.io). See ENGCP-588.
+		vars[VarImage] = DefaultImageRegistry + "/" + vars[VarImage].(string)
 	}
 	vars[VarRunAsUser] = fmt.Sprintf("%v", GetUserID())
 	vars[VarRunAsGroup] = fmt.Sprintf("%v", GetGroupID())

--- a/pkg/coredns/coredns.go
+++ b/pkg/coredns/coredns.go
@@ -62,11 +62,7 @@ func getManifestVariables(defaultImageRegistry string, serverVersion *version.In
 	if defaultImageRegistry != "" {
 		vars[VarImage] = strings.TrimSuffix(defaultImageRegistry, "/") + "/" + vars[VarImage].(string)
 	} else {
-		// Fully-qualify the image with the default registry so CoreDNS pulls
-		// work on clusters that don't expand short (registry-less) image names,
-		// e.g. Kubernetes v1.34+ with strict CRI/registry short-name resolution.
-		// This keeps the image identical to the previously short-named default
-		// (which container runtimes used to expand to docker.io). See ENGCP-588.
+		// No custom registry configured: default to docker.io (ENGCP-588).
 		vars[VarImage] = DefaultImageRegistry + "/" + vars[VarImage].(string)
 	}
 	vars[VarRunAsUser] = fmt.Sprintf("%v", GetUserID())

--- a/pkg/coredns/coredns_test.go
+++ b/pkg/coredns/coredns_test.go
@@ -1,0 +1,53 @@
+package coredns
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetManifestVariablesImage(t *testing.T) {
+	tests := []struct {
+		name                 string
+		major                string
+		minor                string
+		defaultImageRegistry string
+		expectedImage        string
+	}{
+		{
+			name:          "known version is fully qualified with docker.io",
+			major:         "1",
+			minor:         "34",
+			expectedImage: "docker.io/coredns/coredns:1.12.1",
+		},
+		{
+			name:          "unknown version falls back to fully qualified default image",
+			major:         "1",
+			minor:         "99",
+			expectedImage: "docker.io/" + DefaultImage,
+		},
+		{
+			name:                 "custom registry takes precedence over docker.io",
+			major:                "1",
+			minor:                "34",
+			defaultImageRegistry: "my.registry:5000",
+			expectedImage:        "my.registry:5000/coredns/coredns:1.12.1",
+		},
+		{
+			name:                 "custom registry trailing slash is trimmed",
+			major:                "1",
+			minor:                "34",
+			defaultImageRegistry: "my.registry:5000/",
+			expectedImage:        "my.registry:5000/coredns/coredns:1.12.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := getManifestVariables(tt.defaultImageRegistry, &version.Info{Major: tt.major, Minor: tt.minor})
+			assert.Equal(t, vars[VarImage], tt.expectedImage)
+		})
+	}
+}

--- a/pkg/coredns/coredns_test.go
+++ b/pkg/coredns/coredns_test.go
@@ -3,9 +3,8 @@ package coredns
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/version"
-
 	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 func TestGetManifestVariablesImage(t *testing.T) {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
Resolves ENGCP-588.

vCluster rendered the default CoreDNS image as a registry-less ("short") reference — `coredns/coredns:<tag>` (see `pkg/constants/coredns.go` and `DefaultImage` in `pkg/coredns/coredns.go`). Container runtimes have historically auto-expanded such names to `docker.io`, but that behavior is not guaranteed. On clusters with strict short-name resolution (e.g. Kubernetes v1.34+ with certain CRI / registry configurations — CRI-O `short-name-mode=enforcing` without `unqualified-search-registries`, or containerd with a `config_path` and no `_default` host), the image pull fails, CoreDNS never starts, and DNS inside the tenant cluster breaks.

This PR makes the default CoreDNS image **fully qualified**: when no custom image registry is configured, `docker.io` is prepended so the rendered reference is always explicit.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where CoreDNS could fail to pull on clusters that don't expand short (registry-less) image names (e.g. Kubernetes v1.34+ with strict CRI/registry configuration). The default CoreDNS image is now fully qualified (`docker.io/coredns/coredns:<tag>`).

**What else do we need to know?**

### Why this change

The default needs to work out of the box on strict clusters. A registry-less name relies on runtime-specific short-name expansion, which is exactly what fails in the reported environments.

### How users can already work around this today

The image is fully overridable via `controlPlane.coredns.deployment.image`, e.g.:

```yaml
controlPlane:
  coredns:
    deployment:
      image: docker.io/coredns/coredns:1.12.1
```

That override still takes precedence after this change — this PR only fixes the **default** so the manual workaround is no longer required.

### Why `docker.io` specifically

`docker.io` is exactly what the previous short name resolved to on runtimes that do expand it, so the **image content and source are unchanged** — this is the minimal, behavior-preserving fix with no surprise about which image is pulled. Switching to a different registry (e.g. `registry.k8s.io`) would change the image source and could break egress allowlists or mirrors, so it is intentionally avoided here.

### Air-gapped / custom registry is unaffected

The `controlPlane.advanced.defaultImageRegistry` path is left untouched: the version map still stores bare repository paths (`coredns/coredns`), so mirrors like `<registry>/coredns/coredns` keep working. `docker.io` is only prepended when no custom registry is set.

### Tests

Added `TestGetManifestVariablesImage` covering: known version → `docker.io/...`, unknown version fallback, custom registry precedence, and trailing-slash trimming. `go test ./pkg/coredns/...` and `go vet` pass.

## E2E Tests

### Additional test suites

```label-filter
core
```
