### PR TITLE
Engqa 1092

### DIFF
--- a/e2e-next/labels/labels.go
+++ b/e2e-next/labels/labels.go
@@ -24,6 +24,8 @@ var (
 	RuntimeClasses  = Label("runtimeclasses")
 	StorageClasses  = Label("storageclasses")
 	IngressClasses  = Label("ingressclasses")
+	GatewayAPI      = Label("gatewayapi")
+	GatewayClasses  = Label("gatewayclasses")
 	ConfigMaps      = Label("configmaps")
 	Secrets         = Label("secrets")
 	NetworkPolicies = Label("networkpolicies")

--- a/e2e-next/setup/gatewayapi.go
+++ b/e2e-next/setup/gatewayapi.go
@@ -27,10 +27,12 @@ func GatewayAPIPreSetup() func(ctx context.Context) error {
 			"pkg/mappings/resources/gateways.crd.yaml",
 			"pkg/mappings/resources/httproutes.crd.yaml",
 			"pkg/mappings/resources/referencegrants.crd.yaml",
+			"pkg/mappings/resources/tlsroutes.crd.yaml",
+			"pkg/mappings/resources/backendtlspolicies.crd.yaml",
 		}
 		for _, crd := range crds {
 			abs := filepath.Join(repoRoot, crd)
-			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--context", kubeContext, "-f", abs)
+			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--server-side", "--force-conflicts", "--context", kubeContext, "-f", abs)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("apply Gateway API CRD %s: %s: %w", crd, string(out), err)
 			}

--- a/e2e-next/setup/gatewayapi.go
+++ b/e2e-next/setup/gatewayapi.go
@@ -1,0 +1,40 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+)
+
+// GatewayAPIPreSetup installs the local Gateway API CRDs required by the
+// Gateway API e2e suite on the host cluster before vCluster starts. The CRDs
+// are intentionally left installed after the suite because they are shared
+// cluster-scoped infrastructure.
+func GatewayAPIPreSetup() func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		kubeContext := "kind-" + constants.GetHostClusterName()
+		_, file, _, ok := runtime.Caller(0)
+		if !ok {
+			return fmt.Errorf("resolve Gateway API setup source path")
+		}
+		repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+		crds := []string{
+			"pkg/mappings/resources/gatewayclasses.crd.yaml",
+			"pkg/mappings/resources/gateways.crd.yaml",
+			"pkg/mappings/resources/httproutes.crd.yaml",
+			"pkg/mappings/resources/referencegrants.crd.yaml",
+		}
+		for _, crd := range crds {
+			abs := filepath.Join(repoRoot, crd)
+			cmd := exec.CommandContext(ctx, "kubectl", "apply", "--context", kubeContext, "-f", abs)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("apply Gateway API CRD %s: %s: %w", crd, string(out), err)
+			}
+		}
+		return nil
+	}
+}

--- a/e2e-next/suite_gatewayapi_import_test.go
+++ b/e2e-next/suite_gatewayapi_import_test.go
@@ -1,6 +1,6 @@
-// Suite: gatewayapi-vcluster
-// vCluster: Gateway API sync coverage for GatewayClass visibility, Tenant
-// Gateway authorization, and Gateway/HTTPRoute sync.
+// Suite: gatewayapi-import-vcluster
+// vCluster: fromHost imported Gateway coverage (mirroring, allowedRoutes policy,
+// hostname allowlist, deletion recovery, read-only behavior, status sanitization).
 // Run:      just run-e2e 'pr && gatewayapi'
 package e2e_next
 
@@ -17,27 +17,26 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-//go:embed vcluster-gatewayapi.yaml
-var gatewayAPIVClusterYAML string
+//go:embed vcluster-gatewayapi-import.yaml
+var gatewayAPIImportVClusterYAML string
 
-const gatewayAPIVClusterName = "gatewayapi-vcluster"
+const gatewayAPIImportVClusterName = "gatewayapi-import-vcluster"
 
-func init() { suiteGatewayAPIVCluster() }
+func init() { suiteGatewayAPIImportVCluster() }
 
