### PR TITLE
feat(standalone): add controlPlane.standalone.advertiseAddress field

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4857,6 +4857,10 @@
           "type": "string",
           "description": "DataDir defines the data directory for the standalone mode."
         },
+        "advertiseAddress": {
+          "type": "string",
+          "description": "AdvertiseAddress pins the IP address the standalone control plane advertises to the\nkubernetes and konnectivity Services. Defaults to the VCLUSTER_STANDALONE_IP_ADDRESS env\nvar, then default-route interface detection. Set this on multi-homed hosts where the\ndefault route is not reachable from the pod network."
+        },
         "autoNodes": {
           "$ref": "#/$defs/StandaloneAutoNodes",
           "description": "AutoNodes automatically deploys nodes for standalone mode."

--- a/config/config.go
+++ b/config/config.go
@@ -393,6 +393,12 @@ type Standalone struct {
 	// DataDir defines the data directory for the standalone mode.
 	DataDir string `json:"dataDir,omitempty"`
 
+	// AdvertiseAddress pins the IP address the standalone control plane advertises to the
+	// kubernetes and konnectivity Services. Defaults to the VCLUSTER_STANDALONE_IP_ADDRESS env
+	// var, then default-route interface detection. Set this on multi-homed hosts where the
+	// default route is not reachable from the pod network.
+	AdvertiseAddress string `json:"advertiseAddress,omitempty"`
+
 	// AutoNodes automatically deploys nodes for standalone mode.
 	AutoNodes StandaloneAutoNodes `json:"autoNodes,omitempty"`
 


### PR DESCRIPTION
/kind feature

**What does this pull request do?**

Adds a `controlPlane.standalone.advertiseAddress` config field that pins the IP the standalone control plane advertises to the `kubernetes` and `konnectivity` Services.

Today this is only controllable via the `VCLUSTER_STANDALONE_IP_ADDRESS` env var (set indirectly by `install-standalone.sh --node-ip`). On multi-homed hosts (cloud VMs with both a public and a private NIC), `ChooseHostInterface()` selects the default-route IP — typically the public address, which is not reachable from the pod network — so the `kubernetes`/`konnectivity` EndpointSlices end up with unreachable IPs. This exposes a discoverable, first-class config field so operators can pin the in-cluster-reachable address without systemd drop-ins.

The vcluster-pro standalone code consumes it (prefer the config field, then the env var, then default-route detection) in a follow-up PR.

**Please provide a short message that should be published in the vcluster release notes**

Added `controlPlane.standalone.advertiseAddress` to pin the IP the standalone control plane advertises to the kubernetes/konnectivity Services (useful on multi-homed hosts).

Refs ENGCP-733
