### PR TITLE
Fix/test plan p0s

### DIFF
--- a/e2e-next/labels/labels.go
+++ b/e2e-next/labels/labels.go
@@ -24,6 +24,8 @@ var (
 	RuntimeClasses  = Label("runtimeclasses")
 	StorageClasses  = Label("storageclasses")
 	IngressClasses  = Label("ingressclasses")
+	GatewayAPI      = Label("gatewayapi")
+	GatewayClasses  = Label("gatewayclasses")
 	ConfigMaps      = Label("configmaps")
 	Secrets         = Label("secrets")
 	NetworkPolicies = Label("networkpolicies")

--- a/e2e-next/setup/csi.go
+++ b/e2e-next/setup/csi.go
@@ -109,8 +109,15 @@ func InstallCSIHostpath(kubeContext string) func(ctx context.Context) error {
 }
 
 func kubectlApply(ctx context.Context, kubeContext string, files ...string) error {
+	return kubectlApplyWithOptions(ctx, kubeContext, nil, files...)
+}
+
+func kubectlApplyWithOptions(ctx context.Context, kubeContext string, options []string, files ...string) error {
 	for _, f := range files {
-		cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", f, "--context", kubeContext)
+		args := []string{"apply"}
+		args = append(args, options...)
+		args = append(args, "-f", f, "--context", kubeContext)
+		cmd := exec.CommandContext(ctx, "kubectl", args...)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			if !strings.Contains(string(out), "already exists") {
 				return fmt.Errorf("kubectl apply -f %s: %s: %w", f, string(out), err)

--- a/e2e-next/setup/gatewayapi.go
+++ b/e2e-next/setup/gatewayapi.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 
@@ -30,13 +29,9 @@ func GatewayAPIPreSetup() func(ctx context.Context) error {
 			"pkg/mappings/resources/tlsroutes.crd.yaml",
 			"pkg/mappings/resources/backendtlspolicies.crd.yaml",
 		}
-		for _, crd := range crds {
-			abs := filepath.Join(repoRoot, crd)
-			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--server-side", "--force-conflicts", "--context", kubeContext, "-f", abs)
-			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("apply Gateway API CRD %s: %s: %w", crd, string(out), err)
-			}
+		for i, crd := range crds {
+			crds[i] = filepath.Join(repoRoot, crd)
 		}
-		return nil
+		return kubectlApplyWithOptions(ctx, kubeContext, []string{"--server-side", "--force-conflicts"}, crds...)
 	}
 }

--- a/e2e-next/setup/gatewayapi.go
+++ b/e2e-next/setup/gatewayapi.go
@@ -27,10 +27,12 @@ func GatewayAPIPreSetup() func(ctx context.Context) error {
 			"pkg/mappings/resources/gateways.crd.yaml",
 			"pkg/mappings/resources/httproutes.crd.yaml",
 			"pkg/mappings/resources/referencegrants.crd.yaml",
+			"pkg/mappings/resources/tlsroutes.crd.yaml",
+			"pkg/mappings/resources/backendtlspolicies.crd.yaml",
 		}
 		for _, crd := range crds {
 			abs := filepath.Join(repoRoot, crd)
-			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--context", kubeContext, "-f", abs)
+			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--server-side", "--force-conflicts", "--context", kubeContext, "-f", abs)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("apply Gateway API CRD %s: %s: %w", crd, string(out), err)
 			}

--- a/e2e-next/setup/gatewayapi.go
+++ b/e2e-next/setup/gatewayapi.go
@@ -1,0 +1,40 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+)
+
+// GatewayAPIPreSetup installs the local Gateway API CRDs required by the
+// Gateway API e2e suite on the host cluster before vCluster starts. The CRDs
+// are intentionally left installed after the suite because they are shared
+// cluster-scoped infrastructure.
+func GatewayAPIPreSetup() func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		kubeContext := "kind-" + constants.GetHostClusterName()
+		_, file, _, ok := runtime.Caller(0)
+		if !ok {
+			return fmt.Errorf("resolve Gateway API setup source path")
+		}
+		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+		crds := []string{
+			"pkg/mappings/resources/gatewayclasses.crd.yaml",
+			"pkg/mappings/resources/gateways.crd.yaml",
+			"pkg/mappings/resources/httproutes.crd.yaml",
+			"pkg/mappings/resources/referencegrants.crd.yaml",
+		}
+		for _, crd := range crds {
+			abs := filepath.Join(repoRoot, crd)
+			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--context", kubeContext, "-f", abs)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("apply Gateway API CRD %s: %s: %w", crd, string(out), err)
+			}
+		}
+		return nil
+	}
+}

--- a/e2e-next/suite_gatewayapi_combined_test.go
+++ b/e2e-next/suite_gatewayapi_combined_test.go
@@ -1,0 +1,43 @@
+// Suite: gatewayapi-combined-vcluster
+// vCluster: fromHost Gateways and toHost Gateway API Gateways enabled together.
+// Run:      just run-e2e 'pr && gatewayapi'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	"github.com/loft-sh/vcluster/e2e-next/test_gatewayapi"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+//go:embed vcluster-gatewayapi-combined.yaml
+var gatewayAPICombinedVClusterYAML string
+
+const gatewayAPICombinedVClusterName = "gatewayapi-combined-vcluster"
+
+func init() { suiteGatewayAPICombinedVCluster() }
+
+func suiteGatewayAPICombinedVCluster() {
+	// Ordered so the startup regression coverage runs against one vCluster with
+	// both Gateway import and tenant Gateway sync enabled.
+	Describe("gatewayapi-combined-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				return lazyvcluster.LazyVCluster(ctx,
+					gatewayAPICombinedVClusterName,
+					gatewayAPICombinedVClusterYAML,
+					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
+				)
+			})
+
+			test_gatewayapi.GatewayAPICombinedSpec()
+		},
+	)
+}

