### PR TITLE
Engnode 551

### DIFF
--- a/e2e-next/labels/labels.go
+++ b/e2e-next/labels/labels.go
@@ -24,6 +24,8 @@ var (
 	RuntimeClasses  = Label("runtimeclasses")
 	StorageClasses  = Label("storageclasses")
 	IngressClasses  = Label("ingressclasses")
+	GatewayAPI      = Label("gatewayapi")
+	GatewayClasses  = Label("gatewayclasses")
 	ConfigMaps      = Label("configmaps")
 	Secrets         = Label("secrets")
 	NetworkPolicies = Label("networkpolicies")

--- a/e2e-next/setup/gatewayapi.go
+++ b/e2e-next/setup/gatewayapi.go
@@ -1,0 +1,40 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+)
+
+// GatewayAPIPreSetup installs the local Gateway API CRDs required by the
+// Gateway API e2e suite on the host cluster before vCluster starts. The CRDs
+// are intentionally left installed after the suite because they are shared
+// cluster-scoped infrastructure.
+func GatewayAPIPreSetup() func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		kubeContext := "kind-" + constants.GetHostClusterName()
+		_, file, _, ok := runtime.Caller(0)
+		if !ok {
+			return fmt.Errorf("resolve Gateway API setup source path")
+		}
+		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+		crds := []string{
+			"pkg/mappings/resources/gatewayclasses.crd.yaml",
+			"pkg/mappings/resources/gateways.crd.yaml",
+			"pkg/mappings/resources/httproutes.crd.yaml",
+			"pkg/mappings/resources/referencegrants.crd.yaml",
+		}
+		for _, crd := range crds {
+			abs := filepath.Join(repoRoot, crd)
+			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--context", kubeContext, "-f", abs)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("apply Gateway API CRD %s: %s: %w", crd, string(out), err)
+			}
+		}
+		return nil
+	}
+}

