### PR TITLE
Engnode 587

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2586,7 +2586,7 @@
         },
         "gateways": {
           "$ref": "#/$defs/EnableSwitchWithPatches",
-          "description": "Gateways configures tenant-created Gateway sync to the control plane cluster."
+          "description": "Gateways configures tenant-created Gateway sync to the control plane cluster.\nGateway spec.infrastructure.parametersRef names are translated for core ConfigMap and Secret refs.\nReferenced objects must also be synced to the host, for example with a pod reference or sync.toHost.configMaps.all / sync.toHost.secrets.all."
         },
         "tlsRoutes": {
           "$ref": "#/$defs/EnableSwitchWithPatches",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -91,6 +91,8 @@ sync:
         # Enabled defines if this option should be enabled.
         enabled: false
       # Gateways configures tenant-created Gateway sync to the control plane cluster.
+      # Gateway spec.infrastructure.parametersRef names are translated for core ConfigMap and Secret refs.
+      # Referenced objects must also be synced to the host, for example with a pod reference or sync.toHost.configMaps.all / sync.toHost.secrets.all.
       gateways:
         # Enabled defines if this option should be enabled.
         enabled: false

--- a/config/config.go
+++ b/config/config.go
@@ -1308,6 +1308,8 @@ type GatewayAPIEnableSwitchWithPatches struct {
 	HTTPRoutes EnableSwitchWithPatches `json:"httpRoutes,omitempty"`
 
 	// Gateways configures tenant-created Gateway sync to the control plane cluster.
+	// Gateway spec.infrastructure.parametersRef names are translated for core ConfigMap and Secret refs.
+	// Referenced objects must also be synced to the host, for example with a pod reference or sync.toHost.configMaps.all / sync.toHost.secrets.all.
 	Gateways EnableSwitchWithPatches `json:"gateways,omitempty"`
 
 	// TLSRoutes configures TLSRoute sync to the control plane cluster.

--- a/e2e/test_gatewayapi/test_gatewayapi_sync.go
+++ b/e2e/test_gatewayapi/test_gatewayapi_sync.go
@@ -176,17 +176,28 @@ func GatewayAPISyncSpec() {
 
 			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "backend-" + suffix, Namespace: ns.Name}, Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}}}
 			Expect(vClusterClient.Create(ctx, service)).To(Succeed())
+			parameters := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "gw-params-" + suffix, Namespace: ns.Name}, Data: map[string]string{"profile": "edge"}}
+			Expect(vClusterClient.Create(ctx, parameters)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, parameters))).To(Succeed())
+			})
 			gateway := tenantGateway(ns.Name, "gw-"+suffix, allowed.Name)
+			gateway.Spec.Infrastructure = &gatewayv1.GatewayInfrastructure{ParametersRef: &gatewayv1.LocalParametersReference{Group: gatewayv1.Group(corev1.GroupName), Kind: gatewayv1.Kind("ConfigMap"), Name: parameters.Name}}
 			Expect(vClusterClient.Create(ctx, gateway)).To(Succeed())
 			DeferCleanup(func(ctx context.Context) {
 				Expect(ctrlclient.IgnoreNotFound(vClusterClient.Delete(ctx, gateway))).To(Succeed())
 			})
 
 			hostGatewayName := translate.SafeConcatName(gateway.Name, "x", ns.Name, "x", vClusterName)
+			hostParametersName := translate.SafeConcatName(parameters.Name, "x", ns.Name, "x", vClusterName)
 			Eventually(func(g Gomega) {
+				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostParametersName}, &corev1.ConfigMap{})).To(Succeed())
 				got := &gatewayv1.Gateway{}
 				g.Expect(hostClient.Get(ctx, types.NamespacedName{Namespace: vClusterHostNS, Name: hostGatewayName}, got)).To(Succeed())
 				g.Expect(got.Spec.GatewayClassName).To(Equal(gatewayv1.ObjectName(allowed.Name)))
