### PR TITLE
test(snapshot): cover request cancellation in a unit test

### DIFF
--- a/e2e/test_storage/snapshot/test_snapshot.go
+++ b/e2e/test_storage/snapshot/test_snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
 	"github.com/loft-sh/e2e-framework/pkg/setup/cluster"
@@ -191,7 +190,6 @@ func SnapshotAllSpec() {
 			})
 
 			describeSnapshotRestore(&s)
-			describeSnapshotCanceling(&s)
 			describeSnapshotDeletion(&s)
 		},
 	)
@@ -443,81 +441,6 @@ func describeSnapshotRestore(s *snapshotCtx) {
 	})
 }
 
-func describeSnapshotCanceling(s *snapshotCtx) {
-	var (
-		testNS       string
-		snapshotPath string
-	)
-	const (
-		appCount  = 3
-		appPrefix = "test-app-"
-	)
-
-	// Ordered: BeforeAll creates 2 snapshots back-to-back -> spec 1 verifies 2 requests exist ->
-	// spec 2 verifies first was canceled -> spec 3 verifies second completed.
-	Describe("Snapshot canceling", Ordered, func() {
-		BeforeAll(func(ctx context.Context) {
-			testNS = "snap-cancel-" + random.String(6)
-			snapshotPath = "container:///snapshot-data/" + testNS + ".tar.gz"
-			cleanupAllSnapshotArtifacts(ctx, s.hostClient, s.vClusterNS)
-			_, err := s.vClusterClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: testNS},
-			}, metav1.CreateOptions{})
-			Expect(err).To(Succeed())
-			for i := range appCount {
-				createAppWithPVC(ctx, s.vClusterClient, testNS, fmt.Sprintf("%s%d", appPrefix, i))
-			}
-			Eventually(func(g Gomega) {
-				for i := range appCount {
-					dep, err := s.vClusterClient.AppsV1().Deployments(testNS).Get(ctx, fmt.Sprintf("%s%d", appPrefix, i), metav1.GetOptions{})
-					g.Expect(err).To(Succeed())
-					g.Expect(dep.Status.AvailableReplicas).To(Equal(int32(1)))
-				}
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
-
-			createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath)
-			// Brief pause to ensure the first snapshot request is registered before
-			// the second one arrives - tests the cancellation path where a new
-			// snapshot supersedes an in-progress one.
-			time.Sleep(time.Second)
-			createSnapshot(s.vClusterName, s.vClusterNS, s.kubeconfig, true, snapshotPath)
-		})
-
-		It("Has 2 snapshot requests", func(ctx context.Context) {
-			Eventually(func(g Gomega) {
-				cms, err := s.hostClient.CoreV1().ConfigMaps(s.vClusterNS).List(ctx, metav1.ListOptions{
-					LabelSelector: pkgconstants.SnapshotRequestLabel,
-				})
-				g.Expect(err).To(Succeed())
-				g.Expect(cms.Items).To(HaveLen(2))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutLong).Should(Succeed())
-		})
-
-		It("Canceled the previous snapshot request", func(ctx context.Context) {
-			Eventually(func(g Gomega) {
-				previousReq, _ := getTwoSnapshotRequests(g, ctx, s.hostClient, s.vClusterNS)
-				g.Expect(previousReq.Status.Phase).To(Equal(snapshotapi.RequestPhaseCanceled))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
-		})
-
-		It("Completed the new snapshot request", func(ctx context.Context) {
-			Eventually(func(g Gomega) {
-				_, newerReq := getTwoSnapshotRequests(g, ctx, s.hostClient, s.vClusterNS)
-				g.Expect(newerReq.Status.Phase).To(Equal(snapshotapi.RequestPhaseCompleted))
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeoutVeryLong).Should(Succeed())
-		})
-
-		AfterAll(func(ctx context.Context) {
-			err := s.vClusterClient.CoreV1().Namespaces().Delete(ctx, testNS, metav1.DeleteOptions{})
-			if !kerrors.IsNotFound(err) {
-				Expect(err).To(Succeed())
-			}
-			deleteSnapshotRequestConfigMaps(ctx, s.hostClient, s.vClusterNS)
-		})
-	},
-	)
-}
-
 func describeSnapshotDeletion(s *snapshotCtx) {
 	var (
 		testNS                    string
@@ -661,26 +584,4 @@ func createDeploymentWithVolume(ctx context.Context, client kubernetes.Interface
 		},
 	}, metav1.CreateOptions{})
 	Expect(err).To(Succeed())
-}
-
-func getTwoSnapshotRequests(g Gomega, ctx context.Context, hostClient kubernetes.Interface, vClusterNamespace string) (*snapshotapi.Request, *snapshotapi.Request) {
-	configMaps, err := hostClient.CoreV1().ConfigMaps(vClusterNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: pkgconstants.SnapshotRequestLabel,
-	})
-	g.Expect(err).To(Succeed())
-	g.Expect(configMaps.Items).To(HaveLen(2))
-
-	var previousCM, newerCM corev1.ConfigMap
-	if configMaps.Items[0].CreationTimestamp.Time.Before(configMaps.Items[1].CreationTimestamp.Time) {
-		previousCM = configMaps.Items[0]
-		newerCM = configMaps.Items[1]
-	} else {
-		previousCM = configMaps.Items[1]
-		newerCM = configMaps.Items[0]
-	}
-	previous, err := snapshotapi.UnmarshalRequest(&previousCM)
-	g.Expect(err).To(Succeed())
-	newer, err := snapshotapi.UnmarshalRequest(&newerCM)
-	g.Expect(err).To(Succeed())
-	return previous, newer
 }

