### PR TITLE
chore(platform): bump minimum platform version to v4.10.5 (ENG-12190)

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.10.3"
+	MinimumVersionTag = "v4.10.5"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
## What

Bumps `MinimumVersionTag` in `pkg/platform/version.go` from `v4.10.3` to `v4.10.5`, the latest stable vCluster Platform release ([loft-sh/loft v4.10.5](https://github.com/loft-sh/loft/releases/tag/v4.10.5), published 2026-07-07).

## Why

`MinimumVersionTag` is the compatibility floor and fallback used by `LatestCompatibleVersion` when the GitHub release lookup fails or returns something older. Keeping it at the current stable release avoids falling back to a stale version. `v4.11.0` is still in RC (`v4.11.0-rc.3` / `-next.internal.*`), so `v4.10.5` is the correct stable target today.

## Notes

- Single-line change; no behavior change beyond the floor version.
- `v4.9.3` is a stable release on an older minor line and is lower than `v4.10.5`, so `v4.10.5` remains the latest stable.

Closes ENG-12190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change with no logic edits; only raises the documented minimum/fallback Platform version.
> 
> **Overview**
> Raises the vCluster Platform **compatibility floor** by updating `MinimumVersionTag` in `pkg/platform/version.go` from **`v4.10.3`** to **`v4.10.5`**.
> 
> That constant drives `MinimumVersion` and is used when `LatestCompatibleVersion` falls back (GitHub errors, bad tags) and when filtering stable loft releases so only versions **≥** the minimum are considered. Aligning the floor with the current stable Platform release avoids recommending or defaulting to an older minimum when live release lookup is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85348a8d01d9d843ce0d6b76c0e46a87b1daf52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->