### PR TITLE
chore: change deprecate message to match docs

### DIFF
--- a/cmd/vcluster/cmd/snapshot/create.go
+++ b/cmd/vcluster/cmd/snapshot/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/config"
 	setupconfig "github.com/loft-sh/vcluster/pkg/setup/config"
 	"k8s.io/client-go/kubernetes"
@@ -27,6 +28,10 @@ func NewCreateCmd() *cobra.Command {
 			envOptions, err := snapshot.ParseOptionsFromEnv()
 			if err != nil {
 				return fmt.Errorf("failed to parse options from environment: %w", err)
+			}
+
+			if envOptions.IncludeVolumes {
+				log.GetInstance().Warnf("WARNING: --include-volumes is now deprecated and slated for removal in an upcoming release.")
 			}
 
 			restClient, vClusterNamespace, err := setupconfig.InitClientConfig()

--- a/cmd/vclusterctl/cmd/restore.go
+++ b/cmd/vclusterctl/cmd/restore.go
@@ -70,7 +70,7 @@ vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 		ValidArgsFunction: completion.NewValidVClusterNameFunc(globalFlags),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if cmd.RestoreVolumes {
-				cmd.Log.Warnf("WARNING: --restore-volumes is deprecated and will be removed in an upcoming release.")
+				cmd.Log.Warnf("WARNING: --restore-volumes is now deprecated and slated for removal in an upcoming release.")
 			}
 			cfg := cmd.LoadedConfig(cmd.Log)
 			driverType, err := config.ParseDriverType(cmp.Or(cmd.Driver, string(cfg.Driver.Type)))

--- a/cmd/vclusterctl/cmd/snapshot/create.go
+++ b/cmd/vclusterctl/cmd/snapshot/create.go
@@ -18,11 +18,10 @@ import (
 
 type CreateCmd struct {
 	*flags.GlobalFlags
-	Snapshot       snapshotapi.Options
-	Driver         string
-	IncludeVolumes bool
-	Standalone     bool
-	Log            log.Logger
+	Snapshot   snapshotapi.Options
+	Driver     string
+	Standalone bool
+	Log        log.Logger
 }
 
 func NewCreateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
@@ -73,6 +72,10 @@ vcluster snapshot create my-vcluster --driver docker
 			}
 			if cmd.Standalone && driverType == config.DockerDriver {
 				return fmt.Errorf("--standalone cannot be used with --driver docker")
+			}
+
+			if cmd.Snapshot.IncludeVolumes {
+				cmd.Log.Warn("WARNING: --include-volumes is now deprecated and slated for removal in an upcoming release.")
 			}
 			if driverType == config.DockerDriver {
 				vClusterName := args[0]

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -30,9 +30,6 @@ const (
 )
 
 func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, podOpts *pod.Options, newVCluster, restoreVolumes, standalone bool, log log.Logger) error {
-	if restoreVolumes {
-		log.Warnf("WARNING: --restore-volumes is deprecated and will be removed in an upcoming release.")
-	}
 	// init kube client and vCluster
 	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, true, standalone)
 	if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
