### PR TITLE
ci: run independent release steps in parallel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -42,3 +42,10 @@ paths:
     ignore:
       - 'unexpected key "background" for step'
       - 'step must run script with "run" section or run action with "uses" section'
+  # DEVOPS-1029: the release workflow uses `parallel:` blocks of the same
+  # feature; actionlint reports each `parallel:` step as missing a `run`/`uses`
+  # section. Suppress only that message for this one file until native support
+  # lands; then delete this entry.
+  .github/workflows/release.yaml:
+    ignore:
+      - 'step must run script with "run" section or run action with "uses" section'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,27 +47,34 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: git fetch --force --tags
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          cache: false
-          go-version-file: go.mod
-      - name: Setup Just
-        uses: extractions/setup-just@v2
-      - name: Setup Cosgin
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: "v2.2.3"
-      - name: Setup Syft
-        uses: anchore/sbom-action/download-syft@v0.22.2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - uses: azure/setup-helm@v4
-        with:
-          version: "v3.0.2"
+      # DEVOPS-1029: independent setup steps run concurrently. The implicit
+      # wait-all at the end of this parallel block guarantees the tags are
+      # fetched and every tool is installed before get_version and goreleaser
+      # below consume them. No step here depends on another step in the block.
+      - parallel:
+          - name: Fetch tags
+            run: git fetch --force --tags
+          - name: Set up Go
+            uses: actions/setup-go@v6
+            with:
+              cache: false
+              go-version-file: go.mod
+          - name: Setup Just
+            uses: extractions/setup-just@v2
+          - name: Setup Cosgin
+            uses: sigstore/cosign-installer@main
+            with:
+              cosign-release: "v2.2.3"
+          - name: Setup Syft
+            uses: anchore/sbom-action/download-syft@v0.22.2
+          - name: Set up QEMU
+            uses: docker/setup-qemu-action@v3
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v3
+          - name: Set up Helm
+            uses: azure/setup-helm@v4
+            with:
+              version: "v3.0.2"
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo "$GITHUB_REF" | sed -nE 's!refs/tags/!!p')
@@ -135,16 +142,20 @@ jobs:
           TELEMETRY_PRIVATE_KEY: ${{ secrets.VCLUSTER_TELEMETRY_PRIVATE_KEY }}
           GORELEASER_CURRENT_TAG: ${{ steps.get_version.outputs.release_version }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.get_version.outputs.previous_tag }}
-      - name: Save release assets
-        uses: actions/upload-artifact@v6
-        with:
-          name: release-assets
-          path: release/
-      - name: Attach assets to release
-        uses: FabianKramm/release-asset-action@v1
-        with:
-          pattern: "release/*"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # DEVOPS-1029: both uploads only read release/ produced by goreleaser and
+      # are independent of each other, so they run concurrently. The implicit
+      # wait-all surfaces any upload failure (release-blocking, as before).
+      - parallel:
+          - name: Save release assets
+            uses: actions/upload-artifact@v6
+            with:
+              name: release-assets
+              path: release/
+          - name: Attach assets to release
+            uses: FabianKramm/release-asset-action@v1
+            with:
+              pattern: "release/*"
+              github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Best-effort dispatch: a failed notify must not block the release. The
       # receiver in vcluster-docs reconciles on the next release if missed.


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
References DEVOPS-1029 (Linear). This is the vcluster pilot of a three-repo effort (vcluster, vcluster-pro, loft-enterprise); the final PR in the chain carries the `Closes`.

**Please provide a short message that should be published in the vcluster release notes**
No release note. Internal CI/release-pipeline change only; no user-facing behavior changes.

**What else do we need to know?**

## Summary

The release `publish` job runs every setup step (tool installs, QEMU, Buildx) and both post-build uploads in sequence, even though none of them depend on each other. On the `large-8_32` runner that serial setup burns a couple of minutes before goreleaser can start. This groups the genuinely independent steps with the GitHub Actions parallel-steps feature (GA 2026-06-25) so they overlap, while every real ordering is preserved.

