### PR TITLE
fix(backport): reference existing LINEAR_TOKEN secret so sub-issue linking runs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -12,4 +12,4 @@ jobs:
     uses: loft-sh/github-actions/.github/workflows/backport.yaml@2de17e8ed0da1b3063a7959d309478f00f094449 # backport/v1
     secrets:
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
-      linear-token: ${{ secrets.LINEAR_API_TOKEN }}
+      linear-token: ${{ secrets.LINEAR_TOKEN }}


### PR DESCRIPTION
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

Closes DEVOPS-693

The backport workflow caller passed the Linear token as `${{ secrets.LINEAR_API_TOKEN }}`, but no secret by that name exists at the repo or org level. The real secret is `LINEAR_TOKEN`. As a result `linear-token` resolved to an empty string and the reusable backport workflow's `link-backport-prs` step silently skipped, so backport PRs never received their `Fixes` line and Linear sub-issues were never linked.

This points the caller at the existing `LINEAR_TOKEN` secret. It is a one-line change to `.github/workflows/backport.yaml`. No new secret is created.

Corroboration: `release.yaml` in this same repo already references `${{ secrets.LINEAR_TOKEN }}`, which confirms `LINEAR_TOKEN` is the correct existing secret.

**Please provide a short message that should be published in the vcluster release notes**

NONE (internal CI fix, not user-facing)

**What else do we need to know?**

End-to-end verification (a backport PR actually getting its `Fixes ENG-x` line) only completes once this merges and the next backport runs.

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI secret name fix with no runtime or user-facing behavior changes.
> 
> **Overview**
> The automatic backport workflow now passes **`LINEAR_TOKEN`** into the reusable workflow’s `linear-token` input instead of the non-existent **`LINEAR_API_TOKEN`**.
> 
> That restores the Linear token so **`link-backport-prs`** can run and backport PRs get **`Fixes`** lines and linked sub-issues again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2786db105b46b758142bf67d46990095806142. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->