### PR TITLE
fix(e2e-next): exclude pod-level status.Resources from pod sync statu…

### DIFF
--- a/e2e-next/test_core/sync/test_pods.go
+++ b/e2e-next/test_core/sync/test_pods.go
@@ -132,6 +132,9 @@ func PodSyncSpec() {
 					// Since k8s 1.32, status.QOSClass field has become immutable,
 					// hence we have stopped syncing it.
 					pod.Status.QOSClass = vpod.Status.QOSClass
+					// k8s 1.35 tenant can't carry pod-level Resources/AllocatedResources; exclude them from the comparison.
+					vpod.Status.Resources, pod.Status.Resources = nil, nil
+					vpod.Status.AllocatedResources, pod.Status.AllocatedResources = nil, nil
 					Expect(vpod.Status).To(Equal(pod.Status))
 				})
 
@@ -272,6 +275,9 @@ func PodSyncSpec() {
 					pod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					pod.Status.QOSClass = vpod.Status.QOSClass
+					// k8s 1.35 tenant can't carry pod-level Resources/AllocatedResources; exclude them from the comparison.
+					vpod.Status.Resources, pod.Status.Resources = nil, nil
+					vpod.Status.AllocatedResources, pod.Status.AllocatedResources = nil, nil
 					Expect(vpod.Status).To(Equal(pod.Status))
 				})
 


### PR DESCRIPTION
…s assertions (#4012)

(cherry picked from commit 9451761296c36d0b2b7c81a643979035a6c63add)

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement
/kind feature
/kind documentation
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
