### PR TITLE
Engnode 569

### DIFF
--- a/e2e-next/suite_gatewayapi_grants_disabled_test.go
+++ b/e2e-next/suite_gatewayapi_grants_disabled_test.go
@@ -1,0 +1,44 @@
+// Suite: gatewayapi-grants-disabled-vcluster
+// vCluster: Gateway API route sync with referenceGrants.enabled "false" —
+// route controllers must start and virtual ReferenceGrants must stay
+// authoritative for cross-namespace refs without syncing to the host.
+// Run:      just run-e2e 'pr && gatewayapi'
+package e2e_next
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
+	"github.com/loft-sh/vcluster/e2e-next/clusters"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/e2e-next/setup"
+	"github.com/loft-sh/vcluster/e2e-next/setup/lazyvcluster"
+	"github.com/loft-sh/vcluster/e2e-next/test_gatewayapi"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+//go:embed vcluster-gatewayapi-grants-disabled.yaml
+var gatewayAPIGrantsDisabledVClusterYAML string
+
+const gatewayAPIGrantsDisabledVClusterName = "gatewayapi-grants-disabled-vcluster"
+
+func init() { suiteGatewayAPIGrantsDisabledVCluster() }
+
+func suiteGatewayAPIGrantsDisabledVCluster() {
+	// Ordered so all specs share one lazyvcluster bring-up; specs are independent.
+	Describe("gatewayapi-grants-disabled-vcluster", labels.PR, labels.GatewayAPI, Ordered,
+		cluster.Use(clusters.HostCluster),
+		func() {
+			BeforeAll(func(ctx context.Context) context.Context {
+				return lazyvcluster.LazyVCluster(ctx,
+					gatewayAPIGrantsDisabledVClusterName,
+					gatewayAPIGrantsDisabledVClusterYAML,
+					lazyvcluster.WithPreSetup(setup.GatewayAPIPreSetup()),
+				)
+			})
+
+			test_gatewayapi.GatewayAPIGrantsDisabledSpec()
+		},
+	)
+}

