### PR TITLE
fix: install tenant referencegrant crd whenever route sync is enabled

### DIFF
--- a/e2e-next/suite_gatewayapi_grants_disabled_test.go
+++ b/e2e-next/suite_gatewayapi_grants_disabled_test.go
@@ -1,0 +1,44 @@
+// Suite: gatewayapi-grants-disabled-vcluster
+// vCluster: Gateway API route sync with referenceGrants.enabled "false" —
+// route controllers must start and virtual ReferenceGrants must stay
+// authoritative for cross-namespace refs without syncing to the host.
+// Run:      just run-e2e 'pr && gatewayapi'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	"github.com/loft-sh/vcluster/e2e-next/test_gatewayapi"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+//go:embed vcluster-gatewayapi-grants-disabled.yaml
+var gatewayAPIGrantsDisabledVClusterYAML string
+
+const gatewayAPIGrantsDisabledVClusterName = "gatewayapi-grants-disabled-vcluster"
+
+func init() { suiteGatewayAPIGrantsDisabledVCluster() }
+
+func suiteGatewayAPIGrantsDisabledVCluster() {
+	// Ordered so all specs share one lazyvcluster bring-up; specs are independent.
+	Describe("gatewayapi-grants-disabled-vcluster", labels.PR, labels.GatewayAPI, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				return lazyvcluster.LazyVCluster(ctx,
+					gatewayAPIGrantsDisabledVClusterName,
+					gatewayAPIGrantsDisabledVClusterYAML,
+					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
+				)
+			})
+
+			test_gatewayapi.GatewayAPIGrantsDisabledSpec()
+		},
+	)
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_grants_disabled.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_grants_disabled.go
@@ -1,0 +1,154 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+const grantsDisabledGatewayClassSelectorValue = "gatewayapi-grants-disabled-vcluster"
+
+// GatewayAPIGrantsDisabledSpec registers route sync tests for a vCluster with
+// sync.toHost.gatewayApi.referenceGrants.enabled set to "false" while route
+// sync stays on. Disabling grant sync must not break the route controllers and
+// must keep virtual ReferenceGrants authoritative for cross-namespace refs.
+func GatewayAPIGrantsDisabledSpec() {
+	Describe("Gateway API toHost with ReferenceGrant sync disabled", labels.GatewayAPI, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			clients := newGatewayAPIClients(ctx, true)
+			hostClient = clients.HostClient
+			vClusterClient = clients.VClusterClient
+			vClusterName = clients.VClusterName
+			vClusterHostNS = clients.VClusterHostNS
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("syncs HTTPRoutes to the host while ReferenceGrant sync is disabled", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-rgd-"+suffix, grantsDisabledGatewayClassSelectorValue, "grants disabled class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			ns := createTenantNamespace(ctx, vClusterClient, "rgd-app-"+suffix)
+			gw := tenantGateway(ns.Name, "gw-rgd-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			hostGatewayName := translate.SafeConcatName(gw.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "rgd-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			route := tenantHTTPRoute(ns.Name, "route-rgd-"+suffix, gw.Name, svc.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("authorizes cross-namespace backendRefs via virtual ReferenceGrants without syncing grants to the host", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-rgd-xns-"+suffix, grantsDisabledGatewayClassSelectorValue, "grants disabled cross-namespace class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			frontend := createTenantNamespace(ctx, vClusterClient, "rgd-frontend-"+suffix)
+			backend := createTenantNamespace(ctx, vClusterClient, "rgd-backend-"+suffix)
+			gw := tenantGateway(frontend.Name, "gw-rgd-xns-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			hostGatewayName := translate.SafeConcatName(gw.Name, "x", frontend.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "rgd-xns-backend-" + suffix, Namespace: backend.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			var hostRouteName string
+			var route *gatewayv1.HTTPRoute
+			var grant *gatewayv1beta1.ReferenceGrant
+
+			By("creating a route whose backendRef crosses into another namespace and expecting no host sync", func() {
+				route = crossNamespaceRoute(frontend.Name, "route-rgd-xns-"+suffix, gw.Name, backend.Name, svc.Name)
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+
+				hostRouteName = translate.SafeConcatName(route.Name, "x", frontend.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "host route %s should stay absent until a grant permits it, got error: %v", hostRouteName, err)
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+
+			By("creating a virtual ReferenceGrant and expecting the route to sync", func() {
+				// The ReferenceGrant CRD must be served in the tenant cluster even
+				// with grant sync disabled — virtual grants still govern
+				// cross-namespace authorization.
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.List(ctx, &gatewayv1beta1.ReferenceGrantList{}, ctrlclient.InNamespace(backend.Name))).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+				grant = &gatewayv1beta1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-rgd-" + suffix, Namespace: backend.Name},
+					Spec: gatewayv1beta1.ReferenceGrantSpec{
+						From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: gatewayv1.Namespace(frontend.Name)}},
+						To:   []gatewayv1beta1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+					},
+				}
+				Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, grant))).To(Succeed())
+				})
+				Eventually(func(g Gomega) {
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("expecting the virtual ReferenceGrant to never sync to the host", func() {
+				hostGrantName := translate.SafeConcatName(grant.Name, "x", backend.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGrantName}, &gatewayv1beta1.ReferenceGrant{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "host grant %s should not exist with grant sync disabled, got error: %v", hostGrantName, err)
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+		})
+	})
+}

--- a/e2e-next/vcluster-gatewayapi-grants-disabled.yaml
+++ b/e2e-next/vcluster-gatewayapi-grants-disabled.yaml
@@ -1,0 +1,23 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-grants-disabled-vcluster
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      gateways:
+        enabled: true
+      httpRoutes:
+        enabled: true
+      referenceGrants:
+        enabled: false

--- a/pkg/mappings/resources/httproutes.go
+++ b/pkg/mappings/resources/httproutes.go
@@ -25,5 +25,10 @@ func CreateHTTPRouteMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper
 		return nil, err
 	}
 
