### PR TITLE
fix: use docker stop -t instead of --timeout

### DIFF
--- a/pkg/cli/delete_docker.go
+++ b/pkg/cli/delete_docker.go
@@ -152,7 +152,7 @@ func containerExists(ctx context.Context, containerName string) (bool, error) {
 }
 
 func stopContainer(ctx context.Context, containerName string) error {
-	args := []string{"stop", "--timeout=1", containerName}
+	args := []string{"stop", "-t=1", containerName}
 	output, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker stop failed: %w, output: %s", err, string(output))


### PR DESCRIPTION
**What issue type does this pull request address?**

/kind bugfix

---

**What does this pull request do? Which issues does it resolve?**

Fixes Docker driver virtual cluster deletion on Docker clients that do not support the `--timeout` flag for `docker stop`.

The Docker driver currently executes:

```go
docker stop --timeout=1 <container>
```

Some Docker client versions only support `-t` / `--time`, causing cluster deletion to fail with:

```text
docker stop failed: unknown flag: --timeout
```

This change replaces `--timeout=1` with the portable short form:

```go
docker stop -t 1 <container>
```
The short form -t is supported across Docker versions and is equivalent to specifying a stop timeout.
---

**Please provide a short message that should be published in the vCluster release notes**

Fixed an issue where Docker-driver virtual cluster deletion could fail on some Docker client versions due to use of an unsupported `docker stop --timeout` flag.

---

**What else do we need to know?**

### Environment

* macOS Tahoe 26.5.1
* Intel MacBook Pro (2019)
* Docker Client 27.5.0 (darwin/amd64)
* Docker Desktop 4.77.0
* vCluster 0.34.3

### Before

```text
$ vcluster delete my-vcluster

Removing vCluster container vcluster.cp.my-vcluster...
fatal: failed to stop container: docker stop failed:
unknown flag: --timeout
```

### After

```text
$ vcluster delete my-vcluster

Removing vCluster container vcluster.cp.my-vcluster...
Deleted kube context vcluster-docker_my-vcluster
Successfully deleted virtual cluster my-vcluster
```

### Validation

* Reproduced the issue locally
* Verified `docker stop --timeout` is not supported by the local Docker client
* Built the vCluster CLI from source
* Successfully created and deleted Docker-driver virtual clusters using the patched binary

No functional behavior changes beyond the Docker stop command flag.

## E2E Tests

### Additional test suites

```label-filter
none
```
