### PR TITLE
feat(chart): add metricRelabelings support to ServiceMonitor endpoints

### DIFF
--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -35,6 +35,10 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "apiserver"
+    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     tlsConfig:
       ca:
         secret:
@@ -54,6 +58,10 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "controller-manager"
+    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     tlsConfig:
       ca:
         secret:
@@ -74,6 +82,10 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "scheduler"
+    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     tlsConfig:
       ca:
         secret:
@@ -95,6 +107,10 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "etcd"
+    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     tlsConfig:
       ca:
         secret:
@@ -116,6 +132,10 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "kine"
+    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     tlsConfig:
       ca:
         secret:

--- a/chart/templates/service-monitor.yaml
+++ b/chart/templates/service-monitor.yaml
@@ -35,9 +35,9 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "apiserver"
-    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    {{- if .Values.controlPlane.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml . | indent 6 }}
+{{ toYaml .Values.controlPlane.serviceMonitor.metricRelabelings | indent 6 }}
     {{- end }}
     tlsConfig:
       ca:
@@ -58,9 +58,9 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "controller-manager"
-    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    {{- if .Values.controlPlane.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml . | indent 6 }}
+{{ toYaml .Values.controlPlane.serviceMonitor.metricRelabelings | indent 6 }}
     {{- end }}
     tlsConfig:
       ca:
@@ -82,9 +82,9 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "scheduler"
-    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    {{- if .Values.controlPlane.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml . | indent 6 }}
+{{ toYaml .Values.controlPlane.serviceMonitor.metricRelabelings | indent 6 }}
     {{- end }}
     tlsConfig:
       ca:
@@ -107,9 +107,9 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "etcd"
-    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    {{- if .Values.controlPlane.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml . | indent 6 }}
+{{ toYaml .Values.controlPlane.serviceMonitor.metricRelabelings | indent 6 }}
     {{- end }}
     tlsConfig:
       ca:
@@ -132,9 +132,9 @@ spec:
     relabelings:
       - targetLabel: endpoint
         replacement: "kine"
-    {{- with .Values.controlPlane.serviceMonitor.metricRelabelings }}
+    {{- if .Values.controlPlane.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-{{ toYaml . | indent 6 }}
+{{ toYaml .Values.controlPlane.serviceMonitor.metricRelabelings | indent 6 }}
     {{- end }}
     tlsConfig:
       ca:

--- a/chart/tests/service-monitor_test.yaml
+++ b/chart/tests/service-monitor_test.yaml
@@ -41,6 +41,85 @@ tests:
           path: spec.endpoints[2].relabelings[0].replacement
           value: kine
 
+  - it: check metricRelabelings not rendered by default
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - notExists:
+          path: spec.endpoints[0].metricRelabelings
+      - notExists:
+          path: spec.endpoints[1].metricRelabelings
+      - notExists:
+          path: spec.endpoints[2].metricRelabelings
+
+  - it: check metricRelabelings rendered on every endpoint
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        distro:
+          k8s:
+            enabled: true
+            scheduler:
+              enabled: true
+        backingStore:
+          etcd:
+            embedded:
+              enabled: true
+        serviceMonitor:
+          enabled: true
+          metricRelabelings:
+            - action: drop
+              sourceLabels: ["__name__"]
+              regex: apiserver_request_duration_seconds_bucket
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.endpoints
+          count: 4
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].action
+          value: drop
+      - equal:
+          path: spec.endpoints[1].metricRelabelings[0].action
+          value: drop
+      - equal:
+          path: spec.endpoints[2].metricRelabelings[0].action
+          value: drop
+      - equal:
+          path: spec.endpoints[3].metricRelabelings[0].action
+          value: drop
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].regex
+          value: apiserver_request_duration_seconds_bucket
+
+  - it: check metricRelabelings rendered on kine endpoint
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      controlPlane:
+        serviceMonitor:
+          enabled: true
+          metricRelabelings:
+            - action: drop
+              sourceLabels: ["__name__"]
+              regex: apiserver_request_duration_seconds_bucket
+    asserts:
+      - equal:
+          path: spec.endpoints[2].path
+          value: /metrics/kine
+      - equal:
+          path: spec.endpoints[2].metricRelabelings[0].action
+          value: drop
+
   - it: override release label
     release:
       name: my-release

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4595,6 +4595,11 @@
           },
           "type": "object",
           "description": "Annotations are the extra annotations to add to the service monitor."
