### PR TITLE
ci(coverage): comment on unit-test coverage regressions via codecov

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,3 +49,13 @@ jobs:
           cache: false
       - name: Execute unit tests
         run: ./hack/test.sh
+
+      # vcluster is a public repo, so Codecov uploads tokenless. Codecov's
+      # GitHub App posts the coverage comment; no workflow write permission is
+      # needed here.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage.out
+          disable_search: true
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .devspace/
 .DS_Store
 profile.out
+coverage.out
 *.swp
 /vcluster
 /zzz

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+# Codecov configuration for vcluster.
+#
+# Goal (DEVOPS-1053): flag a PR that changes code without tests to hold the
+# line, so overall coverage regresses versus the base branch. A PR that holds
+# or improves coverage stays quiet. Statuses are informational, so nothing
+# blocks merge; this is a review-time signal, not a gate.
+
+coverage:
+  status:
+    project:
+      default:
+        # Compare against the base branch and flag a drop beyond the threshold.
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        # Coverage of the changed lines, shown as supporting detail.
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, components"
+  # Only post when coverage actually changes, so well-covered PRs get nothing.
+  require_changes: true
+
+# Exclude non-product and generated code so it does not skew the delta. Mirrors
+# the exclusions in hack/test.sh.
+ignore:
+  - "vendor"
+  - "test"
+  - "e2e"
+  - "chart"
+  - "**/*.pb.go"
+  - "**/zz_generated*.go"
+  - "**/*_generated.go"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -8,15 +8,29 @@ export GOFLAGS=-mod=vendor
 echo "Building virtual cluster..."
 go generate ./... && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build cmd/vcluster/main.go || exit 1
 
+# Merged coverage profile consumed by CI and uploaded to Codecov. We collect a
+# per-package profile and append it here so the final file spans every package.
+# Previously each package overwrote a single profile, so only the last package
+# survived and the coverage was effectively discarded.
+COVERAGE_OUT="$(pwd)/coverage.out"
+echo "mode: atomic" > "$COVERAGE_OUT"
+
 # List packages
 PKGS=$(go list ./... | grep -v -e /vendor/ -e /test -e /e2e)
 echo "Start testing..."
 fail=false
 for pkg in $PKGS; do
- go test -race -coverprofile=profile.out -covermode=atomic $pkg
+ pkgCover=$(mktemp)
+ go test -race -coverprofile="$pkgCover" -covermode=atomic "$pkg"
  if [ $? -ne 0 ]; then
    fail=true
  fi
+ # Append this package's coverage, dropping its own "mode:" header line so the
+ # merged profile keeps a single header.
+ if [ -s "$pkgCover" ]; then
+   tail -n +2 "$pkgCover" >> "$COVERAGE_OUT"
+ fi
+ rm -f "$pkgCover"
 done
 
 if [ "$fail" = true ]; then


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
Closes DEVOPS-1053 (Linear).

`hack/test.sh` computed per-package coverage but pointed every package at the same `profile.out` and overwrote it each iteration, so the coverage was discarded. This collects a per-package profile, merges it into a single `coverage.out`, and uploads it to Codecov from the unit-test job.

Codecov is free and full-featured on this public repo. The project status compares against the base branch (`target: auto`, informational) and flags a PR that lowers overall coverage: the case where code changed without tests to hold the line. Well-covered PRs stay quiet (the comment posts only on a coverage change) and nothing gates merge.

The Codecov step is tokenless (public repo) and sets `fail_ci_if_error: false`, so CI is unaffected until the Codecov GitHub App is installed on the org and vcluster is activated on codecov.io.

**Please provide a short message that should be published in the vcluster release notes**
NONE

**What else do we need to know?**
Follow-up: extend to the private repos (vcluster-pro, loft-enterprise), where Codecov's regression signal is a paid feature and `fgrosse/go-coverage-report` is the free self-hosted alternative. loft-enterprise is multi-module and needs the same coverage-merge fix in its own test script.

## E2E Tests

No new test suites. The mandatory PR suite runs as usual.

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-script changes only; no runtime product code, and Codecov is configured not to fail the workflow.
> 
> **Overview**
> Fixes unit test coverage collection and wires **Codecov** into the Go unit-test workflow so PRs can surface coverage regressions at review time.
> 
> **`hack/test.sh`** now writes each package’s profile to a temp file and merges them into a single root **`coverage.out`** (instead of reusing one **`profile.out`** that only kept the last package). **`.gitignore`** ignores **`coverage.out`**.
> 
> The **unit-tests** job uploads **`coverage.out`** with **`codecov/codecov-action`** (tokenless public repo, **`fail_ci_if_error: false`**). New **`codecov.yml`** sets informational project/patch statuses (1% drop vs base), comments only when coverage changes, and ignores paths aligned with **`hack/test.sh`** (vendor, test, e2e, chart, generated code). Nothing blocks merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b9cd063c868bdbbeccbbfad2e6139c3981ca591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->