### PR TITLE
fix: remove k3s finalizers after migration

### DIFF
--- a/e2e/test_migration/k3s_to_k8s.go
+++ b/e2e/test_migration/k3s_to_k8s.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
@@ -29,6 +30,7 @@ import (
 const (
 	k3sBaseChartVersion       = "0.32.2"
 	migratedFromK3sAnnotation = "vcluster.loft.sh/migrated-from-k3s"
+	k3sNodeFinalizer          = "wrangler.cattle.io/node"
 )
 
 // K3SToK8SMigrationSpec verifies that k3s-era CA material is migrated into a
@@ -39,10 +41,11 @@ func K3SToK8SMigrationSpec() {
 		Ordered,
 		func() {
 			var (
-				clusterName   string
-				namespace     string
-				hostClient    kubernetes.Interface
-				initialRootCA []byte
+				clusterName       string
+				namespace         string
+				hostClient        kubernetes.Interface
+				initialRootCA     []byte
+				finalizerNodeName string
 			)
 
 			BeforeAll(func(ctx context.Context) {
@@ -70,6 +73,14 @@ func K3SToK8SMigrationSpec() {
 				Expect(secret.Data[certs.ServerCACertName]).To(Equal(initialRootCA))
 			})
 
+			// Under the k3s distro, k3s's wrangler node controller stamps this finalizer onto the
+			// synced node objects on its own. We capture an affected node here so a later spec can
+			// assert the migration strips it; otherwise a terminated host node would ghost.
+			It("has k3s stamp the node finalizer onto synced nodes", func(ctx context.Context) {
+				vClusterClient := connectVClusterClient(ctx, namespace, clusterName)
+				finalizerNodeName = awaitNodeWithK3sFinalizer(ctx, vClusterClient)
+			})
+
 			It("migrates k3s CA aliases when upgraded to the local k8s chart", func(ctx context.Context) {
 				_, err := runHelmCmd(ctx, upgradeToLocalK8SHelmArgs(clusterName, namespace)...)
 				Expect(err).To(Succeed())
@@ -91,6 +102,19 @@ func K3SToK8SMigrationSpec() {
 					g.Expect(secret.Data[certs.CAKeyName]).To(Equal(secret.Data[certs.ClientCAKeyName]))
 					g.Expect(ca).NotTo(Equal(initialRootCA), "ca.crt should not remain the pre-migration kubeadm CA")
 					g.Expect(serverCA).NotTo(Equal(clientCA), "k3s server CA should stay split until kubeadm regenerates leaves")
+				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
+			})
+
+			// The migration step in StartControllers should have stripped the orphaned k3s
+			// finalizer, so a terminated host node no longer gets stuck as a ghost node.
+			It("removes the orphaned k3s node finalizer after migrating to the k8s distro", func(ctx context.Context) {
+				vClusterClient := connectVClusterClient(ctx, namespace, clusterName)
+
+				Eventually(func(g Gomega, ctx context.Context) {
+					node, err := vClusterClient.CoreV1().Nodes().Get(ctx, finalizerNodeName, metav1.GetOptions{})
+					g.Expect(err).To(Succeed())
+					g.Expect(node.Finalizers).NotTo(ContainElement(k3sNodeFinalizer),
+						"node %s still carries the orphaned k3s finalizer after migration", finalizerNodeName)
 				}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
 			})
 
@@ -130,6 +154,8 @@ func createK3SHelmArgs(name, namespace string) []string {
 		"--create-namespace",
 		"--set", "controlPlane.distro.k3s.enabled=true",
 		"--set", "controlPlane.distro.k8s.enabled=false",
+		"--set", "sync.fromHost.nodes.enabled=true",
+		"--set", "sync.fromHost.nodes.selector.all=true",
 		"--set", "controlPlane.statefulSet.image.registry=ghcr.io",
 		"--set", "controlPlane.statefulSet.image.repository=loft-sh/vcluster-oss",
 		"--set", "controlPlane.statefulSet.image.tag=" + k3sBaseChartVersion,
@@ -144,6 +170,8 @@ func upgradeToLocalK8SHelmArgs(name, namespace string) []string {
 		"--reset-values",
 		"--set", "controlPlane.distro.k8s.enabled=true",
 		"--set", "controlPlane.distro.k8s.image.tag=v1.35.0",
+		"--set", "sync.fromHost.nodes.enabled=true",
+		"--set", "sync.fromHost.nodes.selector.all=true",
 		"--set", "controlPlane.statefulSet.image.registry=",
 		"--set", "controlPlane.statefulSet.image.repository=" + constants.GetRepository(),
 		"--set", "controlPlane.statefulSet.image.tag=" + constants.GetTag(),
@@ -272,6 +300,14 @@ func parseCertificate(g Gomega, certPEM []byte) *x509.Certificate {
 
 func expectVClusterAPIReachable(ctx context.Context, namespace, vClusterName string) {
 	GinkgoHelper()
+	connectVClusterClient(ctx, namespace, vClusterName)
+}
+
+// connectVClusterClient connects to the tenant cluster via a background proxy and returns a
+// client for it. The connection is one-shot, so callers must reconnect after destructive
+// operations such as a helm upgrade that restarts the vCluster pod.
+func connectVClusterClient(ctx context.Context, namespace, vClusterName string) kubernetes.Interface {
+	GinkgoHelper()
 	tmpFile, err := os.CreateTemp("", "vcluster-migration-kubeconfig-*")
 	Expect(err).To(Succeed())
 	Expect(tmpFile.Close()).To(Succeed())
@@ -288,6 +324,7 @@ func expectVClusterAPIReachable(ctx context.Context, namespace, vClusterName str
 	)
 	Expect(err).To(Succeed())
 
+	var vClusterClient kubernetes.Interface
 	Eventually(func(g Gomega, ctx context.Context) {
 		data, err := os.ReadFile(tmpFile.Name())
 		g.Expect(err).To(Succeed())
@@ -296,10 +333,37 @@ func expectVClusterAPIReachable(ctx context.Context, namespace, vClusterName str
 		restConfig, err := clientcmd.RESTConfigFromKubeConfig(data)
 		g.Expect(err).To(Succeed())
 
-		client, err := kubernetes.NewForConfig(restConfig)
+		vClusterClient, err = kubernetes.NewForConfig(restConfig)
 		g.Expect(err).To(Succeed())
 
-		_, err = client.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+		_, err = vClusterClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
 		g.Expect(err).To(Succeed())
 	}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
+
+	return vClusterClient
+}
+
+// awaitNodeWithK3sFinalizer waits for the k3s distro to stamp the node finalizer (k3sNodeFinalizer)
+// onto a synced node on its own and returns that node's name, so a later spec can assert the
+// migration cleaned it up. If k3s never adds it, this fails — the correct signal that the bug's
+// premise no longer holds.
+func awaitNodeWithK3sFinalizer(ctx context.Context, vClusterClient kubernetes.Interface) string {
+	GinkgoHelper()
+	var nodeName string
+	Eventually(func(g Gomega, ctx context.Context) {
+		nodes, err := vClusterClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		g.Expect(err).To(Succeed())
+		g.Expect(nodes.Items).NotTo(BeEmpty(), "no nodes were synced into the tenant cluster")
+
+		nodeName = ""
+		for i := range nodes.Items {
+			if slices.Contains(nodes.Items[i].Finalizers, k3sNodeFinalizer) {
+				nodeName = nodes.Items[i].Name
+				break
+			}
+		}
+		g.Expect(nodeName).NotTo(BeEmpty(), "no synced node has acquired the %q finalizer from k3s", k3sNodeFinalizer)
+	}).WithContext(ctx).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
+
+	return nodeName
 }

--- a/pkg/k8s/migrate.go
+++ b/pkg/k8s/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 
 	vclusterconfig "github.com/loft-sh/vcluster/config"
 	"github.com/loft-sh/vcluster/pkg/certs"
@@ -12,14 +13,25 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// k3sNodeFinalizer is the finalizer the k3s distro stamps onto node objects. After migrating to
+// the k8s distro no controller removes it, so it must be cleaned up once as part of the migration.
+// We match this exact finalizer (rather than the whole wrangler.cattle.io/ prefix) so we never
+// strip finalizers a wrangler-based controller such as Rancher might legitimately add to nodes.
+const k3sNodeFinalizer = "wrangler.cattle.io/node"
+
 var (
 	migratedFromK3sAnnotation = "vcluster.loft.sh/migrated-from-k3s"
+
+	// migratedFromK3sNodesCleanedAnnotation marks that the one-time node finalizer cleanup has run,
+	// so it is not repeated on every restart (which could fight a controller re-adding finalizers).
+	migratedFromK3sNodesCleanedAnnotation = "vcluster.loft.sh/migrated-from-k3s-nodes-cleaned"
 
 	k3sClientCACertPath = "/data/server/tls/client-ca.crt"
 	k3sClientCAKeyPath  = "/data/server/tls/client-ca.key"
@@ -210,6 +222,75 @@ func MigrateK3sToK8sStateless(ctx context.Context, currentNamespaceClient kubern
 	_, err = currentNamespaceClient.CoreV1().Secrets(currentNamespace).Patch(ctx, secretName, patch.Type(), patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to patch k3s secret %s: %w", secretName, err)
+	}
+
+	return nil
+}
+
+// k3sMigrationSecretName returns the host-namespace secret that carries the k3s migration markers.
+// The marker lives on the certificate secret for stateful backing stores and on the vc-k3s-<name>
+// secret for stateless ones.
+func k3sMigrationSecretName(options *config.VirtualClusterConfig) string {
+	switch options.BackingStoreType() {
+	case vclusterconfig.StoreTypeDeployedEtcd, vclusterconfig.StoreTypeExternalEtcd, vclusterconfig.StoreTypeExternalDatabase:
+		return "vc-k3s-" + options.Name
+	default:
+		return certs.CertSecretName(options.Name)
+	}
+}
+
+// CleanupK3sNodeFinalizers removes the orphaned k3s node finalizer from synced nodes after a
+// k3s->k8s migration. It is self-gating and runs at most once: it acts only when this vCluster was
+// migrated from k3s and the cleanup has not already run, then records a marker so it never repeats.
+// Running once (rather than every restart) means it never removes a wrangler.cattle.io/node
+// finalizer that a controller such as Rancher could legitimately add to nodes after the migration.
+func CleanupK3sNodeFinalizers(ctx context.Context, currentNamespaceClient kubernetes.Interface, currentNamespace string, vClient client.Client, options *config.VirtualClusterConfig) error {
+	secretName := k3sMigrationSecretName(options)
+	secret, err := currentNamespaceClient.CoreV1().Secrets(currentNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get migration secret %s: %w", secretName, err)
+	} else if secret.Annotations[migratedFromK3sAnnotation] != "true" { // not migrated from k3s
+		return nil
+	} else if secret.Annotations[migratedFromK3sNodesCleanedAnnotation] == "true" { // already cleaned
+		return nil
+	}
+
+	if err := removeK3sNodeFinalizers(ctx, vClient); err != nil {
+		return err
+	}
+
+	// record that the cleanup ran so we don't repeat it on the next restart
+	patchData := fmt.Appendf(nil, `{"metadata":{"annotations":{%q:"true"}}}`, migratedFromK3sNodesCleanedAnnotation)
+	if _, err := currentNamespaceClient.CoreV1().Secrets(currentNamespace).Patch(ctx, secretName, types.MergePatchType, patchData, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("failed to mark k3s node finalizers cleaned on secret %s: %w", secretName, err)
+	}
+
+	return nil
+}
+
+// removeK3sNodeFinalizers strips the k3s node finalizer (k3sNodeFinalizer) from every synced node
+// in the tenant cluster. After migrating to the k8s distro no controller removes it, so a
+// terminated host node would otherwise remain as a ghost node (the syncer sets a deletionTimestamp
+// but the orphaned finalizer blocks actual removal).
+func removeK3sNodeFinalizers(ctx context.Context, vClient client.Client) error {
+	nodeList := &corev1.NodeList{}
+	if err := vClient.List(ctx, nodeList); err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !slices.Contains(node.Finalizers, k3sNodeFinalizer) {
+			continue
+		}
+
+		orig := node.DeepCopy()
+		node.Finalizers = slices.DeleteFunc(node.Finalizers, func(f string) bool { return f == k3sNodeFinalizer })
+		if err := vClient.Patch(ctx, node, client.MergeFrom(orig)); err != nil {
+			return fmt.Errorf("failed to remove %s finalizer from node %s: %w", k3sNodeFinalizer, node.Name, err)
+		}
+		klog.Infof("Removed orphaned %s finalizer from node %s after k3s->k8s migration", k3sNodeFinalizer, node.Name)
 	}
 
 	return nil

--- a/pkg/k8s/migrate_test.go
+++ b/pkg/k8s/migrate_test.go
@@ -1,0 +1,144 @@
+package k8s
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/scheme"
+	testingutil "github.com/loft-sh/vcluster/pkg/util/testing"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func node(name string, finalizers ...string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Finalizers: finalizers,
+		},
+	}
+}
+
+func TestRemoveK3sNodeFinalizers(t *testing.T) {
+	testCases := []struct {
+		name               string
+		nodes              []runtime.Object
+		expectedFinalizers map[string][]string
+	}{
+		{
+			name:  "removes the k3s node finalizer",
+			nodes: []runtime.Object{node("node-1", "wrangler.cattle.io/node")},
+			expectedFinalizers: map[string][]string{
+				"node-1": nil,
+			},
+		},
+		{
+			// Narrowed to the exact k3s finalizer: other wrangler.cattle.io/* finalizers (e.g. ones a
+			// controller like Rancher might add) must be left untouched.
+			name: "removes only the k3s node finalizer, keeps other finalizers",
+			nodes: []runtime.Object{
+				node("node-1", "wrangler.cattle.io/node", "example.com/keep", "wrangler.cattle.io/managed-etcd-controller"),
+			},
+			expectedFinalizers: map[string][]string{
+				"node-1": {"example.com/keep", "wrangler.cattle.io/managed-etcd-controller"},
+			},
+		},
+		{
+			name: "leaves nodes without the k3s finalizer untouched",
+			nodes: []runtime.Object{
+				node("node-1", "example.com/keep"),
+				node("node-2"),
+			},
+			expectedFinalizers: map[string][]string{
+				"node-1": {"example.com/keep"},
+				"node-2": nil,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			fakeClient := testingutil.NewFakeClient(scheme.Scheme, testCase.nodes...)
+
+			err := removeK3sNodeFinalizers(ctx, fakeClient)
+			assert.NilError(t, err)
+
+			for name, expected := range testCase.expectedFinalizers {
+				gotNode := &corev1.Node{}
+				err := fakeClient.Get(ctx, types.NamespacedName{Name: name}, gotNode)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, gotNode.Finalizers)
+			}
+		})
+	}
+}
+
+func TestCleanupK3sNodeFinalizers(t *testing.T) {
+	const namespace = "test-ns"
+	options := &config.VirtualClusterConfig{}
+	options.Name = "test"
+	secretName := k3sMigrationSecretName(options)
+
+	migrationSecret := func(migrated, cleaned bool) *corev1.Secret {
+		annotations := map[string]string{}
+		if migrated {
+			annotations[migratedFromK3sAnnotation] = "true"
+		}
+		if cleaned {
+			annotations[migratedFromK3sNodesCleanedAnnotation] = "true"
+		}
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace, Annotations: annotations},
+		}
+	}
+
+	t.Run("strips the finalizer and records the cleaned marker on first run", func(t *testing.T) {
+		ctx := context.Background()
+		hostClient := k8sfake.NewSimpleClientset(migrationSecret(true, false))
+		vClient := testingutil.NewFakeClient(scheme.Scheme, node("node-1", "wrangler.cattle.io/node"))
+
+		err := CleanupK3sNodeFinalizers(ctx, hostClient, namespace, vClient, options)
+		assert.NilError(t, err)
+
+		gotNode := &corev1.Node{}
+		assert.NilError(t, vClient.Get(ctx, types.NamespacedName{Name: "node-1"}, gotNode))
+		assert.Assert(t, !slices.Contains(gotNode.Finalizers, k3sNodeFinalizer), "finalizer should be stripped")
+
+		gotSecret, err := hostClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, gotSecret.Annotations[migratedFromK3sNodesCleanedAnnotation], "true")
+	})
+
+	t.Run("does nothing when the cleaned marker is already set", func(t *testing.T) {
+		ctx := context.Background()
+		hostClient := k8sfake.NewSimpleClientset(migrationSecret(true, true))
+		vClient := testingutil.NewFakeClient(scheme.Scheme, node("node-1", "wrangler.cattle.io/node"))
+
+		err := CleanupK3sNodeFinalizers(ctx, hostClient, namespace, vClient, options)
+		assert.NilError(t, err)
+
+		gotNode := &corev1.Node{}
+		assert.NilError(t, vClient.Get(ctx, types.NamespacedName{Name: "node-1"}, gotNode))
+		assert.Assert(t, slices.Contains(gotNode.Finalizers, k3sNodeFinalizer), "finalizer should be left in place")
+	})
+
+	t.Run("does nothing when the cluster was not migrated from k3s", func(t *testing.T) {
+		ctx := context.Background()
+		hostClient := k8sfake.NewSimpleClientset(migrationSecret(false, false))
+		vClient := testingutil.NewFakeClient(scheme.Scheme, node("node-1", "wrangler.cattle.io/node"))
+
+		err := CleanupK3sNodeFinalizers(ctx, hostClient, namespace, vClient, options)
+		assert.NilError(t, err)
+
+		gotNode := &corev1.Node{}
+		assert.NilError(t, vClient.Get(ctx, types.NamespacedName{Name: "node-1"}, gotNode))
+		assert.Assert(t, slices.Contains(gotNode.Finalizers, k3sNodeFinalizer), "finalizer should be left in place")
+	})
+}

--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -51,6 +51,15 @@ func StartControllers(controllerContext *synccontext.ControllerContext, syncers 
 		return err
 	}
 
+	// If this vCluster was migrated from the k3s distro, strip the orphaned k3s node finalizer left
+	// on synced nodes. Without this, a terminated host node would remain as a ghost node because no
+	// controller removes the finalizer after migration. CleanupK3sNodeFinalizers is self-gating and
+	// runs once, so it never fights a controller (e.g. Rancher) that re-adds finalizers later.
+	err = k8s.CleanupK3sNodeFinalizers(controllerContext.Context, controllerContext.Config.HostClient, controllerContext.Config.HostNamespace, controllerContext.VirtualManager.GetClient(), controllerContext.Config)
+	if err != nil {
+		return fmt.Errorf("cleanup k3s node finalizers: %w", err)
+	}
+
 	// register init manifests configmap watcher controller
 	err = deploy.RegisterInitManifestsController(controllerContext)
 	if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-903


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
migration
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change patches tenant `Node` finalizers at startup during migration; behavior is gated and narrow, but incorrect gating or over-stripping could affect node lifecycle in migrated clusters with host node sync.
> 
> **Overview**
> Fixes **ghost nodes** after upgrading a k3s-distro vCluster to k8s when host nodes are synced: k3s leaves `wrangler.cattle.io/node` on tenant `Node` objects, and nothing in the k8s distro clears it, so deleted host nodes can stay stuck with a `deletionTimestamp`.
> 
> On controller startup, **`CleanupK3sNodeFinalizers`** runs once (gated by `vcluster.loft.sh/migrated-from-k3s` and a new `vcluster.loft.sh/migrated-from-k3s-nodes-cleaned` marker on the migration secret). It patches tenant nodes to drop only that exact finalizer, leaving other finalizers (including other `wrangler.cattle.io/*` ones) intact.
> 
> **E2E** enables `sync.fromHost.nodes`, records a node that k3s finalizes, and asserts the finalizer is gone after helm upgrade to the local k8s chart. Unit tests cover stripping, idempotency, and non-migrated clusters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb07459b7e04987b9a6a3d33f8c255cae6dc99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->