### PR TITLE
fix: Keep the GatewayCRD valid during translation when sanitization is on

### DIFF
--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -98,6 +98,34 @@ func GatewayAPIImportSpec() {
 			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 		})
 
+		It("imports a TLS-terminating host Gateway with certificateRefs sanitized and the mirror kept valid", func(ctx context.Context) {
+			suffix := random.String(6)
+			class := createGatewayClass(ctx, hostClient, "gwc-tls-"+suffix, importClassSelectorValue, "tls class")
+			hostGW := hostTLSGateway("gwapi-host", "tls-edge-"+suffix, class.Name, "edge-cert-"+suffix)
+
+			By("creating a TLS-terminating host Gateway in the wildcard-mapped source namespace", func() {
+				createHostGateway(ctx, hostClient, hostGW)
+			})
+			By("verifying the tenant mirror keeps the https listener with sanitized certificateRefs", func() {
+				Eventually(func(g Gomega) {
+					mirror := &gatewayv1.Gateway{}
+					g.Expect(vClusterClient.Get(ctx, types.NamespacedName{Namespace: "gwapi-import", Name: hostGW.Name}, mirror)).To(Succeed())
+					g.Expect(mirror.Spec.Listeners).To(HaveLen(1))
+					listener := mirror.Spec.Listeners[0]
+					g.Expect(listener.Protocol).To(Equal(gatewayv1.HTTPSProtocolType))
+					g.Expect(listener.TLS).NotTo(BeNil(), "sanitizing certificateRefs must not drop the TLS config")
+					g.Expect(listener.TLS.CertificateRefs).To(BeEmpty(), "host certificateRefs must not leak into the tenant mirror")
+					g.Expect(listener.TLS.Options).To(HaveKeyWithValue(
+						gatewayv1.AnnotationKey(gateways.SanitizedCertificateRefsTLSOption),
+						gatewayv1.AnnotationValue("true"),
+					), "sanitized Terminate listener needs the marker option to stay CRD-valid")
+					if listener.TLS.Mode != nil {
+						g.Expect(*listener.TLS.Mode).To(Equal(gatewayv1.TLSModeTerminate))
+					}
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+		})
+
 		It("does not sync routes that attach to a tenant-local non-imported Gateway", func(ctx context.Context) {
 			suffix := random.String(6)
 			class := createGatewayClass(ctx, hostClient, "gwc-local-"+suffix, importClassSelectorValue, "local class")
@@ -395,6 +423,25 @@ func hostGateway(namespace, name, className string) *gatewayv1.Gateway {
 				Name:     gatewayv1.SectionName("http"),
 				Protocol: gatewayv1.HTTPProtocolType,
 				Port:     gatewayv1.PortNumber(80),
+			}},
+		},
+	}
+}
+
+func hostTLSGateway(namespace, name, className, certName string) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: gatewayv1.ObjectName(className),
+			Listeners: []gatewayv1.Listener{{
+				Name:     gatewayv1.SectionName("https"),
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Port:     gatewayv1.PortNumber(443),
+				// Mode is omitted so the API server defaults it to Terminate,
+				// matching the shared-edge Gateway shape from the field report.
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{{Name: gatewayv1.ObjectName(certName)}},
+				},
 			}},
 		},
 	}

--- a/e2e-next/test_gatewayapi/test_gatewayapi_import.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_import.go
@@ -119,9 +119,25 @@ func GatewayAPIImportSpec() {
 						gatewayv1.AnnotationKey(gateways.SanitizedCertificateRefsTLSOption),
 						gatewayv1.AnnotationValue("true"),
 					), "sanitized Terminate listener needs the marker option to stay CRD-valid")
