### PR TITLE
fix(e2e): widen webhook-readiness gate timeout in admission test

### DIFF
--- a/e2e/test_security/webhook/test_webhook.go
+++ b/e2e/test_security/webhook/test_webhook.go
@@ -258,7 +258,7 @@ func (w *webhookInfra) registerWebhook(ctx context.Context, configName string) {
 			_ = w.client.CoreV1().ConfigMaps(w.markersNS).Delete(ctx, marker.Name, metav1.DeleteOptions{})
 		}
 		g.Expect(true).To(BeFalse(), "webhook not yet ready")
-	}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+	}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
 }
 
 // AdmissionWebhookSpec registers admission webhook tests.


### PR DESCRIPTION
/kind test

**What does this pull request do?**

Fixes flaky `AdmissionWebhook > should be able to deny pod and configmap creation`. The failure was the webhook-readiness gate in `registerWebhook` (not the deny assertions): `Timed out after 60.001s. webhook not yet ready`.

Root cause from the failing run's apiserver logs: every readiness probe to the webhook backend hit `Post "https://e2e-test-webhook.<ns>.svc:8443/always-deny?timeout=10s": context deadline exceeded` for the full window. The backend pod was healthy (Deployment available + EndpointSlice ready) — the apiserver→service path just wasn't reachable yet, correlated with the vcluster control plane still starting (`readyz` connection-refused just before). Each marker attempt costs the 10s webhook timeout, so the 60s gate only got ~5 tries.

The gate's 60s budget is the bottleneck while the weaker pod-local waits in the same setup get 120s/300s. Widen it to `PollingTimeoutLong` (120s) so a transient sub-2-minute reachability lag is tolerated.

**Release note**

Fixed an issue where the admission-webhook e2e spec could flake on a transient apiserver→webhook-backend reachability lag during vcluster startup.

**What else do we need to know?**

Tracked in ENGQA-1111. The issue's original premise (no readiness gate) was incorrect — the marker gate has existed since 2026-04-03; only its timeout was too tight. Running the node-sync variant below (closest OSS equivalent to the failing `pro-node-sync` setup); the spec also runs in the mandatory PR suite.

## E2E Tests

Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
nodesync
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout change with no production or security impact.
> 
> **Overview**
> **Reduces flake** in the admission webhook e2e spec by giving the `registerWebhook` marker gate more time before it fails with `webhook not yet ready`.
> 
> The readiness loop in `registerWebhook` now uses **`PollingTimeoutLong` (120s)** instead of **`PollingTimeout` (60s)**. That aligns the gate with longer waits already used for deployment and endpoint readiness, so brief apiserver→webhook service reachability delays during vcluster startup are less likely to exhaust the budget (each failed probe can cost up to the webhook’s 10s timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43330dac314548e874aa897edbef7161b5392d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->