### PR TITLE
ci: run independent head-image setup steps in parallel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -31,3 +31,14 @@ name-pattern:
   - "uses: docker://.*"
   # Block actions/checkout@v4 - require sha pinning
   #- "!uses: actions/checkout@v[0-9]+"
+
+# DEVOPS-1029: actionlint (v1.7.x) has no schema yet for the GitHub Actions
+# parallel-steps feature (background:/wait:, GA 2026-06-25). It flags the
+# background: keys and the wait-only barrier step in push-head-images.yaml.
+# Suppress exactly those two messages, only for that one file, until actionlint
+# ships native support; then delete this block.
+paths:
+  .github/workflows/push-head-images.yaml:
+    ignore:
+      - 'unexpected key "background" for step'
+      - 'step must run script with "run" section or run action with "uses" section'

--- a/.github/workflows/push-head-images.yaml
+++ b/.github/workflows/push-head-images.yaml
@@ -64,25 +64,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      # DEVOPS-1029: these setup steps are independent of one another, so they
+      # run concurrently. Each is backgrounded with an id, and the wait barrier
+      # below blocks until all of them finish, guaranteeing every tool is on
+      # PATH before goreleaser builds. The registry login stays serial to avoid
+      # a ~/.docker/config.json write race.
       - name: Set up Go
+        id: setup-go
+        background: true
         uses: actions/setup-go@v6
         with:
           cache: false
           go-version-file: go.mod
 
       - name: Install just
+        id: setup-just
+        background: true
         uses: extractions/setup-just@v1
 
       - name: Set up QEMU
+        id: setup-qemu
+        background: true
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        id: setup-buildx
+        background: true
         uses: docker/setup-buildx-action@v3
 
       - name: Setup Cosgin
+        id: setup-cosign
+        background: true
         uses: sigstore/cosign-installer@main
         with:
           cosign-release: "v2.2.3"
+
+      - name: Wait for setup tools
+        wait: [setup-go, setup-just, setup-qemu, setup-buildx, setup-cosign]
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
/kind enhancement

## Summary

The `build-head-images` job installs Go, just, QEMU, Buildx and Cosign one after another before goreleaser, though none of them depend on each other. This backgrounds those five installs and waits on them before the build so they overlap. Head images build on every push to `main`, so the saving recurs far more often than on a release.

Every real ordering is preserved: the single registry login and the goreleaser build stay serial, and the wait barrier guarantees all tools are on PATH before goreleaser runs.

## Why background + wait (not parallel:)

This is the head-images counterpart to the release pilot (#4042) under DEVOPS-1029. It uses `background:` + `wait:` rather than a `parallel:` block so actionlint keeps validating each step, including the action-pinning check; a `parallel:` block makes actionlint skip every nested step. Verified locally: with `background:` + `wait:`, a deliberately bad pin inside the group is still flagged.

## actionlint

actionlint (v1.7.x) has no schema for the parallel-steps keys (GA 2026-06-25). A scoped ignore in `.github/actionlint.yaml` suppresses exactly the two resulting messages, only for this file, until actionlint ships support; then it is removed.

## Validation

- `actionlint` is clean locally with the scoped ignore (whole repo).
- This workflow triggers only on push to `main`, so the parallel runtime is first exercised on the first head build after merge, not on this PR. Opening as draft, gated on the DEVOPS-1029 vcluster release pilot (#4042) proving the approach on a real run first.

## E2E Tests

### Additional test suites

```label-filter
none
```

References DEVOPS-1029

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow timing change with explicit wait barrier and unchanged serial login/build; temporary actionlint suppressions are narrowly scoped to one file.
> 
> **Overview**
> Speeds up **`build-head-images`** on every `main` push by overlapping five independent tool installs (Go, just, QEMU, Buildx, Cosign) via **`background: true`** step IDs and a **`wait:`** barrier before registry login and GoReleaser.
> 
> **Ordering is unchanged in practice:** GHCR login and the image build still run serially; the wait step ensures all setup tools are ready first (login stays serial to avoid a `~/.docker/config.json` race).
> 
> **actionlint** gets a **file-scoped ignore** in `.github/actionlint.yaml` for the two false positives from `background:` / wait-only steps until actionlint supports the parallel-steps schema (DEVOPS-1029).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa433b928927b9db8830fa3889d94b59a8867b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->