--- a/e2e-next/suite_gatewayapi_import_test.go
+++ b/e2e-next/suite_gatewayapi_import_test.go
@@ -25,6 +25,7 @@ const gatewayAPIImportVClusterName = "gatewayapi-import-vcluster"
 func init() { suiteGatewayAPIImportVCluster() }
 
 func suiteGatewayAPIImportVCluster() {
+	// Ordered so all specs share one lazyvcluster bring-up; specs are independent.
 	Describe("gatewayapi-import-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
 		cluster.Use(clusters.HostCluster),
 		func() {

--- a/e2e-next/suite_gatewayapi_import_test.go
+++ b/e2e-next/suite_gatewayapi_import_test.go
@@ -1,6 +1,6 @@
-// Suite: gatewayapi-vcluster
-// vCluster: Gateway API sync coverage for GatewayClass visibility, Tenant
-// Gateway authorization, and Gateway/HTTPRoute sync.
+// Suite: gatewayapi-import-vcluster
+// vCluster: fromHost imported Gateway coverage (mirroring, allowedRoutes policy,
+// hostname allowlist, deletion recovery, read-only behavior, status sanitization).
 // Run:      just run-e2e 'pr && gatewayapi'
 package e2e_next
 
@@ -17,27 +17,26 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-//go:embed vcluster-gatewayapi.yaml
-var gatewayAPIVClusterYAML string
+//go:embed vcluster-gatewayapi-import.yaml
+var gatewayAPIImportVClusterYAML string
 
-const gatewayAPIVClusterName = "gatewayapi-vcluster"
+const gatewayAPIImportVClusterName = "gatewayapi-import-vcluster"
 
-func init() { suiteGatewayAPIVCluster() }
+func init() { suiteGatewayAPIImportVCluster() }
 
-func suiteGatewayAPIVCluster() {
-	Describe("gatewayapi-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
+func suiteGatewayAPIImportVCluster() {
+	Describe("gatewayapi-import-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
 		cluster.Use(clusters.HostCluster),
 		func() {
 			BeforeAll(func(ctx context.Context) context.Context {
 				return lazyvcluster.LazyVCluster(ctx,
-					gatewayAPIVClusterName,
-					gatewayAPIVClusterYAML,
+					gatewayAPIImportVClusterName,
+					gatewayAPIImportVClusterYAML,
 					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
 				)
 			})
 
-			test_gatewayapi.GatewayAPISyncSpec()
-			test_gatewayapi.GatewayAPIToHostSpec()
+			test_gatewayapi.GatewayAPIImportSpec()
 		},
 	)
 }

--- a/e2e-next/suite_gatewayapi_test.go
+++ b/e2e-next/suite_gatewayapi_test.go
@@ -25,6 +25,7 @@ const gatewayAPIVClusterName = "gatewayapi-vcluster"
 func init() { suiteGatewayAPIVCluster() }
 
 func suiteGatewayAPIVCluster() {
+	// Ordered so all specs share one lazyvcluster bring-up; specs are independent.
 	Describe("gatewayapi-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
 		cluster.Use(clusters.HostCluster),
 		func() {

--- a/e2e-next/suite_gatewayapi_test.go
+++ b/e2e-next/suite_gatewayapi_test.go
@@ -1,0 +1,42 @@
+// Suite: gatewayapi-vcluster
+// vCluster: Gateway API sync coverage for GatewayClass visibility, Tenant
+// Gateway authorization, and Gateway/HTTPRoute sync.
+// Run:      just run-e2e 'pr && gatewayapi'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	"github.com/loft-sh/vcluster/e2e-next/test_gatewayapi"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+//go:embed vcluster-gatewayapi.yaml
+var gatewayAPIVClusterYAML string
+
+const gatewayAPIVClusterName = "gatewayapi-vcluster"
+
+func init() { suiteGatewayAPIVCluster() }
+
+func suiteGatewayAPIVCluster() {
+	Describe("gatewayapi-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				return lazyvcluster.LazyVCluster(ctx,
+					gatewayAPIVClusterName,
+					gatewayAPIVClusterYAML,
+					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
+				)
+			})
+
+			test_gatewayapi.GatewayAPISyncSpec()
+		},
+	)
+}

--- a/e2e-next/test_gatewayapi/clients.go
+++ b/e2e-next/test_gatewayapi/clients.go
@@ -1,0 +1,50 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type gatewayAPIClients struct {
+	HostClient     ctrlclient.Client
+	VClusterClient ctrlclient.Client
+	VClusterName   string
+	VClusterHostNS string
+}
+
+func newGatewayAPIClients(ctx context.Context, installExtendedGatewaySchemes bool) gatewayAPIClients {
+	GinkgoHelper()
+
+	scheme := runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	Expect(gatewayv1.Install(scheme)).To(Succeed())
+	if installExtendedGatewaySchemes {
+		Expect(gatewayv1alpha2.Install(scheme)).To(Succeed())
+		Expect(gatewayv1alpha3.Install(scheme)).To(Succeed())
+		Expect(gatewayv1beta1.Install(scheme)).To(Succeed())
+	}
+
+	hostClient, err := ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+	Expect(err).To(Succeed())
+	vClusterClient, err := ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+	Expect(err).To(Succeed())
+
+	vClusterName := cluster.CurrentClusterNameFrom(ctx)
+	return gatewayAPIClients{
+		HostClient:     hostClient,
+		VClusterClient: vClusterClient,
+		VClusterName:   vClusterName,
+		VClusterHostNS: "vcluster-" + vClusterName,
+	}
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_combined.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_combined.go
@@ -1,0 +1,104 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/gateways"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const combinedClassSelectorValue = "gatewayapi-combined"
+
+// GatewayAPICombinedSpec covers ENGNODE-556 / TC-33: importing host Gateways
+// and syncing tenant Gateways can be enabled together without startup loops.
+func GatewayAPICombinedSpec() {
+	Describe("Gateway API combined import and tenant Gateway sync", labels.GatewayAPI, labels.GatewayClasses, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		gatewayNamespace := "gwapi-combined-host"
+		BeforeEach(func(ctx context.Context) {
+			clients := newGatewayAPIClients(ctx, false)
+			hostClient = clients.HostClient
+			vClusterClient = clients.VClusterClient
+			vClusterName = clients.VClusterName
+			vClusterHostNS = clients.VClusterHostNS
+
+			ensureHostNamespace(ctx, hostClient, gatewayNamespace)
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &corev1.NamespaceList{})).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("starts with both Gateway import and tenant Gateway sync enabled", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-combined-"+suffix, combinedClassSelectorValue, "combined class")
+			hostGW := hostGateway(gatewayNamespace, "edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			importedGatewayNamespace := "gwapi-combined-import"
+			By("verifying the imported Gateway mirror appears after vCluster startup", func() {
+				Eventually(func(g Gomega) {
+					mirror := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: importedGatewayNamespace, Name: hostGW.Name}, mirror)).To(Succeed())
+					g.Expect(mirror.Labels).To(HaveKeyWithValue(gateways.ImportedGatewayLabel, "true"))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("verifying the combined vCluster syncs tenant-authored Gateway API resources to host", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+				tenantNS := createTenantNamespace(ctx, vClusterClient, "gwapi-combined-tenant-"+suffix)
+				service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: tenantNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+				Expect(vClusterClient.Create(ctx, service)).To(Succeed())
+
+				tenantGW := tenantGateway(tenantNS.Name, "tenant-gw-"+suffix, class.Name)
+				Expect(vClusterClient.Create(ctx, tenantGW)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, tenantGW))).To(Succeed())
+				})
+				tenantRoute := tenantHTTPRoute(tenantNS.Name, "tenant-route-"+suffix, tenantGW.Name, service.Name)
+				Expect(vClusterClient.Create(ctx, tenantRoute)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, tenantRoute))).To(Succeed())
+				})
+
+				hostGatewayName := translate.SafeConcatName(tenantGW.Name, "x", tenantNS.Name, "x", vClusterName)
+				hostRouteName := translate.SafeConcatName(tenantRoute.Name, "x", tenantNS.Name, "x", vClusterName)
+				Eventually(func(g Gomega) {
+					gotGateway := &gatewayv1.Gateway{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, gotGateway)).To(Succeed())
+					g.Expect(gotGateway.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(class.Name)))
+
+					gotRoute := &gatewayv1.HTTPRoute{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, gotRoute)).To(Succeed())
+					g.Expect(gotRoute.Spec.ParentRefs).To(HaveLen(1))
+					g.Expect(gotRoute.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGatewayName)))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+				Consistently(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(tenantGW), &gatewayv1.Gateway{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+		})
+	})
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -1,0 +1,393 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const importClassSelectorValue = "gatewayapi-import"
+
+// GatewayAPIImportSpec registers fromHost imported Gateway tests (P0 cases
+// 01-08, 16, control-plane behavior only).
+func GatewayAPIImportSpec() {
+	Describe("Gateway API import", labels.GatewayAPI, labels.GatewayClasses, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+
+			ensureHostNamespace(ctx, hostClient, "gwapi-host")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("imports a host Gateway into the tenant and syncs attached routes to the host Gateway", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-import-"+suffix, importClassSelectorValue, "import class")
+
+			By("creating a host Gateway in the wildcard-mapped source namespace")
+			hostGW := hostGateway("gwapi-host", "edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			By("verifying the tenant mirror, namespace and GatewayClass exist")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+				mirror := &gatewayv1.Gateway{}
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}, mirror)).To(Succeed())
+				g.Expect(mirror.Labels).To(HaveKeyWithValue("vcluster.loft.sh/imported-gateway", "true"))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("creating a tenant HTTPRoute attached to the imported Gateway")
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-app-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import", hostGW.Name, svc.Name, "app.apps.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			By("verifying the host route parentRef points at the host Gateway")
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
+				g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("confirming no tenant-created host Gateway object exists")
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: translate.SafeConcatName(hostGW.Name, "x", "gwapi-import", "x", vClusterName)}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("mirrors the GatewayClass with controllerName preserved and parametersRef stripped", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-sanitize-"+suffix, importClassSelectorValue, "sanitize class")
+
+			Eventually(func(g Gomega) {
+				mirror := &gatewayv1.GatewayClass{}
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, mirror)).To(Succeed())
+				g.Expect(mirror.Spec.ControllerName).To(Equal(gatewayControllerName))
+				g.Expect(mirror.Spec.ParametersRef).To(BeNil())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("does not sync routes that attach to a tenant-local non-imported Gateway", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-local-"+suffix, importClassSelectorValue, "local class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-local-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			By("creating a tenant-local Gateway that is not imported from host")
+			localGW := tenantGateway(routeNS.Name, "local-gw-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, localGW)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, localGW))).To(Succeed())
+			})
+			route := importRoute(routeNS.Name, "route-"+suffix, routeNS.Name, localGW.Name, svc.Name, "app.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("removes the tenant mirror when the host Gateway is deleted and recovers when recreated", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-del-"+suffix, importClassSelectorValue, "deletion class")
+			hostGW := hostGateway("gwapi-host", "del-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			mirrorKey := types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the host Gateway")
+			Expect(hostClient.Delete(ctx, hostGW)).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("recreating the host Gateway")
+			recreated := hostGateway("gwapi-host", hostGW.Name, class.Name)
+			Expect(hostClient.Create(ctx, recreated)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("treats the imported Gateway as read-only and recreates it after tenant deletion", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-ro-"+suffix, importClassSelectorValue, "read-only class")
+			hostGW := hostGateway("gwapi-host", "ro-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			mirrorKey := types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("editing a tenant listener port and expecting it reverted")
+			mirror := &gatewayv1.Gateway{}
+			Expect(vClusterClient.Get(ctx, mirrorKey, mirror)).To(Succeed())
+			mirror.Spec.Listeners[0].Port = gatewayv1.PortNumber(8080)
+			Expect(vClusterClient.Update(ctx, mirror)).To(Succeed())
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+				g.Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the tenant mirror and expecting recreation")
+			toDelete := &gatewayv1.Gateway{}
+			Expect(vClusterClient.Get(ctx, mirrorKey, toDelete)).To(Succeed())
+			Expect(vClusterClient.Delete(ctx, toDelete)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("confirming the host Gateway is never mutated")
+			got := &gatewayv1.Gateway{}
+			Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, got)).To(Succeed())
+			Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+		})
+
+		It("hides host Gateway status addresses on the tenant mirror by default", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-status-"+suffix, importClassSelectorValue, "status class")
+			hostGW := hostGateway("gwapi-host", "status-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			mirrorKey := types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("populating host Gateway status addresses")
+			current := &gatewayv1.Gateway{}
+			Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, current)).To(Succeed())
+			current.Status.Addresses = []gatewayv1.GatewayStatusAddress{{Type: ptr.To(gatewayv1.IPAddressType), Value: "203.0.113.10"}}
+			Expect(hostClient.Status().Update(ctx, current)).To(Succeed())
+
+			By("verifying the tenant mirror hides addresses")
+			Consistently(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+				g.Expect(got.Status.Addresses).To(BeEmpty())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("enforces the virtual allowedRoutes namespace selector policy on imported Gateways", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ensureHostNamespace(ctx, hostClient, "gwapi-host-policy")
+			class := createGatewayClass(ctx, hostClient, "gwc-sel-"+suffix, importClassSelectorValue, "selector class")
+			hostGW := hostGateway("gwapi-host-policy", "selector-edge", class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-policy", Name: "selector-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("creating a route in an unlabeled namespace and expecting no host sync")
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-sel-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-policy", "selector-edge", svc.Name, "app.apps.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			By("labeling the namespace team=apps and expecting the host route to appear")
+			updatedNS := &corev1.Namespace{}
+			Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: routeNS.Name}, updatedNS)).To(Succeed())
+			if updatedNS.Labels == nil {
+				updatedNS.Labels = map[string]string{}
+			}
+			updatedNS.Labels["team"] = "apps"
+			Expect(vClusterClient.Update(ctx, updatedNS)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("enforces the hostname allowlist on imported Gateways", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ensureHostNamespace(ctx, hostClient, "gwapi-host-policy")
+			class := createGatewayClass(ctx, hostClient, "gwc-host-"+suffix, importClassSelectorValue, "hostname class")
+			hostGW := hostGateway("gwapi-host-policy", "hostname-edge", class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-policy", Name: "hostname-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-host-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			By("creating a route with a disallowed hostname and expecting no host sync")
+			denied := importRoute(routeNS.Name, "denied-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "admin.apps.example.com")
+			Expect(vClusterClient.Create(ctx, denied)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, denied))).To(Succeed())
+			})
+			deniedHostName := translate.SafeConcatName(denied.Name, "x", routeNS.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: deniedHostName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			By("creating a route with an allowed hostname and expecting host sync")
+			allowed := importRoute(routeNS.Name, "allowed-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "api.team-a.apps.example.com")
+			Expect(vClusterClient.Create(ctx, allowed)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, allowed))).To(Succeed())
+			})
+			allowedHostName := translate.SafeConcatName(allowed.Name, "x", routeNS.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: allowedHostName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("imports a renamed Gateway and routes attach to the correct host Gateway", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ensureHostNamespace(ctx, hostClient, "gwapi-host-rename")
+			class := createGatewayClass(ctx, hostClient, "gwc-rename-"+suffix, importClassSelectorValue, "rename class")
+			hostGW := hostGateway("gwapi-host-rename", "source-edge", class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			By("verifying the tenant mirror exists under the renamed name")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-rename", Name: "renamed-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("attaching a route to the renamed Gateway and checking the host parentRef")
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-rename-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-rename", "renamed-edge", svc.Name, "app.apps.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName("source-edge")))
+				g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host-rename")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func ensureHostNamespace(ctx context.Context, c ctrlclient.Client, name string) {
+	GinkgoHelper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	err := c.Create(ctx, ns)
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		Expect(err).To(Succeed())
+	}
+}
+
+func createHostGateway(ctx context.Context, c ctrlclient.Client, gw *gatewayv1.Gateway) {
+	GinkgoHelper()
+	key := ctrlclient.ObjectKeyFromObject(gw)
+	stale := &gatewayv1.Gateway{}
+	err := c.Get(ctx, key, stale)
+	if err == nil {
+		Expect(c.Delete(ctx, stale)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := c.Get(ctx, key, &gatewayv1.Gateway{})
+			g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+		}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+	} else {
+		Expect(kerrors.IsNotFound(err)).To(BeTrue())
+	}
+	Expect(c.Create(ctx, gw)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(c.Delete(ctx, gw))).To(Succeed()) })
+}
+
+func hostGateway(namespace, name, className string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     gatewayv1.SectionName("http"),
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+			}},
+		},
+	}
+}
+
+func importRoute(namespace, name, gatewayNamespace, gatewayName, serviceName, hostname string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{
+				Name:      gatewayv1.ObjectName(gatewayName),
+				Namespace: ptr.To(gatewayv1.Namespace(gatewayNamespace)),
+			}}},
+			Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(hostname)},
+			Rules:     []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(serviceName), Port: ptr.To(gatewayv1.PortNumber(80))}}}}}},
+		},
+	}
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -3,9 +3,9 @@ package test_gatewayapi
 import (
 	"context"
 
-	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
 	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/controllers/resources/gateways"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,8 +21,7 @@ import (
 
 const importClassSelectorValue = "gatewayapi-import"
 
-// GatewayAPIImportSpec registers fromHost imported Gateway tests (P0 cases
-// 01-08, 16, control-plane behavior only).
+// GatewayAPIImportSpec registers fromHost imported Gateway tests.
 func GatewayAPIImportSpec() {
 	Describe("Gateway API import", labels.GatewayAPI, labels.GatewayClasses, func() {
 		var (
@@ -34,17 +32,11 @@ func GatewayAPIImportSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			var err error
-			scheme := runtime.NewScheme()
-			Expect(corev1.AddToScheme(scheme)).To(Succeed())
-			Expect(gatewayv1.Install(scheme)).To(Succeed())
-
-			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
-			Expect(err).To(Succeed())
-			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
-			Expect(err).To(Succeed())
-			vClusterName = cluster.CurrentClusterNameFrom(ctx)
-			vClusterHostNS = "vcluster-" + vClusterName
+			clients := newGatewayAPIClients(ctx, false)
+			hostClient = clients.HostClient
+			vClusterClient = clients.VClusterClient
+			vClusterName = clients.VClusterName
+			vClusterHostNS = clients.VClusterHostNS
 
 			ensureHostNamespace(ctx, hostClient, "gwapi-host")
 			Eventually(func(g Gomega) {
@@ -52,51 +44,49 @@ func GatewayAPIImportSpec() {
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
-		It("imports a host Gateway into the tenant and syncs attached routes to the host Gateway", labels.PR, func(ctx context.Context) {
+		It("imports a host Gateway into the tenant and syncs attached routes to the host Gateway", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-import-"+suffix, importClassSelectorValue, "import class")
+			var hostGW *gatewayv1.Gateway
+			var routeNS *corev1.Namespace
+			var route *gatewayv1.HTTPRoute
 
-			By("creating a host Gateway in the wildcard-mapped source namespace")
-			hostGW := hostGateway("gwapi-host", "edge-"+suffix, class.Name)
-			createHostGateway(ctx, hostClient, hostGW)
-
-			By("verifying the tenant mirror, namespace and GatewayClass exist")
-			Eventually(func(g Gomega) {
-				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
-				mirror := &gatewayv1.Gateway{}
-				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}, mirror)).To(Succeed())
-				g.Expect(mirror.Labels).To(HaveKeyWithValue("vcluster.loft.sh/imported-gateway", "true"))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("creating a tenant HTTPRoute attached to the imported Gateway")
-			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-app-"+suffix)
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
-			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
-			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import", hostGW.Name, svc.Name, "app.apps.example.com")
-			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			By("creating a host Gateway in the wildcard-mapped source namespace", func() {
+				hostGW = hostGateway("gwapi-host", "edge-"+suffix, class.Name)
+				createHostGateway(ctx, hostClient, hostGW)
 			})
-
-			By("verifying the host route parentRef points at the host Gateway")
-			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
-			Eventually(func(g Gomega) {
-				got := &gatewayv1.HTTPRoute{}
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
-				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
-				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
-				g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
-				g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host")))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("confirming no tenant-created host Gateway object exists")
-			Consistently(func(g Gomega) {
-				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: translate.SafeConcatName(hostGW.Name, "x", "gwapi-import", "x", vClusterName)}, &gatewayv1.Gateway{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			By("verifying the tenant mirror, namespace and GatewayClass exist", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+					mirror := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}, mirror)).To(Succeed())
+					g.Expect(mirror.Labels).To(HaveKeyWithValue(gateways.ImportedGatewayLabel, "true"))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("creating a tenant HTTPRoute attached to the imported Gateway", func() {
+				routeNS = createTenantNamespace(ctx, vClusterClient, "gwapi-app-"+suffix)
+				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+				route = importRoute(routeNS.Name, "route-"+suffix, "gwapi-import", hostGW.Name, svc.Name, "app.apps.example.com")
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+			})
+			By("verifying the host route parentRef points at the host Gateway", func() {
+				hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.HTTPRoute{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+					g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+					g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
+					g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
+					g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host")))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
 		})
 
-		It("mirrors the GatewayClass with controllerName preserved and parametersRef stripped", labels.PR, func(ctx context.Context) {
+		It("mirrors the GatewayClass with controllerName preserved and parametersRef stripped", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-sanitize-"+suffix, importClassSelectorValue, "sanitize class")
 
@@ -108,7 +98,7 @@ func GatewayAPIImportSpec() {
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
-		It("does not sync routes that attach to a tenant-local non-imported Gateway", labels.PR, func(ctx context.Context) {
+		It("does not sync routes that attach to a tenant-local non-imported Gateway", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-local-"+suffix, importClassSelectorValue, "local class")
 			Eventually(func(g Gomega) {
@@ -119,26 +109,27 @@ func GatewayAPIImportSpec() {
 			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
 			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
 
-			By("creating a tenant-local Gateway that is not imported from host")
-			localGW := tenantGateway(routeNS.Name, "local-gw-"+suffix, class.Name)
-			Expect(vClusterClient.Create(ctx, localGW)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, localGW))).To(Succeed())
-			})
-			route := importRoute(routeNS.Name, "route-"+suffix, routeNS.Name, localGW.Name, svc.Name, "app.example.com")
-			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
-			})
+			By("creating a tenant-local Gateway that is not imported from host", func() {
+				localGW := tenantGateway(routeNS.Name, "local-gw-"+suffix, class.Name)
+				Expect(vClusterClient.Create(ctx, localGW)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, localGW))).To(Succeed())
+				})
+				route := importRoute(routeNS.Name, "route-"+suffix, routeNS.Name, localGW.Name, svc.Name, "app.example.com")
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
 
-			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
-			Consistently(func(g Gomega) {
-				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+				hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
 		})
 
-		It("removes the tenant mirror when the host Gateway is deleted and recovers when recreated", labels.PR, func(ctx context.Context) {
+		It("removes the tenant mirror when the host Gateway is deleted and recovers when recreated", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-del-"+suffix, importClassSelectorValue, "deletion class")
 			hostGW := hostGateway("gwapi-host", "del-edge-"+suffix, class.Name)
@@ -149,22 +140,23 @@ func GatewayAPIImportSpec() {
 				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			By("deleting the host Gateway")
-			Expect(hostClient.Delete(ctx, hostGW)).To(Succeed())
-			Eventually(func(g Gomega) {
-				err := vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("recreating the host Gateway")
-			recreated := hostGateway("gwapi-host", hostGW.Name, class.Name)
-			Expect(hostClient.Create(ctx, recreated)).To(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			By("deleting the host Gateway", func() {
+				Expect(hostClient.Delete(ctx, hostGW)).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("recreating the host Gateway", func() {
+				recreated := hostGateway("gwapi-host", hostGW.Name, class.Name)
+				createHostGateway(ctx, hostClient, recreated)
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
 		})
 
-		It("treats the imported Gateway as read-only and recreates it after tenant deletion", labels.PR, func(ctx context.Context) {
+		It("treats the imported Gateway as read-only and recreates it after tenant deletion", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-ro-"+suffix, importClassSelectorValue, "read-only class")
 			hostGW := hostGateway("gwapi-host", "ro-edge-"+suffix, class.Name)
@@ -175,32 +167,35 @@ func GatewayAPIImportSpec() {
 				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			By("editing a tenant listener port and expecting it reverted")
-			mirror := &gatewayv1.Gateway{}
-			Expect(vClusterClient.Get(ctx, mirrorKey, mirror)).To(Succeed())
-			mirror.Spec.Listeners[0].Port = gatewayv1.PortNumber(8080)
-			Expect(vClusterClient.Update(ctx, mirror)).To(Succeed())
-			Eventually(func(g Gomega) {
-				got := &gatewayv1.Gateway{}
-				g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
-				g.Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("deleting the tenant mirror and expecting recreation")
-			toDelete := &gatewayv1.Gateway{}
-			Expect(vClusterClient.Get(ctx, mirrorKey, toDelete)).To(Succeed())
-			Expect(vClusterClient.Delete(ctx, toDelete)).To(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("confirming the host Gateway is never mutated")
-			got := &gatewayv1.Gateway{}
-			Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, got)).To(Succeed())
-			Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+			By("editing a tenant listener port and expecting it reverted", func() {
+				mirror := &gatewayv1.Gateway{}
+				Expect(vClusterClient.Get(ctx, mirrorKey, mirror)).To(Succeed())
+				mirror.Spec.Listeners[0].Port = gatewayv1.PortNumber(8080)
+				Expect(vClusterClient.Update(ctx, mirror)).To(Succeed())
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+					g.Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("deleting the tenant mirror and expecting recreation", func() {
+				toDelete := &gatewayv1.Gateway{}
+				Expect(vClusterClient.Get(ctx, mirrorKey, toDelete)).To(Succeed())
+				Expect(vClusterClient.Delete(ctx, toDelete)).To(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("confirming the host Gateway is never mutated", func() {
+				Consistently(func(g Gomega) {
+					got := &gatewayv1.Gateway{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, got)).To(Succeed())
+					g.Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
 		})
 
-		It("hides host Gateway status addresses on the tenant mirror by default", labels.PR, func(ctx context.Context) {
+		It("hides host Gateway status addresses on the tenant mirror by default", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-status-"+suffix, importClassSelectorValue, "status class")
 			hostGW := hostGateway("gwapi-host", "status-edge-"+suffix, class.Name)
@@ -211,21 +206,33 @@ func GatewayAPIImportSpec() {
 				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			By("populating host Gateway status addresses")
-			current := &gatewayv1.Gateway{}
-			Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, current)).To(Succeed())
-			current.Status.Addresses = []gatewayv1.GatewayStatusAddress{{Type: ptr.To(gatewayv1.IPAddressType), Value: "203.0.113.10"}}
-			Expect(hostClient.Status().Update(ctx, current)).To(Succeed())
-
-			By("verifying the tenant mirror hides addresses")
-			Consistently(func(g Gomega) {
-				got := &gatewayv1.Gateway{}
-				g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
-				g.Expect(got.Status.Addresses).To(BeEmpty())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			By("populating host Gateway status addresses and a condition", func() {
+				Eventually(func(g Gomega) {
+					current := &gatewayv1.Gateway{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, current)).To(Succeed())
+					current.Status.Addresses = []gatewayv1.GatewayStatusAddress{{Type: ptr.To(gatewayv1.IPAddressType), Value: "203.0.113.10"}}
+					current.Status.Conditions = []metav1.Condition{{Type: "Accepted", Status: metav1.ConditionTrue, Reason: "Accepted", Message: "status propagation gate", LastTransitionTime: metav1.Now()}}
+					g.Expect(hostClient.Status().Update(ctx, current)).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("waiting for non-address status to propagate", func() {
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+					g.Expect(got.Status.Conditions).To(ContainElement(HaveField("Type", "Accepted")))
+					g.Expect(got.Status.Addresses).To(BeEmpty())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("verifying the tenant mirror keeps hiding addresses", func() {
+				Consistently(func(g Gomega) {
+					got := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+					g.Expect(got.Status.Addresses).To(BeEmpty())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
 		})
 
-		It("enforces the virtual allowedRoutes namespace selector policy on imported Gateways", labels.PR, func(ctx context.Context) {
+		It("enforces the virtual allowedRoutes namespace selector policy on imported Gateways", func(ctx context.Context) {
 			suffix := random.String(6)
 			ensureHostNamespace(ctx, hostClient, "gwapi-host-policy")
 			class := createGatewayClass(ctx, hostClient, "gwc-sel-"+suffix, importClassSelectorValue, "selector class")
@@ -235,36 +242,39 @@ func GatewayAPIImportSpec() {
 			Eventually(func(g Gomega) {
 				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-policy", Name: "selector-edge"}, &gatewayv1.Gateway{})).To(Succeed())
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			var routeNS *corev1.Namespace
+			var hostRouteName string
 
-			By("creating a route in an unlabeled namespace and expecting no host sync")
-			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-sel-"+suffix)
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
-			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
-			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-policy", "selector-edge", svc.Name, "app.apps.example.com")
-			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			By("creating a route in an unlabeled namespace and expecting no host sync", func() {
+				routeNS = createTenantNamespace(ctx, vClusterClient, "gwapi-sel-"+suffix)
+				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+				route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-policy", "selector-edge", svc.Name, "app.apps.example.com")
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+				hostRouteName = translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 			})
-			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
-			Consistently(func(g Gomega) {
-				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
-
-			By("labeling the namespace team=apps and expecting the host route to appear")
-			updatedNS := &corev1.Namespace{}
-			Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: routeNS.Name}, updatedNS)).To(Succeed())
-			if updatedNS.Labels == nil {
-				updatedNS.Labels = map[string]string{}
-			}
-			updatedNS.Labels["team"] = "apps"
-			Expect(vClusterClient.Update(ctx, updatedNS)).To(Succeed())
-			Eventually(func(g Gomega) {
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			By("labeling the namespace team=apps and expecting the host route to appear", func() {
+				updatedNS := &corev1.Namespace{}
+				Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: routeNS.Name}, updatedNS)).To(Succeed())
+				if updatedNS.Labels == nil {
+					updatedNS.Labels = map[string]string{}
+				}
+				updatedNS.Labels["team"] = "apps"
+				Expect(vClusterClient.Update(ctx, updatedNS)).To(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
 		})
 
-		It("enforces the hostname allowlist on imported Gateways", labels.PR, func(ctx context.Context) {
+		It("enforces the hostname allowlist on imported Gateways", func(ctx context.Context) {
 			suffix := random.String(6)
 			ensureHostNamespace(ctx, hostClient, "gwapi-host-policy")
 			class := createGatewayClass(ctx, hostClient, "gwc-host-"+suffix, importClassSelectorValue, "hostname class")
@@ -279,71 +289,83 @@ func GatewayAPIImportSpec() {
 			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
 			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
 
-			By("creating a route with a disallowed hostname and expecting no host sync")
-			denied := importRoute(routeNS.Name, "denied-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "admin.apps.example.com")
-			Expect(vClusterClient.Create(ctx, denied)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, denied))).To(Succeed())
+			By("creating a route with a disallowed hostname and expecting no host sync", func() {
+				denied := importRoute(routeNS.Name, "denied-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "admin.apps.example.com")
+				Expect(vClusterClient.Create(ctx, denied)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, denied))).To(Succeed())
+				})
+				deniedHostName := translate.SafeConcatName(denied.Name, "x", routeNS.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: deniedHostName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 			})
-			deniedHostName := translate.SafeConcatName(denied.Name, "x", routeNS.Name, "x", vClusterName)
-			Consistently(func(g Gomega) {
-				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: deniedHostName}, &gatewayv1.HTTPRoute{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
-
-			By("creating a route with an allowed hostname and expecting host sync")
-			allowed := importRoute(routeNS.Name, "allowed-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "api.team-a.apps.example.com")
-			Expect(vClusterClient.Create(ctx, allowed)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, allowed))).To(Succeed())
+			By("creating a route with an allowed hostname and expecting host sync", func() {
+				allowed := importRoute(routeNS.Name, "allowed-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "api.team-a.apps.example.com")
+				Expect(vClusterClient.Create(ctx, allowed)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, allowed))).To(Succeed())
+				})
+				allowedHostName := translate.SafeConcatName(allowed.Name, "x", routeNS.Name, "x", vClusterName)
+				Eventually(func(g Gomega) {
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: allowedHostName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
-			allowedHostName := translate.SafeConcatName(allowed.Name, "x", routeNS.Name, "x", vClusterName)
-			Eventually(func(g Gomega) {
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: allowedHostName}, &gatewayv1.HTTPRoute{})).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
-		It("imports a renamed Gateway and routes attach to the correct host Gateway", labels.PR, func(ctx context.Context) {
+		It("imports a renamed Gateway and routes attach to the correct host Gateway", func(ctx context.Context) {
 			suffix := random.String(6)
 			ensureHostNamespace(ctx, hostClient, "gwapi-host-rename")
 			class := createGatewayClass(ctx, hostClient, "gwc-rename-"+suffix, importClassSelectorValue, "rename class")
 			hostGW := hostGateway("gwapi-host-rename", "source-edge", class.Name)
 			createHostGateway(ctx, hostClient, hostGW)
 
-			By("verifying the tenant mirror exists under the renamed name")
-			Eventually(func(g Gomega) {
-				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-rename", Name: "renamed-edge"}, &gatewayv1.Gateway{})).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("attaching a route to the renamed Gateway and checking the host parentRef")
-			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-rename-"+suffix)
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
-			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
-			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-rename", "renamed-edge", svc.Name, "app.apps.example.com")
-			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			By("verifying the tenant mirror exists under the renamed name", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-rename", Name: "renamed-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
-			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
-			Eventually(func(g Gomega) {
-				got := &gatewayv1.HTTPRoute{}
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
-				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
-				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName("source-edge")))
-				g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
-				g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host-rename")))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			By("attaching a route to the renamed Gateway and checking the host parentRef", func() {
+				routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-rename-"+suffix)
+				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+				route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-rename", "renamed-edge", svc.Name, "app.apps.example.com")
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+				hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.HTTPRoute{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+					g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+					g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName("source-edge")))
+					g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
+					g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host-rename")))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
 		})
 	})
 }
 
 func ensureHostNamespace(ctx context.Context, c ctrlclient.Client, name string) {
 	GinkgoHelper()
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	err := c.Create(ctx, ns)
-	if err != nil && !kerrors.IsAlreadyExists(err) {
-		Expect(err).To(Succeed())
-	}
+	key := types.NamespacedName{Name: name}
+	Eventually(func(g Gomega) {
+		ns := &corev1.Namespace{}
+		err := c.Get(ctx, key, ns)
+		if kerrors.IsNotFound(err) {
+			created := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			g.Expect(c.Create(ctx, created)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(c.Delete(ctx, created))).To(Succeed())
+			})
+			return
+		}
+		g.Expect(err).To(Succeed())
+		g.Expect(ns.DeletionTimestamp.IsZero()).To(BeTrue())
+	}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 }
 
 func createHostGateway(ctx context.Context, c ctrlclient.Client, gw *gatewayv1.Gateway) {

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -113,7 +113,9 @@ func GatewayAPISyncSpec() {
 
 			bad := tenantGateway(ns.Name, "bad-gw-"+suffix, hidden.Name)
 			Expect(vClusterClient.Create(ctx, bad)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed())
+			})
 			badHostName := translate.SafeConcatName(bad.Name, "x", ns.Name, "x", vClusterName)
 			Consistently(func(g Gomega) {
 				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: badHostName}, &gatewayv1.Gateway{})
@@ -122,7 +124,9 @@ func GatewayAPISyncSpec() {
 
 			good := tenantGateway(ns.Name, "good-gw-"+suffix, allowed.Name)
 			Expect(vClusterClient.Create(ctx, good)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed())
+			})
 			goodHostName := translate.SafeConcatName(good.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {
 				got := &gatewayv1.Gateway{}
@@ -133,11 +137,10 @@ func GatewayAPISyncSpec() {
 			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(good), good)).To(Succeed())
 			good.Spec.GatewayClassName = gatewayv1.ObjectName(hidden.Name)
 			Expect(vClusterClient.Update(ctx, good)).To(Succeed())
-			Consistently(func(g Gomega) {
-				got := &gatewayv1.Gateway{}
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
-				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
 		It("syncs Tenant Gateway and HTTPRoute to Host for an available GatewayClass", func(ctx context.Context) {
@@ -152,7 +155,9 @@ func GatewayAPISyncSpec() {
 			Expect(vClusterClient.Create(ctx, service)).To(Succeed())
 			gateway := tenantGateway(ns.Name, "gw-"+suffix, allowed.Name)
 			Expect(vClusterClient.Create(ctx, gateway)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed())
+			})
 
 			hostGatewayName := translate.SafeConcatName(gateway.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {
@@ -170,7 +175,9 @@ func GatewayAPISyncSpec() {
 
 			route := tenantHTTPRoute(ns.Name, "route-"+suffix, gateway.Name, service.Name)
 			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
 
 			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -2,18 +2,18 @@ package test_gatewayapi
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
 	"github.com/loft-sh/vcluster/e2e-next/labels"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,17 +37,11 @@ func GatewayAPISyncSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			var err error
-			scheme := runtime.NewScheme()
-			Expect(corev1.AddToScheme(scheme)).To(Succeed())
-			Expect(gatewayv1.Install(scheme)).To(Succeed())
-
-			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
-			Expect(err).To(Succeed())
-			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
-			Expect(err).To(Succeed())
-			vClusterName = cluster.CurrentClusterNameFrom(ctx)
-			vClusterHostNS = "vcluster-" + vClusterName
+			clients := newGatewayAPIClients(ctx, false)
+			hostClient = clients.HostClient
+			vClusterClient = clients.VClusterClient
+			vClusterName = clients.VClusterName
+			vClusterHostNS = clients.VClusterHostNS
 
 			Eventually(func(g Gomega) {
 				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
@@ -76,6 +70,25 @@ func GatewayAPISyncSpec() {
 					err := vClusterClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, &gatewayv1.GatewayClass{})
 					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+
+			By("relabeling the hidden GatewayClass to matching and waiting for it to appear", func() {
+				Expect(hostClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, hidden)).To(Succeed())
+				hidden.Labels[gatewayClassSelectorKey] = gatewayClassSelectorValue
+				Expect(hostClient.Update(ctx, hidden)).To(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("delabeling the now-matching GatewayClass and waiting for it to disappear", func() {
+				Expect(hostClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, hidden)).To(Succeed())
+				hidden.Labels[gatewayClassSelectorKey] = "other-" + suffix
+				Expect(hostClient.Update(ctx, hidden)).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
 
 			By("updating the Host GatewayClass and ensuring parametersRef remains sanitized", func() {
@@ -137,9 +150,19 @@ func GatewayAPISyncSpec() {
 			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(good), good)).To(Succeed())
 			good.Spec.GatewayClassName = gatewayv1.ObjectName(hidden.Name)
 			Expect(vClusterClient.Update(ctx, good)).To(Succeed())
+			wantMsg := fmt.Sprintf("GatewayClass %q is not available in this virtual cluster", hidden.Name)
 			Eventually(func(g Gomega) {
 				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, &gatewayv1.Gateway{})
 				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+
+				events := &corev1.EventList{}
+				g.Expect(vClusterClient.List(ctx, events, ctrlclient.InNamespace(ns.Name))).To(Succeed())
+				messages := lo.Map(lo.Filter(events.Items, func(e corev1.Event, _ int) bool {
+					return e.InvolvedObject.Name == good.Name && e.Reason == "SyncWarning"
+				}), func(e corev1.Event, _ int) string {
+					return e.Message
+				})
+				g.Expect(messages).To(ContainElement(wantMsg))
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -1,0 +1,258 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	gatewayClassSelectorKey   = "e2e.vcluster.loft.sh/gatewayclass"
+	gatewayClassSelectorValue = "gatewayapi-vcluster"
+	gatewayControllerName     = gatewayv1.GatewayController("example.com/gateway-controller")
+)
+
+// GatewayAPISyncSpec registers Gateway API sync tests.
+func GatewayAPISyncSpec() {
+	Describe("Gateway API sync", labels.GatewayAPI, labels.GatewayClasses, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("mirrors matching Host GatewayClasses into the Tenant Cluster and hides non-matching ones", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed, hidden := createGatewayClassPair(ctx, hostClient, suffix)
+
+			By("waiting for the allowed GatewayClass to appear sanitized in the Tenant Cluster", func() {
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.GatewayClass{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, got)).To(Succeed())
+					g.Expect(got.Spec.ControllerName).To(Equal(gatewayControllerName))
+					g.Expect(got.Spec.Description).NotTo(BeNil())
+					g.Expect(*got.Spec.Description).To(Equal("e2e allowed GatewayClass"))
+					g.Expect(got.Spec.ParametersRef).To(BeNil())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("proving the selector-hidden GatewayClass stays absent from the Tenant Cluster", func() {
+				Consistently(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+
+			By("updating the Host GatewayClass and ensuring parametersRef remains sanitized", func() {
+				Expect(hostClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, allowed)).To(Succeed())
+				if allowed.Annotations == nil {
+					allowed.Annotations = map[string]string{}
+				}
+				allowed.Annotations["e2e.vcluster.loft.sh/resync"] = suffix
+				Expect(hostClient.Update(ctx, allowed)).To(Succeed())
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.GatewayClass{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, got)).To(Succeed())
+					g.Expect(got.Annotations).To(HaveKeyWithValue("e2e.vcluster.loft.sh/resync", suffix))
+					g.Expect(got.Spec.ParametersRef).To(BeNil())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("deleting the Host GatewayClass and waiting for the Tenant mirror to disappear", func() {
+				Expect(ctrlclient.IgnoreNotFound(hostClient.Delete(ctx, allowed))).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+		})
+
+		It("does not sync Tenant Gateways that reference unavailable GatewayClasses", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed, hidden := createGatewayClassPair(ctx, hostClient, suffix)
+			ns := createTenantNamespace(ctx, vClusterClient, "gwapi-reject-"+suffix)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			bad := tenantGateway(ns.Name, "bad-gw-"+suffix, hidden.Name)
+			Expect(vClusterClient.Create(ctx, bad)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed()) })
+			badHostName := translate.SafeConcatName(bad.Name, "x", ns.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: badHostName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			good := tenantGateway(ns.Name, "good-gw-"+suffix, allowed.Name)
+			Expect(vClusterClient.Create(ctx, good)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed()) })
+			goodHostName := translate.SafeConcatName(good.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(good), good)).To(Succeed())
+			good.Spec.GatewayClassName = gatewayv1.ObjectName(hidden.Name)
+			Expect(vClusterClient.Update(ctx, good)).To(Succeed())
+			Consistently(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("syncs Tenant Gateway and HTTPRoute to Host for an available GatewayClass", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed := createGatewayClass(ctx, hostClient, "gc-allowed-"+suffix, gatewayClassSelectorValue, "e2e allowed GatewayClass")
+			ns := createTenantNamespace(ctx, vClusterClient, "gwapi-sync-"+suffix)
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, service)).To(Succeed())
+			gateway := tenantGateway(ns.Name, "gw-"+suffix, allowed.Name)
+			Expect(vClusterClient.Create(ctx, gateway)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed()) })
+
+			hostGatewayName := translate.SafeConcatName(gateway.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+				g.Expect(got.Spec.Listeners).To(HaveLen(1))
+				listener := got.Spec.Listeners[0]
+				g.Expect(listener.Name).To(Equal(gatewayv1.SectionName("http")))
+				g.Expect(listener.Protocol).To(Equal(gatewayv1.HTTPProtocolType))
+				g.Expect(listener.Port).To(Equal(gatewayv1.PortNumber(80)))
+				g.Expect(listener.Hostname).NotTo(BeNil())
+				g.Expect(*listener.Hostname).To(Equal(gatewayv1.Hostname("app.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			route := tenantHTTPRoute(ns.Name, "route-"+suffix, gateway.Name, service.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed()) })
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGatewayName)))
+				g.Expect(got.Spec.ParentRefs[0].SectionName).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].SectionName).To(Equal(gatewayv1.SectionName("http")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func createGatewayClassPair(ctx context.Context, hostClient ctrlclient.Client, suffix string) (*gatewayv1.GatewayClass, *gatewayv1.GatewayClass) {
+	GinkgoHelper()
+	allowed := createGatewayClass(ctx, hostClient, "gc-allowed-"+suffix, gatewayClassSelectorValue, "e2e allowed GatewayClass")
+	hidden := createGatewayClass(ctx, hostClient, "gc-hidden-"+suffix, "other-"+suffix, "e2e hidden GatewayClass")
+	return allowed, hidden
+}
+
+func createGatewayClass(ctx context.Context, hostClient ctrlclient.Client, name, selectorValue, description string) *gatewayv1.GatewayClass {
+	GinkgoHelper()
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{gatewayClassSelectorKey: selectorValue}},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: gatewayControllerName,
+			Description:    ptr.To(description),
+			ParametersRef:  gatewayClassParametersRef(name),
+		},
+	}
+	Expect(hostClient.Create(ctx, gc)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(hostClient.Delete(ctx, gc))).To(Succeed()) })
+	return gc
+}
+
+func gatewayClassParametersRef(name string) *gatewayv1.ParametersReference {
+	ns := gatewayv1.Namespace("host-only-" + name)
+	return &gatewayv1.ParametersReference{Group: gatewayv1.Group("example.com"), Kind: gatewayv1.Kind("GatewayClassConfig"), Name: name + "-config", Namespace: &ns}
+}
+
+func createTenantNamespace(ctx context.Context, c ctrlclient.Client, name string) *corev1.Namespace {
+	GinkgoHelper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	Expect(c.Create(ctx, ns)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(c.Delete(ctx, ns))).To(Succeed()) })
+	return ns
+}
+
+func tenantGateway(namespace, name, className string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     gatewayv1.SectionName("http"),
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+				Hostname: ptr.To(gatewayv1.Hostname("app.example.com")),
+			}},
+		},
+	}
+}
+
+func tenantHTTPRoute(namespace, name, gatewayName, serviceName string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To(gatewayv1.SectionName("http"))}}},
+			Rules:           []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(serviceName), Port: ptr.To(gatewayv1.PortNumber(80))}}}}}},
+		},
+	}
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
@@ -3,7 +3,6 @@ package test_gatewayapi
 import (
 	"context"
 
-	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
 	"github.com/loft-sh/vcluster/e2e-next/constants"
 	"github.com/loft-sh/vcluster/e2e-next/labels"
 	"github.com/loft-sh/vcluster/pkg/util/random"
@@ -13,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,8 +21,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-// GatewayAPIToHostSpec registers tenant-authored route/policy sync tests
-// (P0 cases 13, 18, 19).
+// GatewayAPIToHostSpec registers tenant-authored route/policy sync tests.
 func GatewayAPIToHostSpec() {
 	Describe("Gateway API toHost", labels.GatewayAPI, func() {
 		var (
@@ -35,23 +32,20 @@ func GatewayAPIToHostSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			var err error
-			scheme := runtime.NewScheme()
-			Expect(corev1.AddToScheme(scheme)).To(Succeed())
-			Expect(gatewayv1.Install(scheme)).To(Succeed())
-			Expect(gatewayv1alpha2.Install(scheme)).To(Succeed())
-			Expect(gatewayv1alpha3.Install(scheme)).To(Succeed())
-			Expect(gatewayv1beta1.Install(scheme)).To(Succeed())
+			clients := newGatewayAPIClients(ctx, true)
+			hostClient = clients.HostClient
+			vClusterClient = clients.VClusterClient
+			vClusterName = clients.VClusterName
+			vClusterHostNS = clients.VClusterHostNS
 
-			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
-			Expect(err).To(Succeed())
-			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
-			Expect(err).To(Succeed())
-			vClusterName = cluster.CurrentClusterNameFrom(ctx)
-			vClusterHostNS = "vcluster-" + vClusterName
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1alpha2.TLSRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1alpha3.BackendTLSPolicyList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
-		It("does not sync cross-namespace backendRef routes until a ReferenceGrant permits it", labels.PR, func(ctx context.Context) {
+		It("does not sync cross-namespace backendRef routes until a ReferenceGrant permits it", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gc-rg-"+suffix, gatewayClassSelectorValue, "referencegrant class")
 			Eventually(func(g Gomega) {
@@ -65,51 +59,83 @@ func GatewayAPIToHostSpec() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
 			})
+			hostGatewayName := translate.SafeConcatName(gw.Name, "x", frontend.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
 			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-svc-" + suffix, Namespace: backend.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
 			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			var hostRouteName string
+			var route *gatewayv1.HTTPRoute
+			var grant *gatewayv1beta1.ReferenceGrant
 
-			By("creating a route whose backendRef crosses into another namespace")
-			route := crossNamespaceRoute(frontend.Name, "route-"+suffix, gw.Name, backend.Name, svc.Name)
-			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			By("creating a route whose backendRef crosses into another namespace", func() {
+				route = crossNamespaceRoute(frontend.Name, "route-"+suffix, gw.Name, backend.Name, svc.Name)
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+
+				hostRouteName = translate.SafeConcatName(route.Name, "x", frontend.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 			})
-
-			hostRouteName := translate.SafeConcatName(route.Name, "x", frontend.Name, "x", vClusterName)
-			Consistently(func(g Gomega) {
-				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryShort).Should(Succeed())
-
-			By("creating a ReferenceGrant in the backend namespace and expecting the route to sync")
-			grant := &gatewayv1beta1.ReferenceGrant{
-				ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
-				Spec: gatewayv1beta1.ReferenceGrantSpec{
-					From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace(frontend.Name)}},
-					To:   []gatewayv1beta1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
-				},
-			}
-			Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
+			By("creating a ReferenceGrant in the backend namespace and expecting the route to sync", func() {
+				grant = &gatewayv1beta1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: gatewayv1.Namespace(frontend.Name)}},
+						To:   []gatewayv1beta1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+					},
+				}
+				Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, grant))).To(Succeed())
+				})
+				Eventually(func(g Gomega) {
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("deleting the ReferenceGrant and expecting the host route to be removed", func() {
 				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, grant))).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
-			Eventually(func(g Gomega) {
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
-		It("syncs opt-in TLSRoutes to the host and propagates updates and deletes", labels.PR, func(ctx context.Context) {
+		It("syncs opt-in TLSRoutes to the host and propagates updates and deletes", func(ctx context.Context) {
 			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-tls-"+suffix, gatewayClassSelectorValue, "tlsroute class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
 			ns := createTenantNamespace(ctx, vClusterClient, "tls-"+suffix)
+			gw := tlsGateway(ns.Name, "gw-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			hostGatewayName := translate.SafeConcatName(gw.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
 			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
 			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
 
 			route := &gatewayv1alpha2.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "app-tls-" + suffix, Namespace: ns.Name},
 				Spec: gatewayv1alpha2.TLSRouteSpec{
-					Hostnames: []gatewayv1.Hostname{"app.apps.example.com"},
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gw.Name), SectionName: ptr.To[gatewayv1.SectionName]("tls")}}},
+					Hostnames:       []gatewayv1.Hostname{"app.apps.example.com"},
 					Rules: []gatewayv1alpha2.TLSRouteRule{{BackendRefs: []gatewayv1.BackendRef{{
-						BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(svc.Name), Port: ptr.To(gatewayv1.PortNumber(443))},
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(svc.Name), Port: ptr.To[gatewayv1.PortNumber](443)},
 					}}}},
 				},
 			}
@@ -120,93 +146,143 @@ func GatewayAPIToHostSpec() {
 
 			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
 			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}
+			var current *gatewayv1alpha2.TLSRoute
 			Eventually(func(g Gomega) {
 				got := &gatewayv1alpha2.TLSRoute{}
 				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
 				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app.apps.example.com")))
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGatewayName)))
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
-			By("patching the tenant TLSRoute hostname and expecting the host update")
-			current := &gatewayv1alpha2.TLSRoute{}
-			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(route), current)).To(Succeed())
-			current.Spec.Hostnames = []gatewayv1.Hostname{"app-updated.apps.example.com"}
-			Expect(vClusterClient.Update(ctx, current)).To(Succeed())
-			Eventually(func(g Gomega) {
-				got := &gatewayv1alpha2.TLSRoute{}
-				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
-				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app-updated.apps.example.com")))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("deleting the tenant TLSRoute and expecting host deletion")
-			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
-			Eventually(func(g Gomega) {
-				err := hostClient.Get(ctx, hostKey, &gatewayv1alpha2.TLSRoute{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			By("patching the tenant TLSRoute hostname and expecting the host update", func() {
+				current = &gatewayv1alpha2.TLSRoute{}
+				Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(route), current)).To(Succeed())
+				current.Spec.Hostnames = []gatewayv1.Hostname{"app-updated.apps.example.com"}
+				Expect(vClusterClient.Update(ctx, current)).To(Succeed())
+				Eventually(func(g Gomega) {
+					got := &gatewayv1alpha2.TLSRoute{}
+					g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+					g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app-updated.apps.example.com")))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("deleting the tenant TLSRoute and expecting host deletion", func() {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := hostClient.Get(ctx, hostKey, &gatewayv1alpha2.TLSRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
 		})
 
-		It("syncs opt-in BackendTLSPolicies to the host with a translated targetRef", labels.PR, func(ctx context.Context) {
+		It("syncs opt-in BackendTLSPolicies to the host with a translated targetRef", func(ctx context.Context) {
 			suffix := random.String(6)
 			ns := createTenantNamespace(ctx, vClusterClient, "btls-"+suffix)
-			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
-			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			otherNS := createTenantNamespace(ctx, vClusterClient, "btls-other-"+suffix)
+			otherSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-other-backend-" + suffix, Namespace: otherNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
+			Expect(vClusterClient.Create(ctx, otherSvc)).To(Succeed())
+			var policy *gatewayv1alpha3.BackendTLSPolicy
+			var hostKey types.NamespacedName
+			var current *gatewayv1alpha3.BackendTLSPolicy
 
-			policy := &gatewayv1alpha3.BackendTLSPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: "btls-" + suffix, Namespace: ns.Name},
-				Spec: gatewayv1.BackendTLSPolicySpec{
-					TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
-						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service"), Name: gatewayv1.ObjectName(svc.Name)},
-					}},
-					Validation: gatewayv1.BackendTLSPolicyValidation{
-						WellKnownCACertificates: ptr.To(gatewayv1.WellKnownCACertificatesSystem),
-						Hostname:                gatewayv1.PreciseHostname("backend.apps.example.com"),
+			By("creating a policy with an unresolvable local targetRef and expecting no host sync", func() {
+				unresolvedPolicy := &gatewayv1alpha3.BackendTLSPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: "btls-unresolved-target-" + suffix, Namespace: ns.Name},
+					Spec: gatewayv1.BackendTLSPolicySpec{
+						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+							LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{Group: "", Kind: "Service", Name: gatewayv1.ObjectName(otherSvc.Name)},
+						}},
+						Validation: gatewayv1.BackendTLSPolicyValidation{
+							WellKnownCACertificates: ptr.To(gatewayv1.WellKnownCACertificatesSystem),
+							Hostname:                "backend.apps.example.com",
+						},
 					},
-				},
-			}
-			Expect(vClusterClient.Create(ctx, policy)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, policy))).To(Succeed())
+				}
+				Expect(vClusterClient.Create(ctx, unresolvedPolicy)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, unresolvedPolicy))).To(Succeed())
+				})
+				unresolvedHostPolicyName := translate.SafeConcatName(unresolvedPolicy.Name, "x", ns.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: unresolvedHostPolicyName}, &gatewayv1alpha3.BackendTLSPolicy{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
+				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+				policy = &gatewayv1alpha3.BackendTLSPolicy{
+					ObjectMeta: metav1.ObjectMeta{Name: "btls-" + suffix, Namespace: ns.Name},
+					Spec: gatewayv1.BackendTLSPolicySpec{
+						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+							LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{Group: "", Kind: "Service", Name: gatewayv1.ObjectName(svc.Name)},
+						}},
+						Validation: gatewayv1.BackendTLSPolicyValidation{
+							WellKnownCACertificates: ptr.To(gatewayv1.WellKnownCACertificatesSystem),
+							Hostname:                "backend.apps.example.com",
+						},
+					},
+				}
+				Expect(vClusterClient.Create(ctx, policy)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, policy))).To(Succeed())
+				})
+
+				hostPolicyName := translate.SafeConcatName(policy.Name, "x", ns.Name, "x", vClusterName)
+				hostKey = types.NamespacedName{Namespace: vClusterHostNS, Name: hostPolicyName}
+				Eventually(func(g Gomega) {
+					got := &gatewayv1alpha3.BackendTLSPolicy{}
+					g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+					g.Expect(got.Spec.TargetRefs).To(HaveLen(1))
+					g.Expect(string(got.Spec.TargetRefs[0].Name)).To(Equal(translate.SafeConcatName(svc.Name, "x", ns.Name, "x", vClusterName)))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
-
-			hostPolicyName := translate.SafeConcatName(policy.Name, "x", ns.Name, "x", vClusterName)
-			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostPolicyName}
-			Eventually(func(g Gomega) {
-				got := &gatewayv1alpha3.BackendTLSPolicy{}
-				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
-				g.Expect(got.Spec.TargetRefs).To(HaveLen(1))
-				g.Expect(string(got.Spec.TargetRefs[0].Name)).To(Equal(translate.SafeConcatName(svc.Name, "x", ns.Name, "x", vClusterName)))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("updating the policy hostname and expecting the host update")
-			current := &gatewayv1alpha3.BackendTLSPolicy{}
-			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), current)).To(Succeed())
-			current.Spec.Validation.Hostname = gatewayv1.PreciseHostname("backend-updated.apps.example.com")
-			Expect(vClusterClient.Update(ctx, current)).To(Succeed())
-			Eventually(func(g Gomega) {
-				got := &gatewayv1alpha3.BackendTLSPolicy{}
-				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
-				g.Expect(got.Spec.Validation.Hostname).To(Equal(gatewayv1.PreciseHostname("backend-updated.apps.example.com")))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
-
-			By("deleting the policy and expecting host deletion")
-			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
-			Eventually(func(g Gomega) {
-				err := hostClient.Get(ctx, hostKey, &gatewayv1alpha3.BackendTLSPolicy{})
-				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			By("updating the policy hostname and expecting the host update", func() {
+				current = &gatewayv1alpha3.BackendTLSPolicy{}
+				Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), current)).To(Succeed())
+				current.Spec.Validation.Hostname = "backend-updated.apps.example.com"
+				Expect(vClusterClient.Update(ctx, current)).To(Succeed())
+				Eventually(func(g Gomega) {
+					got := &gatewayv1alpha3.BackendTLSPolicy{}
+					g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+					g.Expect(got.Spec.Validation.Hostname).To(Equal(gatewayv1.PreciseHostname("backend-updated.apps.example.com")))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("deleting the policy and expecting host deletion", func() {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := hostClient.Get(ctx, hostKey, &gatewayv1alpha3.BackendTLSPolicy{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
 		})
 	})
+}
+
+func tlsGateway(namespace, name, className string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     "tls",
+				Protocol: gatewayv1.TLSProtocolType,
+				Port:     443,
+				TLS:      &gatewayv1.ListenerTLSConfig{Mode: ptr.To(gatewayv1.TLSModePassthrough)},
+			}},
+		},
+	}
 }
 
 func crossNamespaceRoute(namespace, name, gatewayName, backendNamespace, serviceName string) *gatewayv1.HTTPRoute {
 	return &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec: gatewayv1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To(gatewayv1.SectionName("http"))}}},
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To[gatewayv1.SectionName]("http")}}},
 			Rules: []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
 				Name:      gatewayv1.ObjectName(serviceName),
 				Namespace: ptr.To(gatewayv1.Namespace(backendNamespace)),
-				Port:      ptr.To(gatewayv1.PortNumber(80)),
+				Port:      ptr.To[gatewayv1.PortNumber](80),
 			}}}}}},
 		},
 	}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
@@ -1,0 +1,213 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// GatewayAPIToHostSpec registers tenant-authored route/policy sync tests
+// (P0 cases 13, 18, 19).
+func GatewayAPIToHostSpec() {
+	Describe("Gateway API toHost", labels.GatewayAPI, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+			Expect(gatewayv1alpha2.Install(scheme)).To(Succeed())
+			Expect(gatewayv1alpha3.Install(scheme)).To(Succeed())
+			Expect(gatewayv1beta1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+		})
+
+		It("does not sync cross-namespace backendRef routes until a ReferenceGrant permits it", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-rg-"+suffix, gatewayClassSelectorValue, "referencegrant class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			frontend := createTenantNamespace(ctx, vClusterClient, "frontend-"+suffix)
+			backend := createTenantNamespace(ctx, vClusterClient, "backend-"+suffix)
+			gw := tenantGateway(frontend.Name, "gw-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-svc-" + suffix, Namespace: backend.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			By("creating a route whose backendRef crosses into another namespace")
+			route := crossNamespaceRoute(frontend.Name, "route-"+suffix, gw.Name, backend.Name, svc.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", frontend.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryShort).Should(Succeed())
+
+			By("creating a ReferenceGrant in the backend namespace and expecting the route to sync")
+			grant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace(frontend.Name)}},
+					To:   []gatewayv1beta1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
+				},
+			}
+			Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, grant))).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("syncs opt-in TLSRoutes to the host and propagates updates and deletes", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ns := createTenantNamespace(ctx, vClusterClient, "tls-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			route := &gatewayv1alpha2.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "app-tls-" + suffix, Namespace: ns.Name},
+				Spec: gatewayv1alpha2.TLSRouteSpec{
+					Hostnames: []gatewayv1.Hostname{"app.apps.example.com"},
+					Rules: []gatewayv1alpha2.TLSRouteRule{{BackendRefs: []gatewayv1.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(svc.Name), Port: ptr.To(gatewayv1.PortNumber(443))},
+					}}}},
+				},
+			}
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha2.TLSRoute{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app.apps.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("patching the tenant TLSRoute hostname and expecting the host update")
+			current := &gatewayv1alpha2.TLSRoute{}
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(route), current)).To(Succeed())
+			current.Spec.Hostnames = []gatewayv1.Hostname{"app-updated.apps.example.com"}
+			Expect(vClusterClient.Update(ctx, current)).To(Succeed())
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha2.TLSRoute{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app-updated.apps.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the tenant TLSRoute and expecting host deletion")
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, hostKey, &gatewayv1alpha2.TLSRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("syncs opt-in BackendTLSPolicies to the host with a translated targetRef", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ns := createTenantNamespace(ctx, vClusterClient, "btls-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			policy := &gatewayv1alpha3.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "btls-" + suffix, Namespace: ns.Name},
+				Spec: gatewayv1.BackendTLSPolicySpec{
+					TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service"), Name: gatewayv1.ObjectName(svc.Name)},
+					}},
+					Validation: gatewayv1.BackendTLSPolicyValidation{
+						WellKnownCACertificates: ptr.To(gatewayv1.WellKnownCACertificatesSystem),
+						Hostname:                gatewayv1.PreciseHostname("backend.apps.example.com"),
+					},
+				},
+			}
+			Expect(vClusterClient.Create(ctx, policy)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, policy))).To(Succeed())
+			})
+
+			hostPolicyName := translate.SafeConcatName(policy.Name, "x", ns.Name, "x", vClusterName)
+			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostPolicyName}
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha3.BackendTLSPolicy{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.TargetRefs).To(HaveLen(1))
+				g.Expect(string(got.Spec.TargetRefs[0].Name)).To(Equal(translate.SafeConcatName(svc.Name, "x", ns.Name, "x", vClusterName)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("updating the policy hostname and expecting the host update")
+			current := &gatewayv1alpha3.BackendTLSPolicy{}
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), current)).To(Succeed())
+			current.Spec.Validation.Hostname = gatewayv1.PreciseHostname("backend-updated.apps.example.com")
+			Expect(vClusterClient.Update(ctx, current)).To(Succeed())
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha3.BackendTLSPolicy{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.Validation.Hostname).To(Equal(gatewayv1.PreciseHostname("backend-updated.apps.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the policy and expecting host deletion")
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, hostKey, &gatewayv1alpha3.BackendTLSPolicy{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func crossNamespaceRoute(namespace, name, gatewayName, backendNamespace, serviceName string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To(gatewayv1.SectionName("http"))}}},
+			Rules: []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name:      gatewayv1.ObjectName(serviceName),
+				Namespace: ptr.To(gatewayv1.Namespace(backendNamespace)),
+				Port:      ptr.To(gatewayv1.PortNumber(80)),
+			}}}}}},
+		},
+	}
+}

--- a/e2e-next/vcluster-gatewayapi-combined.yaml
+++ b/e2e-next/vcluster-gatewayapi-combined.yaml
@@ -1,0 +1,31 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-combined
+    gateways:
+      enabled: true
+      mappings:
+        byName:
+          "gwapi-combined-host/*": "gwapi-combined-import/*"
+      allowedRoutes:
+        defaultVirtualNamespacePolicy:
+          from: All
+      sanitize:
+        certificateRefs: true
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      gateways:
+        enabled: true
+      httpRoutes:
+        enabled: true

--- a/e2e-next/vcluster-gatewayapi-import.yaml
+++ b/e2e-next/vcluster-gatewayapi-import.yaml
@@ -1,0 +1,47 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-import
+    gateways:
+      enabled: true
+      mappings:
+        byName:
+          # Wildcard source namespace: any host Gateway in gwapi-host is imported
+          # into gwapi-import under the same name (allows random per-spec names).
+          "gwapi-host/*": "gwapi-import/*"
+          # Exact mappings for policy-override and rename cases (fixed names).
+          "gwapi-host-policy/selector-edge": "gwapi-import-policy/selector-edge"
+          "gwapi-host-policy/hostname-edge": "gwapi-import-policy/hostname-edge"
+          "gwapi-host-rename/source-edge": "gwapi-import-rename/renamed-edge"
+      allowedRoutes:
+        defaultVirtualNamespacePolicy:
+          from: All
+        overrides:
+          - hostNamespace: gwapi-host-policy
+            name: selector-edge
+            virtualNamespacePolicy:
+              from: Selector
+              selector:
+                matchLabels:
+                  team: apps
+          - hostNamespace: gwapi-host-policy
+            name: hostname-edge
+            allowedHostnames:
+              - "*.team-a.apps.example.com"
+      sanitize:
+        certificateRefs: true
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      httpRoutes:
+        enabled: true

--- a/e2e-next/vcluster-gatewayapi.yaml
+++ b/e2e-next/vcluster-gatewayapi.yaml
@@ -1,0 +1,23 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-vcluster
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      gateways:
+        enabled: true
+      httpRoutes:
+        enabled: true
+      referenceGrants:
+        enabled: true

--- a/e2e-next/vcluster-gatewayapi.yaml
+++ b/e2e-next/vcluster-gatewayapi.yaml
@@ -21,3 +21,7 @@ sync:
         enabled: true
       referenceGrants:
         enabled: true
+      tlsRoutes:
+        enabled: true
+      backendTLSPolicies:
+        enabled: true

--- a/pkg/controllers/resources/gatewayapi/authz/authz.go
+++ b/pkg/controllers/resources/gatewayapi/authz/authz.go
@@ -7,11 +7,15 @@ import (
 	"fmt"
 
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	utiltranslate "github.com/loft-sh/vcluster/pkg/util/translate"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -147,8 +151,10 @@ func ensureReferenceGrantAllows(ctx *synccontext.SyncContext, fromGroup, fromKin
 	}
 
 	for _, grant := range grants.Items {
-		if referenceGrantAllows(grant, fromGroup, fromKind, fromNamespace, target) {
-			return nil
+		if grant.DeletionTimestamp.IsZero() {
+			if referenceGrantAllows(grant, fromGroup, fromKind, fromNamespace, target) {
+				return nil
+			}
 		}
 	}
 
@@ -315,71 +321,99 @@ func namespaceSelectorMatches(ctx *synccontext.SyncContext, routeNamespace strin
 	return parsed.Matches(labels.Set(namespace.Labels)), nil
 }
 
-// RegisterHTTPRouteWatches requeues HTTPRoutes when virtual authz inputs change.
+// RegisterHTTPRouteWatches requeues HTTPRoutes when authz inputs change.
 func RegisterHTTPRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return registerRouteWatches(ctx, builder, listHTTPRouteRequests)
+	return registerRouteWatches(ctx, builder, httpRouteListObject)
 }
 
-// RegisterTLSRouteWatches requeues TLSRoutes when virtual authz inputs change.
+// RegisterTLSRouteWatches requeues TLSRoutes when authz inputs change.
 func RegisterTLSRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return registerRouteWatches(ctx, builder, listTLSRouteRequests)
+	return registerRouteWatches(ctx, builder, tlsRouteListObject)
 }
 
-// RegisterGatewayWatches requeues Gateways when virtual ReferenceGrants change.
-func RegisterGatewayWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return builder.WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1beta1.ReferenceGrant{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1beta1.ReferenceGrant) []reconcile.Request {
-		return listGatewayRequests(mapCtx, ctx.VirtualManager.GetClient())
-	})))
+var (
+	referenceGrantWatchGVK = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1beta1.GroupVersion.Version, Kind: "ReferenceGrant"}
+	httpRouteListGVK       = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version, Kind: "HTTPRouteList"}
+	tlsRouteListGVK        = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1alpha2.GroupVersion.Version, Kind: "TLSRouteList"}
+)
+
+func referenceGrantWatchObject() *unstructured.Unstructured {
+	return unstructuredObject(referenceGrantWatchGVK)
 }
 
-func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder, listRequests func(context.Context, client.Client) []reconcile.Request) *builder.Builder {
-	return builder.
-		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1beta1.ReferenceGrant{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1beta1.ReferenceGrant) []reconcile.Request {
-			return listRequests(mapCtx, ctx.VirtualManager.GetClient())
+func httpRouteListObject() *unstructured.UnstructuredList {
+	return unstructuredList(httpRouteListGVK)
+}
+
+func tlsRouteListObject() *unstructured.UnstructuredList {
+	return unstructuredList(tlsRouteListGVK)
+}
+
+func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder, routeListObject func() *unstructured.UnstructuredList) *builder.Builder {
+	log := ctx.ToSyncContext("gateway-authz").Log
+	listRequests := func(mapCtx context.Context) []reconcile.Request {
+		return listRouteRequests(mapCtx, ctx.VirtualManager.GetClient(), routeListObject(), log)
+	}
+
+	builder = builder.
+		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), referenceGrantWatchObject(), handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *unstructured.Unstructured) []reconcile.Request {
+			return listRequests(mapCtx)
 		}))).
 		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1.Gateway{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1.Gateway) []reconcile.Request {
-			return listRequests(mapCtx, ctx.VirtualManager.GetClient())
+			return listRequests(mapCtx)
 		}))).
 		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &corev1.Namespace{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *corev1.Namespace) []reconcile.Request {
-			return listRequests(mapCtx, ctx.VirtualManager.GetClient())
+			return listRequests(mapCtx)
 		})))