+	err = EnsureReferenceGrantCRD(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return generic.NewMapper(ctx, &gatewayv1.HTTPRoute{}, translate.Default.HostName)
 }

--- a/pkg/mappings/resources/referencegrants.go
+++ b/pkg/mappings/resources/referencegrants.go
@@ -23,10 +23,19 @@ func CreateReferenceGrantMapper(ctx *synccontext.RegisterContext) (synccontext.M
 		return nil, err
 	}
 
-	err = util.EnsureCRD(ctx.Context, ctx.VirtualManager.GetConfig(), []byte(referenceGrantsCRD), mappings.ReferenceGrants())
+	err = EnsureReferenceGrantCRD(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return generic.NewMapper(ctx, &gatewayv1beta1.ReferenceGrant{}, translate.Default.HostName)
+}
+
+// EnsureReferenceGrantCRD installs the ReferenceGrant CRD in the virtual
+// cluster. Route controllers watch virtual ReferenceGrants and cross-namespace
+// authorization lists them even when grant sync to the host is disabled, so
+// route mappers ensure the CRD independently of
+// sync.toHost.gatewayApi.referenceGrants.enabled.
+func EnsureReferenceGrantCRD(ctx *synccontext.RegisterContext) error {
+	return util.EnsureCRD(ctx.Context, ctx.VirtualManager.GetConfig(), []byte(referenceGrantsCRD), mappings.ReferenceGrants())
 }

--- a/pkg/mappings/resources/register_gateway_test.go
+++ b/pkg/mappings/resources/register_gateway_test.go
@@ -7,9 +7,13 @@ import (
 
 	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/scheme"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util"
 	gatewayapiutil "github.com/loft-sh/vcluster/pkg/util/gatewayapi"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
@@ -42,6 +46,45 @@ func TestReferenceGrantMapperChecksHostCRDWithoutNamespaceSync(t *testing.T) {
 	_, err := CreateReferenceGrantMapper(ctx)
 	if err == nil || !strings.Contains(err.Error(), "cannot check host cluster for Gateway API resource gateway.networking.k8s.io/v1beta1, Kind=ReferenceGrant") {
 		t.Fatalf("expected ReferenceGrant host CRD check before tenant CRD install, got %v", err)
+	}
+}
+
+func TestRouteMappersEnsureReferenceGrantCRDWhenGrantSyncDisabled(t *testing.T) {
+	ensured := map[schema.GroupVersionKind]bool{}
+	restoreEnsureCRD := util.EnsureCRD
+	restoreKindExists := util.KindExists
+	util.EnsureCRD = func(_ context.Context, _ *rest.Config, _ []byte, gvk schema.GroupVersionKind) error {
+		ensured[gvk] = true
+		return nil
+	}
+	util.KindExists = func(_ *rest.Config, _ schema.GroupVersionKind) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() {
+		util.EnsureCRD = restoreEnsureCRD
+		util.KindExists = restoreKindExists
+	})
+
+	fakeClient := testingutil.NewFakeClient(scheme.Scheme)
+	ctx := &synccontext.RegisterContext{
+		Context:        context.Background(),
+		Config:         &pkgconfig.VirtualClusterConfig{},
+		VirtualManager: testingutil.NewFakeManager(fakeClient),
+		HostManager:    testingutil.NewFakeManager(fakeClient),
+	}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "false"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+	ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Enabled = true
+
+	if _, err := CreateHTTPRouteMapper(ctx); err != nil {
+		t.Fatalf("create HTTPRoute mapper: %v", err)
+	}
+	if _, err := CreateTLSRouteMapper(ctx); err != nil {
+		t.Fatalf("create TLSRoute mapper: %v", err)
+	}
+
+	if !ensured[mappings.ReferenceGrants()] {
+		t.Fatalf("route mappers must ensure the tenant ReferenceGrant CRD even with grant sync disabled; route controllers watch virtual ReferenceGrants for cross-namespace authorization")
 	}
 }
 

--- a/pkg/mappings/resources/tlsroutes.go
+++ b/pkg/mappings/resources/tlsroutes.go
@@ -30,5 +30,10 @@ func CreateTLSRouteMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper,
 		return nil, err
 	}
 
+	err = EnsureReferenceGrantCRD(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return generic.NewMapper(ctx, &gatewayv1alpha2.TLSRoute{}, translate.Default.HostName)
 }


### PR DESCRIPTION
  - route controllers watch virtual ReferenceGrants for cross-namespace authorization regardless of sync.toHost.gatewayApi.referenceGrants.enabled; with the flag "false" the CRD was never installed and the watch failed forever (no matches for kind "ReferenceGrant"), silently blocking all HTTPRoute/TLSRoute sync
  - extract EnsureReferenceGrantCRD and call it from the HTTPRoute and TLSRoute mappers, independent of grant sync
  - keep "false" semantics: no host discovery check, no mapper, no syncer, grants never sync to the host; virtual grants stay authoritative for cross-namespace refs in single-namespace mode
  - add gatewayapi-grants-disabled e2e suite: same-namespace route syncs, cross-namespace backendRef denied until a virtual ReferenceGrant permits it, grant itself never syncs to the host
  - add unit test asserting route mappers ensure the grant CRD when grant sync is disabled

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-566


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