-func suiteGatewayAPIVCluster() {
-	Describe("gatewayapi-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
+func suiteGatewayAPIImportVCluster() {
+	Describe("gatewayapi-import-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
 		cluster.Use(clusters.HostCluster),
 		func() {
 			BeforeAll(func(ctx context.Context) context.Context {
 				return lazyvcluster.LazyVCluster(ctx,
-					gatewayAPIVClusterName,
-					gatewayAPIVClusterYAML,
+					gatewayAPIImportVClusterName,
+					gatewayAPIImportVClusterYAML,
 					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
 				)
 			})
 
-			test_gatewayapi.GatewayAPISyncSpec()
-			test_gatewayapi.GatewayAPIToHostSpec()
+			test_gatewayapi.GatewayAPIImportSpec()
 		},
 	)
 }

--- a/e2e-next/suite_gatewayapi_test.go
+++ b/e2e-next/suite_gatewayapi_test.go
@@ -1,0 +1,42 @@
+// Suite: gatewayapi-vcluster
+// vCluster: Gateway API sync coverage for GatewayClass visibility, Tenant
+// Gateway authorization, and Gateway/HTTPRoute sync.
+// Run:      just run-e2e 'pr && gatewayapi'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	"github.com/loft-sh/vcluster/e2e-next/test_gatewayapi"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+//go:embed vcluster-gatewayapi.yaml
+var gatewayAPIVClusterYAML string
+
+const gatewayAPIVClusterName = "gatewayapi-vcluster"
+
+func init() { suiteGatewayAPIVCluster() }
+
+func suiteGatewayAPIVCluster() {
+	Describe("gatewayapi-vcluster", labels.PR, labels.GatewayAPI, labels.GatewayClasses, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				return lazyvcluster.LazyVCluster(ctx,
+					gatewayAPIVClusterName,
+					gatewayAPIVClusterYAML,
+					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
+				)
+			})
+
+			test_gatewayapi.GatewayAPISyncSpec()
+		},
+	)
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -1,0 +1,393 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const importClassSelectorValue = "gatewayapi-import"
+
+// GatewayAPIImportSpec registers fromHost imported Gateway tests (P0 cases
+// 01-08, 16, control-plane behavior only).
+func GatewayAPIImportSpec() {
+	Describe("Gateway API import", labels.GatewayAPI, labels.GatewayClasses, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+
+			ensureHostNamespace(ctx, hostClient, "gwapi-host")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("imports a host Gateway into the tenant and syncs attached routes to the host Gateway", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-import-"+suffix, importClassSelectorValue, "import class")
+
+			By("creating a host Gateway in the wildcard-mapped source namespace")
+			hostGW := hostGateway("gwapi-host", "edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			By("verifying the tenant mirror, namespace and GatewayClass exist")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+				mirror := &gatewayv1.Gateway{}
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}, mirror)).To(Succeed())
+				g.Expect(mirror.Labels).To(HaveKeyWithValue("vcluster.loft.sh/imported-gateway", "true"))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("creating a tenant HTTPRoute attached to the imported Gateway")
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-app-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import", hostGW.Name, svc.Name, "app.apps.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			By("verifying the host route parentRef points at the host Gateway")
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
+				g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("confirming no tenant-created host Gateway object exists")
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: translate.SafeConcatName(hostGW.Name, "x", "gwapi-import", "x", vClusterName)}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("mirrors the GatewayClass with controllerName preserved and parametersRef stripped", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-sanitize-"+suffix, importClassSelectorValue, "sanitize class")
+
+			Eventually(func(g Gomega) {
+				mirror := &gatewayv1.GatewayClass{}
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, mirror)).To(Succeed())
+				g.Expect(mirror.Spec.ControllerName).To(Equal(gatewayControllerName))
+				g.Expect(mirror.Spec.ParametersRef).To(BeNil())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("does not sync routes that attach to a tenant-local non-imported Gateway", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-local-"+suffix, importClassSelectorValue, "local class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-local-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			By("creating a tenant-local Gateway that is not imported from host")
+			localGW := tenantGateway(routeNS.Name, "local-gw-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, localGW)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, localGW))).To(Succeed())
+			})
+			route := importRoute(routeNS.Name, "route-"+suffix, routeNS.Name, localGW.Name, svc.Name, "app.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("removes the tenant mirror when the host Gateway is deleted and recovers when recreated", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-del-"+suffix, importClassSelectorValue, "deletion class")
+			hostGW := hostGateway("gwapi-host", "del-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			mirrorKey := types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the host Gateway")
+			Expect(hostClient.Delete(ctx, hostGW)).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("recreating the host Gateway")
+			recreated := hostGateway("gwapi-host", hostGW.Name, class.Name)
+			Expect(hostClient.Create(ctx, recreated)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("treats the imported Gateway as read-only and recreates it after tenant deletion", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-ro-"+suffix, importClassSelectorValue, "read-only class")
+			hostGW := hostGateway("gwapi-host", "ro-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			mirrorKey := types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("editing a tenant listener port and expecting it reverted")
+			mirror := &gatewayv1.Gateway{}
+			Expect(vClusterClient.Get(ctx, mirrorKey, mirror)).To(Succeed())
+			mirror.Spec.Listeners[0].Port = gatewayv1.PortNumber(8080)
+			Expect(vClusterClient.Update(ctx, mirror)).To(Succeed())
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+				g.Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the tenant mirror and expecting recreation")
+			toDelete := &gatewayv1.Gateway{}
+			Expect(vClusterClient.Get(ctx, mirrorKey, toDelete)).To(Succeed())
+			Expect(vClusterClient.Delete(ctx, toDelete)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("confirming the host Gateway is never mutated")
+			got := &gatewayv1.Gateway{}
+			Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, got)).To(Succeed())
+			Expect(got.Spec.Listeners[0].Port).To(Equal(gatewayv1.PortNumber(80)))
+		})
+
+		It("hides host Gateway status addresses on the tenant mirror by default", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-status-"+suffix, importClassSelectorValue, "status class")
+			hostGW := hostGateway("gwapi-host", "status-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			mirrorKey := types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("populating host Gateway status addresses")
+			current := &gatewayv1.Gateway{}
+			Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-host", Name: hostGW.Name}, current)).To(Succeed())
+			current.Status.Addresses = []gatewayv1.GatewayStatusAddress{{Type: ptr.To(gatewayv1.IPAddressType), Value: "203.0.113.10"}}
+			Expect(hostClient.Status().Update(ctx, current)).To(Succeed())
+
+			By("verifying the tenant mirror hides addresses")
+			Consistently(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(vClusterClient.Get(ctx, mirrorKey, got)).To(Succeed())
+				g.Expect(got.Status.Addresses).To(BeEmpty())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("enforces the virtual allowedRoutes namespace selector policy on imported Gateways", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ensureHostNamespace(ctx, hostClient, "gwapi-host-policy")
+			class := createGatewayClass(ctx, hostClient, "gwc-sel-"+suffix, importClassSelectorValue, "selector class")
+			hostGW := hostGateway("gwapi-host-policy", "selector-edge", class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-policy", Name: "selector-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("creating a route in an unlabeled namespace and expecting no host sync")
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-sel-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-policy", "selector-edge", svc.Name, "app.apps.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			By("labeling the namespace team=apps and expecting the host route to appear")
+			updatedNS := &corev1.Namespace{}
+			Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: routeNS.Name}, updatedNS)).To(Succeed())
+			if updatedNS.Labels == nil {
+				updatedNS.Labels = map[string]string{}
+			}
+			updatedNS.Labels["team"] = "apps"
+			Expect(vClusterClient.Update(ctx, updatedNS)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("enforces the hostname allowlist on imported Gateways", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ensureHostNamespace(ctx, hostClient, "gwapi-host-policy")
+			class := createGatewayClass(ctx, hostClient, "gwc-host-"+suffix, importClassSelectorValue, "hostname class")
+			hostGW := hostGateway("gwapi-host-policy", "hostname-edge", class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-policy", Name: "hostname-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-host-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			By("creating a route with a disallowed hostname and expecting no host sync")
+			denied := importRoute(routeNS.Name, "denied-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "admin.apps.example.com")
+			Expect(vClusterClient.Create(ctx, denied)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, denied))).To(Succeed())
+			})
+			deniedHostName := translate.SafeConcatName(denied.Name, "x", routeNS.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: deniedHostName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			By("creating a route with an allowed hostname and expecting host sync")
+			allowed := importRoute(routeNS.Name, "allowed-"+suffix, "gwapi-import-policy", "hostname-edge", svc.Name, "api.team-a.apps.example.com")
+			Expect(vClusterClient.Create(ctx, allowed)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, allowed))).To(Succeed())
+			})
+			allowedHostName := translate.SafeConcatName(allowed.Name, "x", routeNS.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: allowedHostName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("imports a renamed Gateway and routes attach to the correct host Gateway", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ensureHostNamespace(ctx, hostClient, "gwapi-host-rename")
+			class := createGatewayClass(ctx, hostClient, "gwc-rename-"+suffix, importClassSelectorValue, "rename class")
+			hostGW := hostGateway("gwapi-host-rename", "source-edge", class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+
+			By("verifying the tenant mirror exists under the renamed name")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import-rename", Name: "renamed-edge"}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("attaching a route to the renamed Gateway and checking the host parentRef")
+			routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-rename-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+			route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import-rename", "renamed-edge", svc.Name, "app.apps.example.com")
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+			hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName("source-edge")))
+				g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host-rename")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func ensureHostNamespace(ctx context.Context, c ctrlclient.Client, name string) {
+	GinkgoHelper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	err := c.Create(ctx, ns)
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		Expect(err).To(Succeed())
+	}
+}
+
+func createHostGateway(ctx context.Context, c ctrlclient.Client, gw *gatewayv1.Gateway) {
+	GinkgoHelper()
+	key := ctrlclient.ObjectKeyFromObject(gw)
+	stale := &gatewayv1.Gateway{}
+	err := c.Get(ctx, key, stale)
+	if err == nil {
+		Expect(c.Delete(ctx, stale)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := c.Get(ctx, key, &gatewayv1.Gateway{})
+			g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+		}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+	} else {
+		Expect(kerrors.IsNotFound(err)).To(BeTrue())
+	}
+	Expect(c.Create(ctx, gw)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(c.Delete(ctx, gw))).To(Succeed()) })
+}
+
+func hostGateway(namespace, name, className string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     gatewayv1.SectionName("http"),
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+			}},
+		},
+	}
+}
+
+func importRoute(namespace, name, gatewayNamespace, gatewayName, serviceName, hostname string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{
+				Name:      gatewayv1.ObjectName(gatewayName),
+				Namespace: ptr.To(gatewayv1.Namespace(gatewayNamespace)),
+			}}},
+			Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(hostname)},
+			Rules:     []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(serviceName), Port: ptr.To(gatewayv1.PortNumber(80))}}}}}},
+		},
+	}
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -113,7 +113,9 @@ func GatewayAPISyncSpec() {
 
 			bad := tenantGateway(ns.Name, "bad-gw-"+suffix, hidden.Name)
 			Expect(vClusterClient.Create(ctx, bad)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed())
+			})
 			badHostName := translate.SafeConcatName(bad.Name, "x", ns.Name, "x", vClusterName)
 			Consistently(func(g Gomega) {
 				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: badHostName}, &gatewayv1.Gateway{})
