### PR TITLE
ci(release): bump linear-release-sync pin to the -patch.N fix (v0.34)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -221,7 +221,7 @@ jobs:
       contents: read
     steps:
       - name: Sync Linear issues to Released
-        uses: loft-sh/github-actions/.github/actions/linear-release-sync@0eaac503dce88c81646e6798c981bffa3927d83c # linear-release-sync/v1
+        uses: loft-sh/github-actions/.github/actions/linear-release-sync@e5084ddb2df90eab681462408d9b138356db9de4 # linear-release-sync (#156)
         with:
           release-tag: ${{ needs.publish.outputs.release_version }}
           repo-name: vcluster


### PR DESCRIPTION
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

The `v0.34` release branch already uses the shared `linear-release-sync` action but pins the stale `0eaac503` (the April `linear-release-sync/v1` tag), which predates github-actions #142 and #156. This bumps the pin to `e5084dd`. Without #156 the action classifies `-patch.N` tags as prerelease via the old substring rule, so a `-patch.N` backport off this line re-fires the "now in stable release" comment (DEVOPS-1006).

References DEVOPS-1055

**Please provide a short message that should be published in the vcluster release notes**

```release-note
NONE
```

## E2E Tests

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change; no runtime or application code is affected.
> 
> **Overview**
> Updates the **Sync Linear Issues** step in `release.yaml` to pin `linear-release-sync` at `e5084ddb` instead of the older `0eaac503` reference.
> 
> That newer commit includes the fix from loft-sh/github-actions **#156**, so `-patch.N` release tags are no longer treated as prereleases by the legacy substring rule. On the `v0.34` line this avoids incorrectly re-posting the “now in stable release” Linear/GitHub comment when shipping patch backports (DEVOPS-1006 / DEVOPS-1055).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a480bb288d1e03b64e8f1021b250ab9d67957081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->