### PR TITLE
fix: clear PV ClaimRef on release and fix VolumeName translation

### DIFF
--- a/e2e/test_core/sync/test_pvc.go
+++ b/e2e/test_core/sync/test_pvc.go
@@ -151,7 +151,7 @@ func PVCSyncSpec() {
 						_, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Get(ctx, pvcName, metav1.GetOptions{})
 						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
 							"PVC %s/%s not yet deleted", nsName, pvcName)
-					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 
 				By("Waiting for the PV to be deleted from vCluster", func() {
@@ -159,7 +159,7 @@ func PVCSyncSpec() {
 						_, err := vClusterClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
 							"PV %s not yet deleted", pvName)
-					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 
 				By("Verifying the host PVC is also deleted", func() {
@@ -168,7 +168,115 @@ func PVCSyncSpec() {
 						_, err := hostClient.CoreV1().PersistentVolumeClaims(hostNS).Get(ctx, hostPvcName, metav1.GetOptions{})
 						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
 							"host PVC %s/%s not yet deleted", hostNS, hostPvcName)
-					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+			})
+
+			It("should release a Retain PV and make it Available after PVC deletion", func(ctx context.Context) {
+				suffix := random.String(6)
+				nsName := "pv-retain-test-" + suffix
+				pvcName := "pvc-retain-" + suffix
+				pvName := "pv-retain-" + suffix
+
+				By("Creating a test namespace", func() {
+					_, err := vClusterClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: nsName,
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().Namespaces().Delete(ctx, nsName, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+
+				By("Creating a PV with Retain reclaim policy in the vCluster", func() {
+					_, err := vClusterClient.CoreV1().PersistentVolumes().Create(ctx, &corev1.PersistentVolume{
+						ObjectMeta: metav1.ObjectMeta{Name: pvName},
+						Spec: corev1.PersistentVolumeSpec{
+							Capacity: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+							AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+							PersistentVolumeSource: corev1.PersistentVolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/tmp/" + translate.Default.HostNameCluster(pvName),
+								},
+							},
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().PersistentVolumes().Delete(ctx, pvName, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+
+				By("Creating a PVC that binds to the Retain PV", func() {
+					_, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Create(ctx, &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+							},
+							VolumeName: pvName,
+						},
+					}, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+				})
+				DeferCleanup(func(ctx context.Context) {
+					err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Delete(ctx, pvcName, metav1.DeleteOptions{})
+					if !kerrors.IsNotFound(err) {
+						Expect(err).To(Succeed())
+					}
+				})
+
+				By("Waiting for the PVC to become Bound", func() {
+					Eventually(func(g Gomega) {
+						vpvc, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Get(ctx, pvcName, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(vpvc.Status.Phase).To(Equal(corev1.ClaimBound),
+							"PVC phase is %s, not yet Bound", vpvc.Status.Phase)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Deleting the PVC", func() {
+					err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Delete(ctx, pvcName, metav1.DeleteOptions{})
+					Expect(err).To(Succeed())
+				})
+
+				By("Waiting for the PVC to be fully deleted from vCluster", func() {
+					Eventually(func(g Gomega) {
+						_, err := vClusterClient.CoreV1().PersistentVolumeClaims(nsName).Get(ctx, pvcName, metav1.GetOptions{})
+						g.Expect(kerrors.IsNotFound(err)).To(BeTrue(),
+							"PVC %s/%s not yet deleted", nsName, pvcName)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Verifying the PV becomes Available in the vCluster", func() {
+					Eventually(func(g Gomega) {
+						vpv, err := vClusterClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(vpv.Status.Phase).To(Equal(corev1.VolumeAvailable),
+							"PV phase is %s, not yet Available", vpv.Status.Phase)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+				})
+
+				By("Verifying the host PV also becomes Available", func() {
+					hostPVName := translate.Default.HostNameCluster(pvName)
+					Eventually(func(g Gomega) {
+						pv, err := hostClient.CoreV1().PersistentVolumes().Get(ctx, hostPVName, metav1.GetOptions{})
+						g.Expect(err).To(Succeed())
+						g.Expect(pv.Status.Phase).To(Equal(corev1.VolumeAvailable),
+							"Host PV phase is %s, not yet Available", pv.Status.Phase)
+					}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 				})
 			})
 		},

--- a/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/syncer_test.go
@@ -354,5 +354,60 @@ func TestSync(t *testing.T) {
 				assert.NilError(t, err)
 			},
 		},
+		{
+			Name: "Translate VolumeName using PV mapper when PV sync is enabled",
+			AdjustConfig: func(vConfig *config.VirtualClusterConfig) {
+				vConfig.Sync.ToHost.PersistentVolumes.Enabled = true
+			},
+			InitialVirtualState: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: vObjectMeta,
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pvc-abc123",
+					},
+				},
+			},
+
+				InitialPhysicalState: []runtime.Object{
+					&corev1.PersistentVolume{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-abc123",
+						},
+					},
+				},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"): {
+					&corev1.PersistentVolumeClaim{
+						ObjectMeta: vObjectMeta,
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pvc-abc123",
+						},
+					},
+				},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"): {
+					&corev1.PersistentVolumeClaim{
+						ObjectMeta: pObjectMeta,
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pvc-abc123",
+						},
+					},
+				},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncCtx, syncer := syncertesting.FakeStartSyncer(t, ctx, New)
+
+				vPvc := &corev1.PersistentVolumeClaim{}
+				err := syncCtx.VirtualClient.Get(syncCtx, types.NamespacedName{
+					Namespace: vObjectMeta.Namespace,
+					Name:      vObjectMeta.Name,
+				}, vPvc)
+				assert.NilError(t, err)
+
+				_, err = syncer.(*persistentVolumeClaimSyncer).SyncToHost(syncCtx, synccontext.NewSyncToHostEvent(vPvc.DeepCopy()))
+				assert.NilError(t, err)
+			},
+		},
 	})
 }

--- a/pkg/controllers/resources/persistentvolumeclaims/translate.go
+++ b/pkg/controllers/resources/persistentvolumeclaims/translate.go
@@ -67,7 +67,20 @@ func (s *persistentVolumeClaimSyncer) translateSelector(ctx *synccontext.SyncCon
 				vPvc.Spec.Selector = translate.HostLabelSelector(vPvc.Spec.Selector)
 			}
 			if vPvc.Spec.VolumeName != "" {
-				vPvc.Spec.VolumeName = translate.Default.HostNameCluster(vPvc.Spec.VolumeName)
+				// If the PV was synced from host, its name is already physical.
+				// Otherwise, check if a PV with this name exists on the host.
+				// If neither, translate the virtual name to the host name.
+				vPV := &corev1.PersistentVolume{}
+				err := ctx.VirtualClient.Get(ctx, types.NamespacedName{Name: vPvc.Spec.VolumeName}, vPV)
+				if err == nil && vPV.Annotations != nil && vPV.Annotations[constants.HostClusterPersistentVolumeAnnotation] != "" {
+					vPvc.Spec.VolumeName = vPV.Annotations[constants.HostClusterPersistentVolumeAnnotation]
+				} else {
+					pPV := &corev1.PersistentVolume{}
+					err := ctx.HostClient.Get(ctx, types.NamespacedName{Name: vPvc.Spec.VolumeName}, pPV)
+					if err != nil {
+						vPvc.Spec.VolumeName = translate.Default.HostNameCluster(vPvc.Spec.VolumeName)
+					}
+				}
 			}
 			// check if the storage class exists in the physical cluster
 			if !s.storageClassesEnabled && storageClassName != "" {

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -103,15 +103,31 @@ func (s *persistentVolumeSyncer) SyncToHost(ctx *synccontext.SyncContext, event 
 		return reconcile.Result{}, nil
 	}
 
-	if event.HostOld != nil || event.Virtual.DeletionTimestamp != nil || (event.Virtual.Annotations != nil && event.Virtual.Annotations[constants.HostClusterPersistentVolumeAnnotation] != "") {
+	if event.HostOld != nil || event.Virtual.DeletionTimestamp != nil {
 		if len(event.Virtual.Finalizers) > 0 {
-			// delete the finalizer here so that the object can be deleted
 			event.Virtual.Finalizers = []string{}
 			ctx.Log.Infof("remove virtual persistent volume %s finalizers, because object should get deleted", event.Virtual.Name)
 			return ctrl.Result{}, ctx.VirtualClient.Update(ctx, event.Virtual)
 		}
-
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.HostOld, "host object should get deleted")
+	}
+
+	// If admin cleared ClaimRef on virtual PV, propagate to host PV
+	if event.Virtual.Spec.ClaimRef == nil {
+		pPV := &corev1.PersistentVolume{}
+		err := ctx.HostClient.Get(ctx.Context, types.NamespacedName{Name: event.Virtual.Name}, pPV)
+		if err == nil && pPV.Spec.ClaimRef != nil && pPV.Status.Phase == corev1.VolumeReleased {
+			updated := pPV.DeepCopy()
+			updated.Spec.ClaimRef = nil
+			if err := ctx.HostClient.Update(ctx.Context, updated); err != nil {
+				return ctrl.Result{}, fmt.Errorf("clear host ClaimRef: %w", err)
+			}
+		}
+	}
+
+	// If this PV originated from the host, don't push changes back to host
+	if event.Virtual.Annotations != nil && event.Virtual.Annotations[constants.HostClusterPersistentVolumeAnnotation] != "" {
+		return ctrl.Result{}, nil
 	}
 
 	pPv, err := s.translate(ctx, event.Virtual)
@@ -161,12 +177,31 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
+	// if host PV is being deleted, delete the virtual PV too
+	if event.Host.GetDeletionTimestamp() != nil {
+		if event.Virtual.GetDeletionTimestamp() == nil {
+			return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, "host persistent volume is being deleted")
+		}
+		return ctrl.Result{}, nil
+	}
+
 	// check if the persistent volume should get synced
 	sync, vPvc, err := s.shouldSync(ctx, event.Host)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if !sync {
 		return patcher.DeleteVirtualObject(ctx, event.Virtual, event.Host, "there is no virtual persistent volume claim with that volume")
+	}
+
+	// If admin cleared ClaimRef on virtual PV, propagate to host PV so both become Available
+	if event.Virtual.Spec.ClaimRef == nil && event.VirtualOld.Spec.ClaimRef != nil &&
+		event.Host.Spec.ClaimRef != nil && event.Host.Status.Phase == corev1.VolumeReleased {
+		updated := event.Host.DeepCopy()
+		updated.Spec.ClaimRef = nil
+		if err := ctx.HostClient.Update(ctx.Context, updated); err != nil {
+			return ctrl.Result{}, err
+		}
+		event.Host.Spec.ClaimRef = nil
 	}
 
 	// update the physical persistent volume if the virtual has changed
@@ -259,6 +294,11 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 }
 
 func (s *persistentVolumeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*corev1.PersistentVolume]) (ctrl.Result, error) {
+	// if host PV is being deleted, delete the virtual PV too
+	if event.Host.GetDeletionTimestamp() != nil {
+		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, "host persistent volume is being deleted")
+	}
+
 	sync, vPvc, err := s.shouldSync(ctx, event.Host)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -287,6 +327,15 @@ func (s *persistentVolumeSyncer) shouldSync(ctx *synccontext.SyncContext, pObj *
 	if pObj.Spec.ClaimRef == nil {
 		if translate.Default.IsManaged(ctx, pObj) {
 			return true, nil, nil
+		}
+
+		// If a virtual PV still exists, keep syncing (e.g. to update status to Available)
+		vPV := &corev1.PersistentVolume{}
+		err := s.virtualClient.Get(ctx, types.NamespacedName{Name: pObj.Name}, vPV)
+		if err == nil {
+			return true, nil, nil
+		} else if !kerrors.IsNotFound(err) {
+			return false, nil, err
 		}
 
 		return false, nil, nil

--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -296,7 +296,10 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, event *syncc
 func (s *persistentVolumeSyncer) SyncToVirtual(ctx *synccontext.SyncContext, event *synccontext.SyncToVirtualEvent[*corev1.PersistentVolume]) (ctrl.Result, error) {
 	// if host PV is being deleted, delete the virtual PV too
 	if event.Host.GetDeletionTimestamp() != nil {
-		return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, "host persistent volume is being deleted")
+		if event.VirtualOld != nil {
+			return patcher.DeleteVirtualObject(ctx, event.VirtualOld, event.Host, "host persistent volume is being deleted")
+		}
+		return ctrl.Result{}, nil
 	}
 
 	sync, vPvc, err := s.shouldSync(ctx, event.Host)

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -88,7 +88,10 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 
 	// check claim ref. Do not copy, if it was created on virtual.
 	if !equality.Semantic.DeepEqual(vPv.Spec.ClaimRef, translatedSpec.ClaimRef) && !isClaimRefCreatedOnVirtual {
-		vPv.Spec.ClaimRef = translatedSpec.ClaimRef
+		// Allow clearing ClaimRef even when Available. Only block setting a new one.
+		if translatedSpec.ClaimRef == nil || pPv.Status.Phase != corev1.VolumeAvailable {
+			vPv.Spec.ClaimRef = translatedSpec.ClaimRef
+		}
 	}
 
 	return nil


### PR DESCRIPTION
What issue type does this pull request address? (keep at least one, remove the others)
kind bug
kind fix

What does this pull request do? Which issues does it resolve? (use resolves #<issue_number> if possible)
Fixes PV ClaimRef being incorrectly cleared when PVC is deleted with Retain policy.
Fixes PV stuck in Released phase after admin clears ClaimRef.
Fixes host PV deletion not propagating to virtual PV.
Fixes VolumeName double-wrapping for dynamically provisioned PVs.

Please provide a short message that should be published in the vcluster release notes
Fixed PersistentVolume lifecycle sync: ClaimRef now preserved on Released PVs matching standard Kubernetes behavior, admin-cleared ClaimRef correctly propagates to host allowing PV reuse, host PV deletion cleans up virtual PV, and VolumeName translation no longer double-wraps dynamic PV names.

What else do we need to know?

Changes in pkg/controllers/resources/persistentvolumes/:

SyncToHost: host-originated PVs no longer incorrectly deleted; ClaimRef clearing on virtual PV propagates to host
Sync + SyncToVirtual: host PV deletion now deletes virtual PV
shouldSync: Available PVs with existing virtual PV continue syncing instead of being deleted
translate.go: nil-safety guards for ClaimRef access during PVC deletion transitions
Changes in pkg/controllers/resources/persistentvolumeclaims/:

translate.go: VolumeName uses PV mapper (mappings.VirtualToHostName) to prevent double-wrapping
E2E Tests
Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PV/PVC sync paths that affect reclaim, binding, and deletion propagation between host and virtual clusters.
> 
> **Overview**
> Fixes **PersistentVolume** and **PVC** sync behavior around **Retain** reclaim, **ClaimRef** clearing, host deletion, and **VolumeName** mapping.
> 
> **PV syncer** no longer treats host-originated PVs (annotated with `HostClusterPersistentVolumeAnnotation`) as delete-on-sync; clearing **ClaimRef** on the virtual PV now propagates to a **Released** host PV so both can move to **Available**. Host PV deletion triggers virtual PV deletion in **Sync** and **SyncToVirtual**. **shouldSync** keeps syncing host PVs that have no **ClaimRef** when a matching virtual PV still exists (status updates). **translateUpdateBackwards** allows copying a cleared **ClaimRef** from the host while still blocking new claim refs when the host PV is **Available**.
> 
> **PVC translate** replaces blind `HostNameCluster` on **VolumeName** with logic that uses the host PV name from the annotation when the PV was synced from the host, leaves the name unchanged if a host PV with that name already exists, and only translates otherwise—avoiding double-wrapping of dynamic PV names.
> 
> Adds a **Retain** reclaim **e2e** case (PVC delete → PV **Available** on vCluster and host) and wires **WithContext(ctx)** on existing **Eventually** polls; adds a PVC syncer unit test for **VolumeName** when PV sync is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1dfaf9f693f810304a5183d1ea8661f1324c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->