+
+	if hostReferenceGrantWatchEnabled(ctx, log) {
+		builder = builder.WatchesRawSource(source.Kind(ctx.HostManager.GetCache(), referenceGrantWatchObject(), handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *unstructured.Unstructured) []reconcile.Request {
+			return listRequests(mapCtx)
+		})))
+	}
+
+	return builder
 }
 
-func listHTTPRouteRequests(ctx context.Context, c client.Client) []reconcile.Request {
-	list := &gatewayv1.HTTPRouteList{}
+func hostReferenceGrantWatchEnabled(ctx *synccontext.RegisterContext, log loghelper.Logger) bool {
+	if ctx.HostManager == nil || ctx.HostManager.GetConfig() == nil {
+		return false
+	}
+
+	exists, err := util.KindExists(ctx.HostManager.GetConfig(), referenceGrantWatchGVK)
+	if err != nil {
+		if log != nil {
+			log.Errorf("check host cluster for Gateway API resource %s: %v", referenceGrantWatchGVK.String(), err)
+		}
+		return false
+	}
+
+	return exists
+}
+
+func listRouteRequests(ctx context.Context, c client.Client, list *unstructured.UnstructuredList, log loghelper.Logger) []reconcile.Request {
 	if err := c.List(ctx, list); err != nil {
+		if log != nil {
+			log.Errorf("list Gateway API routes %s: %v", list.GroupVersionKind().String(), err)
+		}
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(list.Items))
 	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.GetName(), Namespace: item.GetNamespace()}})
 	}
 	return requests
 }
 