--- a/e2e-next/suite_gatewayapi_test.go
+++ b/e2e-next/suite_gatewayapi_test.go
@@ -1,0 +1,42 @@
+// Suite: gatewayapi-vcluster
+// vCluster: Gateway API sync coverage for GatewayClass visibility, Tenant
+// Gateway authorization, and Gateway/HTTPRoute sync.
+// Run:      just run-e2e 'pr && gatewayapi'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	"github.com/loft-sh/vcluster/e2e-next/test_gatewayapi"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+//go:embed vcluster-gatewayapi.yaml
+var gatewayAPIVClusterYAML string
+
+const gatewayAPIVClusterName = "gatewayapi-vcluster"
+
+func init() { suiteGatewayAPIVCluster() }
+
+func suiteGatewayAPIVCluster() {
+	Describe("gatewayapi-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				return lazyvcluster.LazyVCluster(ctx,
+					gatewayAPIVClusterName,
+					gatewayAPIVClusterYAML,
+					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
+				)
+			})
+
+			test_gatewayapi.GatewayAPISyncSpec()
+		},
+	)
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -1,0 +1,258 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	gatewayClassSelectorKey   = "e2e.vcluster.loft.sh/gatewayclass"
+	gatewayClassSelectorValue = "gatewayapi-vcluster"
+	gatewayControllerName     = gatewayv1.GatewayController("example.com/gateway-controller")
+)
+
+// GatewayAPISyncSpec registers Gateway API sync tests.
+func GatewayAPISyncSpec() {
+	Describe("Gateway API sync", labels.GatewayAPI, labels.GatewayClasses, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("mirrors matching Host GatewayClasses into the Tenant Cluster and hides non-matching ones", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed, hidden := createGatewayClassPair(ctx, hostClient, suffix)
+
+			By("waiting for the allowed GatewayClass to appear sanitized in the Tenant Cluster", func() {
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.GatewayClass{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, got)).To(Succeed())
+					g.Expect(got.Spec.ControllerName).To(Equal(gatewayControllerName))
+					g.Expect(got.Spec.Description).NotTo(BeNil())
+					g.Expect(*got.Spec.Description).To(Equal("e2e allowed GatewayClass"))
+					g.Expect(got.Spec.ParametersRef).To(BeNil())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("proving the selector-hidden GatewayClass stays absent from the Tenant Cluster", func() {
+				Consistently(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+
+			By("updating the Host GatewayClass and ensuring parametersRef remains sanitized", func() {
+				Expect(hostClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, allowed)).To(Succeed())
+				if allowed.Annotations == nil {
+					allowed.Annotations = map[string]string{}
+				}
+				allowed.Annotations["e2e.vcluster.loft.sh/resync"] = suffix
+				Expect(hostClient.Update(ctx, allowed)).To(Succeed())
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.GatewayClass{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, got)).To(Succeed())
+					g.Expect(got.Annotations).To(HaveKeyWithValue("e2e.vcluster.loft.sh/resync", suffix))
+					g.Expect(got.Spec.ParametersRef).To(BeNil())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("deleting the Host GatewayClass and waiting for the Tenant mirror to disappear", func() {
+				Expect(ctrlclient.IgnoreNotFound(hostClient.Delete(ctx, allowed))).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+		})
+
+		It("does not sync Tenant Gateways that reference unavailable GatewayClasses", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed, hidden := createGatewayClassPair(ctx, hostClient, suffix)
+			ns := createTenantNamespace(ctx, vClusterClient, "gwapi-reject-"+suffix)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			bad := tenantGateway(ns.Name, "bad-gw-"+suffix, hidden.Name)
+			Expect(vClusterClient.Create(ctx, bad)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed()) })
+			badHostName := translate.SafeConcatName(bad.Name, "x", ns.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: badHostName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			good := tenantGateway(ns.Name, "good-gw-"+suffix, allowed.Name)
+			Expect(vClusterClient.Create(ctx, good)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed()) })
+			goodHostName := translate.SafeConcatName(good.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(good), good)).To(Succeed())
+			good.Spec.GatewayClassName = gatewayv1.ObjectName(hidden.Name)
+			Expect(vClusterClient.Update(ctx, good)).To(Succeed())
+			Consistently(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("syncs Tenant Gateway and HTTPRoute to Host for an available GatewayClass", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed := createGatewayClass(ctx, hostClient, "gc-allowed-"+suffix, gatewayClassSelectorValue, "e2e allowed GatewayClass")
+			ns := createTenantNamespace(ctx, vClusterClient, "gwapi-sync-"+suffix)
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, service)).To(Succeed())
+			gateway := tenantGateway(ns.Name, "gw-"+suffix, allowed.Name)
+			Expect(vClusterClient.Create(ctx, gateway)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed()) })
+
+			hostGatewayName := translate.SafeConcatName(gateway.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+				g.Expect(got.Spec.Listeners).To(HaveLen(1))
+				listener := got.Spec.Listeners[0]
+				g.Expect(listener.Name).To(Equal(gatewayv1.SectionName("http")))
+				g.Expect(listener.Protocol).To(Equal(gatewayv1.HTTPProtocolType))
+				g.Expect(listener.Port).To(Equal(gatewayv1.PortNumber(80)))
+				g.Expect(listener.Hostname).NotTo(BeNil())
+				g.Expect(*listener.Hostname).To(Equal(gatewayv1.Hostname("app.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			route := tenantHTTPRoute(ns.Name, "route-"+suffix, gateway.Name, service.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed()) })
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGatewayName)))
+				g.Expect(got.Spec.ParentRefs[0].SectionName).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].SectionName).To(Equal(gatewayv1.SectionName("http")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func createGatewayClassPair(ctx context.Context, hostClient ctrlclient.Client, suffix string) (*gatewayv1.GatewayClass, *gatewayv1.GatewayClass) {
+	GinkgoHelper()
+	allowed := createGatewayClass(ctx, hostClient, "gc-allowed-"+suffix, gatewayClassSelectorValue, "e2e allowed GatewayClass")
+	hidden := createGatewayClass(ctx, hostClient, "gc-hidden-"+suffix, "other-"+suffix, "e2e hidden GatewayClass")
+	return allowed, hidden
+}
+
+func createGatewayClass(ctx context.Context, hostClient ctrlclient.Client, name, selectorValue, description string) *gatewayv1.GatewayClass {
+	GinkgoHelper()
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{gatewayClassSelectorKey: selectorValue}},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: gatewayControllerName,
+			Description:    ptr.To(description),
+			ParametersRef:  gatewayClassParametersRef(name),
+		},
+	}
+	Expect(hostClient.Create(ctx, gc)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(hostClient.Delete(ctx, gc))).To(Succeed()) })
+	return gc
+}
+
+func gatewayClassParametersRef(name string) *gatewayv1.ParametersReference {
+	ns := gatewayv1.Namespace("host-only-" + name)
+	return &gatewayv1.ParametersReference{Group: gatewayv1.Group("example.com"), Kind: gatewayv1.Kind("GatewayClassConfig"), Name: name + "-config", Namespace: &ns}
+}
+
+func createTenantNamespace(ctx context.Context, c ctrlclient.Client, name string) *corev1.Namespace {
+	GinkgoHelper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	Expect(c.Create(ctx, ns)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(c.Delete(ctx, ns))).To(Succeed()) })
+	return ns
+}
+
+func tenantGateway(namespace, name, className string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     gatewayv1.SectionName("http"),
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+				Hostname: ptr.To(gatewayv1.Hostname("app.example.com")),
+			}},
+		},
+	}
+}
+
+func tenantHTTPRoute(namespace, name, gatewayName, serviceName string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To(gatewayv1.SectionName("http"))}}},
+			Rules:           []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(serviceName), Port: ptr.To(gatewayv1.PortNumber(80))}}}}}},
+		},
+	}
+}

