### PR TITLE
fix: preserve PV ClaimRef on release and fix host-to-virtual sync gaps

### DIFF
--- a/e2e/test_core/sync/test_pvc.go
+++ b/e2e/test_core/sync/test_pvc.go
@@ -171,6 +171,114 @@ func PVCSyncSpec() {
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 			})
+
+			It("should release a Retain PV and make it Available after PVC deletion", func(ctx context.Context) {
+				suffix := random.String(6)
+				nsName := "pv-retain-test-" + suffix
+				pvcName := "pvc-retain-" + suffix
+				pvName := "pv-retain-" + suffix
+
+				By("Creating a test namespace", func() {
+					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: nsName,
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+
+				By("Creating a PV with Retain reclaim policy in the vCluster", func() {
+					_, err := vClusterClient.CoreV1().PersistentVolumes().Create(ctx, &corev1.PersistentVolume{
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: corev1.PersistentVolumeSpec{
+							Capacity: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+							AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+							PersistentVolumeSource: corev1.PersistentVolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/tmp/" + translate.Default.HostNameCluster(pvName),
+								},
+							},
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().PersistentVolumes().Delete(ctx, pvName, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+
+				By("Creating a PVC that binds to the Retain PV", func() {
+					_, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Create(ctx, &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+							},
+							VolumeName: pvName,
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Delete(ctx, pvcName, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+
+				By("Waiting for the PVC to become Bound", func() {
+					Eventually(func(g Gomega) {
+						vpvc, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Get(ctx, pvcName, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(vpvc.Status.Phase).To(Equal(corev1.ClaimBound),
+							"PVC phase is %s, not yet Bound", vpvc.Status.Phase)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Deleting the PVC", func() {
+					err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Delete(ctx, pvcName, metav1.DeleteOptions{})
+					Expect(err).To(Succeed())
+				})
+
+				By("Waiting for the PVC to be fully deleted from vCluster", func() {
+					Eventually(func(g Gomega) {
+						_, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Get(ctx, pvcName, metav1.GetOptions{})
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"PVC %s/%s not yet deleted", nsName, pvcName)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Verifying the PV becomes Available in the vCluster", func() {
+					Eventually(func(g Gomega) {
+						vpv, err := vClusterClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(vpv.Status.Phase).To(Equal(corev1.VolumeAvailable),
+							"PV phase is %s, not yet Available", vpv.Status.Phase)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Verifying the host PV also becomes Available", func() {
+					hostPVName := translate.Default.HostNameCluster(pvName)
+					Eventually(func(g Gomega) {
+						pv, err := hostClient.CoreV1().PersistentVolumes().Get(ctx, hostPVName, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(pv.Status.Phase).To(Equal(corev1.VolumeAvailable),
+							"Host PV phase is %s, not yet Available", pv.Status.Phase)
+					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+			})
 		},
 	)
 }

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
@@ -354,5 +354,52 @@ func TestSync(t *testing.T) {
 				assert.NilError(t, err)
 			},
 		},
+		{
+			Name: "Translate VolumeName using PV mapper when PV sync is enabled",
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.PersistentVolumes.Enabled = true
+			},
+			InitialVirtualState: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: vObjectMeta,
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pvc-abc123",
+					},
+				},
+			},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"): {
+					&corev1.PersistentVolumeClaim{
+						ObjectMeta: vObjectMeta,
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pvc-abc123",
+						},
+					},
+				},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"): {
+					&corev1.PersistentVolumeClaim{
+						ObjectMeta: pObjectMeta,
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pvc-abc123",
+						},
+					},
+				},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+
+				vPvc := &corev1.PersistentVolumeClaim{}
+				err := syncCtx.VirtualClient.Get(syncCtx, types.NamespacedName{
+					Namespace: vObjectMeta.Namespace,
+					Name:      vObjectMeta.Name,
+				}, vPvc)
+				assert.NilError(t, err)
+
+				_, err = syncer.(*persistentVolumeClaimSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPvc.DeepCopy()))
+				assert.NilError(t, err)
+			},
+		},
 	})
 }

--- a/pkg/controllers/resources/persistentvolumeclaims/translate.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/translate.go
@@ -67,7 +67,7 @@ func (s *persistentVolumeClaimSyncer) translateSelector(ctx *synccontext.SyncCon
 				vPvc.Spec.Selector = translate.HostLabelSelector(vPvc.Spec.Selector)
 			}
 			if vPvc.Spec.VolumeName != "" {
-				vPvc.Spec.VolumeName = translate.Default.HostNameCluster(vPvc.Spec.VolumeName)
+				vPvc.Spec.VolumeName = mappings.VirtualToHostName(ctx, vPvc.Spec.VolumeName, "", mappings.PersistentVolumes())
 			}
 			// check if the storage class exists in the physical cluster
 			if !s.storageClassesEnabled && storageClassName != "" {

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -103,7 +103,7 @@ func (s *persistentVolumeSyncer) SyncToHost(ctx *synccontext.SyncContext, event 
 		return reconcile.Result{}, nil
 	}
 
-	if event.HostOld != nil || event.Virtual.DeletionTimestamp != nil || (event.Virtual.Annotations != nil && event.Virtual.Annotations[constants.HostClusterPersistentVolumeAnnotation] != "") {
+	if event.HostOld != nil || event.Virtual.DeletionTimestamp != nil {
 		if len(event.Virtual.Finalizers) > 0 {
 			// delete the finalizer here so that the object can be deleted
 			event.Virtual.Finalizers = []string{}
@@ -112,6 +112,25 @@ func (s *persistentVolumeSyncer) SyncToHost(ctx *synccontext.SyncContext, event 
 		}
 
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.HostOld, "host object should get deleted")
+	}
+
+	// If admin cleared ClaimRef on virtual PV, propagate to host PV
+	if event.Virtual.Spec.ClaimRef == nil {
+		pPV := &corev1.PersistentVolume{}
+		err := ctx.HostClient.Get(ctx.Context, types.NamespacedName{Name: event.Virtual.Name}, pPV)
+		if err == nil && pPV.Spec.ClaimRef != nil && pPV.Status.Phase == corev1.VolumeReleased {
+			updated := pPV.DeepCopy()
+			updated.Spec.ClaimRef = nil
+			err = ctx.HostClient.Update(ctx.Context, updated)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("clear host ClaimRef: %w", err)
+			}
+		}
+	}
+
+	// If this PV originated from the host, don't push changes back to host
+	if event.Virtual.Annotations != nil && event.Virtual.Annotations[constants.HostClusterPersistentVolumeAnnotation] != "" {
+		return ctrl.Result{}, nil
 	}
 
 	pPv, err := s.translate(ctx, event.Virtual)
@@ -161,12 +180,32 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
+	// if host PV is being deleted, delete the virtual PV too
+	if event.Host.GetDeletionTimestamp() != nil {
+		if event.Virtual.GetDeletionTimestamp() == nil {
+			return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, "host persistent volume is being deleted")
+		}
+		return ctrl.Result{}, nil
+	}
+
 	// check if the persistent volume should get synced
 	sync, vPvc, err := s.shouldSync(ctx, event.Host)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if !sync {
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, "there is no virtual persistent volume claim with that volume")
+	}
+
+	// If admin cleared ClaimRef on virtual PV, propagate to host PV so both become Available
+	if event.Virtual.Spec.ClaimRef == nil && event.VirtualOld.Spec.ClaimRef != nil &&
+		event.Host.Spec.ClaimRef != nil && event.Host.Status.Phase == corev1.VolumeReleased {
+		updated := event.Host.DeepCopy()
+		updated.Spec.ClaimRef = nil
+		err = ctx.HostClient.Update(ctx.Context, updated)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		event.Host.Spec.ClaimRef = nil
 	}
 
 	// update the physical persistent volume if the virtual has changed
@@ -259,6 +298,11 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 }
 
 func (s *persistentVolumeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*corev1.PersistentVolume]) (ctrl.Result, error) {
+	// if host PV is being deleted, delete the virtual PV too
+	if event.Host.GetDeletionTimestamp() != nil {
+		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, "host persistent volume is being deleted")
+	}
+
 	sync, vPvc, err := s.shouldSync(ctx, event.Host)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -287,6 +331,15 @@ func (s *persistentVolumeSyncer) shouldSync(ctx *synccontext.SyncContext, pObj *
 	if pObj.Spec.ClaimRef == nil {
 		if translate.Default.IsManaged(ctx, pObj) {
 			return true, nil, nil
+		}
+
+		// If a virtual PV still exists, keep syncing (e.g. to update status to Available)
+		vPV := &corev1.PersistentVolume{}
+		err := s.virtualClient.Get(ctx, types.NamespacedName{Name: pObj.Name}, vPV)
+		if err == nil {
+			return true, nil, nil
+		} else if !kerrors.IsNotFound(err) {
+			return false, nil, err
 		}
 
 		return false, nil, nil

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -49,7 +49,7 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 	// build virtual persistent volume
 	translatedSpec := *pPv.Spec.DeepCopy()
 	isStorageClassCreatedOnVirtual, isClaimRefCreatedOnVirtual := false, false
-	if vPvc != nil {
+	if vPvc != nil && vPv.Spec.ClaimRef != nil {
 		if translatedSpec.ClaimRef == nil {
 			translatedSpec.ClaimRef = &corev1.ObjectReference{}
 		}
@@ -88,7 +88,9 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 
 	// check claim ref. Do not copy, if it was created on virtual.
 	if !equality.Semantic.DeepEqual(vPv.Spec.ClaimRef, translatedSpec.ClaimRef) && !isClaimRefCreatedOnVirtual {
-		vPv.Spec.ClaimRef = translatedSpec.ClaimRef
+		if pPv.Status.Phase != corev1.VolumeAvailable {
+			vPv.Spec.ClaimRef = translatedSpec.ClaimRef
+		}
 	}
 
 	return nil


### PR DESCRIPTION
What issue type does this pull request address? (keep at least one, remove the others)
kind bug
kind fix

What does this pull request do? Which issues does it resolve? (use resolves #<issue_number> if possible)
Fixes PV ClaimRef being incorrectly cleared when PVC is deleted with Retain policy.
Fixes PV stuck in Released phase after admin clears ClaimRef.
Fixes host PV deletion not propagating to virtual PV.
Fixes VolumeName double-wrapping for dynamically provisioned PVs.

Please provide a short message that should be published in the vcluster release notes
Fixed PersistentVolume lifecycle sync: ClaimRef now preserved on Released PVs matching standard Kubernetes behavior, admin-cleared ClaimRef correctly propagates to host allowing PV reuse, host PV deletion cleans up virtual PV, and VolumeName translation no longer double-wraps dynamic PV names.

What else do we need to know?

Changes in pkg/controllers/resources/persistentvolumes/:
- SyncToHost: host-originated PVs no longer incorrectly deleted; ClaimRef clearing on virtual PV propagates to host
- Sync + SyncToVirtual: host PV deletion now deletes virtual PV
- shouldSync: Available PVs with existing virtual PV continue syncing instead of being deleted
- translate.go: nil-safety guards for ClaimRef access during PVC deletion transitions

Changes in pkg/controllers/resources/persistentvolumeclaims/:
- translate.go: VolumeName uses PV mapper (mappings.VirtualToHostName) to prevent double-wrapping

E2E Tests
Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core storage sync logic (ClaimRef, deletion propagation, and volume name mapping) that can affect binding and reuse of persistent volumes across host and virtual clusters.
> 
> **Overview**
> Fixes **PersistentVolume** sync between virtual and host clusters so Retain volumes and admin **ClaimRef** edits behave like standard Kubernetes, and stops incorrect PVC **VolumeName** rewriting.
> 
> **PV sync** no longer treats host-imported PVs as delete-on-sync in `SyncToHost`; it only skips pushing updates when `HostClusterPersistentVolumeAnnotation` is set. Clearing **ClaimRef** on the virtual PV (while the host PV is **Released**) now clears the host **ClaimRef** in both `SyncToHost` and `Sync`. Host PV deletion propagates by deleting the matching virtual PV in `Sync` and `SyncToVirtual`. `shouldSync` keeps reconciling host PVs with no **ClaimRef** when a virtual PV still exists (e.g. to reach **Available**). Backward translation avoids copying host **ClaimRef** onto the virtual PV when the host phase is **Available**, and tightens when virtual claim refs are rebuilt during PVC deletion.
> 
> **PVC sync** translates `Spec.VolumeName` via `mappings.VirtualToHostName` (PV mapper) instead of `HostNameCluster`, avoiding double-wrapped names for dynamically provisioned volumes when PV sync is enabled.
> 
> Adds a unit sync test for **VolumeName** translation and an e2e case that a **Retain** PV becomes **Available** on both clusters after PVC delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7527fdcfdaac182fc767063d828eb6985ee89543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->