### PR TITLE
fix(e2e-next): exclude pod-level status.Resources from pod sync status assertions (#4012)

### DIFF
--- a/e2e-next/test_core/sync/test_pods.go
+++ b/e2e-next/test_core/sync/test_pods.go
@@ -132,6 +132,9 @@ func PodSyncSpec() {
 					// Since k8s 1.32, status.QOSClass field has become immutable,
 					// hence we have stopped syncing it.
 					pod.Status.QOSClass = vpod.Status.QOSClass
+					// k8s 1.35 tenant can't carry pod-level Resources/AllocatedResources; exclude them from the comparison.
+					vpod.Status.Resources, pod.Status.Resources = nil, nil
+					vpod.Status.AllocatedResources, pod.Status.AllocatedResources = nil, nil
 					Expect(vpod.Status).To(Equal(pod.Status))
 				})
 
@@ -272,6 +275,9 @@ func PodSyncSpec() {
 					pod, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, pPodName, metav1.GetOptions{})
 					Expect(err).To(Succeed())
 					pod.Status.QOSClass = vpod.Status.QOSClass
+					// k8s 1.35 tenant can't carry pod-level Resources/AllocatedResources; exclude them from the comparison.
+					vpod.Status.Resources, pod.Status.Resources = nil, nil
+					vpod.Status.AllocatedResources, pod.Status.AllocatedResources = nil, nil
 					Expect(vpod.Status).To(Equal(pod.Status))
 				})
 


### PR DESCRIPTION
Backport of #4012 to the v0.32 release branch.

(cherry picked from commit 9451761296c36d0b2b7c81a643979035a6c63add)
(cherry picked from commit 761fce85304f18e8082eb369bc4c7d5122618683)

**What issue type does this pull request address?**
/kind test

**What does this pull request do? Which issues does it resolve?**
Excludes pod-level `status.Resources` and `status.AllocatedResources` from the pod sync status assertions, since on k8s 1.35 the tenant pod cannot carry these fields.

**Please provide a short message that should be published in the vcluster release notes**
Fixed a flaky e2e pod sync status assertion on k8s 1.35.
