### PR TITLE
fix(cli): restrict vcluster debug commands to helm driver and resolve parent context

### DIFF
--- a/cmd/vclusterctl/cmd/debug/collect.go
+++ b/cmd/vclusterctl/cmd/debug/collect.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/cli/util"
@@ -139,6 +140,16 @@ vcluster debug collect
 }
 
 func (cmd *CollectCmd) Run(ctx context.Context, args []string) error {
+	cfg := cmd.LoadedConfig(cmd.log)
+	driver, err := config.ParseDriverType(string(cfg.Driver.Type))
+	if err != nil {
+		return fmt.Errorf("parse driver type: %w", err)
+	}
+
+	if driver != config.HelmDriver {
+		return fmt.Errorf("vcluster debug collect is only supported for helm driver")
+	}
+
 	// gather resources
 	cmd.HostResources = mergeResources(defaultHostResources, cmd.HostResources)
 	cmd.VirtualResources = mergeResources(defaultVirtualResources, cmd.VirtualResources)

--- a/cmd/vclusterctl/cmd/debug/shell.go
+++ b/cmd/vclusterctl/cmd/debug/shell.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/loft-sh/log"
 	"github.com/loft-sh/vcluster/pkg/cli/completion"
+	"github.com/loft-sh/vcluster/pkg/cli/config"
 	"github.com/loft-sh/vcluster/pkg/cli/find"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	debugshellutil "github.com/loft-sh/vcluster/pkg/util/debugshell"
@@ -65,19 +66,30 @@ vcluster debug shell my-vcluster --pod=my-vcluster-pod-0 --target=syncer
 }
 
 func (cmd *DebugCmd) Run(ctx context.Context, args []string) error {
+	cfg := cmd.LoadedConfig(cmd.Log)
+	driver, err := config.ParseDriverType(string(cfg.Driver.Type))
+	if err != nil {
+		return fmt.Errorf("parse driver type: %w", err)
+	}
+
+	if driver != config.HelmDriver {
+		return fmt.Errorf("vcluster debug shell is only supported for helm driver")
+	}
+
 	if len(args) == 0 {
 		return fmt.Errorf("please specify a virtual cluster name")
 	}
 	vClusterName := args[0]
-	// Resolve target vCluster and pick the pod to attach an ephemeral debug container to.
-	client, err := find.CreateKubeClient(cmd.Context)
-	if err != nil {
-		return fmt.Errorf("cannot create Kubernetes client: %w", err)
-	}
 
+	// Resolve target vCluster and pick the pod to attach an ephemeral debug container to.
 	virtualCluster, err := find.GetVCluster(ctx, cmd.Context, vClusterName, cmd.Namespace, cmd.Log)
 	if err != nil {
 		return fmt.Errorf("cannot find virtual cluster: %w", err)
+	}
+
+	client, err := find.CreateKubeClient(virtualCluster.Context)
+	if err != nil {
+		return fmt.Errorf("cannot create Kubernetes client: %w", err)
 	}
 
 	pod, err := debugshellutil.SelectTargetPod(virtualCluster.Pods, cmd.VClusterPodName)
@@ -94,7 +106,7 @@ func (cmd *DebugCmd) Run(ctx context.Context, args []string) error {
 				return fmt.Errorf("error waiting for debug container: %w", err)
 			}
 		}
-		return executeCommand(debuggerName, pod.Name, pod.Namespace, cmd.Command, cmd.Log)
+		return executeCommand(virtualCluster.Context, debuggerName, pod.Name, pod.Namespace, cmd.Command, cmd.Log)
 	}
 
 	targetContainer := debugshellutil.FindTargetContainer(pod, cmd.Target)
@@ -145,7 +157,7 @@ func (cmd *DebugCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// Exec into the debug container and start a shell.
-	return executeCommand(debuggerName, pod.Name, pod.Namespace, cmd.Command, cmd.Log)
+	return executeCommand(virtualCluster.Context, debuggerName, pod.Name, pod.Namespace, cmd.Command, cmd.Log)
 }
 
 func (cmd *DebugCmd) waitForContainer(ctx context.Context, client kubernetes.Interface, namespace, podName, containerName string) error {
@@ -174,9 +186,9 @@ func (cmd *DebugCmd) waitForContainer(ctx context.Context, client kubernetes.Int
 	})
 }
 
-func executeCommand(containerName, pod, namespace string, command []string, log log.Logger) error {
+func executeCommand(contextName string, containerName, pod, namespace string, command []string, log log.Logger) error {
 	// Delegate to kubectl exec to get an interactive shell in the ephemeral container.
-	args := []string{"exec", "-n", namespace, pod, "-it", "-c", containerName, "--"}
+	args := []string{"exec", "--context", contextName, "-n", namespace, pod, "-it", "-c", containerName, "--"}
 	if len(command) > 0 {
 		args = append(args, command...)
 	} else {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-864


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster debug collect fails if executed using `docker` or `platform` drivers. In addtion, the debug shell fails if iexecuted while connected to a tenant cluster.

**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [x] **Add labels** to the test suite
- [x] **Update label-filter section** below to execute the new test suite
- [x] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
pr
```
