### PR TITLE
fix(ci): fail curl on HTTP errors in download-latest-cli job

### DIFF
--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -169,7 +169,8 @@ jobs:
     steps:
       - name: download current cli
         run: |
-          curl -L -o vcluster-current "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64"
+          curl -fL --retry 3 --retry-delay 5 -o vcluster-current "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64"
+          file vcluster-current | grep -q "ELF" || { echo "Downloaded file is not a valid binary"; cat vcluster-current; exit 1; }
       - name: Upload vcluster cli to artifact
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -175,7 +175,8 @@ jobs:
     steps:
       - name: download current cli
         run: |
-          curl -L -o vcluster-current "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64"
+          curl -fL --retry 3 --retry-delay 5 -o vcluster-current "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-linux-amd64"
+          file vcluster-current | grep -q "ELF" || { echo "Downloaded file is not a valid binary"; cat vcluster-current; exit 1; }
       - name: Upload vcluster cli to artifact
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
/kind bugfix

resolves #

Fixed an issue where the E2E upgrade-test CI job downloaded HTML error pages instead of the vCluster binary because `curl` did not fail on HTTP errors.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.
