### PR TITLE
ci: convert release pipeline to dispatcher + tag-dispatched validators

### DIFF
--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -46,10 +46,37 @@ env:
   VCLUSTER_NAMESPACE: vcluster
 
 jobs:
+  release_line_gate:
+    # Release (workflow_run) path: validate ONLY new release lines (>= v0.37, the
+    # DEVOPS-1050 cutover). Legacy lines (< v0.37) are intentionally NOT post-build
+    # validated here. pull_request runs skip this job.
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    outputs:
+      validate: ${{ steps.gate.outputs.validate }}
+    steps:
+      - id: gate
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          validate=false
+          if [[ "${HEAD_BRANCH}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
+            maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
+            if [ "$maj" -gt 0 ] || { [ "$maj" -eq 0 ] && [ "$min" -ge 37 ]; }; then
+              validate=true
+            fi
+          fi
+          echo "validate=${validate}" >> "$GITHUB_OUTPUT"
+          echo "release line gate: head=${HEAD_BRANCH:-<none>} -> validate=${validate}"
+
   parse_label-filter:
     name: Parse label filter and check if tests should run
-    # do not run on forks; on the release path only for a green build
-    if: github.repository_owner == 'loft-sh' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    needs: [release_line_gate]
+    # do not run on forks; on the release path only for a green build of a new line (>= v0.37)
+    if: >-
+      !cancelled() && github.repository_owner == 'loft-sh' &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true'))
     runs-on: ubuntu-22.04
 
     outputs:
@@ -100,10 +127,10 @@ jobs:
       !cancelled() && github.repository_owner == 'loft-sh' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
-    needs: detect_changes
+    needs: [detect_changes, release_line_gate]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -150,12 +177,12 @@ jobs:
 
 
   download-latest-cli:
-    needs: detect_changes
+    needs: [detect_changes, release_line_gate]
     if: >-
       !cancelled() &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     name: Download the latest vCluster cli
@@ -177,12 +204,13 @@ jobs:
       - build
       - parse_label-filter
       - detect_changes
+      - release_line_gate
     if: >-
       !cancelled() && needs.build.result == 'success' &&
       needs.parse_label-filter.outputs.skip-edited != 'true' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: large-8_32

--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -4,13 +4,7 @@ permissions:
   contents: read
   pull-requests: write
 
-# Release validation runs post-build via workflow_run on the "Release" builder
-# completing (DEVOPS-1050). On that path detect_changes is skipped, the suite
-# runs against the built tag, and the label filter is resolved as a "release" run.
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       ginkgo-label:
@@ -46,37 +40,11 @@ env:
   VCLUSTER_NAMESPACE: vcluster
 
 jobs:
-  release_line_gate:
-    # Release (workflow_run) path: validate ONLY new release lines (>= v0.37, the
-    # DEVOPS-1050 cutover). Legacy lines (< v0.37) are intentionally NOT post-build
-    # validated here. pull_request runs skip this job.
-    if: github.event_name == 'workflow_run'
-    runs-on: ubuntu-latest
-    outputs:
-      validate: ${{ steps.gate.outputs.validate }}
-    steps:
-      - id: gate
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          validate=false
-          if [[ "${HEAD_BRANCH}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
-            maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
-            if [ "$maj" -gt 0 ] || { [ "$maj" -eq 0 ] && [ "$min" -ge 37 ]; }; then
-              validate=true
-            fi
-          fi
-          echo "validate=${validate}" >> "$GITHUB_OUTPUT"
-          echo "release line gate: head=${HEAD_BRANCH:-<none>} -> validate=${validate}"
-
   parse_label-filter:
     name: Parse label filter and check if tests should run
-    needs: [release_line_gate]
-    # do not run on forks; on the release path only for a green build of a new line (>= v0.37)
+    # do not run on forks
     if: >-
-      !cancelled() && github.repository_owner == 'loft-sh' &&
-      (github.event_name != 'workflow_run' ||
-       (github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true'))
+      !cancelled() && github.repository_owner == 'loft-sh'
     runs-on: ubuntu-22.04
 
     outputs:
@@ -95,15 +63,18 @@ jobs:
         with:
           pr-body: ${{ github.event.pull_request.body }}
           previous-pr-body: ${{ github.event.changes.body.from }}
-          # Treat the release-validation (workflow_run) path like the old
-          # release:created path so the label filter resolves identically.
-          event-name: ${{ github.event_name == 'workflow_run' && 'release' || github.event_name }}
+          # A release-validation dispatch runs at refs/tags/<version>; treat it
+          # like the old release:created path so the label filter resolves
+          # identically. A manual branch dispatch uses the ginkgo-label input;
+          # a PR uses pull_request.
+          event-name: ${{ startsWith(github.ref, 'refs/tags/') && 'release' || github.event_name }}
           event-action: ${{ github.event.action }}
           label-filter-input: ${{ inputs.ginkgo-label }}
 
   detect_changes:
-    # PR-only: the release (workflow_run) path always validates and bypasses
-    # change detection; entry jobs break skip-propagation with !cancelled().
+    # PR-only: the release path is a workflow_dispatch --ref <tag> dispatch that
+    # always validates and bypasses change detection; entry jobs break
+    # skip-propagation with !cancelled().
     if: github.event_name == 'pull_request'
     needs: [parse_label-filter]
     uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
@@ -127,16 +98,14 @@ jobs:
       !cancelled() && github.repository_owner == 'loft-sh' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
-    needs: [detect_changes, release_line_gate]
+    needs: [detect_changes]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - run: git fetch --force --tags
 
@@ -177,12 +146,11 @@ jobs:
 
 
   download-latest-cli:
-    needs: [detect_changes, release_line_gate]
+    needs: [detect_changes]
     if: >-
       !cancelled() &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     name: Download the latest vCluster cli
@@ -204,13 +172,11 @@ jobs:
       - build
       - parse_label-filter
       - detect_changes
-      - release_line_gate
     if: >-
       !cancelled() && needs.build.result == 'success' &&
       needs.parse_label-filter.outputs.skip-edited != 'true' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: large-8_32
@@ -224,7 +190,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - run: git fetch --force --tags
 

--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -4,9 +4,13 @@ permissions:
   contents: read
   pull-requests: write
 
+# Release validation runs post-build via workflow_run on the "Release" builder
+# completing (DEVOPS-1050). On that path detect_changes is skipped, the suite
+# runs against the built tag, and the label filter is resolved as a "release" run.
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       ginkgo-label:
@@ -44,7 +48,8 @@ env:
 jobs:
   parse_label-filter:
     name: Parse label filter and check if tests should run
-    if: github.repository_owner == 'loft-sh' # do not run on forks
+    # do not run on forks; on the release path only for a green build
+    if: github.repository_owner == 'loft-sh' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
 
     outputs:
@@ -63,11 +68,16 @@ jobs:
         with:
           pr-body: ${{ github.event.pull_request.body }}
           previous-pr-body: ${{ github.event.changes.body.from }}
-          event-name: ${{ github.event_name }}
+          # Treat the release-validation (workflow_run) path like the old
+          # release:created path so the label filter resolves identically.
+          event-name: ${{ github.event_name == 'workflow_run' && 'release' || github.event_name }}
           event-action: ${{ github.event.action }}
           label-filter-input: ${{ inputs.ginkgo-label }}
 
   detect_changes:
+    # PR-only: the release (workflow_run) path always validates and bypasses
+    # change detection; entry jobs break skip-propagation with !cancelled().
+    if: github.event_name == 'pull_request'
     needs: [parse_label-filter]
     uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
     with:
@@ -86,13 +96,20 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'loft-sh' && needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() && github.repository_owner == 'loft-sh' &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     needs: detect_changes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - run: git fetch --force --tags
 
@@ -134,7 +151,13 @@ jobs:
 
   download-latest-cli:
     needs: detect_changes
-    if: needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     name: Download the latest vCluster cli
     runs-on: ubuntu-latest
     steps:
@@ -154,9 +177,14 @@ jobs:
       - build
       - parse_label-filter
       - detect_changes
-    if: >
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
       needs.parse_label-filter.outputs.skip-edited != 'true' &&
-      needs.detect_changes.outputs.has_changed == 'true'
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: large-8_32
     permissions:
       id-token: write        # needed for OIDC → AWS
@@ -168,6 +196,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - run: git fetch --force --tags
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,14 @@
 name: E2E CI
 
+# Release validation runs post-build via workflow_run on the "Release" builder
+# completing (DEVOPS-1050): a release created by the builder inside Actions does
+# not emit release:created, so validators keyed on it would silently never run.
+# On the workflow_run path detect_changes is skipped and the suite runs against
+# the built tag (github.event.workflow_run.head_branch).
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   pull_request:
     branches:
       - main
@@ -22,6 +28,9 @@ env:
 
 jobs:
   detect_changes:
+    # PR-only: the release (workflow_run) path always validates, so it bypasses
+    # change detection. Entry jobs break the skip-propagation with !cancelled().
+    if: github.event_name == 'pull_request'
     uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
     with:
       paths: |
@@ -38,13 +47,20 @@ jobs:
         - "manifests/**"
   build:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'loft-sh' && needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() && github.repository_owner == 'loft-sh' &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     needs: detect_changes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - run: git fetch --force --tags
 
@@ -85,11 +101,19 @@ jobs:
 
   get-testsuites-dir:
     needs: detect_changes
-    if: needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - id: set-paths-matrix
         run: |
           set -x
@@ -112,11 +136,19 @@ jobs:
     needs:
       - build
       - detect_changes
-    if: needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - uses: azure/setup-helm@v4
         name: Setup Helm
@@ -169,7 +201,13 @@ jobs:
 
   download-latest-cli:
     needs: detect_changes
-    if: needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     name: Download the latest vCluster cli
     runs-on: ubuntu-latest
     steps:
@@ -189,7 +227,13 @@ jobs:
       - build
       - download-latest-cli
       - detect_changes
-    if: needs.detect_changes.outputs.has_changed == 'true'
+    if: >-
+      !cancelled() && needs.build.result == 'success' && needs.download-latest-cli.result == 'success' &&
+      (
+        (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -198,6 +242,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - uses: azure/setup-helm@v4
         name: Setup Helm

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,6 +27,29 @@ env:
   VCLUSTER_NAMESPACE: vcluster
 
 jobs:
+  release_line_gate:
+    # Release (workflow_run) path: validate ONLY new release lines (>= v0.37, the
+    # DEVOPS-1050 cutover). Legacy lines (< v0.37) are intentionally NOT post-build
+    # validated here. pull_request runs skip this job.
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    outputs:
+      validate: ${{ steps.gate.outputs.validate }}
+    steps:
+      - id: gate
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          validate=false
+          if [[ "${HEAD_BRANCH}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
+            maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
+            if [ "$maj" -gt 0 ] || { [ "$maj" -eq 0 ] && [ "$min" -ge 37 ]; }; then
+              validate=true
+            fi
+          fi
+          echo "validate=${validate}" >> "$GITHUB_OUTPUT"
+          echo "release line gate: head=${HEAD_BRANCH:-<none>} -> validate=${validate}"
+
   detect_changes:
     # PR-only: the release (workflow_run) path always validates, so it bypasses
     # change detection. Entry jobs break the skip-propagation with !cancelled().
@@ -51,10 +74,10 @@ jobs:
       !cancelled() && github.repository_owner == 'loft-sh' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
-    needs: detect_changes
+    needs: [detect_changes, release_line_gate]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -100,12 +123,12 @@ jobs:
           retention-days: 7
 
   get-testsuites-dir:
-    needs: detect_changes
+    needs: [detect_changes, release_line_gate]
     if: >-
       !cancelled() &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
@@ -136,11 +159,12 @@ jobs:
     needs:
       - build
       - detect_changes
+      - release_line_gate
     if: >-
       !cancelled() && needs.build.result == 'success' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
@@ -200,12 +224,12 @@ jobs:
           ./hack/vcluster-install-scripts/test-helm-install.sh
 
   download-latest-cli:
-    needs: detect_changes
+    needs: [detect_changes, release_line_gate]
     if: >-
       !cancelled() &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     name: Download the latest vCluster cli
@@ -227,11 +251,12 @@ jobs:
       - build
       - download-latest-cli
       - detect_changes
+      - release_line_gate
     if: >-
       !cancelled() && needs.build.result == 'success' && needs.download-latest-cli.result == 'success' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,14 +1,6 @@
 name: E2E CI
 
-# Release validation runs post-build via workflow_run on the "Release" builder
-# completing (DEVOPS-1050): a release created by the builder inside Actions does
-# not emit release:created, so validators keyed on it would silently never run.
-# On the workflow_run path detect_changes is skipped and the suite runs against
-# the built tag (github.event.workflow_run.head_branch).
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
   pull_request:
     branches:
       - main
@@ -27,32 +19,10 @@ env:
   VCLUSTER_NAMESPACE: vcluster
 
 jobs:
-  release_line_gate:
-    # Release (workflow_run) path: validate ONLY new release lines (>= v0.37, the
-    # DEVOPS-1050 cutover). Legacy lines (< v0.37) are intentionally NOT post-build
-    # validated here. pull_request runs skip this job.
-    if: github.event_name == 'workflow_run'
-    runs-on: ubuntu-latest
-    outputs:
-      validate: ${{ steps.gate.outputs.validate }}
-    steps:
-      - id: gate
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          validate=false
-          if [[ "${HEAD_BRANCH}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
-            maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
-            if [ "$maj" -gt 0 ] || { [ "$maj" -eq 0 ] && [ "$min" -ge 37 ]; }; then
-              validate=true
-            fi
-          fi
-          echo "validate=${validate}" >> "$GITHUB_OUTPUT"
-          echo "release line gate: head=${HEAD_BRANCH:-<none>} -> validate=${validate}"
-
   detect_changes:
-    # PR-only: the release (workflow_run) path always validates, so it bypasses
-    # change detection. Entry jobs break the skip-propagation with !cancelled().
+    # PR-only: the release path is a workflow_dispatch --ref <tag> dispatch that
+    # always validates, so it bypasses change detection. Entry jobs break the
+    # skip-propagation with !cancelled().
     if: github.event_name == 'pull_request'
     uses: loft-sh/github-actions/.github/workflows/detect-changes.yaml@detect-changes/v1
     with:
@@ -74,16 +44,14 @@ jobs:
       !cancelled() && github.repository_owner == 'loft-sh' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
-    needs: [detect_changes, release_line_gate]
+    needs: [detect_changes]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - run: git fetch --force --tags
 
@@ -123,20 +91,17 @@ jobs:
           retention-days: 7
 
   get-testsuites-dir:
-    needs: [detect_changes, release_line_gate]
+    needs: [detect_changes]
     if: >-
       !cancelled() &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - id: set-paths-matrix
         run: |
           set -x
@@ -159,20 +124,16 @@ jobs:
     needs:
       - build
       - detect_changes
-      - release_line_gate
     if: >-
       !cancelled() && needs.build.result == 'success' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - uses: azure/setup-helm@v4
         name: Setup Helm
@@ -224,12 +185,11 @@ jobs:
           ./hack/vcluster-install-scripts/test-helm-install.sh
 
   download-latest-cli:
-    needs: [detect_changes, release_line_gate]
+    needs: [detect_changes]
     if: >-
       !cancelled() &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     name: Download the latest vCluster cli
@@ -251,12 +211,10 @@ jobs:
       - build
       - download-latest-cli
       - detect_changes
-      - release_line_gate
     if: >-
       !cancelled() && needs.build.result == 'success' && needs.download-latest-cli.result == 'success' &&
       (
         (github.event_name == 'pull_request' && needs.detect_changes.outputs.has_changed == 'true') ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
@@ -267,8 +225,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - uses: azure/setup-helm@v4
         name: Setup Helm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,14 @@
 name: Release
 
+# Builder for the vCluster release pipeline (DEVOPS-1050). The GitHub Release is
+# a pipeline OUTPUT, not a trigger: goreleaser creates it at the end of a green
+# build. This workflow is dispatched by the loft-sh/github-actions
+# vcluster-release action via `gh workflow run release.yaml --ref <tag>`, so
+# github.ref is refs/tags/<version> and github.ref_name is the version. It no
+# longer triggers on release:created, so a monorepo-created OSS release can never
+# re-trigger this builder.
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   check_minimum_version_tag:
@@ -10,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        if: ${{ !contains(github.event.release.tag_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
       - name: Validate MinimumVersionTag is stable
-        if: ${{ !contains(github.event.release.tag_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         run: |
           MINIMUM_VERSION_TAG=$(grep -oP 'MinimumVersionTag\s*=\s*"\Kv[^"]+' pkg/platform/version.go)
           if [[ ! "$MINIMUM_VERSION_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -72,7 +78,10 @@ jobs:
         run: |
           RELEASE_VERSION=$(echo "$GITHUB_REF" | sed -nE 's!refs/tags/!!p')
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "previous_tag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)")" >> "$GITHUB_OUTPUT"
+          # Branch-local previous tag: the tag reachable from this commit's
+          # parent on THIS branch, not the global latest tag (which would be
+          # wrong on a release branch). See DEVOPS-1050.
+          echo "previous_tag=$(git describe --tags --abbrev=0 --match 'v*' "${GITHUB_SHA}^" 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
       - name: Validate semver
         id: semver
         uses: loft-sh/github-actions/.github/actions/semver-validation@semver-validation/v1
@@ -239,7 +248,7 @@ jobs:
       contents: read
     uses: loft-sh/github-actions/.github/workflows/notify-release.yaml@release-notification/v2
     with:
-      release_version: ${{ github.event.release.tag_name }}
+      release_version: ${{ github.ref_name }}
       target_repo: ${{ github.repository }}
       product: vCluster
       status: failure

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,6 +237,30 @@ jobs:
           github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           linear-token: ${{ secrets.LINEAR_TOKEN }}
 
+  trigger-validators:
+    needs: [publish]
+    if: ${{ success() && github.repository_owner == 'loft-sh' && !contains(needs.publish.outputs.release_version, '-next') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch release validators at the built tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.publish.outputs.release_version }}
+        run: |
+          # Run each validator's OWN version at the built tag (per-line consistent).
+          # Each validator exists on the default branch (dispatchable) and carries a
+          # workflow_dispatch trigger in the tag's tree (true for lines cut from main).
+          for wf in e2e.yaml e2e-ginkgo.yaml unit-tests.yaml; do
+            if gh workflow run "$wf" --repo "$GITHUB_REPOSITORY" --ref "$VERSION"; then
+              echo "dispatched $wf @ $VERSION"
+            else
+              echo "::warning::could not dispatch $wf @ $VERSION (missing or no workflow_dispatch at tag)"
+            fi
+          done
+
   notify_failure:
     if: ${{ always() && contains(needs.*.result, 'failure') && github.repository_owner == 'loft-sh' }}
     needs:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,12 +1,7 @@
 name: Unit tests
 
-# Runs on PRs and, post-build, when the "Release" builder completes (DEVOPS-1050:
-# release:created does not fire for builder-created releases). On the workflow_run
-# path the jobs run only for a green build and check out the built tag.
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -25,43 +20,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release_line_gate:
-    # Release (workflow_run) path: validate ONLY new release lines (>= v0.37, the
-    # DEVOPS-1050 cutover). Legacy lines (< v0.37) are intentionally NOT post-build
-    # validated here. pull_request runs skip this job.
-    if: github.event_name == 'workflow_run'
-    runs-on: ubuntu-latest
-    outputs:
-      validate: ${{ steps.gate.outputs.validate }}
-    steps:
-      - id: gate
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          validate=false
-          if [[ "${HEAD_BRANCH}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
-            maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
-            if [ "$maj" -gt 0 ] || { [ "$maj" -eq 0 ] && [ "$min" -ge 37 ]; }; then
-              validate=true
-            fi
-          fi
-          echo "validate=${validate}" >> "$GITHUB_OUTPUT"
-          echo "release line gate: head=${HEAD_BRANCH:-<none>} -> validate=${validate}"
-
   helm-unit-tests:
     name: Execute all helm tests
-    needs: [release_line_gate]
-    # do not run on forks; on the release path only for a green build of a new line (>= v0.37)
-    if: >-
-      !cancelled() && github.repository_owner == 'loft-sh' &&
-      (github.event_name != 'workflow_run' ||
-       (github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true'))
+    # do not run on forks
+    if: github.repository_owner == 'loft-sh'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Install Helm Unit Test Plugin
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4
@@ -71,18 +37,12 @@ jobs:
 
   go-unit-test:
     name: Execute all go tests
-    needs: [release_line_gate]
-    # do not run on forks; on the release path only for a green build of a new line (>= v0.37)
-    if: >-
-      !cancelled() && github.repository_owner == 'loft-sh' &&
-      (github.event_name != 'workflow_run' ||
-       (github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true'))
+    # do not run on forks
+    if: github.repository_owner == 'loft-sh'
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,10 +25,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release_line_gate:
+    # Release (workflow_run) path: validate ONLY new release lines (>= v0.37, the
+    # DEVOPS-1050 cutover). Legacy lines (< v0.37) are intentionally NOT post-build
+    # validated here. pull_request runs skip this job.
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    outputs:
+      validate: ${{ steps.gate.outputs.validate }}
+    steps:
+      - id: gate
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          validate=false
+          if [[ "${HEAD_BRANCH}" =~ ^v([0-9]+)\.([0-9]+) ]]; then
+            maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
+            if [ "$maj" -gt 0 ] || { [ "$maj" -eq 0 ] && [ "$min" -ge 37 ]; }; then
+              validate=true
+            fi
+          fi
+          echo "validate=${validate}" >> "$GITHUB_OUTPUT"
+          echo "release line gate: head=${HEAD_BRANCH:-<none>} -> validate=${validate}"
+
   helm-unit-tests:
     name: Execute all helm tests
-    # do not run on forks; on the release path only for a green build
-    if: github.repository_owner == 'loft-sh' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    needs: [release_line_gate]
+    # do not run on forks; on the release path only for a green build of a new line (>= v0.37)
+    if: >-
+      !cancelled() && github.repository_owner == 'loft-sh' &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,8 +71,12 @@ jobs:
 
   go-unit-test:
     name: Execute all go tests
-    # do not run on forks; on the release path only for a green build
-    if: github.repository_owner == 'loft-sh' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    needs: [release_line_gate]
+    # do not run on forks; on the release path only for a green build of a new line (>= v0.37)
+    if: >-
+      !cancelled() && github.repository_owner == 'loft-sh' &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.conclusion == 'success' && needs.release_line_gate.outputs.validate == 'true'))
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,8 +1,12 @@
 name: Unit tests
 
+# Runs on PRs and, post-build, when the "Release" builder completes (DEVOPS-1050:
+# release:created does not fire for builder-created releases). On the workflow_run
+# path the jobs run only for a green build and check out the built tag.
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   pull_request:
     branches:
       - main
@@ -23,11 +27,14 @@ concurrency:
 jobs:
   helm-unit-tests:
     name: Execute all helm tests
-    if: github.repository_owner == 'loft-sh' # do not run on forks
+    # do not run on forks; on the release path only for a green build
+    if: github.repository_owner == 'loft-sh' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Install Helm Unit Test Plugin
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4
@@ -37,11 +44,14 @@ jobs:
 
   go-unit-test:
     name: Execute all go tests
-    if: github.repository_owner == 'loft-sh' # do not run on forks
+    # do not run on forks; on the release path only for a green build
+    if: github.repository_owner == 'loft-sh' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
Reference conversion for DEVOPS-1050 phase 4 (loft-sh/vcluster `main`). Draft.

## Builder (`release.yaml`)
- `on: release:[created]` → `on: workflow_dispatch`. The GitHub Release is a pipeline **output** (goreleaser creates it at the end of a green build), dispatched by the shared `vcluster-release` action via `gh workflow run release.yaml --ref <tag>`. Nothing listens on `release:created`, closing the DEVOPS-1013 re-trigger gap.
- Decoupled `github.event.release.*` → `github.ref_name`; branch-local `previous_tag`.
- New `trigger-validators` job: on a green, non-`-next` build it dispatches each validator **at the built tag** (`gh workflow run <wf> --ref <tag>`, `GITHUB_TOKEN` + `actions: write`), guarded so a missing validator warns instead of failing.

## Validators (`e2e.yaml`, `e2e-ginkgo.yaml`, `unit-tests.yaml`)
- `on: workflow_dispatch` (+ `pull_request`). **`unit-tests` gains a `workflow_dispatch` trigger** so it is dispatchable at the tag.
- Dispatched with `--ref <tag>`, so each validator runs **its own tag's version** against the tag's code — glue and code both from the release line (no main-branch drift).
- `detect_changes` stays PR-only; the release path (`workflow_dispatch`) runs the full suite. `e2e-ginkgo` resolves the release label filter when `github.ref` is a tag.

## Why dispatch, not `workflow_run`
`workflow_run` is a privileged trigger; checking out the built tag under it tripped CodeQL “untrusted checkout in a privileged context” (3 critical + 2 high). `workflow_dispatch` is a trusted trigger — no untrusted-checkout finding, no alert dismissals — and it lets each validator run the tag's own version rather than `main`'s.

## Legacy vs new lines
Only `main`/new-line (`>= v0.37`) builders carry `trigger-validators`, so legacy lines (`v0.31`–`v0.35`, builder-only PRs) get no post-build validation — matching current behavior. A validator and its dispatch entry travel together per branch, so a `v0.37` branch cut from `main` has everything it needs.

Actionlint-clean; release-as-output + dispatch flow proven on the throwaway fixtures. Draft until the GitHub Actions incident clears and CI can run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core release triggering and when E2E/unit tests run on tags; mistakes could skip validation or break release builds, but scope is CI-only with no runtime product code changes.
> 
> **Overview**
> Reworks vCluster release CI so **GitHub Releases are produced by the pipeline** instead of kicking it off, and **post-release validation runs via explicit workflow dispatches at the release tag**.
> 
> **`release.yaml`** drops `on: release: created` in favor of **`workflow_dispatch`** (expected to be run with `--ref <tag>`). Version/checkout logic moves from `github.event.release.*` to **`github.ref_name`**, **`previous_tag`** is computed branch-locally from the tag commit’s parent, failure notifications use the ref name, and a new **`trigger-validators`** job (non-`-next`, after a green publish) runs `gh workflow run` for **`e2e.yaml`**, **`e2e-ginkgo.yaml`**, and **`unit-tests.yaml`** at the built version.
> 
> **Validator workflows** (`e2e.yaml`, `e2e-ginkgo.yaml`, `unit-tests.yaml`) likewise remove **`release: created`**, add **`workflow_dispatch`**, and gate jobs so **PRs still honor `detect_changes`** while **dispatched release runs always execute the full suite** (`!cancelled()` guards, `workflow_dispatch` bypass). **Ginkgo** treats **`refs/tags/*`** like the old release path when resolving the label filter via **`parse-label-filter`**.
> 
> **`unit-tests.yaml`** only adds clarifying fork-guard comments; behavior is unchanged aside from being dispatchable at a tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be1a4e25e0fc6f276ea0245f4dd9475ea5c4817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->