### PR TITLE
adds: validation to helm chart for volume snapshot fields

### DIFF
--- a/chart/templates/_validate.tpl
+++ b/chart/templates/_validate.tpl
@@ -1,0 +1,27 @@
+{{/*
+  Fail the install/upgrade if any volume-snapshot value is set.
+  These were removed in 0.36.0. The config fields are retained as no-ops so
+  existing configs still parse, but the chart rejects them so users notice.
+*/}}
+{{- define "vcluster.legacy.volumeSnapshots.validate" }}
+{{- $sync := .Values.sync | default dict }}
+{{- $syncToHost := $sync.toHost | default dict }}
+{{- $syncFromHost := $sync.fromHost | default dict }}
+{{- $deploy := .Values.deploy | default dict }}
+{{- $rbac := .Values.rbac | default dict }}
+{{- if hasKey $syncToHost "volumeSnapshots" }}
+{{- fail "sync.toHost.volumeSnapshots was removed in 0.36.0 and is no longer supported. Please remove it from your values." }}
+{{- end }}
+{{- if hasKey $syncToHost "volumeSnapshotContents" }}
+{{- fail "sync.toHost.volumeSnapshotContents was removed in 0.36.0 and is no longer supported. Please remove it from your values." }}
+{{- end }}
+{{- if hasKey $syncFromHost "volumeSnapshotClasses" }}
+{{- fail "sync.fromHost.volumeSnapshotClasses was removed in 0.36.0 and is no longer supported. Please remove it from your values." }}
+{{- end }}
+{{- if hasKey $deploy "volumeSnapshotController" }}
+{{- fail "deploy.volumeSnapshotController was removed in 0.36.0 and is no longer supported. Please remove it from your values." }}
+{{- end }}
+{{- if hasKey $rbac "enableVolumeSnapshotRules" }}
+{{- fail "rbac.enableVolumeSnapshotRules was removed in 0.36.0 and is no longer supported. Please remove it from your values." }}
+{{- end }}
+{{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- include "vcluster.exportKubeConfig.validate" . }}
+{{- include "vcluster.legacy.volumeSnapshots.validate" . }}
 apiVersion: apps/v1
 kind: {{ include "vcluster.kind" . }}
 metadata:

--- a/chart/tests/statefulset_test.yaml
+++ b/chart/tests/statefulset_test.yaml
@@ -1026,6 +1026,79 @@ tests:
           path: spec.template.spec.containers[1].command[2]
           value: echo 'sidecar-container'
 
+  - it: fails when sync.toHost.volumeSnapshots is set
+    set:
+      sync:
+        toHost:
+          volumeSnapshots:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "sync.toHost.volumeSnapshots was removed in 0.36.0 and is no longer supported. Please remove it from your values."
+
+  - it: fails when sync.toHost.volumeSnapshots is set to false
+    set:
+      sync:
+        toHost:
+          volumeSnapshots:
+            enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "sync.toHost.volumeSnapshots was removed in 0.36.0 and is no longer supported. Please remove it from your values."
+
+  - it: fails when sync.toHost.volumeSnapshotContents is set
+    set:
+      sync:
+        toHost:
+          volumeSnapshotContents:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "sync.toHost.volumeSnapshotContents was removed in 0.36.0 and is no longer supported. Please remove it from your values."
+
+  - it: fails when sync.fromHost.volumeSnapshotClasses is set
+    set:
+      sync:
+        fromHost:
+          volumeSnapshotClasses:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "sync.fromHost.volumeSnapshotClasses was removed in 0.36.0 and is no longer supported. Please remove it from your values."
+
+  - it: fails when deploy.volumeSnapshotController is set
+    set:
+      deploy:
+        volumeSnapshotController:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "deploy.volumeSnapshotController was removed in 0.36.0 and is no longer supported. Please remove it from your values."
+
+  - it: fails when rbac.enableVolumeSnapshotRules is set
+    set:
+      rbac:
+        enableVolumeSnapshotRules:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "rbac.enableVolumeSnapshotRules was removed in 0.36.0 and is no longer supported. Please remove it from your values."
+
+  - it: does not error on legacy validation when sync.toHost is null
+    set:
+      sync:
+        toHost: null
+    asserts:
+      - isKind:
+          of: StatefulSet
+
+  - it: does not error on legacy validation when sync is null
+    set:
+      sync: null
+    asserts:
+      - isKind:
+          of: StatefulSet
+
   - it: should add NET_ADMIN and NET_RAW capabilities when kube-vip is enabled
     set:
       controlPlane:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1312,7 +1312,7 @@
         },
         "volumeSnapshotController": {
           "$ref": "#/$defs/VolumeSnapshotController",
-          "description": "VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.\nDeprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse."
+          "description": "VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.\nDeprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config."
         },
         "argoCD": {
           "$ref": "#/$defs/ArgoCDDeploy",
@@ -4216,7 +4216,7 @@
         },
         "enableVolumeSnapshotRules": {
           "$ref": "#/$defs/EnableAutoSwitch",
-          "description": "EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and\nClusterRole.\nDeprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse."
+          "description": "EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and\nClusterRole.\nDeprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config."
         }
       },
       "additionalProperties": false,