+				g.Expect(got.Spec.Infrastructure).NotTo(BeNil())
+				g.Expect(got.Spec.Infrastructure.ParametersRef).NotTo(BeNil())
+				g.Expect(got.Spec.Infrastructure.ParametersRef.Name).To(Equal(hostParametersName))
 				g.Expect(got.Spec.Listeners).To(HaveLen(1))
 				listener := got.Spec.Listeners[0]
 				g.Expect(listener.Name).To(Equal(gatewayv1.SectionName("http")))

--- a/e2e/vcluster-gatewayapi.yaml
+++ b/e2e/vcluster-gatewayapi.yaml
@@ -14,6 +14,9 @@ sync:
   toHost:
     services:
       enabled: true
+    configMaps:
+      enabled: true
+      all: true
     gatewayApi:
       gateways:
         enabled: true

--- a/pkg/controllers/resources/gatewayroutes/translate/translate.go
+++ b/pkg/controllers/resources/gatewayroutes/translate/translate.go
@@ -180,12 +180,12 @@ func parametersRefToHost(ctx *synccontext.SyncContext, localNamespace string, re
 		return err
 	}
 
-	hostName, err := refToHost(ctx, localNamespace, gatewayv1.ObjectName(ref.Name), nil, gvk, validateHostObject)
-	if err != nil {
+	refName := gatewayv1.ObjectName(ref.Name)
+	if err := objectRefToHost(ctx, localNamespace, &refName, nil, gvk, validateHostObject); err != nil {
 		return err
 	}
 
-	ref.Name = hostName.Name
+	ref.Name = string(refName)
 	return nil
 }
 

--- a/pkg/controllers/resources/gatewayroutes/translate/translate.go
+++ b/pkg/controllers/resources/gatewayroutes/translate/translate.go
@@ -115,6 +115,11 @@ func LocalObjectRefToHost(ctx *synccontext.SyncContext, localNamespace string, r
 	return localObjectRefToHost(ctx, localNamespace, ref, options.validateHostObject)
 }
 