-func listTLSRouteRequests(ctx context.Context, c client.Client) []reconcile.Request {
-	list := &gatewayv1alpha2.TLSRouteList{}
-	if err := c.List(ctx, list); err != nil {
-		return nil
-	}
-
-	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
-	}
-	return requests
+func unstructuredObject(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	return obj
 }
 
-func listGatewayRequests(ctx context.Context, c client.Client) []reconcile.Request {
-	list := &gatewayv1.GatewayList{}
-	if err := c.List(ctx, list); err != nil {
-		return nil
-	}
-
-	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
-	}
-	return requests
+func unstructuredList(gvk schema.GroupVersionKind) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+	return list
 }

--- a/pkg/controllers/resources/gatewayapi/authz/authz_test.go
+++ b/pkg/controllers/resources/gatewayapi/authz/authz_test.go
@@ -153,6 +153,27 @@ func TestReferenceGrantNameOmittedAllowsAnyTargetName(t *testing.T) {
 	}
 }
 
+func TestDeletingReferenceGrantDoesNotAllowTargetName(t *testing.T) {
+	restore := setDefaultTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	deletedAt := metav1.Now()
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "backends", Name: "deleting", DeletionTimestamp: &deletedAt, Finalizers: []string{"sync.vcluster.loft.sh/finalizer"}},
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("routes")}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: gatewayv1.Group(corev1.GroupName), Kind: gatewayv1.Kind("Service")}},
+		},
+	}
+	ctx := &synccontext.SyncContext{Context: context.Background(), Config: &config.VirtualClusterConfig{}, VirtualClient: testingutil.NewFakeClient(scheme.Scheme, grant)}
+	backendNamespace := gatewayv1.Namespace("backends")
+
+	err := HTTPRouteBackend(ctx, "routes", &gatewayv1.BackendObjectReference{Name: "api", Namespace: &backendNamespace})
+	if !IsNotPermitted(err) {
+		t.Fatalf("expected deleting ReferenceGrant to deny reference, got %v", err)
+	}
+}
+
 func TestHTTPRouteAttachmentSectionAndPortMustSelectACompatibleListener(t *testing.T) {
 	gateway := &gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "gateways", Name: "edge"},