--- a/e2e-next/vcluster-gatewayapi.yaml
+++ b/e2e-next/vcluster-gatewayapi.yaml
@@ -1,0 +1,23 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-vcluster
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      gateways:
+        enabled: true
+      httpRoutes:
+        enabled: true
+      referenceGrants:
+        enabled: true

--- a/pkg/controllers/resources/gatewayclasses/syncer.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer.go
@@ -2,6 +2,7 @@ package gatewayclasses
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/loft-sh/vcluster/pkg/mappings/generic"
 	mapperresources "github.com/loft-sh/vcluster/pkg/mappings/resources"
@@ -61,12 +62,13 @@ func (g *gatewayClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	}
 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
-	vObj.Spec = gatewayClassSpecToVirtual(event.Host.Spec)
+	vObj.Spec = *event.Host.Spec.DeepCopy()
 
 	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}
+	vObj.Spec = gatewayClassSpecToVirtual(vObj.Spec)
 
 	ctx.Log.Infof("create GatewayClass %s, because it does not exist in virtual cluster", vObj.Name)
 	return patcher.CreateVirtualObject(ctx, event.Host, vObj, g.EventRecorder(), true)
@@ -83,7 +85,7 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, reason)
 	}
 
-	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.FromHost.GatewayClasses.Patches, true))
+	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
 	}
@@ -94,9 +96,13 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 	}()
 
 	// GatewayClasses are mirrored from the host cluster, so host metadata wins.
-	event.Virtual.Annotations = event.Host.Annotations
-	event.Virtual.Labels = event.Host.Labels
-	event.Virtual.Spec = gatewayClassSpecToVirtual(event.Host.Spec)
+	event.Virtual.Annotations = maps.Clone(event.Host.Annotations)
+	event.Virtual.Labels = maps.Clone(event.Host.Labels)
+	event.Virtual.Spec = *event.Host.Spec.DeepCopy()
+	if err := pro.ApplyPatchesVirtualObject(ctx, nil, event.Virtual, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
+	}
+	event.Virtual.Spec = gatewayClassSpecToVirtual(event.Virtual.Spec)
 	event.Virtual.Status = event.Host.Status
 	return ctrl.Result{}, nil
 }
