### PR TITLE
fix(cli): reject snapshots when tenant cluster is not running

### DIFF
--- a/e2e/test_core/lifecycle/test_pause_resume.go
+++ b/e2e/test_core/lifecycle/test_pause_resume.go
@@ -123,7 +123,7 @@ func PauseResumeSpec() {
 func PauseResumeScaledDownSpec() {
 	Describe("pause and resume a scaled-down tenant cluster", labels.PR, labels.Core, Ordered, func() {
 		// Ordered because each spec depends on the state from the prior spec:
-		// create → scale down → pause → resume.
+		// create → scale down → pause → verify snapshot creation is rejected while paused → resume.
 		var (
 			suffix      string
 			clusterName string
@@ -158,6 +158,19 @@ func PauseResumeScaledDownSpec() {
 					"StatefulSet %s/%s should have loft.sh/paused=true annotation", namespace, clusterName)
 				Expect(sts.Annotations).To(HaveKeyWithValue("loft.sh/paused-replicas", "1"),
 					"StatefulSet %s/%s should have loft.sh/paused-replicas=1 annotation", namespace, clusterName)
+			})
+		})
+
+		It("should reject snapshot creation while the tenant cluster is paused", func(ctx context.Context) {
+			By("Attempting to snapshot the paused tenant cluster", func() {
+				out, err := runVClusterCmd(ctx, "snapshot", "create", clusterName,
+					"file:///tmp/e2e-paused-snapshot.tar.gz", "-n", namespace)
+				Expect(err).To(HaveOccurred(),
+					"expected snapshot create to fail for a paused tenant cluster, got output: %s", out)
+				Expect(err.Error()).To(ContainSubstring("because it is not running"),
+					"expected abort error mentioning non-running status, got: %s", err.Error())
+				Expect(err.Error()).To(ContainSubstring(string(find.StatusPaused)),
+					"expected abort error to report Paused status, got: %s", err.Error())
 			})
 		})
 

--- a/pkg/cli/certs/check_helm.go
+++ b/pkg/cli/certs/check_helm.go
@@ -36,7 +36,7 @@ func Check(ctx context.Context, vClusterName string, globalFlags *flags.GlobalFl
 	}
 
 	// abort in case the virtual cluster has a non-running status.
-	if vCluster.Status != find.StatusRunning {
+	if !vCluster.IsRunning() {
 		return fmt.Errorf("aborting operation because virtual cluster %q has status %q", vCluster.Name, vCluster.Status)
 	}
 

--- a/pkg/cli/certs/rotate_helm.go
+++ b/pkg/cli/certs/rotate_helm.go
@@ -45,7 +45,7 @@ func Rotate(ctx context.Context, vClusterName string, rotationCmd RotationCmd, g
 	}
 
 	// abort in case the virtual cluster has a non-running status.
-	if vCluster.Status != find.StatusRunning {
+	if !vCluster.IsRunning() {
 		return fmt.Errorf("aborting operation because virtual cluster %q has status %q", vCluster.Name, vCluster.Status)
 	}
 

--- a/pkg/cli/find/find.go
+++ b/pkg/cli/find/find.go
@@ -66,6 +66,11 @@ const (
 	StatusUnknown          Status = "Unknown"
 )
 
+// IsRunning returns true if the status of the VCluster object is equal to `Running`
+func (v *VCluster) IsRunning() bool {
+	return v.Status == StatusRunning
+}
+
 type VClusterNotFoundError struct {
 	Name string
 }
@@ -745,11 +750,8 @@ func GetStandaloneVCluster() (*VCluster, error) {
 	created := metav1.NewTime(fi.ModTime())
 
 	// Check if the systemd service is actually running.
-	status := StatusUnknown
-	out, err := exec.Command("systemctl", "is-active", constants.VClusterStandaloneSystemdServiceName).Output()
-	if err == nil && strings.TrimSpace(string(out)) == "active" {
-		status = StatusRunning
-	}
+	cmdOut, err := exec.Command("systemctl", "is-active", constants.VClusterStandaloneSystemdServiceName).Output()
+	status := parseSystemdActiveStatus(cmdOut, err)
 
 	return &VCluster{
 		Name:          vConfig.Name,
@@ -760,6 +762,16 @@ func GetStandaloneVCluster() (*VCluster, error) {
 		Status:        status,
 		IsStandalone:  true,
 	}, nil
+}
+
+// parseSystemdActiveStatus interprets the output of `systemctl is-active` and
+// returns StatusRunning only when the command succeeded and reported "active".
+// Any error or other output is treated as StatusUnknown.
+func parseSystemdActiveStatus(cmdOut []byte, err error) Status {
+	if err == nil && strings.TrimSpace(string(cmdOut)) == "active" {
+		return StatusRunning
+	}
+	return StatusUnknown
 }
 
 // isVirtualClusterInstanceResourceAvailable checks if VirtualClusterInstance resources from storage.loft.sh/v1 exist

--- a/pkg/cli/find/status_test.go
+++ b/pkg/cli/find/status_test.go
@@ -1,0 +1,61 @@
+package find
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseSystemdActiveStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		out  []byte
+		err  error
+		want Status
+	}{
+		{
+			name: "active",
+			out:  []byte("active\n"),
+			err:  nil,
+			want: StatusRunning,
+		},
+		{
+			name: "active without trailing newline",
+			out:  []byte("active"),
+			err:  nil,
+			want: StatusRunning,
+		},
+		{
+			name: "inactive",
+			out:  []byte("inactive\n"),
+			err:  nil,
+			want: StatusUnknown,
+		},
+		{
+			name: "command error",
+			out:  []byte("inactive\n"),
+			err:  errors.New("exit status 3"),
+			want: StatusUnknown,
+		},
+		{
+			name: "empty output",
+			out:  nil,
+			err:  nil,
+			want: StatusUnknown,
+		},
+		{
+			name: "command error with active output",
+			out:  []byte("active\n"),
+			err:  errors.New("exit status 1"),
+			want: StatusUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSystemdActiveStatus(tt.out, tt.err)
+			if got != tt.want {
+				t.Fatalf("parseSystemdActiveStatus(%q, %v) = %v, want %v", tt.out, tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/restore_helm.go
+++ b/pkg/cli/restore_helm.go
@@ -31,7 +31,10 @@ const (
 
 func Restore(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, podOpts *pod.Options, newVCluster, standalone bool, log log.Logger) error {
 	// init kube client and vCluster
-	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, true, standalone)
+	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, initSnapshotOptions{
+		CredentialsRequiredInCluster: true,
+		Standalone:                   standalone,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/snapshot_helm.go
+++ b/pkg/cli/snapshot_helm.go
@@ -29,7 +29,11 @@ const (
 
 func CreateSnapshot(ctx context.Context, args []string, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, podOptions *pod.Options, log log.Logger, delegateFromCLIToCluster, standalone bool) error {
 	// init kube client and vCluster
-	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, delegateFromCLIToCluster, standalone)
+	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, initSnapshotOptions{
+		CredentialsRequiredInCluster: delegateFromCLIToCluster,
+		Standalone:                   standalone,
+		RequireRunning:               true,
+	})
 	if err != nil {
 		return err
 	}
@@ -82,7 +86,10 @@ func GetSnapshots(ctx context.Context, args []string, globalFlags *flags.GlobalF
 	// command runs on a local machine.
 	credentialsRequiredInCluster := parsedURL.Scheme == "container"
 	// init kube client and vCluster
-	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, credentialsRequiredInCluster, standalone)
+	vCluster, kubeClient, restConfig, err := initSnapshotCommand(ctx, args, globalFlags, snapshotOpts, log, initSnapshotOptions{
+		CredentialsRequiredInCluster: credentialsRequiredInCluster,
+		Standalone:                   standalone,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to init snapshot command: %w", err)
 	}
@@ -105,28 +112,28 @@ func GetSnapshots(ctx context.Context, args []string, globalFlags *flags.GlobalF
 	return nil
 }
 
+type initSnapshotOptions struct {
+	CredentialsRequiredInCluster bool
+	Standalone                   bool
+	RequireRunning               bool
+}
+
 func initSnapshotCommand(
 	ctx context.Context,
 	args []string,
 	globalFlags *flags.GlobalFlags,
 	snapshotOptions *snapshotapi.Options,
 	log log.Logger,
-	credentialsRequiredInCluster bool,
-	standalone bool,
+	opts initSnapshotOptions,
 ) (*find.VCluster, *kubernetes.Clientset, *rest.Config, error) {
-	vClusterName, snapshotURL, err := resolveSnapshotArgs(args, standalone)
+	vClusterName, snapshotURL, err := resolveSnapshotArgs(args, opts.Standalone)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	err = snapshot.SetURLAndFillCredentials(ctx, snapshotOptions, snapshotURL, credentialsRequiredInCluster)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to set snapshot url and fill credentials: %w", err)
-	}
-
 	// find the vCluster
 	var vCluster *find.VCluster
-	if standalone {
+	if opts.Standalone {
 		vCluster, err = find.GetStandaloneVCluster()
 		if err != nil {
 			return nil, nil, nil, err
@@ -150,6 +157,17 @@ func initSnapshotCommand(
 		}
 	}
 
+	if opts.RequireRunning {
+		if err := validateVClusterIsRunning(vCluster); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	err = snapshot.SetURLAndFillCredentials(ctx, snapshotOptions, snapshotURL, opts.CredentialsRequiredInCluster)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to set snapshot url and fill credentials: %w", err)
+	}
+
 	// build kubernetes client
 	restClient, err := vCluster.ClientFactory.ClientConfig()
 	if err != nil {
@@ -161,6 +179,19 @@ func initSnapshotCommand(
 	}
 
 	return vCluster, kubeClient, restClient, nil
+}
+
+func validateVClusterIsRunning(vCluster *find.VCluster) error {
+	if vCluster.IsRunning() {
+		return nil
+	}
+
+	status := vCluster.Status
+	if status == "" {
+		// this can happen when the status is not yet known (e.g. no pods running yet right after its creation)
+		status = find.StatusUnknown
+	}
+	return fmt.Errorf("cannot snapshot vCluster %q because it is not running (current status: %q)", vCluster.Name, status)
 }
 
 func createSnapshotRequest(ctx context.Context, vCluster *find.VCluster, kubeClient *kubernetes.Clientset, snapshotOpts *snapshotapi.Options, log log.Logger) error {

--- a/pkg/cli/snapshot_helm_test.go
+++ b/pkg/cli/snapshot_helm_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/cli/find"
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateVClusterIsRunning(t *testing.T) {
+	testTable := []struct {
+		name        string
+		status      find.Status
+		expectedErr string
+	}{
+		{
+			name:   "running",
+			status: find.StatusRunning,
+		},
+		{
+			name:        "paused",
+			status:      find.StatusPaused,
+			expectedErr: `cannot snapshot vCluster "my-vcluster" because it is not running (current status: "Paused")`,
+		},
+		{
+			name:        "unknown",
+			status:      find.StatusUnknown,
+			expectedErr: `cannot snapshot vCluster "my-vcluster" because it is not running (current status: "Unknown")`,
+		},
+		{
+			name:        "empty status is treated as unknown",
+			status:      "",
+			expectedErr: `cannot snapshot vCluster "my-vcluster" because it is not running (current status: "Unknown")`,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			vCluster := &find.VCluster{
+				Name:   "my-vcluster",
+				Status: testCase.status,
+			}
+
+			err := validateVClusterIsRunning(vCluster)
+			if testCase.expectedErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, testCase.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
part of ENGCP-847

Skips snapshot creation and reports the correct status when the tenant cluster is not running, instead of attempting the snapshot and failing with a confusing error later on.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster attempted to create snapshots for a tenant cluster that was not running, instead of failing fast with a clear status-based error.


**What else do we need to know?**
Added unit tests for the new status parsing/validation logic and an e2e test verifying snapshot creation is rejected while the tenant cluster is paused.

## E2E Tests

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snapshot and cert CLI guardrails on lifecycle status; wrong status detection could block legitimate operations, but scope is narrow with unit and e2e tests.
> 
> **Overview**
> **Snapshot create** now fails fast when the tenant cluster is not **Running**, instead of starting a snapshot pod and failing later with a vague error. Only `snapshot create` sets `RequireRunning` on `initSnapshotCommand`; list/get/restore paths are unchanged.
> 
> `initSnapshotCommand` takes an **`initSnapshotOptions`** struct (credentials, standalone, require running). The running check runs **after** the vCluster is resolved and version-checked, but **before** snapshot URL/credential setup.
> 
> Adds **`VCluster.IsRunning()`** in `find` and uses it for cert **check**/**rotate** abort logic (same behavior, shared helper). Standalone host status parsing moves to **`parseSystemdActiveStatus`** with unit tests.
> 
> **E2E:** ordered pause/resume suite adds a case that `snapshot create` on a **paused** cluster errors with “not running” and **Paused** status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dc8379619f36c43799df1a626e0a5ad9e0fdc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->