### PR TITLE
fix(e2e-next): normalize pod-level status.Resources in pod sync status assertions

### DIFF
--- a/e2e-next/test_core/sync/test_pods.go
+++ b/e2e-next/test_core/sync/test_pods.go
@@ -132,6 +132,9 @@ func PodSyncSpec() {
 					// Since k8s 1.32, status.QOSClass field has become immutable,
 					// hence we have stopped syncing it.
 					pod.Status.QOSClass = vpod.Status.QOSClass
+					// k8s 1.35 tenant can't carry pod-level Resources/AllocatedResources; exclude them from the comparison.
+					vpod.Status.Resources, pod.Status.Resources = nil, nil
+					vpod.Status.AllocatedResources, pod.Status.AllocatedResources = nil, nil
 					Expect(vpod.Status).To(Equal(pod.Status))
 				})
 
@@ -272,6 +275,9 @@ func PodSyncSpec() {
 					pod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					pod.Status.QOSClass = vpod.Status.QOSClass
+					// k8s 1.35 tenant can't carry pod-level Resources/AllocatedResources; exclude them from the comparison.
+					vpod.Status.Resources, pod.Status.Resources = nil, nil
+					vpod.Status.AllocatedResources, pod.Status.AllocatedResources = nil, nil
 					Expect(vpod.Status).To(Equal(pod.Status))
 				})
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind test

**What does this pull request do? Which issues does it resolve?**

The pod status-sync assertions in `e2e-next/test_core/sync/test_pods.go` (`should start a pod and sync status back to vCluster` and `should sync readiness conditions back to the vCluster pod`) fail on `v0.34` while passing on `main`/`v0.35`.

Root cause: the virtual apiserver on `v0.34` runs k8s **1.35**, where `InPlacePodLevelResourcesVerticalScaling` is alpha and off by default, so the apiserver drops pod-level `status.Resources`. The host pod (KIND) reports a non-nil empty `ResourceRequirements{}`, while the virtual pod reports `nil`, so `Expect(vpod.Status).To(Equal(pod.Status))` fails on that one field. `main`/`v0.35` run k8s **1.36** (gate beta/on), where the field is preserved, so they pass.

Fix: normalize `status.Resources` before the equality check at both assertion sites, mirroring the existing `QOSClass` handling.

**Please provide a short message that should be published in the vcluster release notes**

NONE (e2e test-only fix, no user-facing change)

**What else do we need to know?**

v0.34-only. `main`/`v0.35` already pass because they run k8s 1.36.

## E2E Tests

### Additional test suites

```label-filter
none
```