--- a/e2e-next/test_gatewayapi/clients.go
+++ b/e2e-next/test_gatewayapi/clients.go
@@ -11,9 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type gatewayAPIClients struct {
@@ -23,17 +20,12 @@ type gatewayAPIClients struct {
 	VClusterHostNS string
 }
 
-func newGatewayAPIClients(ctx context.Context, installExtendedGatewaySchemes bool) gatewayAPIClients {
+func newGatewayAPIClients(ctx context.Context) gatewayAPIClients {
 	GinkgoHelper()
 
 	scheme := runtime.NewScheme()
 	Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	Expect(gatewayv1.Install(scheme)).To(Succeed())
-	if installExtendedGatewaySchemes {
-		Expect(gatewayv1alpha2.Install(scheme)).To(Succeed())
-		Expect(gatewayv1alpha3.Install(scheme)).To(Succeed())
-		Expect(gatewayv1beta1.Install(scheme)).To(Succeed())
-	}
 
 	hostClient, err := ctrlclient.New(cluster.From(ctx, constants.GetHostClusterName()).KubernetesRestConfig(), ctrlclient.Options{Scheme: scheme})
 	Expect(err).To(Succeed())

--- a/e2e-next/test_gatewayapi/test_gatewayapi_combined.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_combined.go
@@ -32,7 +32,7 @@ func GatewayAPICombinedSpec() {
 
 		gatewayNamespace := "gwapi-combined-host"
 		BeforeEach(func(ctx context.Context) {
-			clients := newGatewayAPIClients(ctx, false)
+			clients := newGatewayAPIClients(ctx)
 			hostClient = clients.HostClient
 			vClusterClient = clients.VClusterClient
 			vClusterName = clients.VClusterName

--- a/e2e-next/test_gatewayapi/test_gatewayapi_grants_disabled.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_grants_disabled.go
@@ -1,0 +1,153 @@
+package test_gatewayapi
+
+import (
+	"context"
+
+	"github.com/loft-sh/vcluster/e2e-next/constants"
+	"github.com/loft-sh/vcluster/e2e-next/labels"
+	"github.com/loft-sh/vcluster/pkg/util/random"
+	"github.com/loft-sh/vcluster/pkg/util/translate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const grantsDisabledGatewayClassSelectorValue = "gatewayapi-grants-disabled-vcluster"
+
+// GatewayAPIGrantsDisabledSpec registers route sync tests for a vCluster with
+// sync.toHost.gatewayApi.referenceGrants.enabled set to "false" while route
+// sync stays on. Disabling grant sync must not break the route controllers and
+// must keep virtual ReferenceGrants authoritative for cross-namespace refs.
+func GatewayAPIGrantsDisabledSpec() {
+	Describe("Gateway API toHost with ReferenceGrant sync disabled", labels.GatewayAPI, func() {
+		var (
+			hostClient     ctrlclient.Client
+			vClusterClient ctrlclient.Client
+			vClusterName   string
+			vClusterHostNS string
+		)
+
+		BeforeEach(func(ctx context.Context) {
+			clients := newGatewayAPIClients(ctx)
+			hostClient = clients.HostClient
+			vClusterClient = clients.VClusterClient
+			vClusterName = clients.VClusterName
+			vClusterHostNS = clients.VClusterHostNS
+
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("syncs HTTPRoutes to the host while ReferenceGrant sync is disabled", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-rgd-"+suffix, grantsDisabledGatewayClassSelectorValue, "grants disabled class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			ns := createTenantNamespace(ctx, vClusterClient, "rgd-app-"+suffix)
+			gw := tenantGateway(ns.Name, "gw-rgd-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			hostGatewayName := translate.SafeConcatName(gw.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "rgd-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			route := tenantHTTPRoute(ns.Name, "route-rgd-"+suffix, gw.Name, svc.Name)
+			Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+			})
+
+			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+		})
+
+		It("authorizes cross-namespace backendRefs via virtual ReferenceGrants without syncing grants to the host", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gc-rgd-xns-"+suffix, grantsDisabledGatewayClassSelectorValue, "grants disabled cross-namespace class")
+			Eventually(func(g Gomega) {
+				g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Name: class.Name}, &gatewayv1.GatewayClass{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			frontend := createTenantNamespace(ctx, vClusterClient, "rgd-frontend-"+suffix)
+			backend := createTenantNamespace(ctx, vClusterClient, "rgd-backend-"+suffix)
+			gw := tenantGateway(frontend.Name, "gw-rgd-xns-"+suffix, class.Name)
+			Expect(vClusterClient.Create(ctx, gw)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gw))).To(Succeed())
+			})
+			hostGatewayName := translate.SafeConcatName(gw.Name, "x", frontend.Name, "x", vClusterName)
+			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, &gatewayv1.Gateway{})).To(Succeed())
+			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "rgd-xns-backend-" + suffix, Namespace: backend.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+
+			var hostRouteName string
+			var route *gatewayv1.HTTPRoute
+			var grant *gatewayv1.ReferenceGrant
+
+			By("creating a route whose backendRef crosses into another namespace and expecting no host sync", func() {
+				route = crossNamespaceRoute(frontend.Name, "route-rgd-xns-"+suffix, gw.Name, backend.Name, svc.Name)
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+
+				hostRouteName = translate.SafeConcatName(route.Name, "x", frontend.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "host route %s should stay absent until a grant permits it, got error: %v", hostRouteName, err)
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+
+			By("creating a virtual ReferenceGrant and expecting the route to sync", func() {
+				// The ReferenceGrant CRD must be served in the tenant cluster even
+				// with grant sync disabled — virtual grants still govern
+				// cross-namespace authorization.
+				Eventually(func(g Gomega) {
+					g.Expect(vClusterClient.List(ctx, &gatewayv1.ReferenceGrantList{}, ctrlclient.InNamespace(backend.Name))).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+				grant = &gatewayv1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{Name: "allow-rgd-" + suffix, Namespace: backend.Name},
+					Spec: gatewayv1.ReferenceGrantSpec{
+						From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: gatewayv1.Namespace(frontend.Name)}},
+						To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+					},
+				}
+				Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, grant))).To(Succeed())
+				})
+				Eventually(func(g Gomega) {
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+
+			By("expecting the virtual ReferenceGrant to never sync to the host", func() {
+				hostGrantName := translate.SafeConcatName(grant.Name, "x", backend.Name, "x", vClusterName)
+				Consistently(func(g Gomega) {
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGrantName}, &gatewayv1.ReferenceGrant{})
+					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "host grant %s should not exist with grant sync disabled, got error: %v", hostGrantName, err)
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
+			})
+		})
+	})
+}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -32,7 +32,7 @@ func GatewayAPIImportSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			clients := newGatewayAPIClients(ctx, false)
+			clients := newGatewayAPIClients(ctx)
 			hostClient = clients.HostClient
 			vClusterClient = clients.VClusterClient
 			vClusterName = clients.VClusterName

--- a/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_sync.go
@@ -37,7 +37,7 @@ func GatewayAPISyncSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			clients := newGatewayAPIClients(ctx, false)
+			clients := newGatewayAPIClients(ctx)
 			hostClient = clients.HostClient
 			vClusterClient = clients.VClusterClient
 			vClusterName = clients.VClusterName

--- a/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_tohost.go
@@ -16,9 +16,6 @@ import (
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // GatewayAPIToHostSpec registers tenant-authored route/policy sync tests.
@@ -32,7 +29,7 @@ func GatewayAPIToHostSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			clients := newGatewayAPIClients(ctx, true)
+			clients := newGatewayAPIClients(ctx)
 			hostClient = clients.HostClient
 			vClusterClient = clients.VClusterClient
 			vClusterName = clients.VClusterName
@@ -40,8 +37,8 @@ func GatewayAPIToHostSpec() {
 
 			Eventually(func(g Gomega) {
 				g.Expect(vClusterClient.List(ctx, &gatewayv1.HTTPRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
-				g.Expect(vClusterClient.List(ctx, &gatewayv1alpha2.TLSRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
-				g.Expect(vClusterClient.List(ctx, &gatewayv1alpha3.BackendTLSPolicyList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.TLSRouteList{}, ctrlclient.InNamespace("default"))).To(Succeed())
+				g.Expect(vClusterClient.List(ctx, &gatewayv1.BackendTLSPolicyList{}, ctrlclient.InNamespace("default"))).To(Succeed())
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
@@ -68,7 +65,7 @@ func GatewayAPIToHostSpec() {
 			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
 			var hostRouteName string
 			var route *gatewayv1.HTTPRoute
-			var grant *gatewayv1beta1.ReferenceGrant
+			var grant *gatewayv1.ReferenceGrant
 
 			By("creating a route whose backendRef crosses into another namespace", func() {
 				route = crossNamespaceRoute(frontend.Name, "route-"+suffix, gw.Name, backend.Name, svc.Name)
@@ -84,11 +81,11 @@ func GatewayAPIToHostSpec() {
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 			})
 			By("creating a ReferenceGrant in the backend namespace and expecting the route to sync", func() {
-				grant = &gatewayv1beta1.ReferenceGrant{
+				grant = &gatewayv1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
-					Spec: gatewayv1beta1.ReferenceGrantSpec{
-						From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: gatewayv1.Namespace(frontend.Name)}},
-						To:   []gatewayv1beta1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+					Spec: gatewayv1.ReferenceGrantSpec{
+						From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: gatewayv1.Namespace(frontend.Name)}},
+						To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
 					},
 				}
 				Expect(vClusterClient.Create(ctx, grant)).To(Succeed())
@@ -129,12 +126,12 @@ func GatewayAPIToHostSpec() {
 			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
 			Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
 
-			route := &gatewayv1alpha2.TLSRoute{
+			route := &gatewayv1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "app-tls-" + suffix, Namespace: ns.Name},
-				Spec: gatewayv1alpha2.TLSRouteSpec{
+				Spec: gatewayv1.TLSRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName(gw.Name), SectionName: ptr.To[gatewayv1.SectionName]("tls")}}},
 					Hostnames:       []gatewayv1.Hostname{"app.apps.example.com"},
-					Rules: []gatewayv1alpha2.TLSRouteRule{{BackendRefs: []gatewayv1.BackendRef{{
+					Rules: []gatewayv1.TLSRouteRule{{BackendRefs: []gatewayv1.BackendRef{{
 						BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(svc.Name), Port: ptr.To[gatewayv1.PortNumber](443)},
 					}}}},
 				},
@@ -146,9 +143,9 @@ func GatewayAPIToHostSpec() {
 
 			hostRouteName := translate.SafeConcatName(route.Name, "x", ns.Name, "x", vClusterName)
 			hostKey := types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}
-			var current *gatewayv1alpha2.TLSRoute
+			var current *gatewayv1.TLSRoute
 			Eventually(func(g Gomega) {
-				got := &gatewayv1alpha2.TLSRoute{}
+				got := &gatewayv1.TLSRoute{}
 				g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
 				g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app.apps.example.com")))
 				g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
@@ -156,12 +153,12 @@ func GatewayAPIToHostSpec() {
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
 			By("patching the tenant TLSRoute hostname and expecting the host update", func() {
-				current = &gatewayv1alpha2.TLSRoute{}
+				current = &gatewayv1.TLSRoute{}
 				Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(route), current)).To(Succeed())
 				current.Spec.Hostnames = []gatewayv1.Hostname{"app-updated.apps.example.com"}
 				Expect(vClusterClient.Update(ctx, current)).To(Succeed())
 				Eventually(func(g Gomega) {
-					got := &gatewayv1alpha2.TLSRoute{}
+					got := &gatewayv1.TLSRoute{}
 					g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
 					g.Expect(got.Spec.Hostnames).To(ContainElement(gatewayv1.Hostname("app-updated.apps.example.com")))
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
@@ -169,7 +166,7 @@ func GatewayAPIToHostSpec() {
 			By("deleting the tenant TLSRoute and expecting host deletion", func() {
 				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
 				Eventually(func(g Gomega) {
-					err := hostClient.Get(ctx, hostKey, &gatewayv1alpha2.TLSRoute{})
+					err := hostClient.Get(ctx, hostKey, &gatewayv1.TLSRoute{})
 					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
@@ -181,12 +178,12 @@ func GatewayAPIToHostSpec() {
 			otherNS := createTenantNamespace(ctx, vClusterClient, "btls-other-"+suffix)
 			otherSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-other-backend-" + suffix, Namespace: otherNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
 			Expect(vClusterClient.Create(ctx, otherSvc)).To(Succeed())
-			var policy *gatewayv1alpha3.BackendTLSPolicy
+			var policy *gatewayv1.BackendTLSPolicy
 			var hostKey types.NamespacedName
-			var current *gatewayv1alpha3.BackendTLSPolicy
+			var current *gatewayv1.BackendTLSPolicy
 
 			By("creating a policy with an unresolvable local targetRef and expecting no host sync", func() {
-				unresolvedPolicy := &gatewayv1alpha3.BackendTLSPolicy{
+				unresolvedPolicy := &gatewayv1.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{Name: "btls-unresolved-target-" + suffix, Namespace: ns.Name},
 					Spec: gatewayv1.BackendTLSPolicySpec{
 						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
@@ -204,14 +201,14 @@ func GatewayAPIToHostSpec() {
 				})
 				unresolvedHostPolicyName := translate.SafeConcatName(unresolvedPolicy.Name, "x", ns.Name, "x", vClusterName)
 				Consistently(func(g Gomega) {
-					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: unresolvedHostPolicyName}, &gatewayv1alpha3.BackendTLSPolicy{})
+					err := hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: unresolvedHostPolicyName}, &gatewayv1.BackendTLSPolicy{})
 					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 
 				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "btls-backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}}}
 				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
 
-				policy = &gatewayv1alpha3.BackendTLSPolicy{
+				policy = &gatewayv1.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{Name: "btls-" + suffix, Namespace: ns.Name},
 					Spec: gatewayv1.BackendTLSPolicySpec{
 						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{{
@@ -231,19 +228,19 @@ func GatewayAPIToHostSpec() {
 				hostPolicyName := translate.SafeConcatName(policy.Name, "x", ns.Name, "x", vClusterName)
 				hostKey = types.NamespacedName{Namespace: vClusterHostNS, Name: hostPolicyName}
 				Eventually(func(g Gomega) {
-					got := &gatewayv1alpha3.BackendTLSPolicy{}
+					got := &gatewayv1.BackendTLSPolicy{}
 					g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
 					g.Expect(got.Spec.TargetRefs).To(HaveLen(1))
 					g.Expect(string(got.Spec.TargetRefs[0].Name)).To(Equal(translate.SafeConcatName(svc.Name, "x", ns.Name, "x", vClusterName)))
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
 			By("updating the policy hostname and expecting the host update", func() {
-				current = &gatewayv1alpha3.BackendTLSPolicy{}
+				current = &gatewayv1.BackendTLSPolicy{}
 				Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(policy), current)).To(Succeed())
 				current.Spec.Validation.Hostname = "backend-updated.apps.example.com"
 				Expect(vClusterClient.Update(ctx, current)).To(Succeed())
 				Eventually(func(g Gomega) {
-					got := &gatewayv1alpha3.BackendTLSPolicy{}
+					got := &gatewayv1.BackendTLSPolicy{}
 					g.Expect(hostClient.Get(ctx, hostKey, got)).To(Succeed())
 					g.Expect(got.Spec.Validation.Hostname).To(Equal(gatewayv1.PreciseHostname("backend-updated.apps.example.com")))
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
@@ -251,7 +248,7 @@ func GatewayAPIToHostSpec() {
 			By("deleting the policy and expecting host deletion", func() {
 				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, current))).To(Succeed())
 				Eventually(func(g Gomega) {
-					err := hostClient.Get(ctx, hostKey, &gatewayv1alpha3.BackendTLSPolicy{})
+					err := hostClient.Get(ctx, hostKey, &gatewayv1.BackendTLSPolicy{})
 					g.Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})

--- a/e2e-next/vcluster-gatewayapi-grants-disabled.yaml
+++ b/e2e-next/vcluster-gatewayapi-grants-disabled.yaml
@@ -1,0 +1,23 @@
+controlPlane:
+  statefulSet:
+    image:
+      registry: ""
+      repository: {{ .Repository }}
+      tag: {{ .Tag }}
+sync:
+  fromHost:
+    gatewayClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          e2e.vcluster.loft.sh/gatewayclass: gatewayapi-grants-disabled-vcluster
+  toHost:
+    services:
+      enabled: true
+    gatewayApi:
+      gateways:
+        enabled: true
+      httpRoutes:
+        enabled: true
+      referenceGrants:
+        enabled: false

--- a/pkg/controllers/resources/backendtlspolicies/syncer.go
+++ b/pkg/controllers/resources/backendtlspolicies/syncer.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 )
 
 type backendTLSPolicySyncer struct {
@@ -43,13 +42,13 @@ func NewSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	}
 
 	return &backendTLSPolicySyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "backendtlspolicy", &gatewayv1alpha3.BackendTLSPolicy{}, mapper),
+		GenericTranslator: translator.NewGenericTranslator(ctx, "backendtlspolicy", &gatewayv1.BackendTLSPolicy{}, mapper),
 		Importer:          pro.NewImporter(mapper),
 	}, nil
 }
 
 func (s *backendTLSPolicySyncer) Syncer() syncertypes.Sync[client.Object] {
-	return syncer.ToGenericSyncer[*gatewayv1alpha3.BackendTLSPolicy](s)
+	return syncer.ToGenericSyncer[*gatewayv1.BackendTLSPolicy](s)
 }
 
 func (s *backendTLSPolicySyncer) Options() *syncertypes.Options {
@@ -62,13 +61,13 @@ func (s *backendTLSPolicySyncer) ModifyController(ctx *synccontext.RegisterConte
 	return routetranslate.RegisterReferencedWatches(ctx, builder, s.GroupVersionKind(), mappings.Services(), mappings.ConfigMaps(), mappings.Secrets())
 }
 
-func (s *backendTLSPolicySyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1alpha3.BackendTLSPolicy]) (ctrl.Result, error) {
-	return gatewaysync.CreateToHost(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Patches, func() (*gatewayv1alpha3.BackendTLSPolicy, error) {
+func (s *backendTLSPolicySyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.BackendTLSPolicy]) (ctrl.Result, error) {
+	return gatewaysync.CreateToHost(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Patches, func() (*gatewayv1.BackendTLSPolicy, error) {
 		return s.translate(ctx, event.Virtual)
 	})
 }
 
-func (s *backendTLSPolicySyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1alpha3.BackendTLSPolicy]) (ctrl.Result, error) {
+func (s *backendTLSPolicySyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1.BackendTLSPolicy]) (ctrl.Result, error) {
 	var hSpec *gatewayv1.BackendTLSPolicySpec
 	return gatewaysync.Sync(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Patches,
 		func() (err error) {
@@ -92,8 +91,8 @@ func (s *backendTLSPolicySyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 	)
 }
 
-func (s *backendTLSPolicySyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1alpha3.BackendTLSPolicy]) (ctrl.Result, error) {
-	return gatewaysync.CreateToVirtual(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Patches, func() *gatewayv1alpha3.BackendTLSPolicy {
+func (s *backendTLSPolicySyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1.BackendTLSPolicy]) (ctrl.Result, error) {
+	return gatewaysync.CreateToVirtual(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.BackendTLSPolicies.Patches, func() *gatewayv1.BackendTLSPolicy {
 		return translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host))
 	})
 }

--- a/pkg/controllers/resources/backendtlspolicies/translate.go
+++ b/pkg/controllers/resources/backendtlspolicies/translate.go
@@ -8,10 +8,9 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 )
 
-func (s *backendTLSPolicySyncer) translate(ctx *synccontext.SyncContext, vPolicy *gatewayv1alpha3.BackendTLSPolicy) (*gatewayv1alpha3.BackendTLSPolicy, error) {
+func (s *backendTLSPolicySyncer) translate(ctx *synccontext.SyncContext, vPolicy *gatewayv1.BackendTLSPolicy) (*gatewayv1.BackendTLSPolicy, error) {
 	pPolicy := translate.HostMetadata(vPolicy, s.VirtualToHost(ctx, types.NamespacedName{Name: vPolicy.Name, Namespace: vPolicy.Namespace}, vPolicy))
 
 	spec, err := specToHost(ctx, vPolicy, true)
@@ -23,7 +22,7 @@ func (s *backendTLSPolicySyncer) translate(ctx *synccontext.SyncContext, vPolicy
 	return pPolicy, nil
 }
 
-func specToHost(ctx *synccontext.SyncContext, vPolicy *gatewayv1alpha3.BackendTLSPolicy, validateRefs bool) (*gatewayv1.BackendTLSPolicySpec, error) {
+func specToHost(ctx *synccontext.SyncContext, vPolicy *gatewayv1.BackendTLSPolicy, validateRefs bool) (*gatewayv1.BackendTLSPolicySpec, error) {
 	retSpec := vPolicy.Spec.DeepCopy()
 	for i := range retSpec.TargetRefs {
 		err := routetranslate.PolicyTargetRefToHost(ctx, vPolicy.Namespace, &retSpec.TargetRefs[i], routetranslate.WithValidateHostObject(validateRefs))
@@ -42,7 +41,7 @@ func specToHost(ctx *synccontext.SyncContext, vPolicy *gatewayv1alpha3.BackendTL
 	return retSpec, nil
 }
 
-func statusToVirtual(ctx *synccontext.SyncContext, hostPolicy *gatewayv1alpha3.BackendTLSPolicy, virtualPolicyNamespace string, status gatewayv1.PolicyStatus) (gatewayv1.PolicyStatus, error) {
+func statusToVirtual(ctx *synccontext.SyncContext, hostPolicy *gatewayv1.BackendTLSPolicy, virtualPolicyNamespace string, status gatewayv1.PolicyStatus) (gatewayv1.PolicyStatus, error) {
 	retStatus := *status.DeepCopy()
 
 	for i := range retStatus.Ancestors {

--- a/pkg/controllers/resources/gatewayapi/authz/authz.go
+++ b/pkg/controllers/resources/gatewayapi/authz/authz.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,8 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 var errNotPermitted = errors.New("virtual reference not permitted")
@@ -144,7 +141,7 @@ func referenceGrant(ctx *synccontext.SyncContext, fromGroup, fromKind, fromNames
 }
 
 func ensureReferenceGrantAllows(ctx *synccontext.SyncContext, fromGroup, fromKind, fromNamespace string, target referenceTarget) error {
-	grants := &gatewayv1beta1.ReferenceGrantList{}
+	grants := &gatewayv1.ReferenceGrantList{}
 	err := ctx.VirtualClient.List(ctx, grants, client.InNamespace(target.namespace))
 	if err != nil {
 		return fmt.Errorf("list ReferenceGrants in namespace %q: %w", target.namespace, err)
@@ -161,7 +158,7 @@ func ensureReferenceGrantAllows(ctx *synccontext.SyncContext, fromGroup, fromKin
 	return notPermittedf("no matching virtual ReferenceGrant in namespace %q permits %s in namespace %q to reference %s %q in namespace %q", target.namespace, fromKind, fromNamespace, target.kind, target.name, target.namespace)
 }
 
-func referenceGrantAllows(grant gatewayv1beta1.ReferenceGrant, fromGroup, fromKind, fromNamespace string, target referenceTarget) bool {
+func referenceGrantAllows(grant gatewayv1.ReferenceGrant, fromGroup, fromKind, fromNamespace string, target referenceTarget) bool {
 	fromAllowed := false
 	for _, from := range grant.Spec.From {
 		if string(from.Group) == fromGroup &&
@@ -323,40 +320,24 @@ func namespaceSelectorMatches(ctx *synccontext.SyncContext, routeNamespace strin
 
 // RegisterHTTPRouteWatches requeues HTTPRoutes when authz inputs change.
 func RegisterHTTPRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return registerRouteWatches(ctx, builder, httpRouteListObject)
+	return registerRouteWatches(ctx, builder, listHTTPRouteRequests)
 }
 
 // RegisterTLSRouteWatches requeues TLSRoutes when authz inputs change.
 func RegisterTLSRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder) *builder.Builder {
-	return registerRouteWatches(ctx, builder, tlsRouteListObject)
+	return registerRouteWatches(ctx, builder, listTLSRouteRequests)
 }
 
-var (
-	referenceGrantWatchGVK = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1beta1.GroupVersion.Version, Kind: "ReferenceGrant"}
-	httpRouteListGVK       = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version, Kind: "HTTPRouteList"}
-	tlsRouteListGVK        = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1alpha2.GroupVersion.Version, Kind: "TLSRouteList"}
-)
+var referenceGrantWatchGVK = schema.GroupVersionKind{Group: gatewayv1.GroupVersion.Group, Version: gatewayv1.GroupVersion.Version, Kind: "ReferenceGrant"}
 
-func referenceGrantWatchObject() *unstructured.Unstructured {
-	return unstructuredObject(referenceGrantWatchGVK)
-}
-
-func httpRouteListObject() *unstructured.UnstructuredList {
-	return unstructuredList(httpRouteListGVK)
-}
-
-func tlsRouteListObject() *unstructured.UnstructuredList {
-	return unstructuredList(tlsRouteListGVK)
-}
-
-func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder, routeListObject func() *unstructured.UnstructuredList) *builder.Builder {
+func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Builder, listRoutes func(context.Context, client.Client, loghelper.Logger) []reconcile.Request) *builder.Builder {
 	log := ctx.ToSyncContext("gateway-authz").Log
 	listRequests := func(mapCtx context.Context) []reconcile.Request {
-		return listRouteRequests(mapCtx, ctx.VirtualManager.GetClient(), routeListObject(), log)
+		return listRoutes(mapCtx, ctx.VirtualManager.GetClient(), log)
 	}
 
 	builder = builder.
-		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), referenceGrantWatchObject(), handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *unstructured.Unstructured) []reconcile.Request {
+		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1.ReferenceGrant{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1.ReferenceGrant) []reconcile.Request {
 			return listRequests(mapCtx)
 		}))).
 		WatchesRawSource(source.Kind(ctx.VirtualManager.GetCache(), &gatewayv1.Gateway{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1.Gateway) []reconcile.Request {
@@ -367,7 +348,7 @@ func registerRouteWatches(ctx *synccontext.RegisterContext, builder *builder.Bui
 		})))
 
 	if hostReferenceGrantWatchEnabled(ctx, log) {
-		builder = builder.WatchesRawSource(source.Kind(ctx.HostManager.GetCache(), referenceGrantWatchObject(), handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *unstructured.Unstructured) []reconcile.Request {
+		builder = builder.WatchesRawSource(source.Kind(ctx.HostManager.GetCache(), &gatewayv1.ReferenceGrant{}, handler.TypedEnqueueRequestsFromMapFunc(func(mapCtx context.Context, _ *gatewayv1.ReferenceGrant) []reconcile.Request {
 			return listRequests(mapCtx)
 		})))
 	}
@@ -391,29 +372,34 @@ func hostReferenceGrantWatchEnabled(ctx *synccontext.RegisterContext, log loghel
 	return exists
 }
 
-func listRouteRequests(ctx context.Context, c client.Client, list *unstructured.UnstructuredList, log loghelper.Logger) []reconcile.Request {
+func listHTTPRouteRequests(ctx context.Context, c client.Client, log loghelper.Logger) []reconcile.Request {
+	list := &gatewayv1.HTTPRouteList{}
 	if err := c.List(ctx, list); err != nil {
 		if log != nil {
-			log.Errorf("list Gateway API routes %s: %v", list.GroupVersionKind().String(), err)
+			log.Errorf("list Gateway API HTTPRoutes: %v", err)
 		}
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(list.Items))
 	for _, item := range list.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.GetName(), Namespace: item.GetNamespace()}})
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
 	}
 	return requests
 }
 
-func unstructuredObject(gvk schema.GroupVersionKind) *unstructured.Unstructured {
-	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(gvk)
-	return obj
-}
+func listTLSRouteRequests(ctx context.Context, c client.Client, log loghelper.Logger) []reconcile.Request {
+	list := &gatewayv1.TLSRouteList{}
+	if err := c.List(ctx, list); err != nil {
+		if log != nil {
+			log.Errorf("list Gateway API TLSRoutes: %v", err)
+		}
+		return nil
+	}
 
-func unstructuredList(gvk schema.GroupVersionKind) *unstructured.UnstructuredList {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(gvk)
-	return list
+	requests := make([]reconcile.Request, 0, len(list.Items))
+	for _, item := range list.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: item.Name, Namespace: item.Namespace}})
+	}
+	return requests
 }

--- a/pkg/controllers/resources/gatewayapi/authz/authz_test.go
+++ b/pkg/controllers/resources/gatewayapi/authz/authz_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestHTTPRouteAttachmentRespectsAllowedRouteNamespaces(t *testing.T) {
@@ -81,7 +80,7 @@ func TestHTTPRouteBackendRequiresReferenceGrantForCrossNamespaceRefsInSingleName
 		t.Fatalf("expected cross-namespace backend reference without ReferenceGrant to be denied, got %v", err)
 	}
 
-	grant := &gatewayv1beta1.ReferenceGrant{
+	grant := &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "backends", Name: "allow-routes"},
 		Spec: gatewayv1.ReferenceGrantSpec{
 			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("routes")}},
@@ -138,7 +137,7 @@ func TestReferenceGrantNameOmittedAllowsAnyTargetName(t *testing.T) {
 	restore := setDefaultTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
 	defer restore()
 
-	grant := &gatewayv1beta1.ReferenceGrant{
+	grant := &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "backends", Name: "allow-any-service"},
 		Spec: gatewayv1.ReferenceGrantSpec{
 			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("routes")}},
@@ -158,7 +157,7 @@ func TestDeletingReferenceGrantDoesNotAllowTargetName(t *testing.T) {
 	defer restore()
 
 	deletedAt := metav1.Now()
-	grant := &gatewayv1beta1.ReferenceGrant{
+	grant := &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "backends", Name: "deleting", DeletionTimestamp: &deletedAt, Finalizers: []string{"sync.vcluster.loft.sh/finalizer"}},
 		Spec: gatewayv1.ReferenceGrantSpec{
 			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("routes")}},
@@ -200,7 +199,7 @@ func TestReferenceGrantRequiresMatchingFromNamespace(t *testing.T) {
 	restore := setDefaultTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
 	defer restore()
 
-	grant := &gatewayv1beta1.ReferenceGrant{
+	grant := &gatewayv1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "backends", Name: "allow-other"},
 		Spec: gatewayv1.ReferenceGrantSpec{
 			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("other-routes")}},

--- a/pkg/controllers/resources/referencegrants/syncer.go
+++ b/pkg/controllers/resources/referencegrants/syncer.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type referenceGrantSyncer struct {
@@ -41,13 +40,13 @@ func NewSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	}
 
 	return &referenceGrantSyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "referencegrant", &gatewayv1beta1.ReferenceGrant{}, mapper),
+		GenericTranslator: translator.NewGenericTranslator(ctx, "referencegrant", &gatewayv1.ReferenceGrant{}, mapper),
 		Importer:          pro.NewImporter(mapper),
 	}, nil
 }
 
 func (s *referenceGrantSyncer) Syncer() syncertypes.Sync[client.Object] {
-	return syncer.ToGenericSyncer[*gatewayv1beta1.ReferenceGrant](s)
+	return syncer.ToGenericSyncer[*gatewayv1.ReferenceGrant](s)
 }
 
 func (s *referenceGrantSyncer) Options() *syncertypes.Options {
@@ -60,13 +59,13 @@ func (s *referenceGrantSyncer) ModifyController(ctx *synccontext.RegisterContext
 	return routetranslate.RegisterReferencedWatches(ctx, builder, s.GroupVersionKind(), mappings.Services(), mappings.Secrets(), mappings.ConfigMaps())
 }
 
-func (s *referenceGrantSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1beta1.ReferenceGrant]) (ctrl.Result, error) {
-	return gatewaysync.CreateToHost(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Patches, func() (*gatewayv1beta1.ReferenceGrant, error) {
+func (s *referenceGrantSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.ReferenceGrant]) (ctrl.Result, error) {
+	return gatewaysync.CreateToHost(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Patches, func() (*gatewayv1.ReferenceGrant, error) {
 		return s.translate(ctx, event.Virtual)
 	})
 }
 
-func (s *referenceGrantSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1beta1.ReferenceGrant]) (ctrl.Result, error) {
+func (s *referenceGrantSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1.ReferenceGrant]) (ctrl.Result, error) {
 	var hSpec *gatewayv1.ReferenceGrantSpec
 	return gatewaysync.Sync(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Patches,
 		func() (err error) {
@@ -80,8 +79,8 @@ func (s *referenceGrantSyncer) Sync(ctx *synccontext.SyncContext, event *synccon
 	)
 }
 
-func (s *referenceGrantSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1beta1.ReferenceGrant]) (ctrl.Result, error) {
-	return gatewaysync.CreateToVirtual(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Patches, func() *gatewayv1beta1.ReferenceGrant {
+func (s *referenceGrantSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1.ReferenceGrant]) (ctrl.Result, error) {
+	return gatewaysync.CreateToVirtual(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Patches, func() *gatewayv1.ReferenceGrant {
 		return translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host))
 	})
 }

--- a/pkg/controllers/resources/referencegrants/translate.go
+++ b/pkg/controllers/resources/referencegrants/translate.go
@@ -8,10 +8,9 @@ import (
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func (s *referenceGrantSyncer) translate(ctx *synccontext.SyncContext, vGrant *gatewayv1beta1.ReferenceGrant) (*gatewayv1beta1.ReferenceGrant, error) {
+func (s *referenceGrantSyncer) translate(ctx *synccontext.SyncContext, vGrant *gatewayv1.ReferenceGrant) (*gatewayv1.ReferenceGrant, error) {
 	pGrant := translate.HostMetadata(vGrant, s.VirtualToHost(ctx, types.NamespacedName{Name: vGrant.Name, Namespace: vGrant.Namespace}, vGrant))
 
 	spec, err := specToHost(ctx, vGrant, true)
@@ -30,7 +29,7 @@ func (s *referenceGrantSyncer) translate(ctx *synccontext.SyncContext, vGrant *g
 // makes the grant effectively a no-op on host because all referrer routes also
 // live there). Each `to[].name`, when set, is translated through the matching
 // kind's mapper using the grant's own namespace as the lookup namespace.
-func specToHost(ctx *synccontext.SyncContext, vGrant *gatewayv1beta1.ReferenceGrant, validateRefs bool) (*gatewayv1.ReferenceGrantSpec, error) {
+func specToHost(ctx *synccontext.SyncContext, vGrant *gatewayv1.ReferenceGrant, validateRefs bool) (*gatewayv1.ReferenceGrantSpec, error) {
 	retSpec := vGrant.Spec.DeepCopy()
 
 	for i := range retSpec.From {

--- a/pkg/controllers/resources/tlsroutes/syncer.go
+++ b/pkg/controllers/resources/tlsroutes/syncer.go
@@ -17,7 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type tlsRouteSyncer struct {
@@ -43,13 +43,13 @@ func NewSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	}
 
 	return &tlsRouteSyncer{
-		GenericTranslator: translator.NewGenericTranslator(ctx, "tlsroute", &gatewayv1alpha2.TLSRoute{}, mapper),
+		GenericTranslator: translator.NewGenericTranslator(ctx, "tlsroute", &gatewayv1.TLSRoute{}, mapper),
 		Importer:          pro.NewImporter(mapper),
 	}, nil
 }
 
 func (s *tlsRouteSyncer) Syncer() syncertypes.Sync[client.Object] {
-	return syncer.ToGenericSyncer[*gatewayv1alpha2.TLSRoute](s)
+	return syncer.ToGenericSyncer[*gatewayv1.TLSRoute](s)
 }
 
 func (s *tlsRouteSyncer) Options() *syncertypes.Options {
@@ -63,14 +63,14 @@ func (s *tlsRouteSyncer) ModifyController(ctx *synccontext.RegisterContext, buil
 	return routetranslate.RegisterReferencedWatches(ctx, builder, s.GroupVersionKind(), mappings.Gateways(), mappings.Services())
 }
 
-func (s *tlsRouteSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1alpha2.TLSRoute]) (ctrl.Result, error) {
-	return gatewaysync.CreateToHost(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Patches, func() (*gatewayv1alpha2.TLSRoute, error) {
+func (s *tlsRouteSyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.TLSRoute]) (ctrl.Result, error) {
+	return gatewaysync.CreateToHost(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Patches, func() (*gatewayv1.TLSRoute, error) {
 		return s.translate(ctx, event.Virtual)
 	})
 }
 
-func (s *tlsRouteSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1alpha2.TLSRoute]) (ctrl.Result, error) {
-	var hSpec *gatewayv1alpha2.TLSRouteSpec
+func (s *tlsRouteSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.SyncEvent[*gatewayv1.TLSRoute]) (ctrl.Result, error) {
+	var hSpec *gatewayv1.TLSRouteSpec
 	return gatewaysync.Sync(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Patches,
 		func() (err error) {
 			hSpec, err = specToHost(ctx, event.Virtual, false)
@@ -93,8 +93,8 @@ func (s *tlsRouteSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.S
 	)
 }
 
-func (s *tlsRouteSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1alpha2.TLSRoute]) (ctrl.Result, error) {
-	return gatewaysync.CreateToVirtual(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Patches, func() *gatewayv1alpha2.TLSRoute {
+func (s *tlsRouteSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*gatewayv1.TLSRoute]) (ctrl.Result, error) {
+	return gatewaysync.CreateToVirtual(ctx, event, s.EventRecorder(), ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Patches, func() *gatewayv1.TLSRoute {
 		return translate.VirtualMetadata(event.Host, s.HostToVirtual(ctx, types.NamespacedName{Name: event.Host.Name, Namespace: event.Host.Namespace}, event.Host))
 	})
 }

--- a/pkg/controllers/resources/tlsroutes/translate.go
+++ b/pkg/controllers/resources/tlsroutes/translate.go
@@ -8,10 +8,10 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func (s *tlsRouteSyncer) translate(ctx *synccontext.SyncContext, vRoute *gatewayv1alpha2.TLSRoute) (*gatewayv1alpha2.TLSRoute, error) {
+func (s *tlsRouteSyncer) translate(ctx *synccontext.SyncContext, vRoute *gatewayv1.TLSRoute) (*gatewayv1.TLSRoute, error) {
 	pRoute := translate.HostMetadata(vRoute, s.VirtualToHost(ctx, types.NamespacedName{Name: vRoute.Name, Namespace: vRoute.Namespace}, vRoute))
 
 	spec, err := specToHost(ctx, vRoute, true)
@@ -23,7 +23,7 @@ func (s *tlsRouteSyncer) translate(ctx *synccontext.SyncContext, vRoute *gateway
 	return pRoute, nil
 }
 
-func specToHost(ctx *synccontext.SyncContext, vRoute *gatewayv1alpha2.TLSRoute, validateRefs bool) (*gatewayv1alpha2.TLSRouteSpec, error) {
+func specToHost(ctx *synccontext.SyncContext, vRoute *gatewayv1.TLSRoute, validateRefs bool) (*gatewayv1.TLSRouteSpec, error) {
 	if err := routetranslate.ValidateImportedGatewayHostnamePolicy(ctx, "TLSRoute", vRoute.Namespace, vRoute.Spec.ParentRefs, vRoute.Spec.Hostnames); err != nil {
 		return nil, err
 	}
@@ -51,21 +51,21 @@ func specToHost(ctx *synccontext.SyncContext, vRoute *gatewayv1alpha2.TLSRoute, 
 	return retSpec, nil
 }
 
-func statusToVirtual(ctx *synccontext.SyncContext, hostRoute *gatewayv1alpha2.TLSRoute, virtualRouteNamespace string, status gatewayv1alpha2.TLSRouteStatus) (gatewayv1alpha2.TLSRouteStatus, error) {
+func statusToVirtual(ctx *synccontext.SyncContext, hostRoute *gatewayv1.TLSRoute, virtualRouteNamespace string, status gatewayv1.TLSRouteStatus) (gatewayv1.TLSRouteStatus, error) {
 	retStatus := *status.DeepCopy()
 
 	for i := range retStatus.Parents {
 		hostRouteNamespace := routetranslate.ParentStatusHostNamespace(hostRoute.Namespace, hostRoute.Spec.ParentRefs, retStatus.Parents[i].ParentRef)
 		err := routetranslate.ParentRefToVirtual(ctx, hostRouteNamespace, virtualRouteNamespace, &retStatus.Parents[i].ParentRef, hostRoute.Spec.ParentRefs)
 		if err != nil {
-			return gatewayv1alpha2.TLSRouteStatus{}, fmt.Errorf("translate parents[%d].parentRef: %w", i, err)
+			return gatewayv1.TLSRouteStatus{}, fmt.Errorf("translate parents[%d].parentRef: %w", i, err)
 		}
 	}
 
 	return retStatus, nil
 }
 
-func ruleToHost(ctx *synccontext.SyncContext, routeNamespace string, rule *gatewayv1alpha2.TLSRouteRule, translateOpts ...routetranslate.ToHostOption) error {
+func ruleToHost(ctx *synccontext.SyncContext, routeNamespace string, rule *gatewayv1.TLSRouteRule, translateOpts ...routetranslate.ToHostOption) error {
 	for i := range rule.BackendRefs {
 		err := gatewayauthz.TLSRouteBackend(ctx, routeNamespace, &rule.BackendRefs[i].BackendObjectReference)
 		if err != nil {

--- a/pkg/controllers/resources/tlsroutes/translate_test.go
+++ b/pkg/controllers/resources/tlsroutes/translate_test.go
@@ -12,7 +12,6 @@ import (
 	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestTLSRouteSpecToHostRejectsDisallowedImportedGatewayHostname(t *testing.T) {
@@ -44,9 +43,9 @@ func TestTLSRouteSpecToHostRejectsDisallowedImportedGatewayHostname(t *testing.T
 	ctx := registerCtx.ToSyncContext("tlsroute-test")
 	ctx.Context = context.Background()
 
-	route := &gatewayv1alpha2.TLSRoute{
+	route := &gatewayv1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "demo", Name: "app"},
-		Spec: gatewayv1alpha2.TLSRouteSpec{
+		Spec: gatewayv1.TLSRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{Name: "edge", Namespace: &parentNamespace}}},
 			Hostnames:       []gatewayv1.Hostname{"admin.example.com"},
 		},

--- a/pkg/mappings/registry.go
+++ b/pkg/mappings/registry.go
@@ -19,9 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func NewMappingsRegistry(store synccontext.MappingsStore) synccontext.MappingsRegistry {
@@ -151,13 +148,9 @@ func Ingresses() schema.GroupVersionKind {
 // gatewayv1.SchemeGroupVersion.WithKind because that symbol is deprecated; the
 // non-deprecated gatewayv1.GroupVersion is a metav1.GroupVersion without WithKind.
 func gatewayGVK(kind string) schema.GroupVersionKind {
-	return gatewayVersionGVK(gatewayv1.GroupVersion.Version, kind)
-}
-
-func gatewayVersionGVK(version, kind string) schema.GroupVersionKind {
 	return schema.GroupVersionKind{
 		Group:   gatewayv1.GroupName,
-		Version: version,
+		Version: gatewayv1.GroupVersion.Version,
 		Kind:    kind,
 	}
 }
@@ -171,15 +164,15 @@ func HTTPRoutes() schema.GroupVersionKind {
 }
 
 func TLSRoutes() schema.GroupVersionKind {
-	return gatewayVersionGVK(gatewayv1alpha2.GroupVersion.Version, "TLSRoute")
+	return gatewayGVK("TLSRoute")
 }
 
 func BackendTLSPolicies() schema.GroupVersionKind {
-	return gatewayVersionGVK(gatewayv1alpha3.GroupVersion.Version, "BackendTLSPolicy")
+	return gatewayGVK("BackendTLSPolicy")
 }
 
 func ReferenceGrants() schema.GroupVersionKind {
-	return gatewayVersionGVK(gatewayv1beta1.GroupVersion.Version, "ReferenceGrant")
+	return gatewayGVK("ReferenceGrant")
 }
 
 func GatewayClasses() schema.GroupVersionKind {

--- a/pkg/mappings/resources/backendtlspolicies.go
+++ b/pkg/mappings/resources/backendtlspolicies.go
@@ -8,13 +8,13 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // Source: https://github.com/kubernetes-sigs/gateway-api/raw/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
-// Experimental channel serves v1alpha3 alongside v1.
-// Use v1alpha3 for the mapper so hosts with older Gateway API CRDs that do
-// not advertise BackendTLSPolicy v1 can still sync the resource.
+// Serves v1 (storage) plus the deprecated v1alpha3. The syncer speaks v1
+// only; hosts whose CRDs do not serve v1 fail fast in
+// ensureHostGatewayAPIKind.
 //
 //go:embed backendtlspolicies.crd.yaml
 var backendTLSPoliciesCRD string
@@ -30,5 +30,5 @@ func CreateBackendTLSPolicyMapper(ctx *synccontext.RegisterContext) (synccontext
 		return nil, err
 	}
 
-	return generic.NewMapper(ctx, &gatewayv1alpha3.BackendTLSPolicy{}, translate.Default.HostName)
+	return generic.NewMapper(ctx, &gatewayv1.BackendTLSPolicy{}, translate.Default.HostName)
 }

--- a/pkg/mappings/resources/httproutes.go
+++ b/pkg/mappings/resources/httproutes.go
@@ -25,5 +25,10 @@ func CreateHTTPRouteMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper
 		return nil, err
 	}
 
+	err = EnsureReferenceGrantCRD(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return generic.NewMapper(ctx, &gatewayv1.HTTPRoute{}, translate.Default.HostName)
 }

--- a/pkg/mappings/resources/referencegrants.go
+++ b/pkg/mappings/resources/referencegrants.go
@@ -23,10 +23,14 @@ func CreateReferenceGrantMapper(ctx *synccontext.RegisterContext) (synccontext.M
 		return nil, err
 	}
 
-	err = util.EnsureCRD(ctx.Context, ctx.VirtualManager.GetConfig(), []byte(referenceGrantsCRD), mappings.ReferenceGrants())
+	err = EnsureReferenceGrantCRD(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return generic.NewMapper(ctx, &gatewayv1.ReferenceGrant{}, translate.Default.HostName)
+}
+
+func EnsureReferenceGrantCRD(ctx *synccontext.RegisterContext) error {
+	return util.EnsureCRD(ctx.Context, ctx.VirtualManager.GetConfig(), []byte(referenceGrantsCRD), mappings.ReferenceGrants())
 }

--- a/pkg/mappings/resources/referencegrants.go
+++ b/pkg/mappings/resources/referencegrants.go
@@ -8,7 +8,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // referenceGrantsCRD is extracted from Gateway API v1.5.1 standard-install.yaml:
@@ -28,5 +28,5 @@ func CreateReferenceGrantMapper(ctx *synccontext.RegisterContext) (synccontext.M
 		return nil, err
 	}
 
-	return generic.NewMapper(ctx, &gatewayv1beta1.ReferenceGrant{}, translate.Default.HostName)
+	return generic.NewMapper(ctx, &gatewayv1.ReferenceGrant{}, translate.Default.HostName)
 }

--- a/pkg/mappings/resources/register_gateway_test.go
+++ b/pkg/mappings/resources/register_gateway_test.go
@@ -7,9 +7,13 @@ import (
 
 	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
 	"github.com/loft-sh/vcluster/pkg/mappings"
+	"github.com/loft-sh/vcluster/pkg/scheme"
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	"github.com/loft-sh/vcluster/pkg/util"
 	gatewayapiutil "github.com/loft-sh/vcluster/pkg/util/gatewayapi"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -55,5 +59,44 @@ func TestGatewayMappersUseLatestVersions(t *testing.T) {
 	}
 	if got := mappings.ReferenceGrants().GroupVersion(); got != want {
 		t.Fatalf("expected ReferenceGrant mapper to use the latest version %s, got %s", want, got)
+	}
+}
+
+func TestRouteMappersEnsureReferenceGrantCRDWhenGrantSyncDisabled(t *testing.T) {
+	ensured := map[schema.GroupVersionKind]bool{}
+	restoreEnsureCRD := util.EnsureCRD
+	restoreKindExists := util.KindExists
+	util.EnsureCRD = func(_ context.Context, _ *rest.Config, _ []byte, gvk schema.GroupVersionKind) error {
+		ensured[gvk] = true
+		return nil
+	}
+	util.KindExists = func(_ *rest.Config, _ schema.GroupVersionKind) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() {
+		util.EnsureCRD = restoreEnsureCRD
+		util.KindExists = restoreKindExists
+	})
+
+	fakeClient := testingutil.NewFakeClient(scheme.Scheme)
+	ctx := &synccontext.RegisterContext{
+		Context:        context.Background(),
+		Config:         &pkgconfig.VirtualClusterConfig{},
+		VirtualManager: testingutil.NewFakeManager(fakeClient),
+		HostManager:    testingutil.NewFakeManager(fakeClient),
+	}
+	ctx.Config.Sync.ToHost.GatewayAPI.ReferenceGrants.Enabled = "false"
+	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
+	ctx.Config.Sync.ToHost.GatewayAPI.TLSRoutes.Enabled = true
+
+	if _, err := CreateHTTPRouteMapper(ctx); err != nil {
+		t.Fatalf("create HTTPRoute mapper: %v", err)
+	}
+	if _, err := CreateTLSRouteMapper(ctx); err != nil {
+		t.Fatalf("create TLSRoute mapper: %v", err)
+	}
+
+	if !ensured[mappings.ReferenceGrants()] {
+		t.Fatalf("route mappers must ensure the tenant ReferenceGrant CRD even with grant sync disabled; route controllers watch virtual ReferenceGrants for cross-namespace authorization")
 	}
 }

--- a/pkg/mappings/resources/register_gateway_test.go
+++ b/pkg/mappings/resources/register_gateway_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	gatewayapiutil "github.com/loft-sh/vcluster/pkg/util/gatewayapi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func TestReferenceGrantAutoFollowsHTTPRouteMapperWithoutNamespaceSync(t *testing.T) {
@@ -40,14 +40,20 @@ func TestReferenceGrantMapperChecksHostCRDWithoutNamespaceSync(t *testing.T) {
 	ctx.Config.Sync.ToHost.GatewayAPI.HTTPRoutes.Enabled = true
 
 	_, err := CreateReferenceGrantMapper(ctx)
-	if err == nil || !strings.Contains(err.Error(), "cannot check host cluster for Gateway API resource gateway.networking.k8s.io/v1beta1, Kind=ReferenceGrant") {
+	if err == nil || !strings.Contains(err.Error(), "cannot check host cluster for Gateway API resource gateway.networking.k8s.io/v1, Kind=ReferenceGrant") {
 		t.Fatalf("expected ReferenceGrant host CRD check before tenant CRD install, got %v", err)
 	}
 }
 
-func TestTLSRouteMapperKeepsOlderServedVersionForCompatibility(t *testing.T) {
-	want := schema.GroupVersion{Group: gatewayv1alpha2.GroupVersion.Group, Version: gatewayv1alpha2.GroupVersion.Version}
+func TestGatewayMappersUseLatestVersions(t *testing.T) {
+	want := schema.GroupVersion(gatewayv1.GroupVersion)
 	if got := mappings.TLSRoutes().GroupVersion(); got != want {
-		t.Fatalf("expected TLSRoute mapper to keep older served version %s for Gateway API compatibility, got %s", want, got)
+		t.Fatalf("expected TLSRoute mapper to use the latest version %s, got %s", want, got)
+	}
+	if got := mappings.BackendTLSPolicies().GroupVersion(); got != want {
+		t.Fatalf("expected BackendTLSPolicy mapper to use the latest version %s, got %s", want, got)
+	}
+	if got := mappings.ReferenceGrants().GroupVersion(); got != want {
+		t.Fatalf("expected ReferenceGrant mapper to use the latest version %s, got %s", want, got)
 	}
 }

--- a/pkg/mappings/resources/tlsroutes.go
+++ b/pkg/mappings/resources/tlsroutes.go
@@ -8,13 +8,13 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util"
 	"github.com/loft-sh/vcluster/pkg/util/translate"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // Source: https://github.com/kubernetes-sigs/gateway-api/raw/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
-// Experimental channel serves v1alpha2/v1alpha3 alongside v1.
-// Use v1alpha2 for the mapper so hosts with older Gateway API CRDs that do
-// not advertise TLSRoute v1 can still sync the resource.
+// Serves v1 (storage) plus the deprecated v1alpha2 and v1alpha3. The syncer
+// speaks v1 only; hosts whose CRDs do not serve v1 fail fast in
+// ensureHostGatewayAPIKind.
 //
 //go:embed tlsroutes.crd.yaml
 var tlsRoutesCRD string
@@ -30,5 +30,5 @@ func CreateTLSRouteMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper,
 		return nil, err
 	}
 
-	return generic.NewMapper(ctx, &gatewayv1alpha2.TLSRoute{}, translate.Default.HostName)
+	return generic.NewMapper(ctx, &gatewayv1.TLSRoute{}, translate.Default.HostName)
 }

--- a/pkg/mappings/resources/tlsroutes.go
+++ b/pkg/mappings/resources/tlsroutes.go
@@ -30,5 +30,10 @@ func CreateTLSRouteMapper(ctx *synccontext.RegisterContext) (synccontext.Mapper,
 		return nil, err
 	}
 
+	err = EnsureReferenceGrantCRD(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return generic.NewMapper(ctx, &gatewayv1.TLSRoute{}, translate.Default.HostName)
 }

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -15,9 +15,6 @@ import (
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 var Scheme = runtime.NewScheme()
@@ -41,9 +38,6 @@ func init() {
 
 	// Register GatewayAPI CRDs
 	_ = gatewayv1.Install(Scheme)
-	_ = gatewayv1alpha2.Install(Scheme)
-	_ = gatewayv1alpha3.Install(Scheme)
-	_ = gatewayv1beta1.Install(Scheme)
 
 	// Register Loft CRDs
 	_ = agentstoragev1.AddToScheme(Scheme)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-569
resolves #ENGNODE-566
resolves #ENGNODE-577


**Please provide a short message that should be published in the vcluster release notes**
  Sync Gateway API resources using only the latest `v1` versions: ReferenceGrant (was `v1beta1`), TLSRoute (was `v1alpha2`), and BackendTLSPolicy (was`v1alpha3`). 

install tenant referencegrant crd whenever route sync is enabled

**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
