### PR TITLE
fix(e2e): deflake sync error event sanitisation test

### DIFF
--- a/e2e/test_core/sync/test_sync_error_events.go
+++ b/e2e/test_core/sync/test_sync_error_events.go
@@ -116,14 +116,12 @@ func SyncErrorSanitisationSpec() {
 				// event (pkg/controllers/resources/pods/syncer.go) before the conflict is
 				// silently requeued by the outer controller.
 				//
-				// Both goroutines keep mutating for the entire verification window below,
-				// rather than running a fixed number of iterations up front. A single short
-				// burst can finish before the syncer ever loses the race, after which the
-				// syncer settles and no further conflicts occur — that is what made this test
-				// flaky. Keeping the race window open until a SyncError event is observed
-				// makes the conflict reliable. Errors are intentionally ignored: an update
-				// that fails because the syncer just changed the pod is exactly the
-				// contention we want.
+				// Both goroutines mutate continuously until the verification step closes
+				// `stop` via DeferCleanup, keeping the race window open until a SyncError
+				// event is observed. A bounded burst can complete before the syncer ever
+				// loses the race, leaving no contention to verify. Errors are intentionally
+				// ignored: an update that fails because the syncer just changed the pod is
+				// exactly the contention we want.
 				stop := make(chan struct{})
 				var wg sync.WaitGroup
 

--- a/e2e/test_core/sync/test_sync_error_events.go
+++ b/e2e/test_core/sync/test_sync_error_events.go
@@ -16,7 +16,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 )
 
 // SyncErrorSanitisationSpec verifies that SyncError warning events recorded on
@@ -109,7 +108,7 @@ func SyncErrorSanitisationSpec() {
 						Should(Succeed())
 				})
 
-				// Race the syncer against concurrent host and virtual pod updates.
+				// Race the syncer against continuous host and virtual pod updates.
 				//
 				// The pod syncer fetches the host pod once at the start of each reconcile.
 				// If the host pod's resource version changes before the syncer's patch lands,
@@ -117,51 +116,64 @@ func SyncErrorSanitisationSpec() {
 				// event (pkg/controllers/resources/pods/syncer.go) before the conflict is
 				// silently requeued by the outer controller.
 				//
-				// Running both goroutines concurrently widens the race window so that the
-				// syncer is processing a reconcile while we are simultaneously bumping the
-				// host pod's resource version.
-				// Errors are intentionally swallowed — the goal is volume of conflicting
-				// updates, not that every individual update succeeds.
-				By("concurrently bumping the host pod and triggering virtual reconciles to force SyncError events", func() {
-					var wg sync.WaitGroup
+				// Both goroutines keep mutating for the entire verification window below,
+				// rather than running a fixed number of iterations up front. A single short
+				// burst can finish before the syncer ever loses the race, after which the
+				// syncer settles and no further conflicts occur — that is what made this test
+				// flaky. Keeping the race window open until a SyncError event is observed
+				// makes the conflict reliable. Errors are intentionally ignored: an update
+				// that fails because the syncer just changed the pod is exactly the
+				// contention we want.
+				stop := make(chan struct{})
+				var wg sync.WaitGroup
+
+				runMutator := func(bump func(i int) error) {
+					defer wg.Done()
+					for i := 0; ; i++ {
+						select {
+						case <-stop:
+							return
+						case <-ctx.Done():
+							return
+						default:
+						}
+						_ = bump(i)
+					}
+				}
+
+				By("continuously racing host and virtual pod updates against the syncer to force SyncError events", func() {
 					wg.Add(2)
-
-					go func() {
-						defer wg.Done()
-						for i := range 20 {
-							_ = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-								hp, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, hostPodName, metav1.GetOptions{})
-								if err != nil {
-									return err
-								}
-								if hp.Annotations == nil {
-									hp.Annotations = map[string]string{}
-								}
-								hp.Annotations["race-bump"] = fmt.Sprintf("%d", i)
-								_, err = hostClient.CoreV1().Pods(hostNS).Update(ctx, hp, metav1.UpdateOptions{})
-								return err
-							})
+					go runMutator(func(i int) error {
+						hp, err := hostClient.CoreV1().Pods(hostNS).Get(ctx, hostPodName, metav1.GetOptions{})
+						if err != nil {
+							return err
 						}
-					}()
-
-					go func() {
-						defer wg.Done()
-						for i := range 20 {
-							_ = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-								vPod, err := vClusterClient.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
-								if err != nil {
-									return err
-								}
-								if vPod.Annotations == nil {
-									vPod.Annotations = map[string]string{}
-								}
-								vPod.Annotations["reconcile-trigger"] = fmt.Sprintf("%d", i)
-								_, err = vClusterClient.CoreV1().Pods(ns).Update(ctx, vPod, metav1.UpdateOptions{})
-								return err
-							})
+						if hp.Annotations == nil {
+							hp.Annotations = map[string]string{}
 						}
-					}()
+						hp.Annotations["race-bump"] = fmt.Sprintf("%d", i)
+						_, err = hostClient.CoreV1().Pods(hostNS).Update(ctx, hp, metav1.UpdateOptions{})
+						return err
+					})
+					go runMutator(func(i int) error {
+						vPod, err := vClusterClient.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						if vPod.Annotations == nil {
+							vPod.Annotations = map[string]string{}
+						}
+						vPod.Annotations["reconcile-trigger"] = fmt.Sprintf("%d", i)
+						_, err = vClusterClient.CoreV1().Pods(ns).Update(ctx, vPod, metav1.UpdateOptions{})
+						return err
+					})
+				})
 
+				// Stop the background mutators before the pod/namespace cleanups run.
+				// DeferCleanup is LIFO, so this runs before the earlier-registered
+				// pod and namespace deletions.
+				DeferCleanup(func() {
+					close(stop)
 					wg.Wait()
 				})
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
events
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in e2e; no production sync or event-sanitisation logic is modified.
> 
> **Overview**
> The **SyncError event sanitisation** e2e no longer relies on a fixed burst of 20 host/virtual pod updates with `RetryOnConflict`. It now runs two background mutators in a tight loop until verification finishes, so contention with the pod syncer stays open while `Eventually` waits for a `SyncError` event.
> 
> A shared `stop` channel and `runMutator` helper coordinate shutdown; **`DeferCleanup`** closes `stop` and **`wg.Wait()`** before pod/namespace teardown so goroutines do not race cleanup. Raw updates replace conflict retries because failed updates from syncer contention are the desired signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec1afcc9224387748b79233978abc01946437ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->