### PR TITLE
fix: httproute parentRef syncing and clearer error message

### DIFF
--- a/e2e-next/test_gatewayapi/test_gatewayapi_fromhostboth.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_fromhostboth.go
@@ -27,7 +27,7 @@ func GatewayAPIFromHostBothSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			c := newGatewayAPIClients(ctx, false)
+			c := newGatewayAPIClients(ctx)
 			hostClient = c.HostClient
 			vClusterClient = c.VClusterClient
 			vClusterName = c.VClusterName

--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -86,6 +86,67 @@ func GatewayAPIImportSpec() {
 			})
 		})
 
+		It("syncs a same-namespace route attached to the imported Gateway without an explicit parentRef namespace", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-samens-"+suffix, importClassSelectorValue, "same-namespace class")
+			hostGW := hostGateway("gwapi-host", "samens-edge-"+suffix, class.Name)
+			createHostGateway(ctx, hostClient, hostGW)
+			var route *gatewayv1.HTTPRoute
+			var hostRouteName string
+
+			By("verifying the tenant mirror exists in the import target namespace", func() {
+				Eventually(func(g Gomega) {
+					mirror := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}, mirror)).To(Succeed())
+					g.Expect(mirror.Labels).To(HaveKeyWithValue(gateways.ImportedGatewayLabel, "true"))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("creating a backend and a route next to the mirror with the parentRef namespace omitted", func() {
+				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-samens-" + suffix, Namespace: "gwapi-import"}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, svc))).To(Succeed())
+				})
+				route = importRoute("gwapi-import", "route-samens-"+suffix, "", hostGW.Name, svc.Name, "app.apps.example.com")
+				route.Spec.ParentRefs[0].Namespace = nil
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+			})
+			By("verifying the host route parentRef carries the host Gateway namespace", func() {
+				hostRouteName = translate.SafeConcatName(route.Name, "x", "gwapi-import", "x", vClusterName)
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.HTTPRoute{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+					g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+					g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
+					g.Expect(got.Spec.ParentRefs[0].Namespace).NotTo(BeNil(), "implicit parentRef must be rewritten to the imported Gateway host namespace")
+					g.Expect(*got.Spec.ParentRefs[0].Namespace).To(Equal(gatewayv1.Namespace("gwapi-host")))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("writing host route status and verifying the tenant status ref stays implicit like the tenant spec", func() {
+				Eventually(func(g Gomega) {
+					hostRoute := &gatewayv1.HTTPRoute{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, hostRoute)).To(Succeed())
+					hostRoute.Status.Parents = []gatewayv1.RouteParentStatus{{
+						ParentRef:      *hostRoute.Spec.ParentRefs[0].DeepCopy(),
+						ControllerName: gatewayControllerName,
+						Conditions:     []metav1.Condition{{Type: "Accepted", Status: metav1.ConditionTrue, Reason: "Accepted", Message: "route accepted", LastTransitionTime: metav1.Now()}},
+					}}
+					g.Expect(hostClient.Status().Update(ctx, hostRoute)).To(Succeed())
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.HTTPRoute{}
+					g.Expect(vClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(route), got)).To(Succeed())
+					g.Expect(got.Status.Parents).To(HaveLen(1))
+					g.Expect(got.Status.Parents[0].ParentRef.Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
+					g.Expect(got.Status.Parents[0].ParentRef.Namespace).To(BeNil(), "tenant status ref must mirror the implicit tenant spec ref")
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+		})
+
 		It("mirrors the GatewayClass with controllerName preserved and parametersRef stripped", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-sanitize-"+suffix, importClassSelectorValue, "sanitize class")
@@ -436,7 +497,7 @@ func hostGateway(namespace, name, className string) *gatewayv1.Gateway {
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: gatewayv1.ObjectName(className),
 			Listeners: []gatewayv1.Listener{{
-				Name:     gatewayv1.SectionName("http"),
+				Name:     "http",
 				Protocol: gatewayv1.HTTPProtocolType,
 				Port:     gatewayv1.PortNumber(80),
 			}},
@@ -450,7 +511,7 @@ func hostTLSGateway(namespace, name, className, certName string) *gatewayv1.Gate
 		Spec: gatewayv1.GatewaySpec{
 			GatewayClassName: gatewayv1.ObjectName(className),
 			Listeners: []gatewayv1.Listener{{
-				Name:     gatewayv1.SectionName("https"),
+				Name:     "https",
 				Protocol: gatewayv1.HTTPSProtocolType,
 				Port:     gatewayv1.PortNumber(443),
 				TLS: &gatewayv1.ListenerTLSConfig{

--- a/e2e-next/test_gatewayapi/test_gatewayapi_subtoggles.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_subtoggles.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const (
@@ -57,11 +56,11 @@ func GatewayAPISelectiveSpec() {
 				Expect(ctrlclient.IgnoreNotFound(clients.VClusterClient.Delete(ctx, route))).To(Succeed())
 			})
 
-			grant := &gatewayv1beta1.ReferenceGrant{
+			grant := &gatewayv1.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
-				Spec: gatewayv1beta1.ReferenceGrantSpec{
-					From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace(frontend.Name)}},
-					To:   []gatewayv1beta1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
+				Spec: gatewayv1.ReferenceGrantSpec{
+					From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace(frontend.Name)}},
+					To:   []gatewayv1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
 				},
 			}
 			Expect(clients.VClusterClient.Create(ctx, grant)).To(Succeed())
@@ -83,7 +82,7 @@ func GatewayAPISelectiveSpec() {
 				Consistently(func(g Gomega) {
 					err := clients.HostClient.Get(ctx, types.NamespacedName{Namespace: clients.VClusterHostNS, Name: hostRouteName}, &gatewayv1.HTTPRoute{})
 					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "HTTPRoute should not be on host when httpRoutes.enabled=false")
-					err = clients.HostClient.Get(ctx, types.NamespacedName{Namespace: clients.VClusterHostNS, Name: hostGrantName}, &gatewayv1beta1.ReferenceGrant{})
+					err = clients.HostClient.Get(ctx, types.NamespacedName{Namespace: clients.VClusterHostNS, Name: hostGrantName}, &gatewayv1.ReferenceGrant{})
 					g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "ReferenceGrant should not be on host when referenceGrants.enabled=false")
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 			})
@@ -108,11 +107,11 @@ func GatewayAPIReferenceGrantDisabledSpec() {
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 
 			backend := createTenantNamespace(ctx, clients.VClusterClient, "rgdis-backend-"+suffix)
-			grant := &gatewayv1beta1.ReferenceGrant{
+			grant := &gatewayv1.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{Name: "allow-" + suffix, Namespace: backend.Name},
-				Spec: gatewayv1beta1.ReferenceGrantSpec{
-					From: []gatewayv1beta1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("rgdis-frontend-" + suffix)}},
-					To:   []gatewayv1beta1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
+				Spec: gatewayv1.ReferenceGrantSpec{
+					From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupName), Kind: gatewayv1.Kind("HTTPRoute"), Namespace: gatewayv1.Namespace("rgdis-frontend-" + suffix)}},
+					To:   []gatewayv1.ReferenceGrantTo{{Group: gatewayv1.Group(""), Kind: gatewayv1.Kind("Service")}},
 				},
 			}
 			Expect(clients.VClusterClient.Create(ctx, grant)).To(Succeed())
@@ -122,12 +121,12 @@ func GatewayAPIReferenceGrantDisabledSpec() {
 
 			hostGrantName := translate.SafeConcatName(grant.Name, "x", backend.Name, "x", clients.VClusterName)
 			Consistently(func(g Gomega) {
-				err := clients.HostClient.Get(ctx, types.NamespacedName{Namespace: clients.VClusterHostNS, Name: hostGrantName}, &gatewayv1beta1.ReferenceGrant{})
+				err := clients.HostClient.Get(ctx, types.NamespacedName{Namespace: clients.VClusterHostNS, Name: hostGrantName}, &gatewayv1.ReferenceGrant{})
 				g.Expect(kerrors.IsNotFound(err)).To(BeTrue(), "tenant ReferenceGrant must not sync when referenceGrants.enabled is false")
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutShort).Should(Succeed())
 
 			By("confirming the tenant still owns the ReferenceGrant", func() {
-				got := &gatewayv1beta1.ReferenceGrant{}
+				got := &gatewayv1.ReferenceGrant{}
 				Expect(clients.VClusterClient.Get(ctx, ctrlclient.ObjectKeyFromObject(grant), got)).To(Succeed())
 				Expect(got.Spec.From).To(HaveLen(1))
 			})

--- a/e2e-next/test_gatewayapi/test_gatewayapi_subtoggles.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_subtoggles.go
@@ -30,7 +30,7 @@ func GatewayAPISelectiveSpec() {
 
 		BeforeEach(func(ctx context.Context) {
 			installTenantGatewayAPICRDs(ctx, cluster.CurrentClusterFrom(ctx).GetKubeconfig(), tenantHTTPRouteCRD, tenantReferenceGrantCRD)
-			clients = newGatewayAPIClients(ctx, true)
+			clients = newGatewayAPIClients(ctx)
 		})
 
 		It("syncs only Gateway when sub-toggles disable httpRoutes and referenceGrants", func(ctx context.Context) {
@@ -97,7 +97,7 @@ func GatewayAPIReferenceGrantDisabledSpec() {
 
 		BeforeEach(func(ctx context.Context) {
 			installTenantGatewayAPICRDs(ctx, cluster.CurrentClusterFrom(ctx).GetKubeconfig(), tenantReferenceGrantCRD)
-			clients = newGatewayAPIClients(ctx, true)
+			clients = newGatewayAPIClients(ctx)
 		})
 
 		It("does not sync tenant-created ReferenceGrants when referenceGrants.enabled is false", func(ctx context.Context) {

--- a/e2e-next/vcluster-gatewayapi-rg-disabled.yaml
+++ b/e2e-next/vcluster-gatewayapi-rg-disabled.yaml
@@ -20,4 +20,4 @@ sync:
       httpRoutes:
         enabled: true
       referenceGrants:
-        enabled: "false"
+        enabled: false

--- a/e2e-next/vcluster-gatewayapi-selective.yaml
+++ b/e2e-next/vcluster-gatewayapi-selective.yaml
@@ -20,4 +20,4 @@ sync:
       httpRoutes:
         enabled: false
       referenceGrants:
-        enabled: "false"
+        enabled: false

--- a/pkg/config/gateway_validation_test.go
+++ b/pkg/config/gateway_validation_test.go
@@ -123,9 +123,9 @@ func TestValidateFromHostGatewaysEnforcesAtDeployTime(t *testing.T) {
 		{name: "empty key", mappings: map[string]string{"": "tenant-gateways/edge"}, want: "explicit host namespace is required"},
 		{name: "slash-wildcard key", mappings: map[string]string{"/*": "tenant-gateways/*"}, want: "explicit host namespace is required"},
 		{name: "slash-name key", mappings: map[string]string{"/edge": "tenant-gateways/edge"}, want: "explicit host namespace is required"},
-		// wildcard mismatch.
-		{name: "wildcard source exact target", mappings: map[string]string{"host-ns/*": "tenant-ns/edge"}, want: "must map to"},
-		{name: "exact source wildcard target", mappings: map[string]string{"host-ns/edge": "tenant-ns/*"}, want: "must map to"},
+		// wildcard mismatch: each direction blames the wildcard side, not the concrete one.
+		{name: "wildcard source exact target", mappings: map[string]string{"host-ns/*": "tenant-ns/edge"}, want: `wildcard key "host-ns/*" must map to a wildcard target NAMESPACE/*, but "tenant-ns/edge" is concrete`},
+		{name: "exact source wildcard target", mappings: map[string]string{"host-ns/edge": "tenant-ns/*"}, want: `target "tenant-ns/*" requires the source key to be a wildcard NAMESPACE/*, but "host-ns/edge" is concrete`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			gateways := rootconfig.FromHostGateways{}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -308,8 +308,11 @@ func validateGatewayMappings(mappings map[string]string, controlPlaneNamespace s
 		if tenant.namespace == "kube-system" || tenant.namespace == "kube-public" || tenant.namespace == "kube-node-lease" || (controlPlaneNamespace != "" && tenant.namespace == controlPlaneNamespace) {
 			return fmt.Errorf("sync.fromHost.gateways.mappings.byName target namespace %q is reserved", tenant.namespace)
 		}
-		if host.wildcard != tenant.wildcard {
-			return fmt.Errorf("sync.fromHost.gateways.mappings.byName wildcard key %q must map to tenant namespace/*", key)
+		if host.wildcard && !tenant.wildcard {
+			return fmt.Errorf("sync.fromHost.gateways.mappings.byName wildcard key %q must map to a wildcard target NAMESPACE/*, but %q is concrete", key, value)
+		}
+		if !host.wildcard && tenant.wildcard {
+			return fmt.Errorf("sync.fromHost.gateways.mappings.byName target %q requires the source key to be a wildcard NAMESPACE/*, but %q is concrete", value, key)
 		}
 		if host.wildcard {
 			if existing, ok := sourceWildcards[host.namespace]; ok {

--- a/pkg/controllers/resources/gatewayroutes/translate/translate.go
+++ b/pkg/controllers/resources/gatewayroutes/translate/translate.go
@@ -61,24 +61,25 @@ func parentRefToHost(ctx *synccontext.SyncContext, routeNamespace string, ref *g
 }
 
 // ParentRefToVirtual rewrites a host-side ParentReference into the equivalent
-// virtual reference. specParentRefs is the route's spec-side ParentRefs slice
-// (or nil when no such slice exists, e.g. BackendTLSPolicy ancestors); when
-// non-nil, the matching spec ref's explicit-namespace choice is preserved on
-// the returned status ref so spec/status round-trip cleanly.
-func ParentRefToVirtual(ctx *synccontext.SyncContext, hostRouteNamespace, virtualRouteNamespace string, ref *gatewayv1.ParentReference, specParentRefs []gatewayv1.ParentReference) error {
+// virtual reference. virtualSpecParentRefs is the virtual route's spec-side
+// ParentRefs slice (or nil when no such slice exists, e.g. BackendTLSPolicy
+// ancestors); the returned status ref mirrors the matching virtual spec ref's
+// explicit-namespace choice so spec/status round-trip cleanly. The host spec
+// ref cannot stand in for that choice: an implicit tenant ref to an imported
+// Gateway is made explicit on the host.
+func ParentRefToVirtual(ctx *synccontext.SyncContext, hostRouteNamespace, virtualRouteNamespace string, ref *gatewayv1.ParentReference, virtualSpecParentRefs []gatewayv1.ParentReference) error {
 	gvk, err := parentReferenceGVK(ref)
 	if err != nil {
 		return err
 	}
 
-	preserveNamespace := parentRefHasExplicitNamespace(hostRouteNamespace, ref, specParentRefs)
 	virtualName, err := refToVirtual(ctx, hostRouteNamespace, ref.Name, ref.Namespace, gvk)
 	if err != nil {
 		return err
 	}
 
 	ref.Name = gatewayv1.ObjectName(virtualName.Name)
-	if preserveNamespace || virtualName.Namespace != virtualRouteNamespace {
+	if virtualName.Namespace != virtualRouteNamespace || virtualSpecRefHasExplicitNamespace(virtualRouteNamespace, *ref, virtualName, virtualSpecParentRefs) {
 		ref.Namespace = ptr.To(gatewayv1.Namespace(virtualName.Namespace))
 	} else {
 		ref.Namespace = nil
@@ -87,9 +88,11 @@ func ParentRefToVirtual(ctx *synccontext.SyncContext, hostRouteNamespace, virtua
 	return nil
 }
 
-func parentRefHasExplicitNamespace(hostRouteNamespace string, ref *gatewayv1.ParentReference, specParentRefs []gatewayv1.ParentReference) bool {
-	for _, specParentRef := range specParentRefs {
-		if parentRefMatchesWithNamespace(specParentRef, *ref, hostRouteNamespace) && specParentRef.Namespace != nil && *specParentRef.Namespace != "" {
+func virtualSpecRefHasExplicitNamespace(virtualRouteNamespace string, statusRef gatewayv1.ParentReference, virtualName types.NamespacedName, virtualSpecParentRefs []gatewayv1.ParentReference) bool {
+	statusRef.Name = gatewayv1.ObjectName(virtualName.Name)
+	statusRef.Namespace = ptr.To(gatewayv1.Namespace(virtualName.Namespace))
+	for _, specParentRef := range virtualSpecParentRefs {
+		if parentRefMatchesWithNamespace(specParentRef, statusRef, virtualRouteNamespace) && specParentRef.Namespace != nil && *specParentRef.Namespace != "" {
 			return true
 		}
 	}
@@ -187,7 +190,18 @@ func objectRefToHost(ctx *synccontext.SyncContext, localNamespace string, refNam
 	}
 
 	*refName = gatewayv1.ObjectName(hostName.Name)
-	if refNamespace != nil && *refNamespace != nil {
+	if refNamespace == nil {
+		return nil
+	}
+	if *refNamespace != nil {
+		*refNamespace = ptr.To(gatewayv1.Namespace(hostName.Namespace))
+		return nil
+	}
+	// an implicit reference defaults to the referencing object's host
+	// namespace; when the resolved host object lives elsewhere (e.g. an
+	// imported fromHost Gateway), the host reference must name that
+	// namespace explicitly
+	if hostName.Namespace != "" && hostName.Namespace != utiltranslate.Default.HostNamespace(ctx, localNamespace) {
 		*refNamespace = ptr.To(gatewayv1.Namespace(hostName.Namespace))
 	}
 

--- a/pkg/controllers/resources/gatewayroutes/translate/translate_test.go
+++ b/pkg/controllers/resources/gatewayroutes/translate/translate_test.go
@@ -35,6 +35,70 @@ func TestParentRefToHostTranslatesImportedGatewayAndValidatesHostObject(t *testi
 	}
 }
 
+func TestParentRefToHostSetsHostNamespaceForImplicitRefToImportedGateway(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.Enabled = true
+	vcConfig.Sync.FromHost.Gateways.Mappings.ByName = map[string]string{"networking/shared-edge": "routes/edge"}
+
+	hostGateway := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "networking", Name: "shared-edge"}}
+	pClient := testingutil.NewFakeClient(scheme.Scheme, hostGateway)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	syncCtx := syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient).ToSyncContext("gatewayroute-translate-test")
+
+	// the route lives in the import target namespace, so the tenant may omit
+	// the parentRef namespace; on the host the Gateway lives in its own
+	// namespace, so the host ref must carry it explicitly
+	ref := gatewayv1.ParentReference{Name: "edge"}
+	if err := ParentRefToHost(syncCtx, "routes", &ref); err != nil {
+		t.Fatalf("expected implicit same-namespace parentRef to imported Gateway to translate: %v", err)
+	}
+	if ref.Name != "shared-edge" || ref.Namespace == nil || *ref.Namespace != "networking" {
+		t.Fatalf("expected parentRef to translate to networking/shared-edge, got namespace=%v name=%q", ref.Namespace, ref.Name)
+	}
+}
+
+func TestParentRefToVirtualMirrorsImplicitVirtualSpecRefForImportedGateway(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.Enabled = true
+	vcConfig.Sync.FromHost.Gateways.Mappings.ByName = map[string]string{"networking/shared-edge": "routes/edge"}
+
+	syncCtx := syncertesting.NewFakeRegisterContext(vcConfig, testingutil.NewFakeClient(scheme.Scheme), testingutil.NewFakeClient(scheme.Scheme)).ToSyncContext("gatewayroute-translate-test")
+
+	// the host status ref carries the explicit host namespace the toHost
+	// translation set; the tenant spec omitted the namespace, so the virtual
+	// status ref must omit it too
+	ref := gatewayv1.ParentReference{Name: "shared-edge", Namespace: ptr.To(gatewayv1.Namespace("networking"))}
+	virtualSpecParentRefs := []gatewayv1.ParentReference{{Name: "edge"}}
+
+	if err := ParentRefToVirtual(syncCtx, "host-routes", "routes", &ref, virtualSpecParentRefs); err != nil {
+		t.Fatalf("expected host parentRef status to translate: %v", err)
+	}
+	if ref.Name != "edge" || ref.Namespace != nil {
+		t.Fatalf("expected implicit virtual spec ref to stay implicit in status, got namespace=%v name=%q", ref.Namespace, ref.Name)
+	}
+}
+
+func TestParentRefToVirtualMirrorsExplicitSameNamespaceVirtualSpecRefForImportedGateway(t *testing.T) {
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	vcConfig.Sync.FromHost.Gateways.Enabled = true
+	vcConfig.Sync.FromHost.Gateways.Mappings.ByName = map[string]string{"networking/shared-edge": "routes/edge"}
+
+	syncCtx := syncertesting.NewFakeRegisterContext(vcConfig, testingutil.NewFakeClient(scheme.Scheme), testingutil.NewFakeClient(scheme.Scheme)).ToSyncContext("gatewayroute-translate-test")
+
+	// the tenant spec named its own namespace explicitly, so the virtual
+	// status ref keeps the explicit form even though it matches the route
+	// namespace
+	ref := gatewayv1.ParentReference{Name: "shared-edge", Namespace: ptr.To(gatewayv1.Namespace("networking"))}
+	virtualSpecParentRefs := []gatewayv1.ParentReference{{Name: "edge", Namespace: ptr.To(gatewayv1.Namespace("routes"))}}
+
+	if err := ParentRefToVirtual(syncCtx, "host-routes", "routes", &ref, virtualSpecParentRefs); err != nil {
+		t.Fatalf("expected host parentRef status to translate: %v", err)
+	}
+	if ref.Name != "edge" || ref.Namespace == nil || *ref.Namespace != "routes" {
+		t.Fatalf("expected explicit same-namespace virtual spec ref to stay explicit in status, got namespace=%v name=%q", ref.Namespace, ref.Name)
+	}
+}
+
 func TestParentRefToVirtualPreservesExplicitNamespaceFromSpecParentRef(t *testing.T) {
 	vcConfig := &pkgconfig.VirtualClusterConfig{}
 	vcConfig.Sync.FromHost.Gateways.Enabled = true
@@ -42,7 +106,7 @@ func TestParentRefToVirtualPreservesExplicitNamespaceFromSpecParentRef(t *testin
 
 	syncCtx := syncertesting.NewFakeRegisterContext(vcConfig, testingutil.NewFakeClient(scheme.Scheme), testingutil.NewFakeClient(scheme.Scheme)).ToSyncContext("gatewayroute-translate-test")
 	ref := gatewayv1.ParentReference{Name: "shared-edge", Namespace: ptr.To(gatewayv1.Namespace("networking"))}
-	specParentRefs := []gatewayv1.ParentReference{{Name: "shared-edge", Namespace: ptr.To(gatewayv1.Namespace("networking"))}}
+	specParentRefs := []gatewayv1.ParentReference{{Name: "edge", Namespace: ptr.To(gatewayv1.Namespace("tenant-gateways"))}}
 
 	if err := ParentRefToVirtual(syncCtx, "host-routes", "routes", &ref, specParentRefs); err != nil {
 		t.Fatalf("expected host parentRef status to translate: %v", err)

--- a/pkg/controllers/resources/httproutes/syncer.go
+++ b/pkg/controllers/resources/httproutes/syncer.go
@@ -79,7 +79,7 @@ func (s *httpRouteSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.
 		func() error {
 			// Status translation is independent of spec sync; on failure keep applying
 			// the spec but surface the error so the route is requeued and status retried.
-			vStatus, statusErr := statusToVirtual(ctx, event.Host, event.Virtual.Namespace, event.Host.Status)
+			vStatus, statusErr := statusToVirtual(ctx, event.Host, event.Virtual, event.Host.Status)
 			if statusErr == nil {
 				event.Virtual.Status = vStatus
 			}

--- a/pkg/controllers/resources/httproutes/translate.go
+++ b/pkg/controllers/resources/httproutes/translate.go
@@ -53,12 +53,12 @@ func specToHost(ctx *synccontext.SyncContext, vRoute *gatewayv1.HTTPRoute, valid
 	return retSpec, nil
 }
 
-func statusToVirtual(ctx *synccontext.SyncContext, hostRoute *gatewayv1.HTTPRoute, virtualRouteNamespace string, status gatewayv1.HTTPRouteStatus) (gatewayv1.HTTPRouteStatus, error) {
+func statusToVirtual(ctx *synccontext.SyncContext, hostRoute, vRoute *gatewayv1.HTTPRoute, status gatewayv1.HTTPRouteStatus) (gatewayv1.HTTPRouteStatus, error) {
 	retStatus := *status.DeepCopy()
 
 	for i := range retStatus.Parents {
 		hostRouteNamespace := routetranslate.ParentStatusHostNamespace(hostRoute.Namespace, hostRoute.Spec.ParentRefs, retStatus.Parents[i].ParentRef)
-		err := routetranslate.ParentRefToVirtual(ctx, hostRouteNamespace, virtualRouteNamespace, &retStatus.Parents[i].ParentRef, hostRoute.Spec.ParentRefs)
+		err := routetranslate.ParentRefToVirtual(ctx, hostRouteNamespace, vRoute.Namespace, &retStatus.Parents[i].ParentRef, vRoute.Spec.ParentRefs)
 		if err != nil {
 			return gatewayv1.HTTPRouteStatus{}, fmt.Errorf("translate parents[%d].parentRef: %w", i, err)
 		}

--- a/pkg/controllers/resources/tlsroutes/syncer.go
+++ b/pkg/controllers/resources/tlsroutes/syncer.go
@@ -79,7 +79,7 @@ func (s *tlsRouteSyncer) Sync(ctx *synccontext.SyncContext, event *synccontext.S
 		func() error {
 			// Status translation is independent of spec sync; on failure keep applying
 			// the spec but surface the error so the route is requeued and status retried.
-			vStatus, statusErr := statusToVirtual(ctx, event.Host, event.Virtual.Namespace, event.Host.Status)
+			vStatus, statusErr := statusToVirtual(ctx, event.Host, event.Virtual, event.Host.Status)
 			if statusErr == nil {
 				event.Virtual.Status = vStatus
 			}

--- a/pkg/controllers/resources/tlsroutes/translate.go
+++ b/pkg/controllers/resources/tlsroutes/translate.go
@@ -51,12 +51,12 @@ func specToHost(ctx *synccontext.SyncContext, vRoute *gatewayv1.TLSRoute, valida
 	return retSpec, nil
 }
 
-func statusToVirtual(ctx *synccontext.SyncContext, hostRoute *gatewayv1.TLSRoute, virtualRouteNamespace string, status gatewayv1.TLSRouteStatus) (gatewayv1.TLSRouteStatus, error) {
+func statusToVirtual(ctx *synccontext.SyncContext, hostRoute, vRoute *gatewayv1.TLSRoute, status gatewayv1.TLSRouteStatus) (gatewayv1.TLSRouteStatus, error) {
 	retStatus := *status.DeepCopy()
 
 	for i := range retStatus.Parents {
 		hostRouteNamespace := routetranslate.ParentStatusHostNamespace(hostRoute.Namespace, hostRoute.Spec.ParentRefs, retStatus.Parents[i].ParentRef)
-		err := routetranslate.ParentRefToVirtual(ctx, hostRouteNamespace, virtualRouteNamespace, &retStatus.Parents[i].ParentRef, hostRoute.Spec.ParentRefs)
+		err := routetranslate.ParentRefToVirtual(ctx, hostRouteNamespace, vRoute.Namespace, &retStatus.Parents[i].ParentRef, vRoute.Spec.ParentRefs)
 		if err != nil {
 			return gatewayv1.TLSRouteStatus{}, fmt.Errorf("translate parents[%d].parentRef: %w", i, err)
 		}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Closes #ENGNODE-570
Closes #ENGNODE-555


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