@@ -122,7 +124,9 @@ func GatewayAPISyncSpec() {
 
 			good := tenantGateway(ns.Name, "good-gw-"+suffix, allowed.Name)
 			Expect(vClusterClient.Create(ctx, good)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed())
+			})
 			goodHostName := translate.SafeConcatName(good.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {
 				got := &gatewayv1.Gateway{}
@@ -133,11 +137,10 @@ func GatewayAPISyncSpec() {
 			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(good), good)).To(Succeed())
 			good.Spec.GatewayClassName = gatewayv1.ObjectName(hidden.Name)
 			Expect(vClusterClient.Update(ctx, good)).To(Succeed())
-			Consistently(func(g Gomega) {
-				got := &gatewayv1.Gateway{}
-				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
-				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
 		It("syncs Tenant Gateway and HTTPRoute to Host for an available GatewayClass", func(ctx context.Context) {
@@ -152,7 +155,9 @@ func GatewayAPISyncSpec() {
 			Expect(vClusterClient.Create(ctx, service)).To(Succeed())
 			gateway := tenantGateway(ns.Name, "gw-"+suffix, allowed.Name)
 			Expect(vClusterClient.Create(ctx, gateway)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed())
+			})
 
 			hostGatewayName := translate.SafeConcatName(gateway.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {
@@ -170,7 +175,9 @@ func GatewayAPISyncSpec() {
 
 			route := tenantHTTPRoute(ns.Name, "route-"+suffix, gateway.Name, service.Name)
 			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed()) })
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
 
 			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -1,0 +1,258 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	gatewayClassSelectorKey   = "e2e.vcluster.loft.sh/gatewayclass"
+	gatewayClassSelectorValue = "gatewayapi-vcluster"
+	gatewayControllerName     = gatewayv1.GatewayController("example.com/gateway-controller")
+)
+
+// GatewayAPISyncSpec registers Gateway API sync tests.
+func GatewayAPISyncSpec() {
+	Describe("Gateway API sync", labels.GatewayAPI, labels.GatewayClasses, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayClassList{})).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.GatewayList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("mirrors matching Host GatewayClasses into the Tenant Cluster and hides non-matching ones", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed, hidden := createGatewayClassPair(ctx, hostClient, suffix)
+
+			By("waiting for the allowed GatewayClass to appear sanitized in the Tenant Cluster", func() {
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.GatewayClass{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, got)).To(Succeed())
+					g.Expect(got.Spec.ControllerName).To(Equal(gatewayControllerName))
+					g.Expect(got.Spec.Description).NotTo(BeNil())
+					g.Expect(*got.Spec.Description).To(Equal("e2e allowed GatewayClass"))
+					g.Expect(got.Spec.ParametersRef).To(BeNil())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("proving the selector-hidden GatewayClass stays absent from the Tenant Cluster", func() {
+				Consistently(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: hidden.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+
+			By("updating the Host GatewayClass and ensuring parametersRef remains sanitized", func() {
+				Expect(hostClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, allowed)).To(Succeed())
+				if allowed.Annotations == nil {
+					allowed.Annotations = map[string]string{}
+				}
+				allowed.Annotations["e2e.vcluster.loft.sh/resync"] = suffix
+				Expect(hostClient.Update(ctx, allowed)).To(Succeed())
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.GatewayClass{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, got)).To(Succeed())
+					g.Expect(got.Annotations).To(HaveKeyWithValue("e2e.vcluster.loft.sh/resync", suffix))
+					g.Expect(got.Spec.ParametersRef).To(BeNil())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("deleting the Host GatewayClass and waiting for the Tenant mirror to disappear", func() {
+				Expect(ctrlclient.IgnoreNotFound(hostClient.Delete(ctx, allowed))).To(Succeed())
+				Eventually(func(g Gomega) {
+					err := vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+		})
+
+		It("does not sync Tenant Gateways that reference unavailable GatewayClasses", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed, hidden := createGatewayClassPair(ctx, hostClient, suffix)
+			ns := createTenantNamespace(ctx, vClusterClient, "gwapi-reject-"+suffix)
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			bad := tenantGateway(ns.Name, "bad-gw-"+suffix, hidden.Name)
+			Expect(vClusterClient.Create(ctx, bad)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, bad))).To(Succeed()) })
+			badHostName := translate.SafeConcatName(bad.Name, "x", ns.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: badHostName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+
+			good := tenantGateway(ns.Name, "good-gw-"+suffix, allowed.Name)
+			Expect(vClusterClient.Create(ctx, good)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, good))).To(Succeed()) })
+			goodHostName := translate.SafeConcatName(good.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(good), good)).To(Succeed())
+			good.Spec.GatewayClassName = gatewayv1.ObjectName(hidden.Name)
+			Expect(vClusterClient.Update(ctx, good)).To(Succeed())
+			Consistently(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: goodHostName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+		})
+
+		It("syncs Tenant Gateway and HTTPRoute to Host for an available GatewayClass", func(ctx context.Context) {
+			suffix := random.String(6)
+			allowed := createGatewayClass(ctx, hostClient, "gc-allowed-"+suffix, gatewayClassSelectorValue, "e2e allowed GatewayClass")
+			ns := createTenantNamespace(ctx, vClusterClient, "gwapi-sync-"+suffix)
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: allowed.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, service)).To(Succeed())
+			gateway := tenantGateway(ns.Name, "gw-"+suffix, allowed.Name)
+			Expect(vClusterClient.Create(ctx, gateway)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed()) })
+
+			hostGatewayName := translate.SafeConcatName(gateway.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.Gateway{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, got)).To(Succeed())
+				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+				g.Expect(got.Spec.Listeners).To(HaveLen(1))
+				listener := got.Spec.Listeners[0]
+				g.Expect(listener.Name).To(Equal(gatewayv1.SectionName("http")))
+				g.Expect(listener.Protocol).To(Equal(gatewayv1.HTTPProtocolType))
+				g.Expect(listener.Port).To(Equal(gatewayv1.PortNumber(80)))
+				g.Expect(listener.Hostname).NotTo(BeNil())
+				g.Expect(*listener.Hostname).To(Equal(gatewayv1.Hostname("app.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			route := tenantHTTPRoute(ns.Name, "route-"+suffix, gateway.Name, service.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed()) })
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				got := &gatewayv1.HTTPRoute{}
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+				g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGatewayName)))
+				g.Expect(got.Spec.ParentRefs[0].SectionName).NotTo(BeNil())
+				g.Expect(*got.Spec.ParentRefs[0].SectionName).To(Equal(gatewayv1.SectionName("http")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func createGatewayClassPair(ctx context.Context, hostClient ctrlclient.Client, suffix string) (*gatewayv1.GatewayClass, *gatewayv1.GatewayClass) {
+	GinkgoHelper()
+	allowed := createGatewayClass(ctx, hostClient, "gc-allowed-"+suffix, gatewayClassSelectorValue, "e2e allowed GatewayClass")
+	hidden := createGatewayClass(ctx, hostClient, "gc-hidden-"+suffix, "other-"+suffix, "e2e hidden GatewayClass")
+	return allowed, hidden
+}
+
+func createGatewayClass(ctx context.Context, hostClient ctrlclient.Client, name, selectorValue, description string) *gatewayv1.GatewayClass {
+	GinkgoHelper()
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{gatewayClassSelectorKey: selectorValue}},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: gatewayControllerName,
+			Description:    ptr.To(description),
+			ParametersRef:  gatewayClassParametersRef(name),
+		},
+	}
+	Expect(hostClient.Create(ctx, gc)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(hostClient.Delete(ctx, gc))).To(Succeed()) })
+	return gc
+}
+
+func gatewayClassParametersRef(name string) *gatewayv1.ParametersReference {
+	ns := gatewayv1.Namespace("host-only-" + name)
+	return &gatewayv1.ParametersReference{Group: gatewayv1.Group("example.com"), Kind: gatewayv1.Kind("GatewayClassConfig"), Name: name + "-config", Namespace: &ns}
+}
+
+func createTenantNamespace(ctx context.Context, c ctrlclient.Client, name string) *corev1.Namespace {
+	GinkgoHelper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	Expect(c.Create(ctx, ns)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { Expect(ctrlclient.IgnoreNotFound(c.Delete(ctx, ns))).To(Succeed()) })
+	return ns
+}
+
+func tenantGateway(namespace, name, className string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     gatewayv1.SectionName("http"),
+				Protocol: gatewayv1.HTTPProtocolType,
+				Port:     gatewayv1.PortNumber(80),
+				Hostname: ptr.To(gatewayv1.Hostname("app.example.com")),
+			}},
+		},
+	}
+}
+
+func tenantHTTPRoute(namespace, name, gatewayName, serviceName string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To(gatewayv1.SectionName("http"))}}},
+			Rules:           []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(serviceName), Port: ptr.To(gatewayv1.PortNumber(80))}}}}}},
+		},
+	}
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
@@ -1,0 +1,213 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// GatewayAPIToHostSpec registers tenant-authored route/policy sync tests
+// (P0 cases 13, 18, 19).
+func GatewayAPIToHostSpec() {
+	Describe("Gateway API toHost", labels.GatewayAPI, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			var err error
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gatewayv1.Install(scheme)).To(Succeed())
+			Expect(gatewayv1alpha2.Install(scheme)).To(Succeed())
+			Expect(gatewayv1alpha3.Install(scheme)).To(Succeed())
+			Expect(gatewayv1beta1.Install(scheme)).To(Succeed())
+
+			hostClient, err = ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterClient, err = ctrlclient.New(cluster.CurrentClusterFrom(ctx).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
+			Expect(err).To(Succeed())
+			vClusterName = cluster.CurrentClusterNameFrom(ctx)
+			vClusterHostNS = "vcluster-" + vClusterName
+		})
+
+		It("does not sync cross-namespace backendRef routes until a ReferenceGrant permits it", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-rg-"+suffix, gatewayClassSelectorValue, "referencegrant class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			frontend := createTenantNamespace(ctx, vClusterClient, "frontend-"+suffix)
+			backend := createTenantNamespace(ctx, vClusterClient, "backend-"+suffix)
+			gw := tenantGateway(frontend.Name, "gw-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-svc-" + suffix, Namespace: backend.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			By("creating a route whose backendRef crosses into another namespace")
+			route := crossNamespaceRoute(frontend.Name, "route-"+suffix, gw.Name, backend.Name, svc.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", frontend.Name, "x", vClusterName)
+			Consistently(func(g Gomega) {
+				err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryShort).Should(Succeed())
+
+			By("creating a ReferenceGrant in the backend namespace and expecting the route to sync")
+			grant := &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
+				Spec: gatewayv1beta1.ReferenceGrantSpec{
+					From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace(frontend.Name)}},
+					To:   []gatewayv1beta1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
+				},
+			}
+			Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, grant))).To(Succeed())
+			})
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("syncs opt-in TLSRoutes to the host and propagates updates and deletes", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ns := createTenantNamespace(ctx, vClusterClient, "tls-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			route := &gatewayv1alpha2.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "app-tls-" + suffix, Namespace: ns.Name},
+				Spec: gatewayv1alpha2.TLSRouteSpec{
+					Hostnames: []gatewayv1.Hostname{"app.apps.example.com"},
+					Rules: []gatewayv1alpha2.TLSRouteRule{{BackendRefs: []gatewayv1.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(svc.Name), Port: ptr.To(gatewayv1.PortNumber(443))},
+					}}}},
+				},
+			}
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha2.TLSRoute{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app.apps.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("patching the tenant TLSRoute hostname and expecting the host update")
+			current := &gatewayv1alpha2.TLSRoute{}
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(route), current)).To(Succeed())
+			current.Spec.Hostnames = []gatewayv1.Hostname{"app-updated.apps.example.com"}
+			Expect(vClusterClient.Update(ctx, current)).To(Succeed())
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha2.TLSRoute{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app-updated.apps.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the tenant TLSRoute and expecting host deletion")
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, hostKey, &gatewayv1alpha2.TLSRoute{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("syncs opt-in BackendTLSPolicies to the host with a translated targetRef", labels.PR, func(ctx context.Context) {
+			suffix := random.String(6)
+			ns := createTenantNamespace(ctx, vClusterClient, "btls-"+suffix)
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			policy := &gatewayv1alpha3.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "btls-" + suffix, Namespace: ns.Name},
+				Spec: gatewayv1.BackendTLSPolicySpec{
+					TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
+						LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service"), Name: gatewayv1.ObjectName(svc.Name)},
+					}},
+					Validation: gatewayv1.BackendTLSPolicyValidation{
+						WellKnownCACertificates: ptr.To(gatewayv1.WellKnownCACertificatesSystem),
+						Hostname:                gatewayv1.PreciseHostname("backend.apps.example.com"),
+					},
+				},
+			}
+			Expect(vClusterClient.Create(ctx, policy)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, policy))).To(Succeed())
+			})
+
+			hostPolicyName := translate.SafeConcatName(policy.Name, "x", ns.Name, "x", vClusterName)
+			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostPolicyName}
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha3.BackendTLSPolicy{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.TargetRefs).To(HaveLen(1))
+				g.Expect(string(got.Spec.TargetRefs[0].Name)).To(Equal(translate.SafeConcatName(svc.Name, "x", ns.Name, "x", vClusterName)))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("updating the policy hostname and expecting the host update")
+			current := &gatewayv1alpha3.BackendTLSPolicy{}
+			Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), current)).To(Succeed())
+			current.Spec.Validation.Hostname = gatewayv1.PreciseHostname("backend-updated.apps.example.com")
+			Expect(vClusterClient.Update(ctx, current)).To(Succeed())
+			Eventually(func(g Gomega) {
+				got := &gatewayv1alpha3.BackendTLSPolicy{}
+				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
+				g.Expect(got.Spec.Validation.Hostname).To(Equal(gatewayv1.PreciseHostname("backend-updated.apps.example.com")))
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			By("deleting the policy and expecting host deletion")
+			Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := hostClient.Get(ctx, hostKey, &gatewayv1alpha3.BackendTLSPolicy{})
+				g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+	})
+}
+
+func crossNamespaceRoute(namespace, name, gatewayName, backendNamespace, serviceName string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gatewayName), SectionName: ptr.To(gatewayv1.SectionName("http"))}}},
+			Rules: []gatewayv1.HTTPRouteRule{{BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name:      gatewayv1.ObjectName(serviceName),
+				Namespace: ptr.To(gatewayv1.Namespace(backendNamespace)),
+				Port:      ptr.To(gatewayv1.PortNumber(80)),
+			}}}}}},
+		},
+	}
+}

