### PR TITLE
fix(e2e): deflake snapshot deletion spec

### DIFF
--- a/e2e/test_storage/snapshot/test_snapshot.go
+++ b/e2e/test_storage/snapshot/test_snapshot.go
@@ -15,6 +15,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	pkgconstants "github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/loft-sh/vcluster/pkg/etcd"
+	snapshotpkg "github.com/loft-sh/vcluster/pkg/snapshot"
 	"github.com/loft-sh/vcluster/pkg/util/random"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -481,14 +482,12 @@ func describeSnapshotDeletion(s *snapshotCtx) {
 		It("Creates snapshot deletion request", func(ctx context.Context) {
 			listOptions := metav1.ListOptions{LabelSelector: pkgconstants.SnapshotRequestLabel}
 
-			var snapshotOptions *snapshotapi.Options
-			Eventually(func(g Gomega) {
-				secrets, err := s.hostClient.CoreV1().Secrets(s.vClusterNS).List(ctx, listOptions)
-				g.Expect(err).To(Succeed())
-				g.Expect(secrets.Items).To(HaveLen(1))
-				snapshotOptions, err = snapshotapi.UnmarshalOptions(&secrets.Items[0])
-				g.Expect(err).To(Succeed())
-			}).WithPolling(constants.PollingInterval).WithTimeout(constants.PollingTimeout).Should(Succeed())
+			// Build the storage options from the known snapshot path rather than
+			// reading them from the request Secret. The controller deletes that
+			// Secret as soon as the snapshot completes, which now happens almost
+			// immediately, so listing it here is a race.
+			snapshotOptions := &snapshotapi.Options{}
+			Expect(snapshotpkg.Parse(snapshotPath, snapshotOptions)).To(Succeed())
 
 			waitForSnapshotToBeCreated(ctx, s.hostClient, s.vClusterNS)
 


### PR DESCRIPTION
## What

Stop the `Snapshot deletion > Creates snapshot deletion request` spec from reading the snapshot storage options out of the request Secret. Build them directly from the snapshot path with `snapshot.Parse` instead.

## Why

This spec has failed every nightly from 07-04 to 07-07, timing out at the Secret list:

```
Expected <[]v1.Secret | len:0>: nil to have length 1
```

The spec creates a snapshot, then lists the request Secret to recover its `Options` and reuse them when it builds the deletion request. That worked while a snapshot took seconds. After #3989 removed volume snapshots, a snapshot of this near-empty etcd finishes in milliseconds, and the controller deletes the request Secret on completion (`reconcileCompletedRequest -> reconcileDoneRequest -> deleteRequestSecret`, unchanged since #3206). By the first poll the Secret is already gone, so the list stays empty and the `Eventually` times out.

The options are static. The test already holds the `snapshotPath` it created the snapshot with, so it can parse them itself and never touch the transient Secret. This also matters because the spec currently dies before it reaches the deletion it is meant to verify, so the fix restores that coverage rather than papering over it.

The request ConfigMap read later in the spec is fine: the ConfigMap survives completion (24h TTL), only the Secret is cleaned up.

## Testing

- `go vet ./e2e/test_storage/snapshot/` passes
- custom `golangci-lint` reports 0 issues


```label-filter
snapshots
```

Follow-up to #4061, which fixed the sibling cancellation spec broken by the same #3989 change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths affected.
> 
> **Overview**
> The **Snapshot deletion** e2e spec no longer polls the host for the snapshot request **Secret** to recover storage `Options` before building a deletion request. It now derives those options from the same `snapshotPath` used when creating the snapshot via `snapshotpkg.Parse`, with a short comment explaining the race: the controller removes that Secret as soon as the snapshot completes, which is now effectively immediate.
> 
> This restores reliable coverage of the deletion flow instead of timing out on an empty Secret list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547a015a9dc0513da44afc9e30cc5c530f71e044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->