--- a/pkg/controllers/resources/gatewayclasses/syncer.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer.go
@@ -64,6 +64,8 @@ func (g *gatewayClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
 	vObj.Spec = *event.Host.Spec.DeepCopy()
 
+	// Apply patches first, then sanitize, so a patch cannot re-inject host
+	// parametersRef topology into the tenant-visible spec.
 	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
@@ -85,6 +87,9 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, reason)
 	}
 
+	// Unlike sibling from-host syncers we do not pass patcher.TranslatePatches here.
+	// Patches must run before gatewayClassSpecToVirtual sanitization so a patch
+	// cannot re-inject host parametersRef topology into the tenant-visible spec.
 	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
@@ -99,6 +104,7 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 	event.Virtual.Annotations = maps.Clone(event.Host.Annotations)
 	event.Virtual.Labels = maps.Clone(event.Host.Labels)
 	event.Virtual.Spec = *event.Host.Spec.DeepCopy()
+	// Apply patches first, then sanitize, so parametersRef topology stays hidden.
 	if err := pro.ApplyPatchesVirtualObject(ctx, nil, event.Virtual, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}

--- a/pkg/controllers/resources/gatewayclasses/syncer.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer.go
@@ -2,6 +2,7 @@ package gatewayclasses
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/loft-sh/vcluster/pkg/mappings/generic"
 	mapperresources "github.com/loft-sh/vcluster/pkg/mappings/resources"
