### PR TITLE
chore(e2e-next): fix setup for csi.go tests

### DIFF
--- a/e2e-next/setup/csi.go
+++ b/e2e-next/setup/csi.go
@@ -38,6 +38,21 @@ func InstallCSIHostpath(kubeContext string) func(ctx context.Context) error {
 			return fmt.Errorf("install snapshot CRDs: %w", err)
 		}
 
+		// Wait for the snapshot CRDs to be Established before continuing. deploy.sh
+		// applies a VolumeSnapshotClass, which fails with "no matches for kind
+		// VolumeSnapshotClass" if the apiserver has not finished registering the
+		// CRD yet. Waiting here makes the CRDs discoverable for every caller,
+		// including parallel SnapshotPreSetup runs in other Ginkgo processes.
+		establishCmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=established",
+			"--timeout=60s", "--context", kubeContext, "crd",
+			"volumesnapshotclasses.snapshot.storage.k8s.io",
+			"volumesnapshotcontents.snapshot.storage.k8s.io",
+			"volumesnapshots.snapshot.storage.k8s.io",
+		)
+		if out, err := establishCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("wait for snapshot CRDs to be established: %s: %w", string(out), err)
+		}
+
 		// Install snapshot-controller
 		if err := kubectlApplyKustomize(ctx, kubeContext,
 			"https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref="+externalSnapshotterVersion); err != nil {
@@ -61,15 +76,24 @@ func InstallCSIHostpath(kubeContext string) func(ctx context.Context) error {
 		// csi-sanity/csc testing and its StatefulSet is flaky on Kind.
 		_ = os.Remove(filepath.Join(tmpDir, "deploy", "kubernetes-latest", "hostpath", "csi-hostpath-testing.yaml"))
 
-		// Set the kubectl context before running deploy.sh so the CSI driver
-		// is installed into the correct cluster even when multiple contexts exist.
-		setCtxCmd := exec.CommandContext(ctx, "kubectl", "config", "use-context", kubeContext)
-		if out, err := setCtxCmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("set kubectl context to %s: %s: %w", kubeContext, string(out), err)
+		// deploy.sh operates on the current kubeconfig context. Rather than mutate
+		// the shared ~/.kube/config with `kubectl config use-context` (which races
+		// when multiple installs run in parallel Ginkgo processes), write an
+		// isolated kubeconfig minified to the target context and point deploy.sh at
+		// it via KUBECONFIG. The temp dir is removed by the deferred cleanup above.
+		kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+		viewCmd := exec.CommandContext(ctx, "kubectl", "config", "view", "--raw", "--minify", "--context", kubeContext)
+		kubeconfigData, err := viewCmd.Output()
+		if err != nil {
+			return fmt.Errorf("export kubeconfig for context %s: %w", kubeContext, err)
+		}
+		if err := os.WriteFile(kubeconfigPath, kubeconfigData, 0o600); err != nil {
+			return fmt.Errorf("write isolated kubeconfig: %w", err)
 		}
 
 		deployScript := tmpDir + "/deploy/kubernetes-latest/deploy.sh"
 		deployCmd := exec.CommandContext(ctx, "bash", deployScript)
+		deployCmd.Env = append(os.Environ(), "KUBECONFIG="+kubeconfigPath)
 		if out, err := deployCmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("deploy CSI hostpath driver: %s: %w", string(out), err)
 		}


### PR DESCRIPTION
Resolves ENGQA-1085

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #
Resolves ENGQA-1085

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```