@@ -5103,7 +5103,7 @@
         },
         "volumeSnapshotClasses": {
           "$ref": "#/$defs/EnableSwitchWithPatches",
-          "description": "VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.\nDeprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse."
+          "description": "VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.\nDeprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config."
         },
         "configMaps": {
           "$ref": "#/$defs/EnableSwitchWithResourcesMappings",
@@ -5323,11 +5323,11 @@
         },
         "volumeSnapshots": {
           "$ref": "#/$defs/EnableSwitchWithPatches",
-          "description": "VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.\nDeprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse."
+          "description": "VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.\nDeprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config."
         },
         "volumeSnapshotContents": {
           "$ref": "#/$defs/EnableSwitchWithPatches",
-          "description": "VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.\nDeprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse."
+          "description": "VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.\nDeprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config."
         },
         "storageClasses": {
           "$ref": "#/$defs/EnableSwitchWithPatches",

--- a/config/config.go
+++ b/config/config.go
@@ -339,7 +339,7 @@ type Deploy struct {
 	MetricsServer DeployMetricsServer `json:"metricsServer,omitempty"`
 
 	// VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
-	// Deprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse.
+	// Deprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config.
 	VolumeSnapshotController VolumeSnapshotController `json:"volumeSnapshotController,omitempty"`
 
 	// ArgoCD holds dedicated configuration for argoCD Apps to deploy
@@ -352,7 +352,7 @@ type DeployMetricsServer struct {
 }
 
 // VolumeSnapshotController defines CSI volumes snapshot-controller configuration.
-// Deprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse.
+// Deprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config.
 type VolumeSnapshotController struct {
 	// Enabled defines if the CSI volumes snapshot-controller should be enabled.
 	Enabled bool `json:"enabled,omitempty"`
@@ -1264,11 +1264,11 @@ type SyncToHost struct {
 	PersistentVolumes EnableSwitchWithPatches `json:"persistentVolumes,omitempty"`
 
 	// VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
-	// Deprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse.
+	// Deprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config.
 	VolumeSnapshots EnableSwitchWithPatches `json:"volumeSnapshots,omitempty"`
 
 	// VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
-	// Deprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse.
+	// Deprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config.
 	VolumeSnapshotContents EnableSwitchWithPatches `json:"volumeSnapshotContents,omitempty"`
 
 	// StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
@@ -1395,7 +1395,7 @@ type SyncFromHost struct {
 	CustomResources map[string]SyncFromHostCustomResource `json:"customResources,omitempty"`
 
 	// VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
-	// Deprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse.
+	// Deprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config.
 	VolumeSnapshotClasses EnableSwitchWithPatches `json:"volumeSnapshotClasses,omitempty"`
 
 	// ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
@@ -3215,7 +3215,7 @@ type RBAC struct {
 
 	// EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and
 	// ClusterRole.
-	// Deprecated: Removed in 0.36.0. Retained as a no-op so existing configs continue to parse.
+	// Deprecated: Removed in 0.36.0. Setting this value is rejected by the Helm chart; remove it from your config.
 	EnableVolumeSnapshotRules EnableAutoSwitch `json:"enableVolumeSnapshotRules,omitempty"`
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-999


**Please provide a short message that should be published in the vcluster release notes**
Adds validation to fail helm chart installation if volume snapshot values are set


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
snapshots
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart-time validation only; no runtime sync or RBAC behavior changes. Risk is upgrade friction for configs that still list removed keys.
> 
> **Overview**
> **Helm install/upgrade now hard-fails** if values still include any volume-snapshot settings removed in **0.36.0**. A new `vcluster.legacy.volumeSnapshots.validate` template runs from `statefulset.yaml` (alongside existing export-kubeconfig checks) and uses `hasKey`, so **any presence** of these keys fails—even `enabled: false`:
> 
> - `sync.toHost.volumeSnapshots` / `volumeSnapshotContents`
> - `sync.fromHost.volumeSnapshotClasses`
> - `deploy.volumeSnapshotController`
> - `rbac.enableVolumeSnapshotRules`
> 
> Each failure returns a message telling users to remove the key from values. Validation tolerates `sync` / `sync.toHost` being `null` via `default dict`.
> 
> **Docs/schema alignment:** `values.schema.json` and `config/config.go` deprecation text now states these fields are **rejected by the chart** (not silent no-ops). **Helm unit tests** cover every rejected key plus the null `sync` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e037e8e3194802f60f52334b10e9c1cb2e1ee8e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->