@@ -122,12 +128,8 @@ func (g *gatewayClassSyncer) recordDeleteWarning(gwClass *gatewayv1.GatewayClass
 
 func gatewayClassSpecToVirtual(hostSpec gatewayv1.GatewayClassSpec) gatewayv1.GatewayClassSpec {
 	virtualSpec := *hostSpec.DeepCopy()
-	if virtualSpec.ParametersRef != nil {
-		virtualSpec.ParametersRef = virtualSpec.ParametersRef.DeepCopy()
-		// GatewayClasses are cluster-scoped mirrors. Keep host topology details out
-		// of the tenant view when the parameters object lives in a host namespace.
-		virtualSpec.ParametersRef.Namespace = nil
-	}
+	// Tenant-visible GatewayClasses must not expose Host parametersRef topology.
+	virtualSpec.ParametersRef = nil
 
 	return virtualSpec
 }

--- a/pkg/controllers/resources/gatewayclasses/syncer_test.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer_test.go
@@ -1,0 +1,139 @@
+package gatewayclasses
+
+import (
+	"context"
+	"testing"
+
+	rootconfig "github.com/loft-sh/vcluster/config"
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestGatewayClassSpecToVirtualRemovesParametersRefAndPreservesTenantVisibleFields(t *testing.T) {
+	description := "tenant visible class"
+	hostSpec := gatewayv1.GatewayClassSpec{
+		ControllerName: "example.com/gateway-controller",
+		Description:    &description,
+		ParametersRef:  gatewayClassParametersRef("host-config", "host-only"),
+	}
+
+	got := gatewayClassSpecToVirtual(hostSpec)
+	if got.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to be removed, got %#v", got.ParametersRef)
+	}
+	if got.ControllerName != hostSpec.ControllerName {
+		t.Fatalf("expected controllerName %q, got %q", hostSpec.ControllerName, got.ControllerName)
+	}
+	if got.Description == nil || *got.Description != description {
+		t.Fatalf("expected description %q, got %#v", description, got.Description)
+	}
+}
+
+func TestGatewayClassSyncToVirtualSanitizesParametersRefAfterPatches(t *testing.T) {
+	withGatewayClassPatchThatAddsParametersRef(t)
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.GatewayClasses.Enabled = true
+	vcConfig.Sync.FromHost.GatewayClasses.Patches = []rootconfig.TranslatePatch{{Path: "spec.parametersRef.name", Expression: "'patched-config'"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, New)
+	syncer := object.(*gatewayClassSyncer)
+
+	host := gatewayClass("tenant-class")
+	_, err := syncer.SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(host))
+	if err != nil {
+		t.Fatalf("sync to virtual: %v", err)
+	}
+
+	got := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, got); err != nil {
+		t.Fatalf("expected virtual GatewayClass to be created: %v", err)
+	}
+	if got.Spec.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to remain sanitized after create patches, got %#v", got.Spec.ParametersRef)
+	}
+}
+
+func TestGatewayClassSyncSanitizesParametersRefAfterPatches(t *testing.T) {
+	withGatewayClassPatchThatAddsParametersRef(t)
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.GatewayClasses.Enabled = true
+	vcConfig.Sync.FromHost.GatewayClasses.Patches = []rootconfig.TranslatePatch{{Path: "spec.parametersRef.name", Expression: "'patched-config'"}}
+	host := gatewayClass("tenant-class")
+	virtual := &gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: host.Name}, Spec: gatewayv1.GatewayClassSpec{ControllerName: "old.example.com/controller"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme, host)
+	vClient := testingutil.NewFakeClient(scheme.Scheme, virtual.DeepCopy())
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, New)
+	syncer := object.(*gatewayClassSyncer)
+	currentVirtual := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, currentVirtual); err != nil {
+		t.Fatalf("get current virtual GatewayClass: %v", err)
+	}
+
+	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, currentVirtual))
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	got := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, got); err != nil {
+		t.Fatalf("expected virtual GatewayClass to be updated: %v", err)
+	}
+	if got.Spec.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to remain sanitized after update patches, got %#v", got.Spec.ParametersRef)
+	}
+}
+
+func withGatewayClassPatchThatAddsParametersRef(t *testing.T) {
+	t.Helper()
+	origVirtual := pro.ApplyPatchesVirtualObject
+	origHost := pro.ApplyPatchesHostObject
+	patchFn := func(_ *synccontext.SyncContext, _, obj, _ client.Object, _ []rootconfig.TranslatePatch, _ bool) error {
+		gwClass, ok := obj.(*gatewayv1.GatewayClass)
+		if ok {
+			gwClass.Spec.ParametersRef = gatewayClassParametersRef("patched-config", "patched-namespace")
+		}
+		return nil
+	}
+	pro.ApplyPatchesVirtualObject = patchFn
+	pro.ApplyPatchesHostObject = patchFn
+	t.Cleanup(func() {
+		pro.ApplyPatchesVirtualObject = origVirtual
+		pro.ApplyPatchesHostObject = origHost
+	})
+}
+
+func gatewayClass(name string) *gatewayv1.GatewayClass {
+	description := "tenant visible class"
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "example.com/gateway-controller",
+			Description:    &description,
+			ParametersRef:  gatewayClassParametersRef(name+"-config", "host-only"),
+		},
+	}
+}
+
+func gatewayClassParametersRef(name string, namespace string) *gatewayv1.ParametersReference {
+	ns := gatewayv1.Namespace(namespace)
+	return &gatewayv1.ParametersReference{
+		Group:     gatewayv1.Group("example.com"),
+		Kind:      gatewayv1.Kind("GatewayClassConfig"),
+		Name:      name,
+		Namespace: &ns,
+	}
+}
+
+var _ runtime.Object = &gatewayv1.GatewayClass{}

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -71,7 +71,7 @@ func NewToHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, erro
 	}
 
 	return &tenantGatewaySyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "gateway", &gatewayv1.Gateway{}, mapper),