@@ -61,12 +62,13 @@ func (g *gatewayClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	}
 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
-	vObj.Spec = gatewayClassSpecToVirtual(event.Host.Spec)
+	vObj.Spec = *event.Host.Spec.DeepCopy()
 
 	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}
+	vObj.Spec = gatewayClassSpecToVirtual(vObj.Spec)
 
 	ctx.Log.Infof("create GatewayClass %s, because it does not exist in virtual cluster", vObj.Name)
 	return patcher.CreateVirtualObject(ctx, event.Host, vObj, g.EventRecorder(), true)
@@ -83,7 +85,7 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, reason)
 	}
 
-	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.FromHost.GatewayClasses.Patches, true))
+	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
 	}
@@ -94,9 +96,13 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 	}()
 
 	// GatewayClasses are mirrored from the host cluster, so host metadata wins.
-	event.Virtual.Annotations = event.Host.Annotations
-	event.Virtual.Labels = event.Host.Labels
-	event.Virtual.Spec = gatewayClassSpecToVirtual(event.Host.Spec)
+	event.Virtual.Annotations = maps.Clone(event.Host.Annotations)
+	event.Virtual.Labels = maps.Clone(event.Host.Labels)
+	event.Virtual.Spec = *event.Host.Spec.DeepCopy()
+	if err := pro.ApplyPatchesVirtualObject(ctx, nil, event.Virtual, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
+	}
+	event.Virtual.Spec = gatewayClassSpecToVirtual(event.Virtual.Spec)
 	event.Virtual.Status = event.Host.Status
 	return ctrl.Result{}, nil
 }
@@ -122,12 +128,8 @@ func (g *gatewayClassSyncer) recordDeleteWarning(gwClass *gatewayv1.GatewayClass
 
 func gatewayClassSpecToVirtual(hostSpec gatewayv1.GatewayClassSpec) gatewayv1.GatewayClassSpec {
 	virtualSpec := *hostSpec.DeepCopy()
-	if virtualSpec.ParametersRef != nil {
-		virtualSpec.ParametersRef = virtualSpec.ParametersRef.DeepCopy()
-		// GatewayClasses are cluster-scoped mirrors. Keep host topology details out
-		// of the tenant view when the parameters object lives in a host namespace.
-		virtualSpec.ParametersRef.Namespace = nil
-	}
+	// Tenant-visible GatewayClasses must not expose Host parametersRef topology.
+	virtualSpec.ParametersRef = nil
 
 	return virtualSpec
 }

--- a/pkg/controllers/resources/gatewayclasses/syncer_test.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer_test.go
@@ -1,0 +1,139 @@
+package gatewayclasses
+
+import (
+	"context"
+	"testing"
+
+	rootconfig "github.com/loft-sh/vcluster/config"
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestGatewayClassSpecToVirtualRemovesParametersRefAndPreservesTenantVisibleFields(t *testing.T) {
+	description := "tenant visible class"
+	hostSpec := gatewayv1.GatewayClassSpec{
+		ControllerName: "example.com/gateway-controller",
+		Description:    &description,
+		ParametersRef:  gatewayClassParametersRef("host-config", "host-only"),
+	}
+
+	got := gatewayClassSpecToVirtual(hostSpec)
+	if got.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to be removed, got %#v", got.ParametersRef)
+	}
+	if got.ControllerName != hostSpec.ControllerName {
+		t.Fatalf("expected controllerName %q, got %q", hostSpec.ControllerName, got.ControllerName)
+	}
+	if got.Description == nil || *got.Description != description {
+		t.Fatalf("expected description %q, got %#v", description, got.Description)
+	}
+}
+
+func TestGatewayClassSyncToVirtualSanitizesParametersRefAfterPatches(t *testing.T) {
+	withGatewayClassPatchThatAddsParametersRef(t)
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.GatewayClasses.Enabled = true
+	vcConfig.Sync.FromHost.GatewayClasses.Patches = []rootconfig.TranslatePatch{{Path: "spec.parametersRef.name", Expression: "'patched-config'"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, New)
+	syncer := object.(*gatewayClassSyncer)
+
+	host := gatewayClass("tenant-class")
+	_, err := syncer.SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(host))
+	if err != nil {
+		t.Fatalf("sync to virtual: %v", err)
+	}
+
+	got := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, got); err != nil {
+		t.Fatalf("expected virtual GatewayClass to be created: %v", err)
+	}
+	if got.Spec.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to remain sanitized after create patches, got %#v", got.Spec.ParametersRef)
+	}
+}
+
+func TestGatewayClassSyncSanitizesParametersRefAfterPatches(t *testing.T) {
+	withGatewayClassPatchThatAddsParametersRef(t)
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.GatewayClasses.Enabled = true
+	vcConfig.Sync.FromHost.GatewayClasses.Patches = []rootconfig.TranslatePatch{{Path: "spec.parametersRef.name", Expression: "'patched-config'"}}
+	host := gatewayClass("tenant-class")
+	virtual := &gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: host.Name}, Spec: gatewayv1.GatewayClassSpec{ControllerName: "old.example.com/controller"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme, host)
+	vClient := testingutil.NewFakeClient(scheme.Scheme, virtual.DeepCopy())
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, New)
+	syncer := object.(*gatewayClassSyncer)
+	currentVirtual := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, currentVirtual); err != nil {
+		t.Fatalf("get current virtual GatewayClass: %v", err)
+	}
+
+	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, currentVirtual))
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	got := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, got); err != nil {
+		t.Fatalf("expected virtual GatewayClass to be updated: %v", err)
+	}
+	if got.Spec.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to remain sanitized after update patches, got %#v", got.Spec.ParametersRef)
+	}
+}
+
+func withGatewayClassPatchThatAddsParametersRef(t *testing.T) {
+	t.Helper()
+	origVirtual := pro.ApplyPatchesVirtualObject
+	origHost := pro.ApplyPatchesHostObject
+	patchFn := func(_ *synccontext.SyncContext, _, obj, _ client.Object, _ []rootconfig.TranslatePatch, _ bool) error {
+		gwClass, ok := obj.(*gatewayv1.GatewayClass)
+		if ok {
+			gwClass.Spec.ParametersRef = gatewayClassParametersRef("patched-config", "patched-namespace")
+		}
+		return nil
+	}
+	pro.ApplyPatchesVirtualObject = patchFn
+	pro.ApplyPatchesHostObject = patchFn
+	t.Cleanup(func() {
+		pro.ApplyPatchesVirtualObject = origVirtual
+		pro.ApplyPatchesHostObject = origHost
+	})
+}
+
+func gatewayClass(name string) *gatewayv1.GatewayClass {
+	description := "tenant visible class"
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "example.com/gateway-controller",
+			Description:    &description,
+			ParametersRef:  gatewayClassParametersRef(name+"-config", "host-only"),
+		},
+	}
+}
+
+func gatewayClassParametersRef(name string, namespace string) *gatewayv1.ParametersReference {
+	ns := gatewayv1.Namespace(namespace)
+	return &gatewayv1.ParametersReference{
+		Group:     gatewayv1.Group("example.com"),
+		Kind:      gatewayv1.Kind("GatewayClassConfig"),
+		Name:      name,
+		Namespace: &ns,
+	}
+}
+
+var _ runtime.Object = &gatewayv1.GatewayClass{}

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -261,8 +261,8 @@ func gatewaySpecToVirtual(ctx *synccontext.SyncContext, host *gatewayv1.Gateway)
 	}
 	policy := virtualNamespacePolicyFor(ctx, host)
 	for i := range spec.Listeners {
-		if ctx.Config.Sync.FromHost.Gateways.Sanitize.CertificateRefs {
-			spec.Listeners[i].TLS = nil
+		if ctx.Config.Sync.FromHost.Gateways.Sanitize.CertificateRefs && spec.Listeners[i].TLS != nil {
+			spec.Listeners[i].TLS.CertificateRefs = nil
 		}
 		if policy != nil {
 			spec.Listeners[i].AllowedRoutes = toGatewayAllowedRoutes(policy)
@@ -281,7 +281,7 @@ func gatewayStatusToVirtual(ctx *synccontext.SyncContext, status gatewayv1.Gatew
 
 func virtualNamespacePolicyFor(ctx *synccontext.SyncContext, host *gatewayv1.Gateway) *rootconfig.GatewayVirtualNamespacePolicy {
 	for _, override := range ctx.Config.Sync.FromHost.Gateways.AllowedRoutes.Overrides {
-		if override.HostNamespace == host.Namespace && override.Name == host.Name {
+		if override.HostNamespace == host.Namespace && override.Name == host.Name && override.VirtualNamespacePolicy.From != "" {
 			return &override.VirtualNamespacePolicy
 		}
 	}

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -80,6 +80,9 @@ func (s *tenantGatewaySyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (s *tenantGatewaySyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.Gateway]) (ctrl.Result, error) {
+	if isImportedGateway(event.Virtual) {
+		return ctrl.Result{}, nil
+	}
 	if event.HostOld != nil || event.Virtual.DeletionTimestamp != nil {
 		return patcher.DeleteHostObject(ctx, event.HostOld, event.Virtual, "virtual Gateway was deleted")
 	}
@@ -105,6 +108,9 @@ func (s *tenantGatewaySyncer) SyncToHost(ctx *synccontext.SyncContext, event *sy
 }
 
 func (s *tenantGatewaySyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1.Gateway]) (_ ctrl.Result, retErr error) {
+	if isImportedGateway(event.Virtual) {
+		return ctrl.Result{}, nil
+	}
 	eligible, err := tenantGatewayEligible(ctx, s, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -133,8 +139,15 @@ func (s *tenantGatewaySyncer) Sync(ctx *synccontext.SyncContext, event *synccont
 }
 
 func (s *tenantGatewaySyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1.Gateway]) (ctrl.Result, error) {
+	if resources.GatewayHostCoveredByMapping(ctx, types.NamespacedName{Namespace: event.Host.Namespace, Name: event.Host.Name}) || isImportedGateway(event.VirtualOld) {
+		return ctrl.Result{}, nil
+	}
 	reason := fmt.Sprintf("host Gateway for tenant Gateway %s/%s is missing", event.Host.Namespace, event.Host.Name)
 	return patcher.DeleteHostObject(ctx, event.Host, event.VirtualOld, reason)
+}
+
+func isImportedGateway(gateway *gatewayv1.Gateway) bool {
+	return gateway != nil && gateway.Labels[ImportedGatewayLabel] == "true"
 }
 
 func tenantGatewayHostConflict(ctx *synccontext.SyncContext, s *tenantGatewaySyncer, gateway *gatewayv1.Gateway, hostName types.NamespacedName) (bool, error) {
@@ -198,6 +211,10 @@ func (s *gatewaySyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *syncc
 }
 
 func (s *gatewaySyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1.Gateway]) (_ ctrl.Result, retErr error) {
+	if !isImportedGateway(event.Virtual) {
+		return ctrl.Result{}, nil
+	}
+
 	selected, reason, err := gatewaySelected(ctx, event.Host)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -226,6 +243,10 @@ func (s *gatewaySyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.Sy
 }
 
 func (s *gatewaySyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.Gateway]) (ctrl.Result, error) {
+	if !isImportedGateway(event.Virtual) {
+		return ctrl.Result{}, nil
+	}
+
 	reason := fmt.Sprintf("host Gateway for imported mirror %s/%s is missing", event.Virtual.Namespace, event.Virtual.Name)
 	s.EventRecorder().Eventf(event.Virtual, nil, "Warning", "SyncWarning", "SyncGateway", "Deleting virtual Gateway: %s", reason)
 	return ctrl.Result{}, ctx.VirtualClient.Delete(ctx, event.Virtual)

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -71,7 +71,7 @@ func NewToHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, erro
 	}
 
 	return &tenantGatewaySyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "gateway", &gatewayv1.Gateway{}, mapper),
+		GenericTranslator: translator.NewGenericTranslator(ctx, "tenant-gateway", &gatewayv1.Gateway{}, mapper),
 	}, nil
 }
 
@@ -168,7 +168,7 @@ func tenantGatewayEligible(ctx *synccontext.SyncContext, s *tenantGatewaySyncer,
 	gatewayClass := &gatewayv1.GatewayClass{}
 	err := ctx.VirtualClient.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass)
 	if kerrors.IsNotFound(err) {
-		s.EventRecorder().Eventf(gateway, nil, "Warning", "SyncWarning", "SyncGateway", "GatewayClass %q is not visible in the virtual cluster", gateway.Spec.GatewayClassName)
+		s.EventRecorder().Eventf(gateway, nil, "Warning", "SyncWarning", "SyncGateway", "GatewayClass %q is not available in this virtual cluster", gateway.Spec.GatewayClassName)
 		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("get virtual GatewayClass %q: %w", gateway.Spec.GatewayClassName, err)

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -161,7 +161,7 @@ func TestTenantGatewaySyncToHostCreatesGatewayWhenExplicitlyEnabled(t *testing.T
 	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
 	syncer := object.(*tenantGatewaySyncer)
 
-	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("tenant-class")}}
+	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
 		t.Fatalf("sync tenant Gateway to host: %v", err)
@@ -172,8 +172,90 @@ func TestTenantGatewaySyncToHostCreatesGatewayWhenExplicitlyEnabled(t *testing.T
 	if err := pClient.Get(context.Background(), expected, host); err != nil {
 		t.Fatalf("expected host Gateway %s to be created: %v", expected.String(), err)
 	}
-	if host.Spec.GatewayClassName != gatewayv1.ObjectName("tenant-class") {
+	if host.Spec.GatewayClassName != "tenant-class" {
 		t.Fatalf("expected host GatewayClassName to be preserved, got %q", host.Spec.GatewayClassName)
+	}
+}
+
+func TestTenantGatewaySyncIgnoresImportedMirror(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme,
+		&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "tenant-class"}},
+	)
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
+	syncer := object.(*tenantGatewaySyncer)
+
+	mirror := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "shared-gateways", Name: "edge", Labels: map[string]string{ImportedGatewayLabel: "true"}},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"},
+	}
+	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(mirror))
+	if err != nil {
+		t.Fatalf("expected imported mirror to be ignored by tenant Gateway syncer: %v", err)
+	}
+
+	host := &gatewayv1.Gateway{}
+	if err := pClient.Get(context.Background(), translate.Default.HostName(syncCtx, "edge", "shared-gateways"), host); err == nil {
+		t.Fatalf("did not expect tenant Gateway syncer to create a host Gateway for imported mirror")
+	}
+}
+
+func TestTenantGatewaySyncUpdatesManagedHostGatewayWhenVirtualExists(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
+	hostName := types.NamespacedName{Namespace: testingutil.DefaultTestTargetNamespace, Name: "edge-x-team-a-x-suffix"}
+	host := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{
+		Namespace: hostName.Namespace,
+		Name:      hostName.Name,
+		Labels:    map[string]string{translate.MarkerLabel: translate.VClusterName},
+		Annotations: map[string]string{
+			translate.NameAnnotation:      "edge",
+			translate.NamespaceAnnotation: "team-a",
+		},
+	}}
+	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme, host)
+	vClient := testingutil.NewFakeClient(scheme.Scheme,
+		virtual,
+		&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "tenant-class"}},
+	)
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
+	syncer := object.(*tenantGatewaySyncer)
+
+	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, virtual))
+	if err != nil {
+		t.Fatalf("sync managed host Gateway with existing virtual Gateway: %v", err)
+	}
+	got := &gatewayv1.Gateway{}
+	if err := pClient.Get(context.Background(), hostName, got); err != nil {
+		t.Fatalf("expected managed host Gateway to remain: %v", err)
+	}
+	if got.Spec.GatewayClassName != "tenant-class" {
+		t.Fatalf("expected managed host Gateway to be updated, got class %q", got.Spec.GatewayClassName)
+	}
+}
+
+func TestTenantGatewaySyncToVirtualIgnoresImportedHostMapping(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
+	vcConfig.Sync.FromHost.Gateways.Mappings.ByName = map[string]string{"platform/edge": "shared-gateways/edge"}
+	host := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "platform", Name: "edge"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme, host)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
+	syncer := object.(*tenantGatewaySyncer)
+
+	_, err := syncer.SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(host))
+	if err != nil {
+		t.Fatalf("expected imported host mapping to be ignored by tenant Gateway syncer: %v", err)
+	}
+	if err := pClient.Get(context.Background(), types.NamespacedName{Namespace: "platform", Name: "edge"}, &gatewayv1.Gateway{}); err != nil {
+		t.Fatalf("expected imported host Gateway to remain: %v", err)
 	}
 }
 