--- a/e2e-next/vcluster-gatewayapi-import.yaml
+++ b/e2e-next/vcluster-gatewayapi-import.yaml
@@ -1,0 +1,47 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-import
+    gateways:
+      enabled: true
+      mappings:
+        byName:
+          # Wildcard source namespace: any host Gateway in gwapi-host is imported
+          # into gwapi-import under the same name (allows random per-spec names).
+          "gwapi-host/*": "gwapi-import/*"
+          # Exact mappings for policy-override and rename cases (fixed names).
+          "gwapi-host-policy/selector-edge": "gwapi-import-policy/selector-edge"
+          "gwapi-host-policy/hostname-edge": "gwapi-import-policy/hostname-edge"
+          "gwapi-host-rename/source-edge": "gwapi-import-rename/renamed-edge"
+      allowedRoutes:
+        defaultVirtualNamespacePolicy:
+          from: All
+        overrides:
+          - hostNamespace: gwapi-host-policy
+            name: selector-edge
+            virtualNamespacePolicy:
+              from: Selector
+              selector:
+                matchLabels:
+                  team: apps
+          - hostNamespace: gwapi-host-policy
+            name: hostname-edge
+            allowedHostnames:
+              - "*.team-a.apps.example.com"
+      sanitize:
+        certificateRefs: true
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      httpRoutes:
+        enabled: true

--- a/e2e-next/vcluster-gatewayapi.yaml
+++ b/e2e-next/vcluster-gatewayapi.yaml
@@ -1,0 +1,23 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-vcluster
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      gateways:
+        enabled: true
+      httpRoutes:
+        enabled: true
+      referenceGrants:
+        enabled: true

--- a/e2e-next/vcluster-gatewayapi.yaml
+++ b/e2e-next/vcluster-gatewayapi.yaml
@@ -21,3 +21,7 @@ sync:
         enabled: true
       referenceGrants:
         enabled: true