## Key Changes

- `.github/workflows/release.yaml`, `publish` job:
  - Block A (setup): the tag fetch and the tool installs (Go, Just, Cosign, Syft, QEMU, Buildx, Helm) now run inside a `parallel:` block. The block's implicit wait-all guarantees all tools are on PATH and tags are fetched before `get_version` and goreleaser consume them.
  - Block B (post-build): the two `release/` uploads (`upload-artifact` and the release-asset attach) run inside a `parallel:` block. Both only read `release/`, so they are independent; the implicit wait-all still surfaces any upload failure (release-blocking, exactly as before).
  - Unchanged ordering: the goreleaser build (the serial spine), the two docker logins (kept serial to avoid a `~/.docker/config.json` write race), the version/semver/homebrew-downgrade steps, and the best-effort vcluster-docs notify steps (still serial, still `continue-on-error`).
- `.github/actionlint.yaml`: a scoped `paths:` ignore for `.github/workflows/release.yaml`. actionlint (v1.7.x) has no schema for the new keys yet and flags each `parallel:` step as missing a `run`/`uses` section; the ignore suppresses only that one message, only for that one file. Remove it once actionlint ships native support.

## Validation

I verified the feature on a real `large-8_32` runner with a throwaway probe before writing this change:
- a `parallel:` block of `uses:` setup actions leaves every tool on PATH after the block (env propagation across concurrent `uses:` steps works);
- a backgrounded `uses:` action plus an explicit `wait` also lands its tool on PATH;
- there is an implicit "wait for all background steps" at job end, so a failing background step fails the job even if never waited on (only relevant here in that the post-build uploads stay release-blocking, which is the prior behavior).

`actionlint .github/workflows/release.yaml` is clean with the scoped ignore, and the workflow is valid YAML.

Known trade-off: actionlint cannot parse a `parallel:` block, so it skips validation of the steps inside the two blocks (the action-pinning check among them) until it ships support for the syntax. The steps moved are stable and already pinned; the ignore is intentionally narrow and time-boxed.

## Dependencies

None. Independent of the vcluster-pro and loft-enterprise PRs in the same DEVOPS-1029 chain.

## TODO

- [ ] Reviewer sanity-check the parallel grouping (no hidden data dependency among the grouped steps).
- [ ] Confirm identical artifacts/signatures/SBOMs and the wall-clock drop on the first real release (only verifiable on an actual release run; the goreleaser spine dominates, so the expected win is modest, roughly 2-3 min of setup overlap).
- [ ] Drop the `.github/actionlint.yaml` ignore once actionlint recognizes `background`/`parallel`/`wait`.

## E2E Tests

### Additional test suites

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal release workflow timing only; release ordering for goreleaser, docker logins, and blocking uploads is preserved, with a temporary reduction in actionlint coverage inside the parallel blocks.
> 
> **Overview**
> The **release `publish` job** now uses GitHub Actions **`parallel:`** blocks so work that does not depend on other steps in the same group can overlap on `large-8_32` runners.
> 
> **Setup (before `get_version` / goreleaser):** tag fetch plus tool installs (Go, Just, Cosign, Syft, QEMU, Buildx, Helm) run concurrently inside one `parallel:` block, with the block’s implicit wait-all preserving the prior guarantee that tags and PATH are ready before version resolution and the build.
> 
> **Post-goreleaser uploads:** `upload-artifact` and the release-asset attach step run in a second `parallel:` block; both still only read `release/` and failures remain release-blocking via wait-all.
> 
> **Unchanged:** checkout/disk cleanup, semver/homebrew checks, **serial** Docker Hub/ghcr logins, the goreleaser step, and best-effort vcluster-docs notifies.
> 
> **`.github/actionlint.yaml`:** adds a **file-scoped** ignore for actionlint’s false “missing run/uses” errors on `parallel:` in `release.yaml` until actionlint supports the syntax (DEVOPS-1029).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee330be6c2495285439dd119c20e5a4f655c092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->