### PR TITLE
Fix: Platform destroy cleans up machineconfigtemplates

### DIFF
--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -61,6 +61,7 @@ var resourceOrder = []string{
 	"nodeproviders",
 	"nodetypes",
 	"osimages",
+	"machineconfigtemplates",
 	"sshkeys",
 
 	// access

--- a/pkg/cli/destroy/destroy.go
+++ b/pkg/cli/destroy/destroy.go
@@ -156,8 +156,7 @@ func destroy(ctxWithoutTimeout context.Context, opts DeleteOptions) error {
 
 	unhandledResourceSet := clusterResourceSet.Difference(handledResourceSet)
 	if unhandledResourceSet.Len() != 0 {
-		opts.Log.Errorf("some storage.loft.sh resources are unhandled: %v. Try a newer cli version", unhandledResourceSet.UnsortedList())
-		return err
+		return fmt.Errorf("some storage.loft.sh resources are unhandled: %v, try a newer cli version", unhandledResourceSet.UnsortedList())
 	}
 
 	for _, resourceName := range resourceOrder {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