+      tlsRoutes:
+        enabled: true
+      backendTLSPolicies:
+        enabled: true

--- a/pkg/controllers/resources/gatewayapi/authz/authz.go
+++ b/pkg/controllers/resources/gatewayapi/authz/authz.go
@@ -11,7 +11,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -317,69 +319,69 @@ func namespaceSelectorMatches(ctx *synccontext.SyncContext, routeNamespace strin
 
 // RegisterHTTPRouteWatches requeues HTTPRoutes when virtual authz inputs change.
 func RegisterHTTPRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return registerRouteWatches(ctx, builder, listHTTPRouteRequests)
+	return registerRouteWatches(ctx, builder, httpRouteListObject)
 }
 
 // RegisterTLSRouteWatches requeues TLSRoutes when virtual authz inputs change.
 func RegisterTLSRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return registerRouteWatches(ctx, builder, listTLSRouteRequests)
+	return registerRouteWatches(ctx, builder, tlsRouteListObject)
 }
 
-// RegisterGatewayWatches requeues Gateways when virtual ReferenceGrants change.
-func RegisterGatewayWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return builder.WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1beta1.ReferenceGrant{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1beta1.ReferenceGrant) []reconcile.Request {
-		return listGatewayRequests(mapCtx, ctx.VirtualManager.GetClient())
-	})))
+var (
+	referenceGrantWatchGVK = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1beta1.GroupVersion.Version, Kind: "ReferenceGrant"}
+	httpRouteListGVK       = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version, Kind: "HTTPRouteList"}
+	tlsRouteListGVK        = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1alpha2.GroupVersion.Version, Kind: "TLSRouteList"}
+)
+
+func referenceGrantWatchObject() *unstructured.Unstructured {
+	return unstructuredObject(referenceGrantWatchGVK)
 }
 
-func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder, listRequests func(context.Context, client.Client) []reconcile.Request) *builder.Builder {
+func httpRouteListObject() *unstructured.UnstructuredList {
+	return unstructuredList(httpRouteListGVK)
+}
+
+func tlsRouteListObject() *unstructured.UnstructuredList {
+	return unstructuredList(tlsRouteListGVK)
+}
+
+func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder, routeListObject func() *unstructured.UnstructuredList) *builder.Builder {
+	listRequests := func(mapCtx context.Context) []reconcile.Request {
+		return listRouteRequests(mapCtx, ctx.VirtualManager.GetClient(), routeListObject())
+	}
+
 	return builder.
-		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1beta1.ReferenceGrant{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1beta1.ReferenceGrant) []reconcile.Request {
-			return listRequests(mapCtx, ctx.VirtualManager.GetClient())
+		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), referenceGrantWatchObject(), handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *unstructured.Unstructured) []reconcile.Request {
+			return listRequests(mapCtx)
 		}))).
 		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1.Gateway{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1.Gateway) []reconcile.Request {
-			return listRequests(mapCtx, ctx.VirtualManager.GetClient())
+			return listRequests(mapCtx)
 		}))).
 		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &corev1.Namespace{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *corev1.Namespace) []reconcile.Request {
-			return listRequests(mapCtx, ctx.VirtualManager.GetClient())
+			return listRequests(mapCtx)
 		})))
 }
 
-func listHTTPRouteRequests(ctx context.Context, c client.Client) []reconcile.Request {
-	list := &gatewayv1.HTTPRouteList{}
+func listRouteRequests(ctx context.Context, c client.Client, list *unstructured.UnstructuredList) []reconcile.Request {
 	if err := c.List(ctx, list); err != nil {
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(list.Items))
 	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.GetName(), Namespace: item.GetNamespace()}})
 	}
 	return requests
 }
 
-func listTLSRouteRequests(ctx context.Context, c client.Client) []reconcile.Request {
-	list := &gatewayv1alpha2.TLSRouteList{}
-	if err := c.List(ctx, list); err != nil {
-		return nil
-	}
-
-	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
-	}
-	return requests
+func unstructuredObject(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	return obj
 }
 
-func listGatewayRequests(ctx context.Context, c client.Client) []reconcile.Request {
-	list := &gatewayv1.GatewayList{}
-	if err := c.List(ctx, list); err != nil {
-		return nil
-	}
-
-	requests := make([]reconcile.Request, 0, len(list.Items))
-	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
-	}
-	return requests
+func unstructuredList(gvk schema.GroupVersionKind) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+	return list
 }

--- a/pkg/controllers/resources/gatewayclasses/syncer.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer.go
@@ -2,6 +2,7 @@ package gatewayclasses
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/loft-sh/vcluster/pkg/mappings/generic"
 	mapperresources "github.com/loft-sh/vcluster/pkg/mappings/resources"
@@ -61,12 +62,13 @@ func (g *gatewayClassSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *
 	}
 
 	vObj := translate.CopyObjectWithName(event.Host, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, false)
-	vObj.Spec = gatewayClassSpecToVirtual(event.Host.Spec)
+	vObj.Spec = *event.Host.Spec.DeepCopy()
 
 	err = pro.ApplyPatchesVirtualObject(ctx, nil, vObj, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
 	}
+	vObj.Spec = gatewayClassSpecToVirtual(vObj.Spec)
 
 	ctx.Log.Infof("create GatewayClass %s, because it does not exist in virtual cluster", vObj.Name)
 	return patcher.CreateVirtualObject(ctx, event.Host, vObj, g.EventRecorder(), true)
@@ -83,7 +85,7 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, reason)
 	}
 
-	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual, patcher.TranslatePatches(ctx.Config.Sync.FromHost.GatewayClasses.Patches, true))
+	patch, err := patcher.NewSyncerPatcher(ctx, event.Host, event.Virtual)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("new syncer patcher: %w", err)
 	}
@@ -94,9 +96,13 @@ func (g *gatewayClassSyncer) Sync(ctx *synccontext.SyncContext, event *syncconte
 	}()
 
 	// GatewayClasses are mirrored from the host cluster, so host metadata wins.
-	event.Virtual.Annotations = event.Host.Annotations
-	event.Virtual.Labels = event.Host.Labels
-	event.Virtual.Spec = gatewayClassSpecToVirtual(event.Host.Spec)
+	event.Virtual.Annotations = maps.Clone(event.Host.Annotations)
+	event.Virtual.Labels = maps.Clone(event.Host.Labels)
+	event.Virtual.Spec = *event.Host.Spec.DeepCopy()
+	if err := pro.ApplyPatchesVirtualObject(ctx, nil, event.Virtual, event.Host, ctx.Config.Sync.FromHost.GatewayClasses.Patches, true); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error applying patches: %w", err)
+	}
+	event.Virtual.Spec = gatewayClassSpecToVirtual(event.Virtual.Spec)
 	event.Virtual.Status = event.Host.Status
 	return ctrl.Result{}, nil
 }
