### PR TITLE
ci(backport): bump backport pin and wire linear-token

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     uses: loft-sh/github-actions/.github/workflows/backport.yaml@2de17e8ed0da1b3063a7959d309478f00f094449 # backport/v1

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   backport:
-    uses: loft-sh/github-actions/.github/workflows/backport.yaml@36bd60efa4d72d6195f9222b67b1c633044bf90a # backport/v1
+    uses: loft-sh/github-actions/.github/workflows/backport.yaml@2de17e8ed0da1b3063a7959d309478f00f094449 # backport/v1
     secrets:
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      linear-token: ${{ secrets.LINEAR_API_TOKEN }}


### PR DESCRIPTION
/kind enhancement

**What does this pull request do? Which issues does it resolve?**

Bumps the `backport` reusable-workflow pin from `36bd60e` to the loft-sh/github-actions#157 merge commit `2de17e8`, and passes `linear-token` to the workflow.

The shared `backport.yaml` now links each backport PR to its matching Linear sub-issue (`[X.Y] Copy of ...`) so the sub-issue closes on merge. That step only runs when the caller supplies a `linear-token`; without one it no-ops. `linear-token` is declared as a `workflow_call` secret in the shared workflow, so it is passed in `secrets:` (alongside `gh-access-token`), not `with:`.

Closes DEVOPS-1060

**Please provide a short message that should be published in the vcluster release notes**
NONE

**What else do we need to know?**

The link step is `continue-on-error` and skips cleanly when the token is absent, so backporting is unaffected until the secret exists.

Ordering (tracked in DEVOPS-1060): the pinned workflow at `2de17e8` references `link-backport-prs@link-backport-prs/v1`, a tag that is not published yet. Publishing that tag at `2de17e8` and adding the `LINEAR_API_TOKEN` secret are prerequisites for the link step to do real work. Both are non-blocking; the step never fails the backport job.

## E2E Tests

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to workflow pin and an optional secret; backport behavior is unchanged when `LINEAR_API_TOKEN` is absent.
> 
> **Overview**
> The **Automatic backport** workflow now calls a newer `loft-sh/github-actions` `backport.yaml` pin (`2de17e8` instead of `36bd60e`) and forwards **`linear-token`** from repo secret `LINEAR_API_TOKEN` alongside the existing GitHub token.
> 
> That enables the shared workflow’s optional step to associate each backport PR with its Linear `[X.Y] Copy of …` sub-issue so it can close on merge. If the secret is missing, the shared workflow is designed to skip that step without failing the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8b9c7f43bb160044c4588ae9e1ce91e761b2c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->