### PR TITLE
fix(e2e): bound per-attempt exec timeout in coredns hostname test

### DIFF
--- a/e2e/test_core/coredns/test_coredns.go
+++ b/e2e/test_core/coredns/test_coredns.go
@@ -129,7 +129,9 @@ func CoreDNSSpec() {
 					url := fmt.Sprintf("http://nginx-%s.%s.svc:8080/", suffix, nsName)
 					cmd := []string{"curl", "-s", "--show-error", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", url}
 					Eventually(func(g Gomega) {
-						stdout, _, err := podhelper.ExecBuffered(ctx, vClusterConfig, nsName, curlPodName, "curl", cmd, nil)
+						execCtx, cancel := context.WithTimeout(ctx, constants.PollingTimeoutShort)
+						defer cancel()
+						stdout, _, err := podhelper.ExecBuffered(execCtx, vClusterConfig, nsName, curlPodName, "curl", cmd, nil)
 						g.Expect(err).NotTo(HaveOccurred(), "curl exec failed")
 						g.Expect(string(stdout)).To(Equal("200"), "expected 200 from nginx service, got %s", string(stdout))
 					}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())


### PR DESCRIPTION
/kind test

**What does this pull request do?**

Fixes flaky CoreDNS hostname spec (`should resolve a service via its hostname`). The final `Eventually` runs `curl` via exec; the exec call had no per-attempt timeout, so when the backend dial was briefly unreachable a single attempt blocked ~125s on the OS TCP connect timeout and ate the whole 120s budget — the retry loop effectively never retried. Observed in CI as "Timed out after 209.749s" with `error dialing backend: dial tcp 10.96.0.1:443: connect: connection timed out`.

Caps each attempt at `PollingTimeoutShort` (20s) so failed dials return fast and `Eventually` retries across the budget, surviving a transient sub-minute blip. Mirrors the existing `context.WithTimeout` per-attempt pattern in `test_connect.go`.

**Release note**

Fixed an issue where the CoreDNS hostname e2e spec could flake on a transient exec-connection timeout.

**What else do we need to know?**

Tracked in ENGQA-1234. The flake surfaced in the rootless suite, which is not in the default PR suite — running it below to validate.

## E2E Tests

Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
rootless
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to retry behavior; no production or security impact.
> 
> **Overview**
> Reduces flakiness in the CoreDNS **“should resolve a service via its hostname”** e2e by capping how long each `Eventually` attempt can block on `podhelper.ExecBuffered`.
> 
> Inside the curl-via-exec retry loop, each attempt now uses `context.WithTimeout(ctx, constants.PollingTimeoutShort)` before calling exec, matching the per-attempt timeout pattern used in `test_connect.go`. Failed or slow backend dials return within ~20s instead of holding the whole attempt for OS-level connect timeouts (~125s), so `Eventually` can retry within its 120s budget during transient connectivity blips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d3d7ac616c72a89560a06226039822897841b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->