@@ -122,12 +128,8 @@ func (g *gatewayClassSyncer) recordDeleteWarning(gwClass *gatewayv1.GatewayClass
 
 func gatewayClassSpecToVirtual(hostSpec gatewayv1.GatewayClassSpec) gatewayv1.GatewayClassSpec {
 	virtualSpec := *hostSpec.DeepCopy()
-	if virtualSpec.ParametersRef != nil {
-		virtualSpec.ParametersRef = virtualSpec.ParametersRef.DeepCopy()
-		// GatewayClasses are cluster-scoped mirrors. Keep host topology details out
-		// of the tenant view when the parameters object lives in a host namespace.
-		virtualSpec.ParametersRef.Namespace = nil
-	}
+	// Tenant-visible GatewayClasses must not expose Host parametersRef topology.
+	virtualSpec.ParametersRef = nil
 
 	return virtualSpec
 }

--- a/pkg/controllers/resources/gatewayclasses/syncer_test.go
+++ b/pkg/controllers/resources/gatewayclasses/syncer_test.go
@@ -1,0 +1,139 @@
+package gatewayclasses
+
+import (
+	"context"
+	"testing"
+
+	rootconfig "github.com/loft-sh/vcluster/config"
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/pro"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestGatewayClassSpecToVirtualRemovesParametersRefAndPreservesTenantVisibleFields(t *testing.T) {
+	description := "tenant visible class"
+	hostSpec := gatewayv1.GatewayClassSpec{
+		ControllerName: "example.com/gateway-controller",
+		Description:    &description,
+		ParametersRef:  gatewayClassParametersRef("host-config", "host-only"),
+	}
+
+	got := gatewayClassSpecToVirtual(hostSpec)
+	if got.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to be removed, got %#v", got.ParametersRef)
+	}
+	if got.ControllerName != hostSpec.ControllerName {
+		t.Fatalf("expected controllerName %q, got %q", hostSpec.ControllerName, got.ControllerName)
+	}
+	if got.Description == nil || *got.Description != description {
+		t.Fatalf("expected description %q, got %#v", description, got.Description)
+	}
+}
+
+func TestGatewayClassSyncToVirtualSanitizesParametersRefAfterPatches(t *testing.T) {
+	withGatewayClassPatchThatAddsParametersRef(t)
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.GatewayClasses.Enabled = true
+	vcConfig.Sync.FromHost.GatewayClasses.Patches = []rootconfig.TranslatePatch{{Path: "spec.parametersRef.name", Expression: "'patched-config'"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, New)
+	syncer := object.(*gatewayClassSyncer)
+
+	host := gatewayClass("tenant-class")
+	_, err := syncer.SyncToVirtual(syncCtx, synccontext.NewSyncToVirtualEvent(host))
+	if err != nil {
+		t.Fatalf("sync to virtual: %v", err)
+	}
+
+	got := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, got); err != nil {
+		t.Fatalf("expected virtual GatewayClass to be created: %v", err)
+	}
+	if got.Spec.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to remain sanitized after create patches, got %#v", got.Spec.ParametersRef)
+	}
+}
+
+func TestGatewayClassSyncSanitizesParametersRefAfterPatches(t *testing.T) {
+	withGatewayClassPatchThatAddsParametersRef(t)
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.GatewayClasses.Enabled = true
+	vcConfig.Sync.FromHost.GatewayClasses.Patches = []rootconfig.TranslatePatch{{Path: "spec.parametersRef.name", Expression: "'patched-config'"}}
+	host := gatewayClass("tenant-class")
+	virtual := &gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: host.Name}, Spec: gatewayv1.GatewayClassSpec{ControllerName: "old.example.com/controller"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme, host)
+	vClient := testingutil.NewFakeClient(scheme.Scheme, virtual.DeepCopy())
+	registerCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient)
+	syncCtx, object := syncertesting.FakeStartSyncer(t, registerCtx, New)
+	syncer := object.(*gatewayClassSyncer)
+	currentVirtual := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, currentVirtual); err != nil {
+		t.Fatalf("get current virtual GatewayClass: %v", err)
+	}
+
+	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, currentVirtual))
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	got := &gatewayv1.GatewayClass{}
+	if err := vClient.Get(context.Background(), types.NamespacedName{Name: host.Name}, got); err != nil {
+		t.Fatalf("expected virtual GatewayClass to be updated: %v", err)
+	}
+	if got.Spec.ParametersRef != nil {
+		t.Fatalf("expected parametersRef to remain sanitized after update patches, got %#v", got.Spec.ParametersRef)
+	}
+}
+
+func withGatewayClassPatchThatAddsParametersRef(t *testing.T) {
+	t.Helper()
+	origVirtual := pro.ApplyPatchesVirtualObject
+	origHost := pro.ApplyPatchesHostObject
+	patchFn := func(_ *synccontext.SyncContext, _, obj, _ client.Object, _ []rootconfig.TranslatePatch, _ bool) error {
+		gwClass, ok := obj.(*gatewayv1.GatewayClass)
+		if ok {
+			gwClass.Spec.ParametersRef = gatewayClassParametersRef("patched-config", "patched-namespace")
+		}
+		return nil
+	}
+	pro.ApplyPatchesVirtualObject = patchFn
+	pro.ApplyPatchesHostObject = patchFn
+	t.Cleanup(func() {
+		pro.ApplyPatchesVirtualObject = origVirtual
+		pro.ApplyPatchesHostObject = origHost
+	})
+}
+
+func gatewayClass(name string) *gatewayv1.GatewayClass {
+	description := "tenant visible class"
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "example.com/gateway-controller",
+			Description:    &description,
+			ParametersRef:  gatewayClassParametersRef(name+"-config", "host-only"),
+		},
+	}
+}
+
+func gatewayClassParametersRef(name string, namespace string) *gatewayv1.ParametersReference {
+	ns := gatewayv1.Namespace(namespace)
+	return &gatewayv1.ParametersReference{
+		Group:     gatewayv1.Group("example.com"),
+		Kind:      gatewayv1.Kind("GatewayClassConfig"),
+		Name:      name,
+		Namespace: &ns,
+	}
+}
+
+var _ runtime.Object = &gatewayv1.GatewayClass{}

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -261,8 +261,8 @@ func gatewaySpecToVirtual(ctx *synccontext.SyncContext, host *gatewayv1.Gateway)
 	}
 	policy := virtualNamespacePolicyFor(ctx, host)
 	for i := range spec.Listeners {
-		if ctx.Config.Sync.FromHost.Gateways.Sanitize.CertificateRefs {
-			spec.Listeners[i].TLS = nil
+		if ctx.Config.Sync.FromHost.Gateways.Sanitize.CertificateRefs && spec.Listeners[i].TLS != nil {
+			spec.Listeners[i].TLS.CertificateRefs = nil
 		}
 		if policy != nil {
 			spec.Listeners[i].AllowedRoutes = toGatewayAllowedRoutes(policy)
@@ -281,7 +281,7 @@ func gatewayStatusToVirtual(ctx *synccontext.SyncContext, status gatewayv1.Gatew
 
 func virtualNamespacePolicyFor(ctx *synccontext.SyncContext, host *gatewayv1.Gateway) *rootconfig.GatewayVirtualNamespacePolicy {
 	for _, override := range ctx.Config.Sync.FromHost.Gateways.AllowedRoutes.Overrides {
-		if override.HostNamespace == host.Namespace && override.Name == host.Name {
+		if override.HostNamespace == host.Namespace && override.Name == host.Name && override.VirtualNamespacePolicy.From != "" {
 			return &override.VirtualNamespacePolicy
 		}
 	}

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -71,7 +71,7 @@ func NewToHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, erro
 	}
 
 	return &tenantGatewaySyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "gateway", &gatewayv1.Gateway{}, mapper),
+		GenericTranslator: translator.NewGenericTranslator(ctx, "tenant-gateway", &gatewayv1.Gateway{}, mapper),
 	}, nil
 }
 
@@ -168,7 +168,7 @@ func tenantGatewayEligible(ctx *synccontext.SyncContext, s *tenantGatewaySyncer,
 	gatewayClass := &gatewayv1.GatewayClass{}
 	err := ctx.VirtualClient.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass)
 	if kerrors.IsNotFound(err) {
-		s.EventRecorder().Eventf(gateway, nil, "Warning", "SyncWarning", "SyncGateway", "GatewayClass %q is not visible in the virtual cluster", gateway.Spec.GatewayClassName)
+		s.EventRecorder().Eventf(gateway, nil, "Warning", "SyncWarning", "SyncGateway", "GatewayClass %q is not available in this virtual cluster", gateway.Spec.GatewayClassName)
 		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("get virtual GatewayClass %q: %w", gateway.Spec.GatewayClassName, err)

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -24,24 +24,94 @@ func TestGatewaySpecToVirtualSanitizesTLSInfrastructureAndAppliesVirtualAllowedR
 	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.DefaultVirtualNamespacePolicy = &rootconfig.GatewayVirtualNamespacePolicy{From: string(gatewayv1.NamespacesFromAll)}
 	ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
 	vcConfig.Sync.FromHost.Gateways.Sanitize.Infrastructure = true
+	terminate := gatewayv1.TLSModeTerminate
 	host := &gatewayv1.Gateway{Spec: gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{}, Listeners: []gatewayv1.Listener{{
 		Name:     "https",
 		Protocol: gatewayv1.HTTPSProtocolType,
 		Port:     443,
-		TLS: &gatewayv1.ListenerTLSConfig{CertificateRefs: []gatewayv1.SecretObjectReference{{
-			Name: "edge-cert",
-		}}},
+		TLS: &gatewayv1.ListenerTLSConfig{
+			Mode: &terminate,
+			CertificateRefs: []gatewayv1.SecretObjectReference{{
+				Name: "edge-cert",
+			}},
+		},
 	}}}}
 
 	spec := gatewaySpecToVirtual(ctx, host)
-	if spec.Listeners[0].TLS != nil {
-		t.Fatalf("expected TLS config to be sanitized")
+	if spec.Listeners[0].TLS == nil {
+		t.Fatalf("expected TLS config to preserve mode while sanitizing certificateRefs")
+	}
+	if spec.Listeners[0].TLS.Mode == nil || *spec.Listeners[0].TLS.Mode != gatewayv1.TLSModeTerminate {
+		t.Fatalf("expected TLS mode to be preserved, got %#v", spec.Listeners[0].TLS.Mode)
+	}
+	if len(spec.Listeners[0].TLS.CertificateRefs) != 0 {
+		t.Fatalf("expected TLS certificateRefs to be sanitized, got %#v", spec.Listeners[0].TLS.CertificateRefs)
 	}
 	if spec.Infrastructure != nil {
 		t.Fatalf("expected infrastructure to be sanitized")
 	}
 	if spec.Listeners[0].AllowedRoutes == nil || spec.Listeners[0].AllowedRoutes.Namespaces == nil || *spec.Listeners[0].AllowedRoutes.Namespaces.From != gatewayv1.NamespacesFromAll {
 		t.Fatalf("expected tenant-facing allowedRoutes from All, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+}
+
+func TestGatewaySpecToVirtualAllowedHostnameOverrideInheritsDefaultNamespacePolicy(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.DefaultVirtualNamespacePolicy = &rootconfig.GatewayVirtualNamespacePolicy{From: string(gatewayv1.NamespacesFromAll)}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.Overrides = []rootconfig.GatewayAllowedRoutesPolicyOverride{{
+		HostNamespace:    "networking",
+		Name:             "shared-edge",
+		AllowedHostnames: []string{"*.apps.example.com"},
+	}}
+	ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
+	host := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "networking", Name: "shared-edge"},
+		Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{
+			Name:     "http",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     80,
+		}}},
+	}
+
+	spec := gatewaySpecToVirtual(ctx, host)
+	if spec.Listeners[0].AllowedRoutes == nil || spec.Listeners[0].AllowedRoutes.Namespaces == nil || spec.Listeners[0].AllowedRoutes.Namespaces.From == nil {
+		t.Fatalf("expected hostname-only override to inherit default tenant-facing allowedRoutes, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+	if *spec.Listeners[0].AllowedRoutes.Namespaces.From != gatewayv1.NamespacesFromAll {
+		t.Fatalf("expected hostname-only override to inherit default namespace policy from All, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+}
+
+func TestGatewaySpecToVirtualExplicitOverrideReplacesDefaultNamespacePolicy(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.DefaultVirtualNamespacePolicy = &rootconfig.GatewayVirtualNamespacePolicy{From: string(gatewayv1.NamespacesFromAll)}
+	vcConfig.Sync.FromHost.Gateways.AllowedRoutes.Overrides = []rootconfig.GatewayAllowedRoutesPolicyOverride{{
+		HostNamespace: "networking",
+		Name:          "shared-edge",
+		VirtualNamespacePolicy: rootconfig.GatewayVirtualNamespacePolicy{
+			From: string(gatewayv1.NamespacesFromSelector),
+			Selector: rootconfig.StandardLabelSelector{
+				MatchLabels: map[string]string{"team": "apps"},
+			},
+		},
+	}}
+	ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
+	host := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "networking", Name: "shared-edge"},
+		Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{
+			Name:     "http",
+			Protocol: gatewayv1.HTTPProtocolType,
+			Port:     80,
+		}}},
+	}
+
+	spec := gatewaySpecToVirtual(ctx, host)
+	got := spec.Listeners[0].AllowedRoutes
+	if got == nil || got.Namespaces == nil || got.Namespaces.From == nil || *got.Namespaces.From != gatewayv1.NamespacesFromSelector {
+		t.Fatalf("expected explicit override selector policy, got %#v", got)
+	}
+	if got.Namespaces.Selector == nil || got.Namespaces.Selector.MatchLabels["team"] != "apps" {
+		t.Fatalf("expected explicit override selector labels, got %#v", got.Namespaces.Selector)
 	}
 }
 

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -107,7 +107,7 @@ func TestTenantGatewaySyncToHostCreatesGatewayWhenExplicitlyEnabled(t *testing.T
 	}
 }
 
