### PR TITLE
fix: node's bundle download timeout

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -189,8 +189,12 @@ func (s *Server) ServeOnListenerTLS(ctx *synccontext.ControllerContext) error {
 		GrouplessAPIPrefixes: sets.NewString("api"),
 	}
 	serverConfig.LongRunningFunc = func(r *http.Request, requestInfo *request.RequestInfo) bool {
-		// internal registry requests are long running
-		if !requestInfo.IsResourceRequest && strings.HasPrefix(requestInfo.Path, "/v2") {
+		// Exempt long-running requests from the default RequestTimeout (60s):
+		// the internal image registry and private-node bundle downloads that
+		// stream (potentially large) tar.gz binaries.
+		if !requestInfo.IsResourceRequest && (strings.HasPrefix(requestInfo.Path, "/v2") ||
+			strings.HasPrefix(requestInfo.Path, "/node/download") ||
+			strings.HasPrefix(requestInfo.Path, "/node/control-plane-download")) {
 			return true
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENGCP-1029


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...


**What else do we need to know?** 

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
<!--
You can specify custom Ginkgo label filters for e2e tests by adding a label-filter code block.

Available labels: core, sync, pr

For a complete list of existing labels, see: e2e/labels/labels.go

You can combine labels using Ginkgo syntax: && (AND), || (OR), ! (NOT)

Examples:
- Run only pr tests: "none" (default) - test labeled "pr" are always run
- Additionally run virtual cluster tests: "core"
- Run all tests: "!pr" - litte hack, this results in "!pr || pr" which actually means all tests
- Run tests that have the label 'team' within the 'managementv1' label category: "managementv1: containsAny team" or "managementv1: containsAll team"
- Run tests that have labels 'virtual-cluster-instance' or 'user' within the 'managementv1' label category: "managementv1: consistsOf { virtual-cluster-instance, user }"
-->
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to long-running request classification for two download paths; no auth or data-model changes.
> 
> **Overview**
> Fixes **private-node bundle downloads** timing out when large `tar.gz` streams exceed the apiserver proxy’s default **60s** `RequestTimeout`.
> 
> `ServeOnListenerTLS`’s `LongRunningFunc` already treated internal registry traffic under `/v2` as long-running. It now also marks non-resource paths **`/node/download`** and **`/node/control-plane-download`** as long-running, alongside `/v2`, so those downloads are not cut off by the non-long-running timeout filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e936bc3be51b364ffed1799a87f6a7deec7a1f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->