@@ -186,7 +268,7 @@ func TestTenantGatewaySyncSkipsUnavailableVirtualGatewayClass(t *testing.T) {
 	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
 	syncer := object.(*tenantGatewaySyncer)
 
-	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
+	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "missing"}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
 		t.Fatalf("expected unavailable GatewayClass to skip without reconcile error, got %v", err)
@@ -210,7 +292,7 @@ func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassBecomesUnavailable(
 	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
 	syncer := object.(*tenantGatewaySyncer)
 
-	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
+	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "missing"}}
 	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, virtual))
 	if err != nil {
 		t.Fatalf("expected unavailable GatewayClass update to delete host without reconcile error, got %v", err)
@@ -234,7 +316,7 @@ func TestTenantGatewaySyncSkipsMappedImportedTargetButAllowsSameNamespace(t *tes
 	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
 	syncer := object.(*tenantGatewaySyncer)
 
-	mapped := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("tenant-class")}}
+	mapped := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(mapped))
 	if err != nil {
 		t.Fatalf("expected mapped imported target to be a warning/skip, not hard error: %v", err)
@@ -243,7 +325,7 @@ func TestTenantGatewaySyncSkipsMappedImportedTargetButAllowsSameNamespace(t *tes
 		t.Fatalf("did not expect mapped imported target Gateway to sync to host")
 	}
 
-	other := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "other"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("tenant-class")}}
+	other := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "other"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"}}
 	_, err = syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(other))
 	if err != nil {
 		t.Fatalf("expected non-mapped Gateway in same namespace to sync: %v", err)
@@ -263,7 +345,7 @@ func TestTenantGatewaySyncSkipsImportedHostNameConflict(t *testing.T) {
 	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
 	syncer := object.(*tenantGatewaySyncer)
 
-	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("tenant-class")}}
+	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
 		t.Fatalf("expected imported host conflict to be a warning/skip, not hard error: %v", err)
@@ -278,14 +360,14 @@ func TestTenantGatewaySyncSkipsImportedHostNameConflict(t *testing.T) {
 func TestTenantGatewaySyncDoesNotOverwriteUnmanagedHostGateway(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
-	existing := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: testingutil.DefaultTestTargetNamespace, Name: "edge-x-team-a-x-suffix"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("existing-class")}}
+	existing := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: testingutil.DefaultTestTargetNamespace, Name: "edge-x-team-a-x-suffix"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "existing-class"}}
 	pClient := testingutil.NewFakeClient(scheme.Scheme, existing)
 	vClient := testingutil.NewFakeClient(scheme.Scheme, &gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "tenant-class"}})
 	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
 	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, NewToHost)
 	syncer := object.(*tenantGatewaySyncer)
 
-	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("tenant-class")}}
+	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: "tenant-class"}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
 		t.Fatalf("expected unmanaged host conflict to be a warning/skip, not hard error: %v", err)
@@ -295,7 +377,7 @@ func TestTenantGatewaySyncDoesNotOverwriteUnmanagedHostGateway(t *testing.T) {
 	if err := pClient.Get(context.Background(), translate.Default.HostName(syncCtx, "edge", "team-a"), host); err != nil {
 		t.Fatalf("expected existing host Gateway to remain: %v", err)
 	}
-	if host.Spec.GatewayClassName != gatewayv1.ObjectName("existing-class") {
+	if host.Spec.GatewayClassName != "existing-class" {
 		t.Fatalf("expected unmanaged host Gateway to remain untouched, got class %q", host.Spec.GatewayClassName)
 	}
 }

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -24,24 +24,94 @@ func TestGatewaySpecToVirtualSanitizesTLSInfrastructureAndAppliesVirtualAllowedR
 	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.DefaultVirtualNamespacePolicy = &rootconfig.GatewayVirtualNamespacePolicy{From: string(gatewayv1.NamespacesFromAll)}
 	ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
 	vcConfig.Sync.FromHost.Gateways.Sanitize.Infrastructure = true
+	terminate := gatewayv1.TLSModeTerminate
 	host := &gatewayv1.Gateway{Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{}, Listeners: []gatewayv1.Listener{{
 		Name:     "https",
 		Protocol: gatewayv1.HTTPSProtocolType,
 		Port:     443,
-		TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{{
-			Name: "edge-cert",
-		}}},
+		TLS: &gatewayv1.ListenerTLSConfig{
+			Mode: &terminate,
+			CertificateRefs: []gatewayv1.SecretObjectReference{{
+				Name: "edge-cert",
+			}},
+		},
 	}}}}
 
 	spec := gatewaySpecToVirtual(ctx, host)
-	if spec.Listeners[0].TLS != nil {
-		t.Fatalf("expected TLS config to be sanitized")
+	if spec.Listeners[0].TLS == nil {
+		t.Fatalf("expected TLS config to preserve mode while sanitizing certificateRefs")
+	}
+	if spec.Listeners[0].TLS.Mode == nil || *spec.Listeners[0].TLS.Mode != gatewayv1.TLSModeTerminate {
+		t.Fatalf("expected TLS mode to be preserved, got %#v", spec.Listeners[0].TLS.Mode)
+	}
+	if len(spec.Listeners[0].TLS.CertificateRefs) != 0 {
+		t.Fatalf("expected TLS certificateRefs to be sanitized, got %#v", spec.Listeners[0].TLS.CertificateRefs)
 	}
 	if spec.Infrastructure != nil {
 		t.Fatalf("expected infrastructure to be sanitized")
 	}
 	if spec.Listeners[0].AllowedRoutes == nil || spec.Listeners[0].AllowedRoutes.Namespaces == nil || *spec.Listeners[0].AllowedRoutes.Namespaces.From != gatewayv1.NamespacesFromAll {
 		t.Fatalf("expected tenant-facing allowedRoutes from All, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+}
+
+func TestGatewaySpecToVirtualAllowedHostnameOverrideInheritsDefaultNamespacePolicy(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.DefaultVirtualNamespacePolicy = &rootconfig.GatewayVirtualNamespacePolicy{From: string(gatewayv1.NamespacesFromAll)}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.Overrides = []rootconfig.GatewayAllowedRoutesPolicyOverride{{
+		HostNamespace:    "networking",
+		Name:             "shared-edge",
+		AllowedHostnames: []string{"*.apps.example.com"},
+	}}
+	ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
+	host := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "networking", Name: "shared-edge"},
+		Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{
+			Name:     "http",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     80,
+		}}},
+	}
+
+	spec := gatewaySpecToVirtual(ctx, host)
+	if spec.Listeners[0].AllowedRoutes == nil || spec.Listeners[0].AllowedRoutes.Namespaces == nil || spec.Listeners[0].AllowedRoutes.Namespaces.From == nil {
+		t.Fatalf("expected hostname-only override to inherit default tenant-facing allowedRoutes, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+	if *spec.Listeners[0].AllowedRoutes.Namespaces.From != gatewayv1.NamespacesFromAll {
+		t.Fatalf("expected hostname-only override to inherit default namespace policy from All, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+}
+
+func TestGatewaySpecToVirtualExplicitOverrideReplacesDefaultNamespacePolicy(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.DefaultVirtualNamespacePolicy = &rootconfig.GatewayVirtualNamespacePolicy{From: string(gatewayv1.NamespacesFromAll)}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.Overrides = []rootconfig.GatewayAllowedRoutesPolicyOverride{{
+		HostNamespace: "networking",
+		Name:          "shared-edge",
+		VirtualNamespacePolicy: rootconfig.GatewayVirtualNamespacePolicy{
+			From: string(gatewayv1.NamespacesFromSelector),
+			Selector: rootconfig.StandardLabelSelector{
+				MatchLabels: map[string]string{"team": "apps"},
+			},
+		},
+	}}
+	ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
+	host := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "networking", Name: "shared-edge"},
+		Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{
+			Name:     "http",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     80,
+		}}},
+	}
+
+	spec := gatewaySpecToVirtual(ctx, host)
+	got := spec.Listeners[0].AllowedRoutes
+	if got == nil || got.Namespaces == nil || got.Namespaces.From == nil || *got.Namespaces.From != gatewayv1.NamespacesFromSelector {
+		t.Fatalf("expected explicit override selector policy, got %#v", got)
+	}
+	if got.Namespaces.Selector == nil || got.Namespaces.Selector.MatchLabels["team"] != "apps" {
+		t.Fatalf("expected explicit override selector labels, got %#v", got.Namespaces.Selector)
 	}
 }
 

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -107,7 +107,7 @@ func TestTenantGatewaySyncToHostCreatesGatewayWhenExplicitlyEnabled(t *testing.T
 	}
 }
 
-func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
+func TestTenantGatewaySyncSkipsUnavailableVirtualGatewayClass(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 	pClient := testingutil.NewFakeClient(scheme.Scheme)
@@ -119,7 +119,7 @@ func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
 	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
-		t.Fatalf("expected missing GatewayClass to be a warning/skip, not hard error: %v", err)
+		t.Fatalf("expected unavailable GatewayClass to skip without reconcile error, got %v", err)
 	}
 
 	expected := translate.Default.HostName(syncCtx, "edge", "team-a")
@@ -129,7 +129,7 @@ func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
 	}
 }
 
-func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassDisappears(t *testing.T) {
+func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassBecomesUnavailable(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 	hostName := types.NamespacedName{Namespace: testingutil.DefaultTestTargetNamespace, Name: "edge-x-team-a-x-suffix"}
@@ -143,12 +143,12 @@ func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassDisappears(t *testi
 	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
 	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, virtual))
 	if err != nil {
-		t.Fatalf("expected missing GatewayClass to delete stale host Gateway without hard error: %v", err)
+		t.Fatalf("expected unavailable GatewayClass update to delete host without reconcile error, got %v", err)
 	}
 
 	got := &gatewayv1.Gateway{}
 	if err := pClient.Get(context.Background(), hostName, got); err == nil {
-		t.Fatalf("expected stale host Gateway to be deleted")
+		t.Fatalf("expected existing host Gateway to be deleted when GatewayClass becomes unavailable")
 	}
 }
 

--- a/pkg/controllers/resources/register.go
+++ b/pkg/controllers/resources/register.go
@@ -160,5 +160,5 @@ func gatewayReferenceGrantsEnabled(ctx *synccontext.RegisterContext) bool {
 	if mode == "false" {
 		return false
 	}
-	return ctx.Config.Sync.ToHost.Namespaces.Enabled && (gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx))
+	return gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx)
 }

--- a/pkg/controllers/resources/register.go
+++ b/pkg/controllers/resources/register.go
@@ -36,6 +36,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/controllers/resources/volumesnapshots"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	syncertypes "github.com/loft-sh/vcluster/pkg/syncer/types"
+	gatewayapiutil "github.com/loft-sh/vcluster/pkg/util/gatewayapi"
 	"github.com/loft-sh/vcluster/pkg/util/loghelper"
 	"github.com/pkg/errors"
 )
@@ -137,28 +138,21 @@ func gatewayClassesEnabled(ctx *synccontext.RegisterContext) bool {
 }
 
 func gatewayGatewaysEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.Gateways.Enabled
+	return gatewayapiutil.GatewaysEnabled(ctx.Config)
 }
 
 func gatewayHTTPRoutesEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled || ctx.Config.Sync.ToHost.GatewayAPI.Enabled
+	return gatewayapiutil.HTTPRoutesEnabled(ctx.Config)
 }
 
 func gatewayTLSRoutesEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Enabled
+	return gatewayapiutil.TLSRoutesEnabled(ctx.Config)
 }
 
 func gatewayBackendTLSPoliciesEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Enabled
+	return gatewayapiutil.BackendTLSPoliciesEnabled(ctx.Config)
 }
 
 func gatewayReferenceGrantsEnabled(ctx *synccontext.RegisterContext) bool {
-	mode := ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled
-	if mode == "true" {
-		return true
-	}
-	if mode == "false" {
-		return false
-	}
-	return gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx)
+	return gatewayapiutil.ReferenceGrantsEnabled(ctx.Config)
 }

--- a/pkg/controllers/resources/register_gateway_test.go
+++ b/pkg/controllers/resources/register_gateway_test.go
@@ -48,3 +48,13 @@ func TestReferenceGrantAutoDoesNotFollowGatewaySyncAlone(t *testing.T) {
 		t.Fatalf("referenceGrants=auto should not be enabled by Gateway sync alone")
 	}
 }
+
+func TestReferenceGrantAutoFollowsHTTPRouteSyncWithoutNamespaceSync(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+
+	if !gatewayReferenceGrantsEnabled(ctx) {
+		t.Fatalf("referenceGrants=auto should install the tenant CRD when HTTPRoute sync watches ReferenceGrant")
+	}
+}

--- a/pkg/mappings/resources/referencegrants.go
+++ b/pkg/mappings/resources/referencegrants.go
@@ -18,14 +18,12 @@ import (
 var referenceGrantsCRD string
 
 func CreateReferenceGrantMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper, error) {
-	if ctx.Config.Sync.ToHost.Namespaces.Enabled {
-		err := ensureHostGatewayAPIKind(ctx, mappings.ReferenceGrants(), "sync.toHost.gatewayApi.referenceGrants.enabled")
-		if err != nil {
-			return nil, err
-		}
+	err := ensureHostGatewayAPIKind(ctx, mappings.ReferenceGrants(), "sync.toHost.gatewayApi.referenceGrants.enabled")
+	if err != nil {
+		return nil, err
 	}
 
-	err := util.EnsureCRD(ctx.Context, ctx.VirtualManager.GetConfig(), []byte(referenceGrantsCRD), mappings.ReferenceGrants())
+	err = util.EnsureCRD(ctx.Context, ctx.VirtualManager.GetConfig(), []byte(referenceGrantsCRD), mappings.ReferenceGrants())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mappings/resources/register.go
+++ b/pkg/mappings/resources/register.go
@@ -106,5 +106,5 @@ func gatewayReferenceGrantsEnabled(ctx *synccontext.RegisterContext) bool {
 	if mode == "false" {
 		return false
 	}
-	return ctx.Config.Sync.ToHost.Namespaces.Enabled && (gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx))
+	return gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx)
 }

--- a/pkg/mappings/resources/register.go
+++ b/pkg/mappings/resources/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	gatewayapiutil "github.com/loft-sh/vcluster/pkg/util/gatewayapi"
 )
 
 // ExtraMappers that will be started as well