-func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
+func TestTenantGatewaySyncSkipsUnavailableVirtualGatewayClass(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 	pClient := testingutil.NewFakeClient(scheme.Scheme)
@@ -119,7 +119,7 @@ func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
 	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
 	_, err := syncer.SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(virtual))
 	if err != nil {
-		t.Fatalf("expected missing GatewayClass to be a warning/skip, not hard error: %v", err)
+		t.Fatalf("expected unavailable GatewayClass to skip without reconcile error, got %v", err)
 	}
 
 	expected := translate.Default.HostName(syncCtx, "edge", "team-a")
@@ -129,7 +129,7 @@ func TestTenantGatewaySyncRequiresVirtualGatewayClass(t *testing.T) {
 	}
 }
 
-func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassDisappears(t *testing.T) {
+func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassBecomesUnavailable(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
 	hostName := types.NamespacedName{Namespace: testingutil.DefaultTestTargetNamespace, Name: "edge-x-team-a-x-suffix"}
@@ -143,12 +143,12 @@ func TestTenantGatewaySyncDeletesExistingHostWhenGatewayClassDisappears(t *testi
 	virtual := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"}, Spec: gatewayv1.GatewaySpec{GatewayClassName: gatewayv1.ObjectName("missing")}}
 	_, err := syncer.Sync(syncCtx, synccontext.NewSyncEvent(host, virtual))
 	if err != nil {
-		t.Fatalf("expected missing GatewayClass to delete stale host Gateway without hard error: %v", err)
+		t.Fatalf("expected unavailable GatewayClass update to delete host without reconcile error, got %v", err)
 	}
 
 	got := &gatewayv1.Gateway{}
 	if err := pClient.Get(context.Background(), hostName, got); err == nil {
-		t.Fatalf("expected stale host Gateway to be deleted")
+		t.Fatalf("expected existing host Gateway to be deleted when GatewayClass becomes unavailable")
 	}
 }
 

--- a/pkg/controllers/resources/register.go
+++ b/pkg/controllers/resources/register.go
@@ -160,5 +160,5 @@ func gatewayReferenceGrantsEnabled(ctx *synccontext.RegisterContext) bool {
 	if mode == "false" {
 		return false
 	}
-	return ctx.Config.Sync.ToHost.Namespaces.Enabled && (gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx))
+	return gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx)
 }

--- a/pkg/controllers/resources/register_gateway_test.go
+++ b/pkg/controllers/resources/register_gateway_test.go
@@ -48,3 +48,13 @@ func TestReferenceGrantAutoDoesNotFollowGatewaySyncAlone(t *testing.T) {
 		t.Fatalf("referenceGrants=auto should not be enabled by Gateway sync alone")
 	}
 }
+
+func TestReferenceGrantAutoFollowsHTTPRouteSyncWithoutNamespaceSync(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+
+	if !gatewayReferenceGrantsEnabled(ctx) {
+		t.Fatalf("referenceGrants=auto should install the tenant CRD when HTTPRoute sync watches ReferenceGrant")
+	}
+}