-					if listener.TLS.Mode != nil {
-						g.Expect(*listener.TLS.Mode).To(Equal(gatewayv1.TLSModeTerminate))
-					}
+					g.Expect(listener.TLS.Mode).NotTo(BeNil(), "sanitizing must preserve the TLS mode")
+					g.Expect(*listener.TLS.Mode).To(Equal(gatewayv1.TLSModeTerminate))
+				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			})
+			By("attaching a tenant HTTPRoute to the sanitized Gateway and verifying it reaches the host", func() {
+				routeNS := createTenantNamespace(ctx, vClusterClient, "gwapi-tls-"+suffix)
+				svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: routeNS.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
+				Expect(vClusterClient.Create(ctx, svc)).To(Succeed())
+				route := importRoute(routeNS.Name, "route-"+suffix, "gwapi-import", hostGW.Name, svc.Name, "app.apps.example.com")
+				Expect(vClusterClient.Create(ctx, route)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, route))).To(Succeed())
+				})
+				hostRouteName := translate.SafeConcatName(route.Name, "x", routeNS.Name, "x", vClusterName)
+				Eventually(func(g Gomega) {
+					got := &gatewayv1.HTTPRoute{}
+					g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostRouteName}, got)).To(Succeed())
+					g.Expect(got.Spec.ParentRefs).To(HaveLen(1))
+					g.Expect(got.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName(hostGW.Name)))
 				}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
 			})
 		})
@@ -437,9 +453,8 @@ func hostTLSGateway(namespace, name, className, certName string) *gatewayv1.Gate
 				Name:     gatewayv1.SectionName("https"),
 				Protocol: gatewayv1.HTTPSProtocolType,
 				Port:     gatewayv1.PortNumber(443),