@@ -20,11 +21,11 @@ func getMappers(ctx *synccontext.RegisterContext) []BuildMapper {
 		CreateEndpointSlicesMapper,
 		CreateEventsMapper,
 		isEnabled(ctx.Config.Sync.ToHost.Ingresses.Enabled, CreateIngressesMapper),
-		isEnabled(gatewayGatewaysEnabled(ctx) || ctx.Config.Sync.FromHost.Gateways.Enabled, CreateGatewayMapper),
-		isEnabled(gatewayHTTPRoutesEnabled(ctx), CreateHTTPRouteMapper),
-		isEnabled(gatewayTLSRoutesEnabled(ctx), CreateTLSRouteMapper),
-		isEnabled(gatewayBackendTLSPoliciesEnabled(ctx), CreateBackendTLSPolicyMapper),
-		isEnabled(gatewayReferenceGrantsEnabled(ctx), CreateReferenceGrantMapper),
+		isEnabled(gatewayapiutil.GatewaysEnabled(ctx.Config) || ctx.Config.Sync.FromHost.Gateways.Enabled, CreateGatewayMapper),
+		isEnabled(gatewayapiutil.HTTPRoutesEnabled(ctx.Config), CreateHTTPRouteMapper),
+		isEnabled(gatewayapiutil.TLSRoutesEnabled(ctx.Config), CreateTLSRouteMapper),
+		isEnabled(gatewayapiutil.BackendTLSPoliciesEnabled(ctx.Config), CreateBackendTLSPolicyMapper),
+		isEnabled(gatewayapiutil.ReferenceGrantsEnabled(ctx.Config), CreateReferenceGrantMapper),
 		CreateNamespacesMapper,
 		isEnabled(ctx.Config.Sync.ToHost.NetworkPolicies.Enabled, CreateNetworkPoliciesMapper),
 		CreateNodesMapper,
@@ -80,31 +81,4 @@ func isEnabled[T any](enabled bool, fn T) T {
 	}
 	var ret T
 	return ret
-}
-
-func gatewayGatewaysEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.Gateways.Enabled
-}
-
-func gatewayHTTPRoutesEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled || ctx.Config.Sync.ToHost.GatewayAPI.Enabled
-}
-
-func gatewayTLSRoutesEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Enabled
-}
-
-func gatewayBackendTLSPoliciesEnabled(ctx *synccontext.RegisterContext) bool {
-	return ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Enabled
-}
-
-func gatewayReferenceGrantsEnabled(ctx *synccontext.RegisterContext) bool {
-	mode := ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled
-	if mode == "true" {
-		return true
-	}
-	if mode == "false" {
-		return false
-	}
-	return gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx)
 }

--- a/pkg/mappings/resources/register_gateway_test.go
+++ b/pkg/mappings/resources/register_gateway_test.go
@@ -1,0 +1,39 @@
+package resources
+
+import (
+	"testing"
+
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestReferenceGrantAutoFollowsHTTPRouteMapperWithoutNamespaceSync(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+
+	if !gatewayReferenceGrantsEnabled(ctx) {
+		t.Fatalf("referenceGrants=auto should install the tenant CRD when HTTPRoute mapper watches ReferenceGrant")
+	}
+}
+
+func TestReferenceGrantAutoDoesNotFollowGatewayMapperAlone(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.Namespaces.Enabled = true
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
+
+	if gatewayReferenceGrantsEnabled(ctx) {
+		t.Fatalf("referenceGrants=auto should not be enabled by Gateway mapper alone")
+	}
+}
+
+func TestTLSRouteMapperKeepsOlderServedVersionForCompatibility(t *testing.T) {
+	want := schema.GroupVersion{Group: gatewayv1alpha2.GroupVersion.Group, Version: gatewayv1alpha2.GroupVersion.Version}
+	if got := mappings.TLSRoutes().GroupVersion(); got != want {
+		t.Fatalf("expected TLSRoute mapper to keep older served version %s for Gateway API compatibility, got %s", want, got)
+	}
+}

--- a/pkg/mappings/resources/register_gateway_test.go
+++ b/pkg/mappings/resources/register_gateway_test.go
@@ -1,11 +1,14 @@
 package resources
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	gatewayapiutil "github.com/loft-sh/vcluster/pkg/util/gatewayapi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
@@ -15,7 +18,7 @@ func TestReferenceGrantAutoFollowsHTTPRouteMapperWithoutNamespaceSync(t *testing
 	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
 	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
 
-	if !gatewayReferenceGrantsEnabled(ctx) {
+	if !gatewayapiutil.ReferenceGrantsEnabled(ctx.Config) {
 		t.Fatalf("referenceGrants=auto should install the tenant CRD when HTTPRoute mapper watches ReferenceGrant")
 	}
 }
@@ -26,8 +29,19 @@ func TestReferenceGrantAutoDoesNotFollowGatewayMapperAlone(t *testing.T) {
 	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
 	ctx.Config.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 
-	if gatewayReferenceGrantsEnabled(ctx) {
+	if gatewayapiutil.ReferenceGrantsEnabled(ctx.Config) {
 		t.Fatalf("referenceGrants=auto should not be enabled by Gateway mapper alone")
+	}
+}
+
+func TestReferenceGrantMapperChecksHostCRDWithoutNamespaceSync(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Context: context.Background(), Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+
+	_, err := CreateReferenceGrantMapper(ctx)
+	if err == nil || !strings.Contains(err.Error(), "cannot check host cluster for Gateway API resource gateway.networking.k8s.io/v1beta1, Kind=ReferenceGrant") {
+		t.Fatalf("expected ReferenceGrant host CRD check before tenant CRD install, got %v", err)
 	}
 }
 

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
@@ -116,10 +115,10 @@ func NewControllerContext(ctx context.Context, options *config.VirtualClusterCon
 func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	// is multi namespace mode?
 	defaultNamespaces := make(map[string]cache.Config)
-	gatewayNamespaces := map[string]cache.Config(nil)
+	gatewayNamespaces := make(map[string]cache.Config)
 	if !options.Sync.ToHost.Namespaces.Enabled {
 		defaultNamespaces[options.HostNamespace] = cache.Config{}
-		gatewayNamespaces = fromHostGatewaySourceNamespaces(options)
+		gatewayNamespaces = gatewaySourceNamespaces(options)
 	}
 	// do we need access to another namespace to export the kubeconfig ?
 	// we will need access to all the objects that the vcluster usually has access to
@@ -145,24 +144,6 @@ func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	}
 
 	return cacheOptions
-}
-
-func fromHostGatewaySourceNamespaces(options *config.VirtualClusterConfig) map[string]cache.Config {
-	if !options.Sync.FromHost.Gateways.Enabled {
-		return nil
-	}
-
-	gatewayNamespaces := map[string]cache.Config{}
-	for hostName := range options.Sync.FromHost.Gateways.Mappings.ByName {
-		hostNamespace, _, hasName := strings.Cut(hostName, "/")
-		if !hasName || hostNamespace == "" {
-			continue
-		}
-
-		gatewayNamespaces[hostNamespace] = cache.Config{}
-	}
-
-	return gatewayNamespaces
 }
 
 func startPlugins(ctx context.Context, virtualConfig *rest.Config, virtualRawConfig *clientcmdapi.Config, options *config.VirtualClusterConfig) error {

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // NewLocalManager is used to create a new local manager
@@ -114,8 +116,10 @@ func NewControllerContext(ctx context.Context, options *config.VirtualClusterCon
 func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	// is multi namespace mode?
 	defaultNamespaces := make(map[string]cache.Config)
+	gatewayNamespaces := map[string]cache.Config(nil)
 	if !options.Sync.ToHost.Namespaces.Enabled {
 		defaultNamespaces[options.HostNamespace] = cache.Config{}
+		gatewayNamespaces = fromHostGatewaySourceNamespaces(options)
 	}
 	// do we need access to another namespace to export the kubeconfig ?
 	// we will need access to all the objects that the vcluster usually has access to
@@ -126,11 +130,39 @@ func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 		}
 	}
 
-	if len(defaultNamespaces) == 0 {
+	if len(defaultNamespaces) == 0 && len(gatewayNamespaces) == 0 {
 		return cache.Options{DefaultNamespaces: nil}
 	}
 
-	return cache.Options{DefaultNamespaces: defaultNamespaces}
+	cacheOptions := cache.Options{DefaultNamespaces: defaultNamespaces}
+	if len(gatewayNamespaces) > 0 {
+		for namespace := range defaultNamespaces {
+			gatewayNamespaces[namespace] = cache.Config{}
+		}
+		cacheOptions.ByObject = map[client.Object]cache.ByObject{
+			&gatewayv1.Gateway{}: {Namespaces: gatewayNamespaces},
+		}
+	}
+
+	return cacheOptions
+}
+
+func fromHostGatewaySourceNamespaces(options *config.VirtualClusterConfig) map[string]cache.Config {
+	if !options.Sync.FromHost.Gateways.Enabled {
+		return nil
+	}
+
+	gatewayNamespaces := map[string]cache.Config{}
+	for hostName := range options.Sync.FromHost.Gateways.Mappings.ByName {
+		hostNamespace, _, hasName := strings.Cut(hostName, "/")
+		if !hasName || hostNamespace == "" {
+			continue
+		}
+
+		gatewayNamespaces[hostNamespace] = cache.Config{}
+	}
+
+	return gatewayNamespaces
 }
 
 func startPlugins(ctx context.Context, virtualConfig *rest.Config, virtualRawConfig *clientcmdapi.Config, options *config.VirtualClusterConfig) error {

--- a/pkg/setup/controller_context_gateway_test.go
+++ b/pkg/setup/controller_context_gateway_test.go
@@ -1,0 +1,67 @@
+package setup
+
+import (
+	"testing"
+
+	rootconfig "github.com/loft-sh/vcluster/config"
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestLocalCacheWatchesFromHostGatewayMappingSourceNamespaces(t *testing.T) {
+	options := &pkgconfig.VirtualClusterConfig{}
+	options.HostNamespace = "loft-default-v-test"
+	options.Sync.FromHost.Gateways.Enabled = true
+	options.Sync.FromHost.Gateways.Mappings.ByName = map[string]string{
+		"platform-gateways/*":          "shared-gateways/*",
+		"platform-ingress/shared-edge": "shared-gateways/shared-edge",
+	}
+
+	cacheOptions := getLocalCacheOptions(options)
+	if _, ok := cacheOptions.DefaultNamespaces["loft-default-v-test"]; !ok {
+		t.Fatalf("expected default local cache to watch host namespace, got %#v", cacheOptions.DefaultNamespaces)
+	}
+	for _, namespace := range []string{"platform-gateways", "platform-ingress"} {
+		if _, ok := cacheOptions.DefaultNamespaces[namespace]; ok {
+			t.Fatalf("expected default local cache not to watch gateway source namespace %q, got %#v", namespace, cacheOptions.DefaultNamespaces)
+		}
+	}
+
+	gatewayNamespaces := gatewayCacheNamespaces(t, cacheOptions)
+	for _, namespace := range []string{"loft-default-v-test", "platform-gateways", "platform-ingress"} {
+		if _, ok := gatewayNamespaces[namespace]; !ok {
+			t.Fatalf("expected Gateway cache to watch namespace %q, got %#v", namespace, gatewayNamespaces)
+		}
+	}
+}
+
+func TestLocalCacheDoesNotAddVirtualGatewayMappingNamespaces(t *testing.T) {
+	options := &pkgconfig.VirtualClusterConfig{}
+	options.HostNamespace = "loft-default-v-test"
+	options.Sync.FromHost.Gateways.Enabled = true
+	options.Sync.FromHost.Gateways.Mappings = rootconfig.FromHostMappings{ByName: map[string]string{
+		"platform-gateways/public-web": "shared-gateways/shared-web",
+	}}
+
+	cacheOptions := getLocalCacheOptions(options)
+	if _, ok := cacheOptions.DefaultNamespaces["shared-gateways"]; ok {
+		t.Fatalf("expected default local cache not to watch virtual gateway mapping namespace, got %#v", cacheOptions.DefaultNamespaces)
+	}
+	if _, ok := gatewayCacheNamespaces(t, cacheOptions)["shared-gateways"]; ok {
+		t.Fatalf("expected Gateway cache to watch host source namespaces only, got %#v", cacheOptions.ByObject)
+	}
+}
+
+func gatewayCacheNamespaces(t *testing.T, cacheOptions cache.Options) map[string]cache.Config {
+	t.Helper()
+
+	for obj, byObject := range cacheOptions.ByObject {
+		if _, ok := obj.(*gatewayv1.Gateway); ok {
+			return byObject.Namespaces
+		}
+	}
+
+	t.Fatalf("expected Gateway cache ByObject config, got %#v", cacheOptions.ByObject)
+	return nil
+}

--- a/pkg/setup/gateway_cache.go
+++ b/pkg/setup/gateway_cache.go
@@ -1,0 +1,26 @@
+package setup
+
+import (
+	"strings"
+
+	"github.com/loft-sh/vcluster/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func gatewaySourceNamespaces(options *config.VirtualClusterConfig) map[string]cache.Config {
+	if !options.Sync.FromHost.Gateways.Enabled {
+		return nil
+	}
+
+	gatewayNamespaces := map[string]cache.Config{}
+	for hostName := range options.Sync.FromHost.Gateways.Mappings.ByName {
+		hostNamespace, _, hasName := strings.Cut(hostName, "/")
+		if !hasName || hostNamespace == "" {
+			continue
+		}
+
+		gatewayNamespaces[hostNamespace] = cache.Config{}
+	}
+
+	return gatewayNamespaces
+}

--- a/pkg/util/gatewayapi/enabled.go
+++ b/pkg/util/gatewayapi/enabled.go
@@ -1,0 +1,35 @@
+package gatewayapi
+
+import "github.com/loft-sh/vcluster/pkg/config"
+
+// GatewaysEnabled reports whether tenant-created Gateway sync is explicitly enabled.
+func GatewaysEnabled(config *config.VirtualClusterConfig) bool {
+	return config.Sync.ToHost.GatewayAPI.Gateways.Enabled
+}
+
+// HTTPRoutesEnabled reports whether HTTPRoute sync is enabled via the legacy umbrella or explicit switch.
+func HTTPRoutesEnabled(config *config.VirtualClusterConfig) bool {
+	return config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled || config.Sync.ToHost.GatewayAPI.Enabled
+}
+
+// TLSRoutesEnabled reports whether TLSRoute sync is enabled.
+func TLSRoutesEnabled(config *config.VirtualClusterConfig) bool {
+	return config.Sync.ToHost.GatewayAPI.TLSRoutes.Enabled
+}
+
+// BackendTLSPoliciesEnabled reports whether BackendTLSPolicy sync is enabled.
+func BackendTLSPoliciesEnabled(config *config.VirtualClusterConfig) bool {
+	return config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Enabled
+}
+
+// ReferenceGrantsEnabled reports whether ReferenceGrant sync/CRD setup is required.
+func ReferenceGrantsEnabled(config *config.VirtualClusterConfig) bool {
+	mode := config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled
+	if mode == "true" {
+		return true
+	}
+	if mode == "false" {
+		return false
+	}
+	return HTTPRoutesEnabled(config) || TLSRoutesEnabled(config) || BackendTLSPoliciesEnabled(config)
+}

--- a/pkg/util/gatewayapi/enabled_test.go
+++ b/pkg/util/gatewayapi/enabled_test.go
@@ -1,0 +1,32 @@
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/config"
+)
+
+func TestReferenceGrantsEnabledFollowsRouteFeaturesOnlyInAuto(t *testing.T) {
+	cfg := &config.VirtualClusterConfig{}
+	cfg.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	cfg.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
+	if ReferenceGrantsEnabled(cfg) {
+		t.Fatalf("referenceGrants=auto must not follow Gateway sync alone")
+	}
+
+	cfg.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+	if !ReferenceGrantsEnabled(cfg) {
+		t.Fatalf("referenceGrants=auto should follow HTTPRoute sync")
+	}
+
+	cfg.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "false"
+	if ReferenceGrantsEnabled(cfg) {
+		t.Fatalf("referenceGrants=false should disable ReferenceGrant sync")
+	}
+
+	cfg.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "true"
+	cfg.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = false
+	if !ReferenceGrantsEnabled(cfg) {
+		t.Fatalf("referenceGrants=true should enable ReferenceGrant sync")
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

Resolves ENGNODE-552
Resolves ENGNODE-553
Resolves ENGNODE-554
Resolves ENGNODE-556
Resolves ENGNODE-557
Resolves ENGNODE-558
Resolves ENGNODE-560

**Please provide a short message that should be published in the vcluster release notes**
This covers several issues found in qa checks for PO cases and adds e2e tests for those P0 checks.

**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