+		GenericTranslator: translator.NewGenericTranslator(ctx, "tenant-gateway", &gatewayv1.Gateway{}, mapper),
 	}, nil
 }
 
@@ -168,7 +168,7 @@ func tenantGatewayEligible(ctx *synccontext.SyncContext, s *tenantGatewaySyncer,
 	gatewayClass := &gatewayv1.GatewayClass{}
 	err := ctx.VirtualClient.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass)
 	if kerrors.IsNotFound(err) {
-		s.EventRecorder().Eventf(gateway, nil, "Warning", "SyncWarning", "SyncGateway", "GatewayClass %q is not visible in the virtual cluster", gateway.Spec.GatewayClassName)
+		s.EventRecorder().Eventf(gateway, nil, "Warning", "SyncWarning", "SyncGateway", "GatewayClass %q is not available in this virtual cluster", gateway.Spec.GatewayClassName)
 		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("get virtual GatewayClass %q: %w", gateway.Spec.GatewayClassName, err)

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -107,7 +107,7 @@ func TestTenantGatewaySyncToHostCreatesGatewayWhenExplicitlyEnabled(t *testing.T
 	}
 }
 
-func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
+func TestTenantGatewaySyncSkipsUnavailableVirtualGatewayClass(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 	pClient := testingutil.NewFakeClient(scheme.Scheme)
@@ -119,7 +119,7 @@ func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
 	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
-		t.Fatalf("expected missing GatewayClass to be a warning/skip, not hard error: %v", err)
+		t.Fatalf("expected unavailable GatewayClass to skip without reconcile error, got %v", err)
 	}
 
 	expected := translate.Default.HostName(syncCtx, "edge", "team-a")
@@ -129,7 +129,7 @@ func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
 	}
 }
 
-func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassDisappears(t *testing.T) {
+func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassBecomesUnavailable(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 	hostName := types.NamespacedName{Namespace: testingutil.DefaultTestTargetNamespace, Name: "edge-x-team-a-x-suffix"}
@@ -143,12 +143,12 @@ func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassDisappears(t *testi
 	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
 	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, virtual))
 	if err != nil {
-		t.Fatalf("expected missing GatewayClass to delete stale host Gateway without hard error: %v", err)
+		t.Fatalf("expected unavailable GatewayClass update to delete host without reconcile error, got %v", err)
 	}
 
 	got := &gatewayv1.Gateway{}
 	if err := pClient.Get(context.Background(), hostName, got); err == nil {
-		t.Fatalf("expected stale host Gateway to be deleted")
+		t.Fatalf("expected existing host Gateway to be deleted when GatewayClass becomes unavailable")
 	}
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-551


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
