### PR TITLE
fix: blame the wildcard target, not the source key, in gateway mapping mismatch errors

### DIFF
--- a/e2e-next/test_gatewayapi/test_gatewayapi_fromhostboth.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_fromhostboth.go
@@ -27,7 +27,7 @@ func GatewayAPIFromHostBothSpec() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			c := newGatewayAPIClients(ctx, false)
+			c := newGatewayAPIClients(ctx)
 			hostClient = c.HostClient
 			vClusterClient = c.VClusterClient
 			vClusterName = c.VClusterName

--- a/e2e-next/test_gatewayapi/test_gatewayapi_subtoggles.go
+++ b/e2e-next/test_gatewayapi/test_gatewayapi_subtoggles.go
@@ -30,7 +30,7 @@ func GatewayAPISelectiveSpec() {
 
 		BeforeEach(func(ctx context.Context) {
 			installTenantGatewayAPICRDs(ctx, cluster.CurrentClusterFrom(ctx).GetKubeconfig(), tenantHTTPRouteCRD, tenantReferenceGrantCRD)
-			clients = newGatewayAPIClients(ctx, true)
+			clients = newGatewayAPIClients(ctx)
 		})
 
 		It("syncs only Gateway when sub-toggles disable httpRoutes and referenceGrants", func(ctx context.Context) {
@@ -97,7 +97,7 @@ func GatewayAPIReferenceGrantDisabledSpec() {
 
 		BeforeEach(func(ctx context.Context) {
 			installTenantGatewayAPICRDs(ctx, cluster.CurrentClusterFrom(ctx).GetKubeconfig(), tenantReferenceGrantCRD)
-			clients = newGatewayAPIClients(ctx, true)
+			clients = newGatewayAPIClients(ctx)
 		})
 
 		It("does not sync tenant-created ReferenceGrants when referenceGrants.enabled is false", func(ctx context.Context) {

--- a/pkg/config/gateway_validation_test.go
+++ b/pkg/config/gateway_validation_test.go
@@ -123,9 +123,9 @@ func TestValidateFromHostGatewaysEnforcesAtDeployTime(t *testing.T) {
 		{name: "empty key", mappings: map[string]string{"": "tenant-gateways/edge"}, want: "explicit host namespace is required"},
 		{name: "slash-wildcard key", mappings: map[string]string{"/*": "tenant-gateways/*"}, want: "explicit host namespace is required"},
 		{name: "slash-name key", mappings: map[string]string{"/edge": "tenant-gateways/edge"}, want: "explicit host namespace is required"},
-		// wildcard mismatch.
-		{name: "wildcard source exact target", mappings: map[string]string{"host-ns/*": "tenant-ns/edge"}, want: "must map to"},
-		{name: "exact source wildcard target", mappings: map[string]string{"host-ns/edge": "tenant-ns/*"}, want: "must map to"},
+		// wildcard mismatch: each direction blames the wildcard side, not the concrete one.
+		{name: "wildcard source exact target", mappings: map[string]string{"host-ns/*": "tenant-ns/edge"}, want: `wildcard key "host-ns/*" must map to a wildcard target NAMESPACE/*, but "tenant-ns/edge" is concrete`},
+		{name: "exact source wildcard target", mappings: map[string]string{"host-ns/edge": "tenant-ns/*"}, want: `target "tenant-ns/*" requires the source key to be a wildcard NAMESPACE/*, but "host-ns/edge" is concrete`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			gateways := rootconfig.FromHostGateways{}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -308,8 +308,11 @@ func validateGatewayMappings(mappings map[string]string, controlPlaneNamespace s
 		if tenant.namespace == "kube-system" || tenant.namespace == "kube-public" || tenant.namespace == "kube-node-lease" || (controlPlaneNamespace != "" && tenant.namespace == controlPlaneNamespace) {
 			return fmt.Errorf("sync.fromHost.gateways.mappings.byName target namespace %q is reserved", tenant.namespace)
 		}
-		if host.wildcard != tenant.wildcard {
-			return fmt.Errorf("sync.fromHost.gateways.mappings.byName wildcard key %q must map to tenant namespace/*", key)
+		if host.wildcard && !tenant.wildcard {
+			return fmt.Errorf("sync.fromHost.gateways.mappings.byName wildcard key %q must map to a wildcard target NAMESPACE/*, but %q is concrete", key, value)
+		}
+		if !host.wildcard && tenant.wildcard {
+			return fmt.Errorf("sync.fromHost.gateways.mappings.byName target %q requires the source key to be a wildcard NAMESPACE/*, but %q is concrete", value, key)
 		}
 		if host.wildcard {
 			if existing, ok := sourceWildcards[host.namespace]; ok {


### PR DESCRIPTION
Closes ENGNODE-555

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-555


**Please provide a short message that should be published in the vcluster release notes**
Fixed a misleading error message in the logs.


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e-next/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
