### PR TITLE
fix: exempt node bundle downloads from the request timeout

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -194,6 +194,14 @@ func (s *Server) ServeOnListenerTLS(ctx *synccontext.ControllerContext) error {
 			return true
 		}
 
+		// private nodes bundle downloads stream >100MB and must not be killed
+		// by the default 60s request timeout
+		if !requestInfo.IsResourceRequest &&
+			(strings.HasPrefix(requestInfo.Path, "/node/download/") ||
+				strings.HasPrefix(requestInfo.Path, "/node/control-plane-download/")) {
+			return true
+		}
+
 		// use the default long running check
 		return genericfilters.BasicLongRunningRequestCheck(
 			sets.NewString("watch", "proxy"),


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
Closes ENGCP-1029

The `/node/download/` and `/node/control-plane-download/` endpoints stream the Kubernetes node bundle (>100MB). They pass through the apiserver handler chain, where `WithRequestDeadline` + `WithTimeoutForNonLongRunningRequests` enforce the default 60s request timeout: any node that cannot fetch the bundle within 60s (~2.3MB/s sustained for the amd64 bundle) has the transfer killed mid-stream, logs `Post-timeout activity ... /node/download/...` on the control plane, and can never join or upgrade. The client (`vcluster node upgrade` / join script fallback) retries from byte zero and hits the same wall every time, so worker nodes stay on the old Kubernetes version forever.

This PR marks these paths as long-running, the same approach used for the embedded registry in #2944. Long-running requests are also exempt from the max-in-flight limit, the same trade-off #2944 made; these are static-file transfers served from disk.

**Verification**
- Reproduced on the released v0.36.0-rc.1 binary (docker standalone) and end-to-end on EC2 (t3.small private node, ingress policed to 12Mbit/s, 1.35→1.36 upgrade): download killed at exactly 60s, node stuck on v1.35.0; identical logs to the customer report.
- Rebuilt v0.36.0-rc.1 with only this change: the same throttled download (1MB/s) completed the full 122MB bundle in 117s with zero `Post-timeout activity` lines; API behavior otherwise unchanged.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vCluster terminated private node bundle downloads after 60 seconds, which prevented nodes on slower connections from joining or upgrading.

**What else do we need to know?**
- Needs backports to release-0.35 and release-0.36 (both affected).
- A vcluster-pro e2e regression test exercising `/node/download` through a throttled client follows in a separate PR (the handler is pro-only).

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core proxy timeout and concurrency behavior for pro-only paths; scope is narrow and mirrors an existing registry exemption, but misclassified paths could allow unusually long or unbounded requests.
> 
> **Overview**
> **Fixes private node join/upgrade failures** when bundle downloads take longer than the apiserver’s default 60s non–long-running timeout.
> 
> `LongRunningFunc` in `pkg/server/server.go` now treats non-resource requests under `/node/download/` and `/node/control-plane-download/` as long-running (same pattern as embedded registry `/v2`), so those large streaming transfers are not cut off by `WithTimeoutForNonLongRunningRequests` / `WithRequestDeadline` and are also excluded from max-in-flight limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f5062a08a7f67253d4bbf561219f3225689f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->