### PR TITLE
chore(cve-fixes): bump release image base to alpine 3.24 to resolve openssl cves

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 # we use alpine for easier debugging
-FROM alpine:3.23
+FROM alpine:3.24
 
 # install runtime dependencies
 RUN apk upgrade --no-cache zlib && apk add --no-cache ca-certificates zstd tzdata


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves part of ENGNODE-617


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single base-image tag bump on the release Dockerfile with no application code changes; typical low-risk dependency refresh, with usual minor risk from distro upgrades.
> 
> **Overview**
> Updates the **release** container image base from `alpine:3.23` to **`alpine:3.24`** in `Dockerfile.release` to pick up patched OpenSSL and address related CVEs (ENGNODE-617).
> 
> Runtime install steps (`apk upgrade` for zlib, ca-certificates, zstd, tzdata) and the `vcluster start` entrypoint are unchanged; only the base image tag moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4da7a784255c5a27a965654d68c2ebed2b59286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->