### PR TITLE
fix(gateway-api): translate Gateway frontend CA refs

### DIFF
--- a/pkg/controllers/resources/gatewayapi/authz/authz.go
+++ b/pkg/controllers/resources/gatewayapi/authz/authz.go
@@ -75,6 +75,11 @@ func GatewayCertificate(ctx *synccontext.SyncContext, gatewayNamespace string, r
 	return referenceGrant(ctx, gatewayv1.GroupVersion.Group, "Gateway", gatewayNamespace, secretRefTarget(gatewayNamespace, ref))
 }
 
+// GatewayCACertificate checks whether a Gateway frontend CA certificateRef is allowed by virtual ReferenceGrants.
+func GatewayCACertificate(ctx *synccontext.SyncContext, gatewayNamespace string, ref *gatewayv1.ObjectReference) error {
+	return referenceGrant(ctx, gatewayv1.GroupVersion.Group, "Gateway", gatewayNamespace, objectRefTarget(gatewayNamespace, ref))
+}
+
 type referenceTarget struct {
 	group     string
 	kind      string
@@ -115,6 +120,15 @@ func secretRefTarget(localNamespace string, ref *gatewayv1.SecretObjectReference
 	return referenceTarget{
 		group:     group,
 		kind:      kind,
+		namespace: referenceNamespace(localNamespace, ref.Namespace),
+		name:      string(ref.Name),
+	}
+}
+
+func objectRefTarget(localNamespace string, ref *gatewayv1.ObjectReference) referenceTarget {
+	return referenceTarget{
+		group:     string(ref.Group),
+		kind:      string(ref.Kind),
 		namespace: referenceNamespace(localNamespace, ref.Namespace),
 		name:      string(ref.Name),
 	}

--- a/pkg/controllers/resources/gatewayroutes/translate/translate.go
+++ b/pkg/controllers/resources/gatewayroutes/translate/translate.go
@@ -115,6 +115,11 @@ func LocalObjectRefToHost(ctx *synccontext.SyncContext, localNamespace string, r
 	return localObjectRefToHost(ctx, localNamespace, ref, options.validateHostObject)
 }
 
+func ObjectRefToHost(ctx *synccontext.SyncContext, localNamespace string, ref *gatewayv1.ObjectReference, opts ...ToHostOption) error {
+	options := newToHostOptions(opts...)
+	return objectReferenceRefToHost(ctx, localNamespace, ref, options.validateHostObject)
+}
+
 func PolicyTargetRefToHost(ctx *synccontext.SyncContext, policyNamespace string, ref *gatewayv1.LocalPolicyTargetReferenceWithSectionName, opts ...ToHostOption) error {
 	options := newToHostOptions(opts...)
 	return policyTargetRefToHost(ctx, policyNamespace, ref, options.validateHostObject)
@@ -167,6 +172,15 @@ func localObjectRefToHost(ctx *synccontext.SyncContext, localNamespace string, r
 	}
 
 	return objectRefToHost(ctx, localNamespace, &ref.Name, nil, gvk, validateHostObject)
+}
+
+func objectReferenceRefToHost(ctx *synccontext.SyncContext, localNamespace string, ref *gatewayv1.ObjectReference, validateHostObject bool) error {
+	gvk, err := objectReferenceGVK(ref)
+	if err != nil {
+		return err
+	}
+
+	return objectRefToHost(ctx, localNamespace, &ref.Name, &ref.Namespace, gvk, validateHostObject)
 }
 
 func policyTargetRefToHost(ctx *synccontext.SyncContext, policyNamespace string, ref *gatewayv1.LocalPolicyTargetReferenceWithSectionName, validateHostObject bool) error {
@@ -443,9 +457,14 @@ func secretObjectReferenceGVK(ref *gatewayv1.SecretObjectReference) (schema.Grou
 }
 
 func localObjectReferenceGVK(ref *gatewayv1.LocalObjectReference) (schema.GroupVersionKind, error) {
-	group := string(ref.Group)
-	kind := string(ref.Kind)
+	return objectReferenceGroupKindGVK(string(ref.Group), string(ref.Kind), "localObjectRef")
+}
 
+func objectReferenceGVK(ref *gatewayv1.ObjectReference) (schema.GroupVersionKind, error) {
+	return objectReferenceGroupKindGVK(string(ref.Group), string(ref.Kind), "objectRef")
+}
+
+func objectReferenceGroupKindGVK(group, kind, field string) (schema.GroupVersionKind, error) {
 	if group == corev1.GroupName && kind == "ConfigMap" {
 		return mappings.ConfigMaps(), nil
 	}
@@ -453,7 +472,7 @@ func localObjectReferenceGVK(ref *gatewayv1.LocalObjectReference) (schema.GroupV
 		return mappings.Secrets(), nil
 	}
 
-	return schema.GroupVersionKind{}, unsupportedReferencef("localObjectRef group %q kind %q is not supported", group, kind)
+	return schema.GroupVersionKind{}, unsupportedReferencef("%s group %q kind %q is not supported", field, group, kind)
 }
 
 func policyTargetReferenceGVK(ref *gatewayv1.LocalPolicyTargetReferenceWithSectionName) (schema.GroupVersionKind, error) {

--- a/pkg/controllers/resources/gateways/translate.go
+++ b/pkg/controllers/resources/gateways/translate.go
@@ -26,6 +26,54 @@ func (s *tenantGatewaySyncer) translate(ctx *synccontext.SyncContext, vGateway *
 func listenersToHost(ctx *synccontext.SyncContext, vGateway *gatewayv1.Gateway, validateRefs bool) (*gatewayv1.GatewaySpec, error) {
 	retSpec := vGateway.Spec.DeepCopy()
 
+	if retSpec.TLS != nil {
+		if retSpec.TLS.Backend != nil && retSpec.TLS.Backend.ClientCertificateRef != nil {
+			err := gatewayauthz.GatewayCertificate(ctx, vGateway.Namespace, retSpec.TLS.Backend.ClientCertificateRef)
+			if err != nil {
+				return nil, fmt.Errorf("authorize tls.backend.clientCertificateRef: %w", err)
+			}
+
+			err = routetranslate.SecretObjectRefToHost(ctx, vGateway.Namespace, retSpec.TLS.Backend.ClientCertificateRef, routetranslate.WithValidateHostObject(validateRefs))
+			if err != nil {
+				return nil, fmt.Errorf("translate tls.backend.clientCertificateRef: %w", err)
+			}
+		}
+
+		if retSpec.TLS.Frontend != nil {
+			if retSpec.TLS.Frontend.Default.Validation != nil {
+				for i := range retSpec.TLS.Frontend.Default.Validation.CACertificateRefs {
+					err := gatewayauthz.GatewayCACertificate(ctx, vGateway.Namespace, &retSpec.TLS.Frontend.Default.Validation.CACertificateRefs[i])
+					if err != nil {
+						return nil, fmt.Errorf("authorize tls.frontend.default.validation.caCertificateRefs[%d]: %w", i, err)
+					}
+
+					err = routetranslate.ObjectRefToHost(ctx, vGateway.Namespace, &retSpec.TLS.Frontend.Default.Validation.CACertificateRefs[i], routetranslate.WithValidateHostObject(validateRefs))
+					if err != nil {
+						return nil, fmt.Errorf("translate tls.frontend.default.validation.caCertificateRefs[%d]: %w", i, err)
+					}
+				}
+			}
+
+			for i := range retSpec.TLS.Frontend.PerPort {
+				if retSpec.TLS.Frontend.PerPort[i].TLS.Validation == nil {
+					continue
+				}
+
+				for j := range retSpec.TLS.Frontend.PerPort[i].TLS.Validation.CACertificateRefs {
+					err := gatewayauthz.GatewayCACertificate(ctx, vGateway.Namespace, &retSpec.TLS.Frontend.PerPort[i].TLS.Validation.CACertificateRefs[j])
+					if err != nil {
+						return nil, fmt.Errorf("authorize tls.frontend.perPort[%d].tls.validation.caCertificateRefs[%d]: %w", i, j, err)
+					}
+
+					err = routetranslate.ObjectRefToHost(ctx, vGateway.Namespace, &retSpec.TLS.Frontend.PerPort[i].TLS.Validation.CACertificateRefs[j], routetranslate.WithValidateHostObject(validateRefs))
+					if err != nil {
+						return nil, fmt.Errorf("translate tls.frontend.perPort[%d].tls.validation.caCertificateRefs[%d]: %w", i, j, err)
+					}
+				}
+			}
+		}
+	}
+
 	for i := range retSpec.Listeners {
 		ensureAllowedRoutesAttachableOnHost(retSpec.Listeners[i].AllowedRoutes)
 

--- a/pkg/controllers/resources/gateways/translate_frontend_tls_test.go
+++ b/pkg/controllers/resources/gateways/translate_frontend_tls_test.go
@@ -1,0 +1,308 @@
+package gateways
+
+import (
+	"strings"
+	"testing"
+
+	pkgconfig "github.com/loft-sh/vcluster/pkg/config"
+	routetranslate "github.com/loft-sh/vcluster/pkg/controllers/resources/gatewayroutes/translate"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
+	syncertesting "github.com/loft-sh/vcluster/pkg/syncer/testing"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	utiltranslate "github.com/loft-sh/vcluster/pkg/util/translate"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestListenersToHostTranslatesDefaultFrontendCACertificateRefs(t *testing.T) {
+	tests := []struct {
+		name      string
+		ref       gatewayv1.ObjectReference
+		configMap *corev1.ConfigMap
+		secret    *corev1.Secret
+	}{
+		{
+			name:      "configmap",
+			ref:       gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "client-ca"},
+			configMap: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "client-ca"}},
+		},
+		{
+			name:   "secret",
+			ref:    gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "Secret", Name: "client-ca"},
+			secret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "client-ca"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncCtx := newGatewayFrontendTLSTranslateSyncContext(t, tt.configMap, tt.secret)
+			expected := utiltranslate.Default.HostName(syncCtx, "client-ca", "team-a")
+			gateway := gatewayWithDefaultFrontendCACertificateRefs(tt.ref)
+
+			spec, err := listenersToHost(syncCtx, gateway, true)
+			if err != nil {
+				t.Fatalf("translate Gateway spec: %v", err)
+			}
+			gotRefs := spec.TLS.Frontend.Default.Validation.CACertificateRefs
+			if len(gotRefs) != 1 {
+				t.Fatalf("expected one default frontend CA certificate ref, got %#v", gotRefs)
+			}
+			if gotRefs[0].Name != gatewayv1.ObjectName(expected.Name) {
+				t.Fatalf("expected CA certificate ref name %q, got %q", expected.Name, gotRefs[0].Name)
+			}
+			if gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs[0].Name != "client-ca" {
+				t.Fatalf("expected virtual Gateway to stay unchanged, got %q", gateway.Spec.TLS.Frontend.Default.Validation.CACertificateRefs[0].Name)
+			}
+		})
+	}
+}
+
+func TestListenersToHostAllowsGrantedCrossNamespaceDefaultFrontendCACertificateRef(t *testing.T) {
+	restore := setDefaultGatewayFrontendTLSTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	caNamespace := gatewayv1.Namespace("security")
+	grant := &gatewayv1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "allow-gateway-ca"},
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("Gateway"), Namespace: gatewayv1.Namespace("team-a")}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: gatewayv1.Group(corev1.GroupName), Kind: gatewayv1.Kind("ConfigMap"), Name: ptr.To(gatewayv1.ObjectName("client-ca"))}},
+		},
+	}
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "client-ca"}},
+		nil,
+		grant,
+	)
+	expected := utiltranslate.Default.HostName(syncCtx, "client-ca", "security")
+	gateway := gatewayWithDefaultFrontendCACertificateRefs(gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "client-ca", Namespace: &caNamespace})
+
+	spec, err := listenersToHost(syncCtx, gateway, true)
+	if err != nil {
+		t.Fatalf("translate Gateway spec: %v", err)
+	}
+	got := spec.TLS.Frontend.Default.Validation.CACertificateRefs[0]
+	if got.Name != gatewayv1.ObjectName(expected.Name) || got.Namespace == nil || *got.Namespace != gatewayv1.Namespace(expected.Namespace) {
+		t.Fatalf("expected CA certificate ref %s/%s, got %#v", expected.Namespace, expected.Name, got)
+	}
+}
+
+func TestListenersToHostRequiresReferenceGrantForCrossNamespaceDefaultFrontendCACertificateRef(t *testing.T) {
+	restore := setDefaultGatewayFrontendTLSTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	caNamespace := gatewayv1.Namespace("security")
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "client-ca"}},
+		nil,
+	)
+	gateway := gatewayWithDefaultFrontendCACertificateRefs(gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "client-ca", Namespace: &caNamespace})
+
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if err == nil || !strings.Contains(err.Error(), "ReferenceGrant") {
+		t.Fatalf("expected cross-namespace default frontend CA certificate ref to require ReferenceGrant, got %v", err)
+	}
+}
+
+func TestListenersToHostAllowsGrantedCrossNamespacePerPortFrontendCACertificateRef(t *testing.T) {
+	restore := setDefaultGatewayFrontendTLSTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	caNamespace := gatewayv1.Namespace("security")
+	grant := &gatewayv1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "allow-gateway-ca"},
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("Gateway"), Namespace: gatewayv1.Namespace("team-a")}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: gatewayv1.Group(corev1.GroupName), Kind: gatewayv1.Kind("ConfigMap"), Name: ptr.To(gatewayv1.ObjectName("client-ca"))}},
+		},
+	}
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "client-ca"}},
+		nil,
+		grant,
+	)
+	expected := utiltranslate.Default.HostName(syncCtx, "client-ca", "security")
+	gateway := gatewayWithPerPortFrontendCACertificateRefs(443, gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "client-ca", Namespace: &caNamespace})
+
+	spec, err := listenersToHost(syncCtx, gateway, true)
+	if err != nil {
+		t.Fatalf("translate Gateway spec: %v", err)
+	}
+	got := spec.TLS.Frontend.PerPort[0].TLS.Validation.CACertificateRefs[0]
+	if got.Name != gatewayv1.ObjectName(expected.Name) || got.Namespace == nil || *got.Namespace != gatewayv1.Namespace(expected.Namespace) {
+		t.Fatalf("expected per-port CA certificate ref %s/%s, got %#v", expected.Namespace, expected.Name, got)
+	}
+	if gateway.Spec.TLS.Frontend.PerPort[0].TLS.Validation.CACertificateRefs[0].Name != "client-ca" {
+		t.Fatalf("expected virtual Gateway to stay unchanged, got %q", gateway.Spec.TLS.Frontend.PerPort[0].TLS.Validation.CACertificateRefs[0].Name)
+	}
+}
+
+func TestListenersToHostRequiresReferenceGrantForCrossNamespacePerPortFrontendCACertificateRef(t *testing.T) {
+	restore := setDefaultGatewayFrontendTLSTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	caNamespace := gatewayv1.Namespace("security")
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "client-ca"}},
+		nil,
+	)
+	gateway := gatewayWithPerPortFrontendCACertificateRefs(443, gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "client-ca", Namespace: &caNamespace})
+
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if err == nil || !strings.Contains(err.Error(), "ReferenceGrant") || !strings.Contains(err.Error(), "tls.frontend.perPort[0].tls.validation.caCertificateRefs[0]") {
+		t.Fatalf("expected cross-namespace per-port frontend CA certificate ref to require ReferenceGrant with field context, got %v", err)
+	}
+}
+
+func TestListenersToHostTranslatesGrantedBackendTLSClientCertificateRef(t *testing.T) {
+	restore := setDefaultGatewayFrontendTLSTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	certNamespace := gatewayv1.Namespace("security")
+	grant := &gatewayv1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "allow-gateway-client-cert"},
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: gatewayv1.Kind("Gateway"), Namespace: gatewayv1.Namespace("team-a")}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: gatewayv1.Group(corev1.GroupName), Kind: gatewayv1.Kind("Secret"), Name: ptr.To(gatewayv1.ObjectName("client-cert"))}},
+		},
+	}
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t,
+		nil,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "client-cert"}},
+		grant,
+	)
+	expected := utiltranslate.Default.HostName(syncCtx, "client-cert", "security")
+	gateway := gatewayWithBackendTLSClientCertificateRef(gatewayv1.SecretObjectReference{Name: "client-cert", Namespace: &certNamespace})
+
+	spec, err := listenersToHost(syncCtx, gateway, true)
+	if err != nil {
+		t.Fatalf("translate Gateway spec: %v", err)
+	}
+	got := spec.TLS.Backend.ClientCertificateRef
+	if got == nil {
+		t.Fatalf("expected backend TLS client certificate ref")
+	}
+	if got.Name != gatewayv1.ObjectName(expected.Name) || got.Namespace == nil || *got.Namespace != gatewayv1.Namespace(expected.Namespace) {
+		t.Fatalf("expected backend TLS client certificate ref %s/%s, got %#v", expected.Namespace, expected.Name, got)
+	}
+	if gateway.Spec.TLS.Backend.ClientCertificateRef.Name != "client-cert" {
+		t.Fatalf("expected virtual Gateway to stay unchanged, got %q", gateway.Spec.TLS.Backend.ClientCertificateRef.Name)
+	}
+}
+
+func TestListenersToHostRequiresReferenceGrantForCrossNamespaceBackendTLSClientCertificateRef(t *testing.T) {
+	restore := setDefaultGatewayFrontendTLSTranslator(utiltranslate.NewSingleNamespaceTranslator("vcluster-host"))
+	defer restore()
+
+	certNamespace := gatewayv1.Namespace("security")
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t,
+		nil,
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "security", Name: "client-cert"}},
+	)
+	gateway := gatewayWithBackendTLSClientCertificateRef(gatewayv1.SecretObjectReference{Name: "client-cert", Namespace: &certNamespace})
+
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if err == nil || !strings.Contains(err.Error(), "ReferenceGrant") || !strings.Contains(err.Error(), "tls.backend.clientCertificateRef") {
+		t.Fatalf("expected cross-namespace backend TLS client certificate ref to require ReferenceGrant with field context, got %v", err)
+	}
+}
+
+func TestListenersToHostRequiresManagedHostDefaultFrontendCACertificateRef(t *testing.T) {
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t, nil, nil)
+	gateway := gatewayWithDefaultFrontendCACertificateRefs(gatewayv1.ObjectReference{Group: corev1.GroupName, Kind: "ConfigMap", Name: "client-ca"})
+
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if err == nil || !strings.Contains(err.Error(), "has no synced host object") {
+		t.Fatalf("expected missing host ConfigMap to reject Gateway, got %v", err)
+	}
+}
+
+func TestListenersToHostRejectsUnsupportedDefaultFrontendCACertificateRef(t *testing.T) {
+	syncCtx := newGatewayFrontendTLSTranslateSyncContext(t, nil, nil)
+	gateway := gatewayWithDefaultFrontendCACertificateRefs(gatewayv1.ObjectReference{Group: gatewayv1.Group(gatewayv1.GroupVersion.Group), Kind: "GatewayClass", Name: "client-ca"})
+
+	_, err := listenersToHost(syncCtx, gateway, true)
+	if !routetranslate.IsUnsupportedReference(err) {
+		t.Fatalf("expected unsupported default frontend CA certificate ref to be terminal, got %v", err)
+	}
+}
+
+func newGatewayFrontendTLSTranslateSyncContext(t *testing.T, configMap *corev1.ConfigMap, secret *corev1.Secret, virtualObjects ...runtime.Object) *synccontext.SyncContext {
+	t.Helper()
+	vcConfig := &pkgconfig.VirtualClusterConfig{}
+	seedCtx := syncertesting.NewFakeRegisterContext(vcConfig, testingutil.NewFakeClient(scheme.Scheme), testingutil.NewFakeClient(scheme.Scheme)).ToSyncContext("gateway-frontend-tls-translate-test")
+
+	var hostObjects []runtime.Object
+	if configMap != nil {
+		hostObjects = append(hostObjects, utiltranslate.HostMetadata(configMap, utiltranslate.Default.HostName(seedCtx, configMap.Name, configMap.Namespace)))
+	}
+	if secret != nil {
+		hostObjects = append(hostObjects, utiltranslate.HostMetadata(secret, utiltranslate.Default.HostName(seedCtx, secret.Name, secret.Namespace)))
+	}
+
+	pClient := testingutil.NewFakeClient(scheme.Scheme, hostObjects...)
+	vClient := testingutil.NewFakeClient(scheme.Scheme, virtualObjects...)
+	return syncertesting.NewFakeRegisterContext(vcConfig, pClient, vClient).ToSyncContext("gateway-frontend-tls-translate-test")
+}
+
+func setDefaultGatewayFrontendTLSTranslator(translator utiltranslate.Translator) func() {
+	previous := utiltranslate.Default
+	utiltranslate.Default = translator
+	return func() { utiltranslate.Default = previous }
+}
+
+func gatewayWithDefaultFrontendCACertificateRefs(refs ...gatewayv1.ObjectReference) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "tenant-class",
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{CACertificateRefs: refs},
+					},
+				},
+			},
+		},
+	}
+}
+
+func gatewayWithPerPortFrontendCACertificateRefs(port gatewayv1.PortNumber, refs ...gatewayv1.ObjectReference) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "tenant-class",
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{},
+					PerPort: []gatewayv1.TLSPortConfig{
+						{
+							Port: port,
+							TLS: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{CACertificateRefs: refs},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func gatewayWithBackendTLSClientCertificateRef(ref gatewayv1.SecretObjectReference) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "edge"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "tenant-class",
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Backend: &gatewayv1.GatewayBackendTLS{
+					ClientCertificateRef: &ref,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
- translate spec.tls.frontend.default.validation.caCertificateRefs
- Enforce ReferenceGrant checks for cross-namespace CA refs
- Add coverage for translated, missing, unsupported, and granted refs

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #ENGNODE-588


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
