### PR TITLE
chore(ci): bump ci-test-notify to skip cancelled and skipped runs

### DIFF
--- a/.github/workflows/check-brew-tap-drift.yaml
+++ b/.github/workflows/check-brew-tap-drift.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Notify eng-releases
         if: steps.compare.outputs.drifted == 'true'
-        uses: loft-sh/github-actions/.github/actions/ci-test-notify@85d7023c5749421d369f59430c7849f2d00ad694 # ci-test-notify/v1
+        uses: loft-sh/github-actions/.github/actions/ci-test-notify@b5a50da8a53ca1021b783290630061078bdb12cf # ci-test-notify/v1
         with:
           test-name: Homebrew Tap Drift
           status: failure

--- a/.github/workflows/e2e-ginkgo-nightly.yaml
+++ b/.github/workflows/e2e-ginkgo-nightly.yaml
@@ -172,7 +172,7 @@ jobs:
 
     steps:
       - name: Notify ci-tests-alerts
-        uses: loft-sh/github-actions/.github/actions/ci-test-notify@85d7023c5749421d369f59430c7849f2d00ad694 # ci-test-notify/v1
+        uses: loft-sh/github-actions/.github/actions/ci-test-notify@b5a50da8a53ca1021b783290630061078bdb12cf # ci-test-notify/v1
         with:
           test-name: "vCluster E2E Nightly"
           status: ${{ needs.e2e-tests.result }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Notify dev-vcluster
         if: always() && needs.e2e-tests.result != 'success'
-        uses: loft-sh/github-actions/.github/actions/ci-test-notify@85d7023c5749421d369f59430c7849f2d00ad694 # ci-test-notify/v1
+        uses: loft-sh/github-actions/.github/actions/ci-test-notify@b5a50da8a53ca1021b783290630061078bdb12cf # ci-test-notify/v1
         with:
           test-name: "vCluster E2E Nightly"
           status: ${{ needs.e2e-tests.result }}


### PR DESCRIPTION
## What

Bump the pinned `ci-test-notify` action to the released `ci-test-notify/v1` commit (`b5a50da`), which carries the cancelled/skipped no-op fix.

## Why

Cancelled GitHub Actions runs were posting Slack alerts as if they had failed. The action now treats `cancelled` and `skipped` statuses as no-ops and sends nothing; only `success` and `failure` notify. This repo was still pinned to the pre-fix commit (`85d7023`), so it kept firing false alerts on cancelled runs.

References DEVOPS-960