--- a/pkg/snapshot/controller_test.go
+++ b/pkg/snapshot/controller_test.go
@@ -1,0 +1,195 @@
+package snapshot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/config"
+	"github.com/loft-sh/vcluster/pkg/util/loghelper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testRequestNamespace = "vcluster-test"
+	testVClusterName     = "test"
+	testSnapshotURL      = "container:///snapshot-data/test.tar.gz"
+)
+
+// newRequestConfigMap builds a snapshot request ConfigMap the way the CLI does,
+// then stamps it with an explicit name and creation timestamp so tests can
+// control request ordering.
+func newRequestConfigMap(t *testing.T, name, url string, phase snapshotapi.RequestPhase, created metav1.Time) *corev1.ConfigMap {
+	t.Helper()
+	req := &snapshotapi.Request{
+		RequestMetadata: snapshotapi.RequestMetadata{
+			Name:              name,
+			CreationTimestamp: created,
+		},
+		Spec:   snapshotapi.RequestSpec{URL: url},
+		Status: snapshotapi.RequestStatus{Phase: phase},
+	}
+	cm, err := snapshotapi.NewSnapshotRequestConfigMap(testRequestNamespace, testVClusterName, req)
+	if err != nil {
+		t.Fatalf("failed to build snapshot request ConfigMap: %v", err)
+	}
+	cm.Name = name
+	return cm
+}
+
+// phaseOf reads the current request phase back out of the ConfigMap stored in the client.
+func phaseOf(t *testing.T, ctx context.Context, c client.Client, name string) snapshotapi.RequestPhase {
+	t.Helper()
+	var cm corev1.ConfigMap
+	if err := c.Get(ctx, types.NamespacedName{Namespace: testRequestNamespace, Name: name}, &cm); err != nil {
+		t.Fatalf("failed to get ConfigMap %s: %v", name, err)
+	}
+	req, err := snapshotapi.UnmarshalRequest(&cm)
+	if err != nil {
+		t.Fatalf("failed to unmarshal request from ConfigMap %s: %v", name, err)
+	}
+	return req.Status.Phase
+}
+
+// TestCancelPreviousRequests covers the cancellation decision that a new snapshot
+// request supersedes an earlier one. This used to be exercised by an e2e spec, but
+// after volume snapshots were removed a request completes too fast to reliably catch
+// mid-flight, so the behavior is verified here deterministically instead.
+func TestCancelPreviousRequests(t *testing.T) {
+	newer := metav1.NewTime(time.Unix(2000, 0))
+	older := metav1.NewTime(time.Unix(1000, 0))
+
+	tests := []struct {
+		name string
+		// current is the incoming request passed to cancelPreviousRequests.
+		currentName  string
+		currentPhase snapshotapi.RequestPhase
+		currentURL   string
+		currentTime  metav1.Time
+		// other is the pre-existing request stored as a ConfigMap.
+		otherPhase snapshotapi.RequestPhase
+		otherURL   string
+		otherTime  metav1.Time
+
+		wantOtherPhase  snapshotapi.RequestPhase
+		wantCanContinue bool
+	}{
+		{
+			name:            "cancels an older request that is still creating the etcd backup",
+			currentName:     "req-new",
+			currentPhase:    snapshotapi.RequestPhaseNotStarted,
+			currentURL:      testSnapshotURL,
+			currentTime:     newer,
+			otherPhase:      snapshotapi.RequestPhaseCreatingEtcdBackup,
+			otherURL:        testSnapshotURL,
+			otherTime:       older,
+			wantOtherPhase:  snapshotapi.RequestPhaseCanceling,
+			wantCanContinue: false,
+		},
+		{
+			name:            "cancels an older request that has not started yet",
+			currentName:     "req-new",
+			currentPhase:    snapshotapi.RequestPhaseNotStarted,
+			currentURL:      testSnapshotURL,
+			currentTime:     newer,
+			otherPhase:      snapshotapi.RequestPhaseNotStarted,
+			otherURL:        testSnapshotURL,
+			otherTime:       older,
+			wantOtherPhase:  snapshotapi.RequestPhaseCanceling,
+			wantCanContinue: false,
+		},
+		{
+			name:            "does not cancel an older request that already completed",
+			currentName:     "req-new",
+			currentPhase:    snapshotapi.RequestPhaseNotStarted,
+			currentURL:      testSnapshotURL,
+			currentTime:     newer,
+			otherPhase:      snapshotapi.RequestPhaseCompleted,
+			otherURL:        testSnapshotURL,
+			otherTime:       older,
+			wantOtherPhase:  snapshotapi.RequestPhaseCompleted,
+			wantCanContinue: true,
+		},
+		{
+			name:            "does not cancel a request for a different snapshot URL",
+			currentName:     "req-new",
+			currentPhase:    snapshotapi.RequestPhaseNotStarted,
+			currentURL:      testSnapshotURL,
+			currentTime:     newer,
+			otherPhase:      snapshotapi.RequestPhaseCreatingEtcdBackup,
+			otherURL:        "container:///snapshot-data/other.tar.gz",
+			otherTime:       older,
+			wantOtherPhase:  snapshotapi.RequestPhaseCreatingEtcdBackup,
+			wantCanContinue: true,
+		},
+		{
+			name:            "does nothing once the current request has already started",
+			currentName:     "req-new",
+			currentPhase:    snapshotapi.RequestPhaseCreatingEtcdBackup,
+			currentURL:      testSnapshotURL,
+			currentTime:     newer,
+			otherPhase:      snapshotapi.RequestPhaseCreatingEtcdBackup,
+			otherURL:        testSnapshotURL,
+			otherTime:       older,
+			wantOtherPhase:  snapshotapi.RequestPhaseCreatingEtcdBackup,
+			wantCanContinue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			otherCM := newRequestConfigMap(t, "req-old", tt.otherURL, tt.otherPhase, tt.otherTime)
+
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to register corev1 scheme: %v", err)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(otherCM).Build()
+
+			// Reconciler shadows several reconcilerBase fields (logger, vConfig,
+			// isHostMode); its own methods read the outer ones, so both must be set.
+			logger := loghelper.NewFromExisting(logr.Discard(), "test")
+			vConfig := &config.VirtualClusterConfig{HostNamespace: testRequestNamespace}
+			r := &Reconciler{
+				reconcilerBase: reconcilerBase{
+					vConfig:            vConfig,
+					requestsKubeClient: fakeClient,
+					logger:             logger,
+					isHostMode:         true,
+				},
+				vConfig:    vConfig,
+				logger:     logger,
+				isHostMode: true,
+			}
+
+			current := &snapshotapi.Request{
+				RequestMetadata: snapshotapi.RequestMetadata{
+					Name:              tt.currentName,
+					CreationTimestamp: tt.currentTime,
+				},
+				Spec:   snapshotapi.RequestSpec{URL: tt.currentURL},
+				Status: snapshotapi.RequestStatus{Phase: tt.currentPhase},
+			}
+
+			canContinue, err := r.cancelPreviousRequests(ctx, current)
+			if err != nil {
+				t.Fatalf("cancelPreviousRequests returned error: %v", err)
+			}
+			if canContinue != tt.wantCanContinue {
+				t.Errorf("canContinue = %v, want %v", canContinue, tt.wantCanContinue)
+			}
+			if got := phaseOf(t, ctx, fakeClient, "req-old"); got != tt.wantOtherPhase {
+				t.Errorf("other request phase = %q, want %q", got, tt.wantOtherPhase)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Move snapshot-request cancellation coverage out of the flaky `Snapshot canceling` e2e spec and into a deterministic unit test on `cancelPreviousRequests`.

- Add `pkg/snapshot/controller_test.go` with table-driven cases for the cancellation decision.
- Remove the `Snapshot canceling` `Describe` block from `e2e/test_storage/snapshot/test_snapshot.go` (plus the now-unused `getTwoSnapshotRequests` helper and `time` import).

## Why

The nightly Ginkgo run started failing on `Snapshot canceling > Canceled the previous snapshot request`:

```
Expected
    <snapshot.RequestPhase>: Completed
to equal
    <snapshot.RequestPhase>: Canceled
```

It failed identically two nights running (2026-07-02 and 2026-07-03), first appearing right after #3989 ("removes volume snapshot and restore code") merged on 2026-07-01. The last green nightly ran before that merge.

The spec created snapshot A, waited a second, created snapshot B, and asserted that B canceled A. Cancellation only fires while the previous request is still in progress: `ShouldCancel` returns true only for the `NotStarted` and `CreatingEtcdBackup` phases (previously also `CreatingVolumeSnapshots`).

Before #3989 a request went `NotStarted -> CreatingVolumeSnapshots -> CreatingEtcdBackup -> Completed`. The spec set up three apps with PVCs specifically so the volume-snapshot phase took real time, and that was the window in which B could catch A and cancel it.

#3989 removed the volume-snapshot phase. A request now goes straight from `NotStarted -> CreatingEtcdBackup -> Completed`, and a backup of this near-empty etcd finishes in milliseconds (the run logs show `COMPACT compacted from 0 to 7515 in ... 9ms`). By the time B reconciles, A is already `Completed`, `ShouldCancel` returns false, and A is never canceled. The assertion then fails.

That window cannot be reliably reopened from an e2e test. Spacing two CLI calls to land inside a millisecond-scale phase is a race by construction, and widening it by inflating etcd would just make the test depend on CI machine speed. The cancellation logic itself is pure orchestration over ConfigMaps, so a unit test with a fake client covers the same behavior without any timing assumption:

- an older request still creating the etcd backup is moved to `Canceling`
- an older request that has not started yet is moved to `Canceling`
- an older request that already `Completed` is left untouched (the exact case that broke the nightly)
- a request for a different snapshot URL is left untouched
- nothing happens once the current request has already started

## Testing

- `go test ./pkg/snapshot/` passes
- `go vet ./e2e/test_storage/snapshot/` passes
- custom `golangci-lint` reports 0 issues on both packages


```label-filter
snaoshots
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths modified; reduces nightly flake risk.
> 
> **Overview**
> Replaces the flaky **Snapshot canceling** Ginkgo suite with deterministic coverage of snapshot request supersession.
> 
> The e2e flow that fired two snapshots back-to-back and expected the first to reach `Canceled` is removed from `e2e/test_storage/snapshot/test_snapshot.go`, along with `getTwoSnapshotRequests` and the unused `time` import. **Snapshot and restore** now only runs restore and deletion e2e groups.
> 
> New `pkg/snapshot/controller_test.go` adds `TestCancelPreviousRequests`, a table-driven test against `cancelPreviousRequests` using a fake client. Cases assert when an older same-URL request moves to `Canceling` vs stays put, when reconciliation should wait (`canContinue`), and that in-progress or completed peers and different URLs are not canceled incorrectly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2d5bc0cf31ed1690e3b91a81a13e17ebdb8216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->