+        },
+        "metricRelabelings": {
+          "items": true,
+          "type": "array",
+          "description": "MetricRelabelings are extra metricRelabelings to add to each endpoint of the service monitor. This allows filtering scraped metrics before ingestion, e.g. dropping high-cardinality metrics. Follows the Prometheus Operator RelabelConfig format."
         }
       },
       "additionalProperties": false,

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -786,6 +786,8 @@ controlPlane:
     enabled: false
     labels: {}
     annotations: {}
+    # MetricRelabelings are extra metricRelabelings to add to each endpoint of the service monitor. This allows filtering scraped metrics before ingestion, e.g. dropping high-cardinality metrics. Follows the Prometheus Operator RelabelConfig format.
+    metricRelabelings: []
   
   # Advanced holds additional configuration for the vCluster control plane.
   advanced:

--- a/config/config.go
+++ b/config/config.go
@@ -1690,6 +1690,9 @@ type ServiceMonitor struct {
 
 	// Annotations are the extra annotations to add to the service monitor.
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// MetricRelabelings are extra metricRelabelings to add to each endpoint of the service monitor. This allows filtering scraped metrics before ingestion, e.g. dropping high-cardinality metrics. Follows the Prometheus Operator RelabelConfig format.
+	MetricRelabelings []interface{} `json:"metricRelabelings,omitempty"`
 }
 
 type Networking struct {

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -414,6 +414,7 @@ controlPlane:
     enabled: false
     labels: {}
     annotations: {}
+    metricRelabelings: []
 
   advanced:
     defaultImageRegistry: ""


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind feature

**What does this pull request do? Which issues does it resolve?**

Adds an optional `controlPlane.serviceMonitor.metricRelabelings` value that gets rendered into every endpoint of the chart's ServiceMonitor, next to the existing `labels` and `annotations` options.

Motivation: when running many vclusters on shared host clusters, the control plane endpoints emit large histogram families (`apiserver_request_duration_seconds_bucket` and friends) that quickly dominate downstream TSDB cardinality. In our fleet (~750 vclusters) these added up to tens of millions of active series. ServiceMonitor supports `metricRelabelings` for dropping such series at scrape time, but the chart currently has no way to set them: the values schema rejects the key (`additionalProperties: false`), so the workarounds are post-scrape filtering at the agent layer or patching the rendered object out-of-band.

Changes:
- `config`: added `MetricRelabelings` to the `ServiceMonitor` struct as `[]interface{}`, same as other passthrough fields whose shape is owned by an external API (`tolerations`, `extraEnv`)
- regenerated `chart/values.schema.json` and `chart/values.yaml` via `go run hack/schema/main.go`
- `chart`: the value is rendered under each of the 5 endpoint entries (apiserver, controller-manager, scheduler, etcd, kine)
- `chart/tests`: added cases for the default (field absent) and set (present on every rendered endpoint, including conditional ones) paths

When the value is not set, the rendered ServiceMonitor is unchanged.

Example usage:

```yaml
controlPlane:
  serviceMonitor:
    enabled: true
    metricRelabelings:
      - action: drop
        sourceLabels: ["__name__"]
        regex: "apiserver_request_duration_seconds_bucket"
```

**Please provide a short message that should be published in the vcluster release notes**
Added `controlPlane.serviceMonitor.metricRelabelings` to allow filtering scraped control plane metrics at the source, e.g. dropping high-cardinality apiserver histograms.

**What else do we need to know?**

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only Helm template and values changes; no runtime control-plane or security behavior is modified when the new value is unset.
> 
> **Overview**
> Adds **`controlPlane.serviceMonitor.metricRelabelings`** so Helm can inject Prometheus Operator **metric relabel rules** on every ServiceMonitor scrape endpoint (apiserver, controller-manager, and the conditional scheduler, etcd, and kine targets).
> 
> The value is wired through **`config`**, **`chart/values.yaml`**, and **`values.schema.json`**, and is only rendered when set—default installs keep the same ServiceMonitor YAML as before. Chart tests cover the absent-by-default path and propagation across all rendered endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baad7f6221f87436c4f72f69823ded052017c0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->