### PR TITLE
fix(ci): accept pre-release tags and enable manual dispatch for platform version bump

### DIFF
--- a/.github/workflows/update-platform-minimum-version.yaml
+++ b/.github/workflows/update-platform-minimum-version.yaml
@@ -1,9 +1,14 @@
-
 name: Update MinimumVersionTag from Platform
 
 on:
   repository_dispatch:
     types: [update-platform-version]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Platform version tag to set as MinimumVersionTag (e.g. v4.10.0 or v4.10.0-rc.5)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,34 +20,58 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # create-pull-request authenticates with GH_ACCESS_TOKEN, so the
+          # default checkout credentials don't need to persist.
+          persist-credentials: false
 
-      - name: Validate and compare versions
+      - name: Resolve incoming tag
+        id: resolve
+        env:
+          # workflow_dispatch passes inputs.tag; repository_dispatch passes client_payload.tag.
+          TAG: ${{ inputs.tag || github.event.client_payload.tag }}
+        run: |
+          if [[ -z "$TAG" ]]; then
+            printf "Error: no tag provided via workflow_dispatch input or repository_dispatch client_payload.\n"
+            exit 1
+          fi
+          printf "tag=%s\n" "$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate tag is semver
+        id: semver
+        uses: loft-sh/github-actions/.github/actions/semver-validation@semver-validation/v1
+        with:
+          version: ${{ steps.resolve.outputs.tag }}
+
+      - name: Fail on invalid tag
+        if: steps.semver.outputs.is_valid != 'true'
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+          ERR: ${{ steps.semver.outputs.error_message }}
+        run: |
+          printf "Error: tag '%s' is not valid semver: %s\n" "$TAG" "$ERR"
+          exit 1
+
+      - name: Compare versions
         id: version-check
         env:
-          TAG: ${{ github.event.client_payload.tag }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
-          SEMVER_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
-
-          if [[ -z "$TAG" ]]; then
-            printf "Error: TAG is not set. Exiting step."
-            exit 1
-          fi
-
-          if ! [[ "$TAG" =~ $SEMVER_REGEX ]]; then
-            printf "Error: TAG does not match semver pattern (vMAJOR.MINOR.PATCH), e.g., v1.2.3. Exiting step."
-            exit 1
-          fi
-
           CURRENT=$(grep -oP 'MinimumVersionTag\s*=\s*"\Kv[^"]+' pkg/platform/version.go)
           if [[ -z "$CURRENT" ]]; then
-            printf "Error: could not extract current MinimumVersionTag from pkg/platform/version.go."
+            printf "Error: could not extract current MinimumVersionTag from pkg/platform/version.go.\n"
             exit 1
           fi
 
           printf "Current MinimumVersionTag: %s\n" "$CURRENT"
           printf "Incoming tag: %s\n" "$TAG"
 
-          HIGHEST=$(printf '%s\n%s\n' "$CURRENT" "$TAG" | sort -V | tail -n1)
+          # Normalize the semver pre-release separator '-' to '~' before sorting:
+          # GNU `sort -V` ranks 'v4.10.0-rc.5' above 'v4.10.0', which is backwards.
+          # '~' sorts before everything in `sort -V`, so this restores semver
+          # precedence (pre-release < final). Restore '-' afterwards for comparison.
+          HIGHEST=$(printf '%s\n%s\n' "${CURRENT//-/\~}" "${TAG//-/\~}" | sort -V | tail -n1)
+          HIGHEST=${HIGHEST//\~/-}
           if [[ "$HIGHEST" == "$CURRENT" ]]; then
             printf "Skipping: incoming tag %s is not newer than current %s.\n" "$TAG" "$CURRENT"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -53,9 +82,9 @@ jobs:
       - name: Update MinimumVersionTag
         if: steps.version-check.outputs.skip != 'true'
         env:
-          TAG: ${{ github.event.client_payload.tag }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
-          sed -i 's/MinimumVersionTag = "v[0-9]\+\.[0-9]\+\.[0-9]\+"/MinimumVersionTag = "'"$TAG"'"/' pkg/platform/version.go
+          sed -i 's/MinimumVersionTag = "[^"]*"/MinimumVersionTag = "'"$TAG"'"/' pkg/platform/version.go
 
       - name: Create Pull Request
         if: steps.version-check.outputs.skip != 'true'
@@ -64,7 +93,7 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           committer: Loft Bot <loft-bot@users.noreply.github.com>
           base: main
-          branch: update-platform-version-tag/${{ github.event.client_payload.tag }}
-          title: "chore(deps): bump platform MinimumVersionTag to ${{ github.event.client_payload.tag }}"
-          body: "Bumps MinimumVersionTag to the new Platform release ${{ github.event.client_payload.tag }}."
+          branch: update-platform-version-tag/${{ steps.resolve.outputs.tag }}
+          title: "chore(deps): bump platform MinimumVersionTag to ${{ steps.resolve.outputs.tag }}"
+          body: "Bumps MinimumVersionTag to the new Platform release ${{ steps.resolve.outputs.tag }}."
           delete-branch: true


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
Closes DEVOPS-993

The `update-platform-version` CI job (`.github/workflows/update-platform-minimum-version.yaml`) failed on every dispatch and could not be run manually. The platform team needs it to pin vcluster's `MinimumVersionTag` to an RC build for final RC checks. Two independent root causes:

1. **Run failed.** Validation used `^v[0-9]+\.[0-9]+\.[0-9]+$`, which only accepts stable versions. The platform release process in `loft-sh/loft-enterprise` (`release-notify-repositories.yaml`) deliberately notifies on **stable and `-rc.`** tags, so the receiver here was stricter than the sender. The latest failed run received `TAG=v4.10.0-rc.5` and exited with *"TAG does not match semver pattern"*.
2. **No manual run.** The workflow only had a `repository_dispatch` trigger, so it never appeared as a manually runnable job in the Actions UI.

### Key Changes
- Add a `workflow_dispatch` trigger with a required `tag` input; resolve the tag from `inputs.tag` (manual) or `github.event.client_payload.tag` (dispatch).
- Replace the hand-rolled regex with the shared `loft-sh/github-actions` **`semver-validation`** action, which accepts pre-releases (reuse-first; already used in `release.yaml`).
- Fix the `sed` update to match any current value (`[^"]*`), so a pre-release current pin is replaced too, not just a stable one.
- Normalize `-` to `~` before `sort -V` so pre-releases rank **below** their final release, matching semver precedence (GNU `sort -V` gets `v4.10.0-rc.5` vs `v4.10.0` backwards).
- Set `persist-credentials: false` on checkout (`create-pull-request` authenticates with `GH_ACCESS_TOKEN`), matching other push-capable jobs in this repo.

**Please provide a short message that should be published in the vcluster release notes**
N/A. CI-only change to a release-automation workflow; no user-facing vcluster behavior.

**What else do we need to know?**

### Verification
- `actionlint` clean; `zizmor` clean except the expected `unpinned-uses` on our own internal `semver-validation` action, which is referenced by action-specific tag per the `github-actions` convention and must not be SHA-pinned.
- Comparison, `sed`, and `semver.valid()` behavior verified with standalone scripts across upgrade / downgrade / equal / rc-to-final / rc.5-vs-rc.10 cases.

### Dependencies
- Introduces a CI dependency on the shared `loft-sh/github-actions` `semver-validation@semver-validation/v1` action (already in use in this repo's `release.yaml`). No runtime or code dependencies.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