+func ParametersRefToHost(ctx *synccontext.SyncContext, localNamespace string, ref *gatewayv1.LocalParametersReference, opts ...ToHostOption) error {
+	options := newToHostOptions(opts...)
+	return parametersRefToHost(ctx, localNamespace, ref, options.validateHostObject)
+}
+
 func PolicyTargetRefToHost(ctx *synccontext.SyncContext, policyNamespace string, ref *gatewayv1.LocalPolicyTargetReferenceWithSectionName, opts ...ToHostOption) error {
 	options := newToHostOptions(opts...)
 	return policyTargetRefToHost(ctx, policyNamespace, ref, options.validateHostObject)
@@ -167,6 +172,21 @@ func localObjectRefToHost(ctx *synccontext.SyncContext, localNamespace string, r
 	}
 
 	return objectRefToHost(ctx, localNamespace, &ref.Name, nil, gvk, validateHostObject)
+}
+
+func parametersRefToHost(ctx *synccontext.SyncContext, localNamespace string, ref *gatewayv1.LocalParametersReference, validateHostObject bool) error {
+	gvk, err := parametersReferenceGVK(ref)
+	if err != nil {
+		return err
+	}
+
+	hostName, err := refToHost(ctx, localNamespace, gatewayv1.ObjectName(ref.Name), nil, gvk, validateHostObject)
+	if err != nil {
+		return err
+	}
+
+	ref.Name = hostName.Name
+	return nil
 }
 
 func policyTargetRefToHost(ctx *synccontext.SyncContext, policyNamespace string, ref *gatewayv1.LocalPolicyTargetReferenceWithSectionName, validateHostObject bool) error {
@@ -446,6 +466,17 @@ func localObjectReferenceGVK(ref *gatewayv1.LocalObjectReference) (schema.GroupV
 	group := string(ref.Group)
 	kind := string(ref.Kind)
 
+	return localReferenceGVK("localObjectRef", group, kind)
+}
+
+func parametersReferenceGVK(ref *gatewayv1.LocalParametersReference) (schema.GroupVersionKind, error) {
+	group := string(ref.Group)
+	kind := string(ref.Kind)
+
+	return localReferenceGVK("parametersRef", group, kind)
+}
+
+func localReferenceGVK(refType, group, kind string) (schema.GroupVersionKind, error) {
 	if group == corev1.GroupName && kind == "ConfigMap" {
 		return mappings.ConfigMaps(), nil
 	}
@@ -453,7 +484,7 @@ func localObjectReferenceGVK(ref *gatewayv1.LocalObjectReference) (schema.GroupV
 		return mappings.Secrets(), nil
 	}
 
-	return schema.GroupVersionKind{}, unsupportedReferencef("localObjectRef group %q kind %q is not supported", group, kind)
+	return schema.GroupVersionKind{}, unsupportedReferencef("%s group %q kind %q is not supported", refType, group, kind)
 }
 
 func policyTargetReferenceGVK(ref *gatewayv1.LocalPolicyTargetReferenceWithSectionName) (schema.GroupVersionKind, error) {

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	rootconfig "github.com/loft-sh/vcluster/config"
-	gatewayroutetranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/gatewayroutes/translate"
+	routetranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/gatewayroutes/translate"
 	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/mappings/resources"
 	"github.com/loft-sh/vcluster/pkg/patcher"
@@ -85,7 +85,7 @@ func (s *tenantGatewaySyncer) Syncer() syncertypes.Sync[client.Object] {
 }
 
 func (s *tenantGatewaySyncer) ModifyController(ctx *synccontext.RegisterContext, builder *builder.Builder) (*builder.Builder, error) {
-	return gatewayroutetranslate.RegisterReferencedWatches(ctx, builder, s.GroupVersionKind(), mappings.ConfigMaps(), mappings.Secrets())
+	return routetranslate.RegisterReferencedWatches(ctx, builder, s.GroupVersionKind(), mappings.ConfigMaps(), mappings.Secrets())
 }
 
 func (s *tenantGatewaySyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.Gateway]) (ctrl.Result, error) {

--- a/pkg/controllers/resources/gateways/syncer.go
+++ b/pkg/controllers/resources/gateways/syncer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	rootconfig "github.com/loft-sh/vcluster/config"
+	gatewayroutetranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/gatewayroutes/translate"
+	"github.com/loft-sh/vcluster/pkg/mappings"
 	"github.com/loft-sh/vcluster/pkg/mappings/resources"
 	"github.com/loft-sh/vcluster/pkg/patcher"
 	"github.com/loft-sh/vcluster/pkg/pro"
@@ -17,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -64,6 +67,7 @@ type tenantGatewaySyncer struct {
 
 var _ syncertypes.Object = &tenantGatewaySyncer{}
 var _ syncertypes.Syncer = &tenantGatewaySyncer{}
+var _ syncertypes.ControllerModifier = &tenantGatewaySyncer{}
 
 func NewToHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, error) {
 	mapper, err := ctx.Mappings.ByGVK(resources.NewImportedGatewayMapper().GroupVersionKind())
@@ -78,6 +82,10 @@ func NewToHostSyncer(ctx *synccontext.RegisterContext) (syncertypes.Object, erro
 
 func (s *tenantGatewaySyncer) Syncer() syncertypes.Sync[client.Object] {
 	return syncer.ToGenericSyncer[*gatewayv1.Gateway](s)
+}
+
+func (s *tenantGatewaySyncer) ModifyController(ctx *synccontext.RegisterContext, builder *builder.Builder) (*builder.Builder, error) {
+	return gatewayroutetranslate.RegisterReferencedWatches(ctx, builder, s.GroupVersionKind(), mappings.ConfigMaps(), mappings.Secrets())
 }
 
 func (s *tenantGatewaySyncer) SyncToHost(ctx *synccontext.SyncContext, event *synccontext.SyncToHostEvent[*gatewayv1.Gateway]) (ctrl.Result, error) {

--- a/pkg/controllers/resources/gateways/translate.go
+++ b/pkg/controllers/resources/gateways/translate.go
@@ -44,7 +44,21 @@ func listenersToHost(ctx *synccontext.SyncContext, vGateway *gatewayv1.Gateway, 
 		}
 	}
 
+	if infra := retSpec.Infrastructure; infra != nil && infra.ParametersRef != nil {
+		if err := infrastructureParametersRefToHost(ctx, vGateway.Namespace, infra.ParametersRef, validateRefs); err != nil {
+			return nil, fmt.Errorf("translate infrastructure.parametersRef: %w", err)
+		}
+	}
+
 	return retSpec, nil
+}
+
+func infrastructureParametersRefToHost(ctx *synccontext.SyncContext, gatewayNamespace string, ref *gatewayv1.LocalParametersReference, validateRefs bool) error {
+	err := routetranslate.ParametersRefToHost(ctx, gatewayNamespace, ref, routetranslate.WithValidateHostObject(validateRefs))
+	if routetranslate.IsUnsupportedReference(err) {
+		return nil
+	}
+	return err
 }
 
 // In single-namespace mode, vCluster authorizes virtual route attachment before

--- a/pkg/controllers/resources/gateways/translate.go
+++ b/pkg/controllers/resources/gateways/translate.go
@@ -45,20 +45,12 @@ func listenersToHost(ctx *synccontext.SyncContext, vGateway *gatewayv1.Gateway, 
 	}
 
 	if infra := retSpec.Infrastructure; infra != nil && infra.ParametersRef != nil {
-		if err := infrastructureParametersRefToHost(ctx, vGateway.Namespace, infra.ParametersRef, validateRefs); err != nil {
+		if err := routetranslate.ParametersRefToHost(ctx, vGateway.Namespace, infra.ParametersRef, routetranslate.WithValidateHostObject(validateRefs)); err != nil {
 			return nil, fmt.Errorf("translate infrastructure.parametersRef: %w", err)
 		}
 	}
 
 	return retSpec, nil
-}
-
-func infrastructureParametersRefToHost(ctx *synccontext.SyncContext, gatewayNamespace string, ref *gatewayv1.LocalParametersReference, validateRefs bool) error {
-	err := routetranslate.ParametersRefToHost(ctx, gatewayNamespace, ref, routetranslate.WithValidateHostObject(validateRefs))
-	if routetranslate.IsUnsupportedReference(err) {
-		return nil
-	}
-	return err
 }
 
 // In single-namespace mode, vCluster authorizes virtual route attachment before

--- a/pkg/controllers/resources/gateways/translate_test.go
+++ b/pkg/controllers/resources/gateways/translate_test.go
@@ -58,16 +58,13 @@ func TestListenersToHostTranslatesInfrastructureParametersRef(t *testing.T) {
 	}
 }
 
-func TestListenersToHostLeavesUnsupportedInfrastructureParametersRefUnchanged(t *testing.T) {
+func TestListenersToHostRejectsUnsupportedInfrastructureParametersRef(t *testing.T) {
 	syncCtx := newGatewayTranslateSyncContext(t, nil, nil)
 	gateway := gatewayWithParametersRef(gatewayv1.LocalParametersReference{Group: "example.com", Kind: "GatewayConfig", Name: "params"})
 
-	spec, err := listenersToHost(syncCtx, gateway, true)
-	if err != nil {
-		t.Fatalf("expected unsupported infrastructure.parametersRef to be skipped, got %v", err)
-	}
-	if spec.Infrastructure.ParametersRef.Name != "params" {
-		t.Fatalf("expected unsupported parametersRef name to stay verbatim, got %q", spec.Infrastructure.ParametersRef.Name)
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if err == nil || !strings.Contains(err.Error(), "parametersRef group \"example.com\" kind \"GatewayConfig\" is not supported") {
+		t.Fatalf("expected unsupported infrastructure.parametersRef to reject Gateway, got %v", err)
 	}
 }
 

--- a/pkg/controllers/resources/gateways/translate_test.go
+++ b/pkg/controllers/resources/gateways/translate_test.go
@@ -1,0 +1,112 @@
+package gateways
+
+import (
+	"strings"
+	"testing"
+
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	utiltranslate "github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestListenersToHostTranslatesInfrastructureParametersRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		ref       gatewayv1.LocalParametersReference
+		configMap *corev1.ConfigMap
+		secret    *corev1.Secret
+	}{
+		{
+			name:      "configmap",
+			ref:       gatewayv1.LocalParametersReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "params"},
+			configMap: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "params"}},
+		},
+		{
+			name:   "secret",
+			ref:    gatewayv1.LocalParametersReference{Group: corev1.GroupName, Kind: "Secret", Name: "params"},
+			secret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "params"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncCtx := newGatewayTranslateSyncContext(t, tt.configMap, tt.secret)
+			expected := utiltranslate.Default.HostName(syncCtx, "params", "team-a")
+			gateway := gatewayWithParametersRef(tt.ref)
+
+			spec, err := listenersToHost(syncCtx, gateway, true)
+			if err != nil {
+				t.Fatalf("translate Gateway spec: %v", err)
+			}
+			if spec.Infrastructure == nil || spec.Infrastructure.ParametersRef == nil {
+				t.Fatalf("expected infrastructure.parametersRef to be preserved")
+			}
+			if spec.Infrastructure.ParametersRef.Name != expected.Name {
+				t.Fatalf("expected parametersRef name %q, got %q", expected.Name, spec.Infrastructure.ParametersRef.Name)
+			}
+			if gateway.Spec.Infrastructure.ParametersRef.Name != "params" {
+				t.Fatalf("expected virtual Gateway to stay unchanged, got %q", gateway.Spec.Infrastructure.ParametersRef.Name)
+			}
+		})
+	}
+}
+
+func TestListenersToHostLeavesUnsupportedInfrastructureParametersRefUnchanged(t *testing.T) {
+	syncCtx := newGatewayTranslateSyncContext(t, nil, nil)
+	gateway := gatewayWithParametersRef(gatewayv1.LocalParametersReference{Group: "example.com", Kind: "GatewayConfig", Name: "params"})
+
+	spec, err := listenersToHost(syncCtx, gateway, true)
+	if err != nil {
+		t.Fatalf("expected unsupported infrastructure.parametersRef to be skipped, got %v", err)
+	}
+	if spec.Infrastructure.ParametersRef.Name != "params" {
+		t.Fatalf("expected unsupported parametersRef name to stay verbatim, got %q", spec.Infrastructure.ParametersRef.Name)
+	}
+}
+
+func TestListenersToHostRequiresManagedHostInfrastructureParametersRef(t *testing.T) {
+	syncCtx := newGatewayTranslateSyncContext(t, nil, nil)
+	gateway := gatewayWithParametersRef(gatewayv1.LocalParametersReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "params"})
+
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if err == nil || !strings.Contains(err.Error(), "has no synced host object") {
+		t.Fatalf("expected missing host ConfigMap to reject Gateway, got %v", err)
+	}
+}
+
+func newGatewayTranslateSyncContext(t *testing.T, configMap *corev1.ConfigMap, secret *corev1.Secret) *synccontext.SyncContext {
+	t.Helper()
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	seedCtx := syncertesting.NewFakeRegisterContext(vcConfig, testingutil.NewFakeClient(scheme.Scheme), testingutil.NewFakeClient(scheme.Scheme)).ToSyncContext("gateway-translate-test")
+
+	var hostObjects []runtime.Object
+	if configMap != nil {
+		hostObjects = append(hostObjects, utiltranslate.HostMetadata(configMap, utiltranslate.Default.HostName(seedCtx, configMap.Name, configMap.Namespace)))
+	}
+	if secret != nil {
+		hostObjects = append(hostObjects, utiltranslate.HostMetadata(secret, utiltranslate.Default.HostName(seedCtx, secret.Name, secret.Namespace)))
+	}
+
+	pClient := testingutil.NewFakeClient(scheme.Scheme, hostObjects...)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+	return syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient).ToSyncContext("gateway-translate-test")
+}
+
+func gatewayWithParametersRef(ref gatewayv1.LocalParametersReference) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "tenant-class",
+			Infrastructure: &gatewayv1.GatewayInfrastructure{
+				ParametersRef: &ref,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-587


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