--- a/pkg/mappings/resources/register.go
+++ b/pkg/mappings/resources/register.go
@@ -106,5 +106,5 @@ func gatewayReferenceGrantsEnabled(ctx *synccontext.RegisterContext) bool {
 	if mode == "false" {
 		return false
 	}
-	return ctx.Config.Sync.ToHost.Namespaces.Enabled && (gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx))
+	return gatewayHTTPRoutesEnabled(ctx) || gatewayTLSRoutesEnabled(ctx) || gatewayBackendTLSPoliciesEnabled(ctx)
 }

--- a/pkg/mappings/resources/register_gateway_test.go
+++ b/pkg/mappings/resources/register_gateway_test.go
@@ -1,0 +1,39 @@
+package resources
+
+import (
+	"testing"
+
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestReferenceGrantAutoFollowsHTTPRouteMapperWithoutNamespaceSync(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+
+	if !gatewayReferenceGrantsEnabled(ctx) {
+		t.Fatalf("referenceGrants=auto should install the tenant CRD when HTTPRoute mapper watches ReferenceGrant")
+	}
+}
+
+func TestReferenceGrantAutoDoesNotFollowGatewayMapperAlone(t *testing.T) {
+	ctx := &synccontext.RegisterContext{Config: &pkgconfig.VirtualClusterConfig{}}
+	ctx.Config.Sync.ToHost.Namespaces.Enabled = true
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "auto"
+	ctx.Config.Sync.ToHost.GatewayAPI.Gateways.Enabled = true
+
+	if gatewayReferenceGrantsEnabled(ctx) {
+		t.Fatalf("referenceGrants=auto should not be enabled by Gateway mapper alone")
+	}
+}
+
+func TestTLSRouteMapperKeepsOlderServedVersionForCompatibility(t *testing.T) {
+	want := schema.GroupVersion{Group: gatewayv1alpha2.GroupVersion.Group, Version: gatewayv1alpha2.GroupVersion.Version}
+	if got := mappings.TLSRoutes().GroupVersion(); got != want {
+		t.Fatalf("expected TLSRoute mapper to keep older served version %s for Gateway API compatibility, got %s", want, got)
+	}
+}

--- a/pkg/setup/controller_context.go
+++ b/pkg/setup/controller_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // NewLocalManager is used to create a new local manager
@@ -114,8 +116,10 @@ func NewControllerContext(ctx context.Context, options *config.VirtualClusterCon
 func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 	// is multi namespace mode?
 	defaultNamespaces := make(map[string]cache.Config)
+	gatewayNamespaces := map[string]cache.Config(nil)
 	if !options.Sync.ToHost.Namespaces.Enabled {
 		defaultNamespaces[options.HostNamespace] = cache.Config{}
+		gatewayNamespaces = fromHostGatewaySourceNamespaces(options)
 	}
 	// do we need access to another namespace to export the kubeconfig ?
 	// we will need access to all the objects that the vcluster usually has access to
@@ -126,11 +130,39 @@ func getLocalCacheOptions(options *config.VirtualClusterConfig) cache.Options {
 		}
 	}
 
-	if len(defaultNamespaces) == 0 {
+	if len(defaultNamespaces) == 0 && len(gatewayNamespaces) == 0 {
 		return cache.Options{DefaultNamespaces: nil}
 	}
 
-	return cache.Options{DefaultNamespaces: defaultNamespaces}
+	cacheOptions := cache.Options{DefaultNamespaces: defaultNamespaces}
+	if len(gatewayNamespaces) > 0 {
+		for namespace := range defaultNamespaces {
+			gatewayNamespaces[namespace] = cache.Config{}
+		}
+		cacheOptions.ByObject = map[client.Object]cache.ByObject{
+			&gatewayv1.Gateway{}: {Namespaces: gatewayNamespaces},
+		}
+	}
+
+	return cacheOptions
+}
+
+func fromHostGatewaySourceNamespaces(options *config.VirtualClusterConfig) map[string]cache.Config {
+	if !options.Sync.FromHost.Gateways.Enabled {
+		return nil
+	}
+
+	gatewayNamespaces := map[string]cache.Config{}
+	for hostName := range options.Sync.FromHost.Gateways.Mappings.ByName {
+		hostNamespace, _, hasName := strings.Cut(hostName, "/")
+		if !hasName || hostNamespace == "" {
+			continue
+		}
+
+		gatewayNamespaces[hostNamespace] = cache.Config{}
+	}
+
+	return gatewayNamespaces
 }
 
 func startPlugins(ctx context.Context, virtualConfig *rest.Config, virtualRawConfig *clientcmdapi.Config, options *config.VirtualClusterConfig) error {

--- a/pkg/setup/controller_context_gateway_test.go
+++ b/pkg/setup/controller_context_gateway_test.go
@@ -1,0 +1,67 @@
+package setup
+
+import (
+	"testing"
+
+	rootconfig "github.com/loft-sh/vcluster/config"
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestLocalCacheWatchesFromHostGatewayMappingSourceNamespaces(t *testing.T) {
+	options := &pkgconfig.VirtualClusterConfig{}
+	options.HostNamespace = "loft-default-v-test"
+	options.Sync.FromHost.Gateways.Enabled = true
+	options.Sync.FromHost.Gateways.Mappings.ByName = map[string]string{
+		"platform-gateways/*":          "shared-gateways/*",
+		"platform-ingress/shared-edge": "shared-gateways/shared-edge",
+	}
+
+	cacheOptions := getLocalCacheOptions(options)
+	if _, ok := cacheOptions.DefaultNamespaces["loft-default-v-test"]; !ok {
+		t.Fatalf("expected default local cache to watch host namespace, got %#v", cacheOptions.DefaultNamespaces)
+	}
+	for _, namespace := range []string{"platform-gateways", "platform-ingress"} {
+		if _, ok := cacheOptions.DefaultNamespaces[namespace]; ok {
+			t.Fatalf("expected default local cache not to watch gateway source namespace %q, got %#v", namespace, cacheOptions.DefaultNamespaces)
+		}
+	}
+
+	gatewayNamespaces := gatewayCacheNamespaces(t, cacheOptions)
+	for _, namespace := range []string{"loft-default-v-test", "platform-gateways", "platform-ingress"} {
+		if _, ok := gatewayNamespaces[namespace]; !ok {
+			t.Fatalf("expected Gateway cache to watch namespace %q, got %#v", namespace, gatewayNamespaces)
+		}
+	}
+}
+
+func TestLocalCacheDoesNotAddVirtualGatewayMappingNamespaces(t *testing.T) {
+	options := &pkgconfig.VirtualClusterConfig{}
+	options.HostNamespace = "loft-default-v-test"
+	options.Sync.FromHost.Gateways.Enabled = true
+	options.Sync.FromHost.Gateways.Mappings = rootconfig.FromHostMappings{ByName: map[string]string{
+		"platform-gateways/public-web": "shared-gateways/shared-web",
+	}}
+
+	cacheOptions := getLocalCacheOptions(options)
+	if _, ok := cacheOptions.DefaultNamespaces["shared-gateways"]; ok {
+		t.Fatalf("expected default local cache not to watch virtual gateway mapping namespace, got %#v", cacheOptions.DefaultNamespaces)
+	}
+	if _, ok := gatewayCacheNamespaces(t, cacheOptions)["shared-gateways"]; ok {
+		t.Fatalf("expected Gateway cache to watch host source namespaces only, got %#v", cacheOptions.ByObject)
+	}
+}
+
+func gatewayCacheNamespaces(t *testing.T, cacheOptions cache.Options) map[string]cache.Config {
+	t.Helper()
+
+	for obj, byObject := range cacheOptions.ByObject {
+		if _, ok := obj.(*gatewayv1.Gateway); ok {
+			return byObject.Namespaces
+		}
+	}
+
+	t.Fatalf("expected Gateway cache ByObject config, got %#v", cacheOptions.ByObject)
+	return nil
+}


### PR DESCRIPTION
## Comes after #3985 

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGQA-1092


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