-				// Mode is omitted so the API server defaults it to Terminate,
-				// matching the shared-edge Gateway shape from the field report.
 				TLS: &gatewayv1.ListenerTLSConfig{
+					Mode:            ptr.To(gatewayv1.TLSModeTerminate),
 					CertificateRefs: []gatewayv1.SecretObjectReference{{Name: gatewayv1.ObjectName(certName)}},
 				},
 			}},

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	ImportedGatewayLabel    = "vcluster.loft.sh/imported-gateway"
-	ManagedByAnnotation     = "vcluster.loft.sh/managed-by"
-	SourceGatewayAnnotation = "vcluster.loft.sh/source-gateway"
+	ImportedGatewayLabel              = "vcluster.loft.sh/imported-gateway"
+	ManagedByAnnotation               = "vcluster.loft.sh/managed-by"
+	SourceGatewayAnnotation           = "vcluster.loft.sh/source-gateway"
+	SanitizedCertificateRefsTLSOption = "vcluster.loft.sh/certificate-refs-sanitized"
 )
 
 type gatewaySyncer struct {
@@ -283,7 +284,15 @@ func gatewaySpecToVirtual(ctx *synccontext.SyncContext, host *gatewayv1.Gateway)
 	policy := virtualNamespacePolicyFor(ctx, host)
 	for i := range spec.Listeners {
 		if ctx.Config.Sync.FromHost.Gateways.Sanitize.CertificateRefs && spec.Listeners[i].TLS != nil {
-			spec.Listeners[i].TLS.CertificateRefs = nil
+			tls := spec.Listeners[i].TLS
+			tls.CertificateRefs = nil
+			// The CRD requires certificateRefs or options when mode is Terminate
+			// (the default); add a marker option so the sanitized mirror stays valid.
+			if (tls.Mode == nil || *tls.Mode == gatewayv1.TLSModeTerminate) && len(tls.Options) == 0 {
+				tls.Options = map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+					SanitizedCertificateRefsTLSOption: "true",
+				}
+			}
 		}
 		if policy != nil {
 			spec.Listeners[i].AllowedRoutes = toGatewayAllowedRoutes(policy)

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -47,11 +47,94 @@ func TestGatewaySpecToVirtualSanitizesTLSInfrastructureAndAppliesVirtualAllowedR
 	if len(spec.Listeners[0].TLS.CertificateRefs) != 0 {
 		t.Fatalf("expected TLS certificateRefs to be sanitized, got %#v", spec.Listeners[0].TLS.CertificateRefs)
 	}
+	if spec.Listeners[0].TLS.Options[SanitizedCertificateRefsTLSOption] != "true" {
+		t.Fatalf("expected sanitize marker option on Terminate listener so the mirror stays CRD-valid, got %#v", spec.Listeners[0].TLS.Options)
+	}
 	if spec.Infrastructure != nil {
 		t.Fatalf("expected infrastructure to be sanitized")
 	}
 	if spec.Listeners[0].AllowedRoutes == nil || spec.Listeners[0].AllowedRoutes.Namespaces == nil || *spec.Listeners[0].AllowedRoutes.Namespaces.From != gatewayv1.NamespacesFromAll {
 		t.Fatalf("expected tenant-facing allowedRoutes from All, got %#v", spec.Listeners[0].AllowedRoutes)
+	}
+}
+
+func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
+	terminate := gatewayv1.TLSModeTerminate
+	passthrough := gatewayv1.TLSModePassthrough
+	certRefs := []gatewayv1.SecretObjectReference{{Name: "edge-cert"}}
+
+	tests := []struct {
+		name        string
+		sanitize    bool
+		tls         *gatewayv1.ListenerTLSConfig
+		wantRefs    int
+		wantOptions map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue
+	}{
+		{
+			name:        "terminate mode without options gets marker",
+			sanitize:    true,
+			tls:         &gatewayv1.ListenerTLSConfig{Mode: &terminate, CertificateRefs: certRefs},
+			wantRefs:    0,
+			wantOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{SanitizedCertificateRefsTLSOption: "true"},
+		},
+		{
+			name:        "nil mode defaults to terminate and gets marker",
+			sanitize:    true,
+			tls:         &gatewayv1.ListenerTLSConfig{CertificateRefs: certRefs},
+			wantRefs:    0,
+			wantOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{SanitizedCertificateRefsTLSOption: "true"},
+		},
+		{
+			name:        "existing host options are preserved without marker",
+			sanitize:    true,
+			tls:         &gatewayv1.ListenerTLSConfig{Mode: &terminate, CertificateRefs: certRefs, Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{"example.com/min-version": "TLSv1_2"}},
+			wantRefs:    0,
+			wantOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{"example.com/min-version": "TLSv1_2"},
+		},
+		{
+			name:        "passthrough mode needs no marker",
+			sanitize:    true,
+			tls:         &gatewayv1.ListenerTLSConfig{Mode: &passthrough, CertificateRefs: certRefs},
+			wantRefs:    0,
+			wantOptions: nil,
+		},
+		{
+			name:        "sanitize disabled leaves refs and options untouched",
+			sanitize:    false,
+			tls:         &gatewayv1.ListenerTLSConfig{Mode: &terminate, CertificateRefs: certRefs},
+			wantRefs:    1,
+			wantOptions: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vcConfig := &pkgconfig.VirtualClusterConfig{}
+			vcConfig.Sync.FromHost.Gateways.Sanitize.CertificateRefs = tt.sanitize
+			ctx := &synccontext.SyncContext{Context: context.Background(), Config: vcConfig}
+			host := &gatewayv1.Gateway{Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{
+				Name:     "https",
+				Protocol: gatewayv1.HTTPSProtocolType,
+				Port:     443,
+				TLS:      tt.tls,
+			}}}}
+
+			spec := gatewaySpecToVirtual(ctx, host)
+			got := spec.Listeners[0].TLS
+			if got == nil {
+				t.Fatalf("expected TLS config to be preserved")
+			}
+			if len(got.CertificateRefs) != tt.wantRefs {
+				t.Fatalf("expected %d certificateRefs, got %#v", tt.wantRefs, got.CertificateRefs)
+			}
+			if len(got.Options) != len(tt.wantOptions) {
+				t.Fatalf("expected options %#v, got %#v", tt.wantOptions, got.Options)
+			}
+			for k, v := range tt.wantOptions {
+				if got.Options[k] != v {
+					t.Fatalf("expected option %q=%q, got %#v", k, v, got.Options)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/controllers/resources/gateways/syncer_test.go
+++ b/pkg/controllers/resources/gateways/syncer_test.go
@@ -69,6 +69,7 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 		tls         *gatewayv1.ListenerTLSConfig
 		wantRefs    int
 		wantOptions map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue
+		wantMode    *gatewayv1.TLSModeType
 	}{
 		{
 			name:        "terminate mode without options gets marker",
@@ -76,6 +77,7 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 			tls:         &gatewayv1.ListenerTLSConfig{Mode: &terminate, CertificateRefs: certRefs},
 			wantRefs:    0,
 			wantOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{SanitizedCertificateRefsTLSOption: "true"},
+			wantMode:    &terminate,
 		},
 		{
 			name:        "nil mode defaults to terminate and gets marker",
@@ -83,6 +85,7 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 			tls:         &gatewayv1.ListenerTLSConfig{CertificateRefs: certRefs},
 			wantRefs:    0,
 			wantOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{SanitizedCertificateRefsTLSOption: "true"},
+			wantMode:    nil,
 		},
 		{
 			name:        "existing host options are preserved without marker",
@@ -90,6 +93,7 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 			tls:         &gatewayv1.ListenerTLSConfig{Mode: &terminate, CertificateRefs: certRefs, Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{"example.com/min-version": "TLSv1_2"}},
 			wantRefs:    0,
 			wantOptions: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{"example.com/min-version": "TLSv1_2"},
+			wantMode:    &terminate,
 		},
 		{
 			name:        "passthrough mode needs no marker",
@@ -97,6 +101,7 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 			tls:         &gatewayv1.ListenerTLSConfig{Mode: &passthrough, CertificateRefs: certRefs},
 			wantRefs:    0,
 			wantOptions: nil,
+			wantMode:    &passthrough,
 		},
 		{
 			name:        "sanitize disabled leaves refs and options untouched",
@@ -104,6 +109,7 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 			tls:         &gatewayv1.ListenerTLSConfig{Mode: &terminate, CertificateRefs: certRefs},
 			wantRefs:    1,
 			wantOptions: nil,
+			wantMode:    &terminate,
 		},
 	}
 	for _, tt := range tests {
@@ -125,6 +131,13 @@ func TestGatewaySpecToVirtualSanitizeKeepsTerminateListenerValid(t *testing.T) {
 			}
 			if len(got.CertificateRefs) != tt.wantRefs {
 				t.Fatalf("expected %d certificateRefs, got %#v", tt.wantRefs, got.CertificateRefs)
+			}
+			if tt.wantMode == nil {
+				if got.Mode != nil {
+					t.Fatalf("expected nil TLS mode to stay nil, got %q", *got.Mode)
+				}
+			} else if got.Mode == nil || *got.Mode != *tt.wantMode {
+				t.Fatalf("expected TLS mode %q to be preserved, got %#v", *tt.wantMode, got.Mode)
 			}
 			if len(got.Options) != len(tt.wantOptions) {
 				t.Fatalf("expected options %#v, got %#v", tt.wantOptions, got.Options)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-571


**Please provide a short message that should be published in the vcluster release notes**
  
### Problem: 
With sanitize.certificateRefs: true (the default), the import syncer stripped only certificateRefs from the mirror's listeners and left the rest of theTLS block intact. For an HTTPS listener with tls.mode: Terminate (also the CRD default when mode is omitted), this violates the Gateway API CEL rule "certificateRefs or options must be specified when mode is Terminate". The tenant API server rejected the mirror on every reconcile, so the imported Gateway never appeared in the tenant cluster and any HTTPRoute parented to it could never attach. Switching the mode is not an option either, since a second CEL rule requires HTTPS listeners to keep mode Terminate.

### Fix: 

When sanitizing strips the refs from a listener whose effective mode is Terminate and which has no tls.options, the syncer now adds a marker option so the
  mirror stays CRD-valid:

```yaml
  tls:
    mode: Terminate
    options:
      vcluster.loft.sh/certificate-refs-sanitized: "true"
```

  This keeps the https listener in the mirror (so tenant routes can still reference it by sectionName) and self-documents why the certs are absent. Host-provided tls.options already satisfy the rule and are preserved unchanged; Passthrough listeners need no marker.


## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
