### PR TITLE
feat(e2e): consume shared specpriority scheduling fixture

### DIFF
--- a/.github/workflows/e2e-ginkgo-nightly.yaml
+++ b/.github/workflows/e2e-ginkgo-nightly.yaml
@@ -106,6 +106,24 @@ jobs:
         if: steps.gcp-auth.outcome == 'success'
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Download spec duration stats
+        continue-on-error: true
+        env:
+          E2E_INSIGHTS_BUCKET: ${{ vars.E2E_INSIGHTS_BUCKET }}
+        run: |
+          slug="${GITHUB_REPOSITORY//\//-}"
+          src="gs://${E2E_INSIGHTS_BUCKET}/stats/specs/v1/latest/${slug}.json.gz"
+          if gcloud storage cp "$src" "$RUNNER_TEMP/spec-stats.json.gz"; then
+            gunzip -f "$RUNNER_TEMP/spec-stats.json.gz"
+            echo "E2E_SPEC_STATS_FILE=$RUNNER_TEMP/spec-stats.json" >> "$GITHUB_ENV"
+            # Per-run seed: identical across the parallel ginkgo processes of this
+            # run (so spec ordering is consistent), but different between runs so
+            # the spread reshuffles and flakes surface in new combinations.
+            echo "E2E_SPEC_SPREAD_SEED=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+          else
+            echo "no spec stats available; running with default ordering"
+          fi
+
       - name: Run e2e-next tests
         id: run-tests
         uses: loft-sh/github-actions/.github/actions/run-ginkgo@run-ginkgo/v1

--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -247,6 +247,24 @@ jobs:
         if: steps.gcp-auth.outcome == 'success'
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Download spec duration stats
+        continue-on-error: true
+        env:
+          E2E_INSIGHTS_BUCKET: ${{ vars.E2E_INSIGHTS_BUCKET }}
+        run: |
+          slug="${GITHUB_REPOSITORY//\//-}"
+          src="gs://${E2E_INSIGHTS_BUCKET}/stats/specs/v1/latest/${slug}.json.gz"
+          if gcloud storage cp "$src" "$RUNNER_TEMP/spec-stats.json.gz"; then
+            gunzip -f "$RUNNER_TEMP/spec-stats.json.gz"
+            echo "E2E_SPEC_STATS_FILE=$RUNNER_TEMP/spec-stats.json" >> "$GITHUB_ENV"
+            # Per-run seed: identical across the parallel ginkgo processes of this
+            # run (so spec ordering is consistent), but different between runs so
+            # the spread reshuffles and flakes surface in new combinations.
+            echo "E2E_SPEC_SPREAD_SEED=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+          else
+            echo "no spec stats available; running with default ordering"
+          fi
+
       - name: Run vCluster Ginkgo E2E Tests
         id: execute-e2e-tests
         uses: loft-sh/github-actions/.github/actions/run-ginkgo@run-ginkgo/v1

--- a/e2e-next/init/init.go
+++ b/e2e-next/init/init.go
@@ -2,6 +2,7 @@ package init
 
 import (
 	"github.com/loft-sh/e2e-framework/pkg/e2e"
+	"github.com/loft-sh/e2e-framework/pkg/e2e/specpriority"
 	"github.com/loft-sh/e2e-framework/pkg/setup/suite"
 	. "github.com/onsi/ginkgo/v2"
 )
@@ -9,3 +10,4 @@ import (
 // This must be called before any ginkgo DSL evaluation
 var _ = AddTreeConstructionNodeArgsTransformer(suite.NodeTransformer)
 var _ = AddTreeConstructionNodeArgsTransformer(e2e.ContextualNodeTransformer)
+var _ = AddTreeConstructionNodeArgsTransformer(specpriority.Transformer)

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/loft-sh/agentapi/v4 v4.10.0-rc.3
 	github.com/loft-sh/analytics-client v0.0.0-20240219162240-2f4c64b2494e
 	github.com/loft-sh/api/v4 v4.10.0-rc.3
-	github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979
+	github.com/loft-sh/e2e-framework v0.0.0-20260717104111-3d76694dc267
 	github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364
 	github.com/loft-sh/utils v0.0.29
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/loft-sh/api/v4 v4.10.0-rc.3 h1:op4H0vyjKcu+ksS8Q4TiXHMyr8tB/9CqBh7BFw
 github.com/loft-sh/api/v4 v4.10.0-rc.3/go.mod h1:w2wsgKTRZukWfZcMz8HIxLPyHZeyEFktZTILNRlT0u0=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530 h1:2B4XhZ30FVt17PbWj2iRKcqys8a+3DoPLabvxGswPmU=
 github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530/go.mod h1:YfIUirXHfVcUb3bVtj7yzIAVT6etrHj9wkOkMgnEuz0=
-github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979 h1:5nhHRJIGlxkvJappR0SdBEsuM/ziBke+Z2dVI+A4G3I=
-github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979/go.mod h1:o9z8GQTFYGgX+AzYJoJvO7zVAYt6zDtYhMU2Ma7rSvA=
+github.com/loft-sh/e2e-framework v0.0.0-20260717104111-3d76694dc267 h1:12zDqSVRmZtvVDCOeJB2547LPUBgTuV37SFMxo0WWME=
+github.com/loft-sh/e2e-framework v0.0.0-20260717104111-3d76694dc267/go.mod h1:o5/96Y/TKloaGKv+mCZ7bhKbM10TEL3cMU85Ioq7rtk=
 github.com/loft-sh/external-types v0.1.0-alpha.2.0.20260409132559-a38365a8cbf2 h1:WZWBuzM3QtIW/9qNXHFcfFEKGcpi602hGI8wYjkidUM=
 github.com/loft-sh/external-types v0.1.0-alpha.2.0.20260409132559-a38365a8cbf2/go.mod h1:cpx5mpwOZZjQaiFbydE9VjhRTap9Yho3wdNk/KJm03c=
 github.com/loft-sh/image v0.0.0-20250625154753-87447a6ad364 h1:vSuqHqh4w2zrG+WvnyH64JAUhX+Bou19n0gvCrPirOs=

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/core_dsl.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/core_dsl.go
@@ -47,8 +47,24 @@ func DeferCleanupCtx(ctx context.Context, fn func(context.Context) (context.Cont
 	})
 }
 
+var currentSpecID string
+
 func ContextualAroundNode(ctx context.Context) context.Context {
 	report := ginkgo.CurrentSpecReport()
+
+	// A context popped during one spec's cleanup must not be observable from
+	// the next spec: it may reference resources that the previous spec tore
+	// down (e.g. ephemeral platform clients). Invalidate Stack.last when a new
+	// spec starts. Suite-level nodes (AfterSuite, ReportAfterSuite, ...) are
+	// excluded because they legitimately resolve values from the context
+	// popped when the BeforeSuite cleanup ran.
+	if report.LeafNodeType == types.NodeTypeIt {
+		if id := report.FullText() + "|" + report.LeafNodeLocation.String(); id != currentSpecID {
+			currentSpecID = id
+			suiteContextStack.NextGeneration()
+		}
+	}
+
 	events := report.SpecEvents.WithType(types.SpecEventNodeStart)
 	event := events[len(events)-1]
 

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/specpriority/index.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/specpriority/index.go
@@ -1,0 +1,162 @@
+package specpriority
+
+import (
+	"hash/fnv"
+	"math"
+	"sort"
+	"strings"
+)
+
+// keySep joins hierarchy parts into a map key. NUL never appears in spec text.
+const keySep = "\x00"
+
+// keyFor builds a stable lookup key from a hierarchy, dropping empty entries so the
+// producer's container_hierarchy (no root, no empties) and ginkgo's construction-time
+// ContainerHierarchyTexts (which carries a leading "" for the synthetic root) both
+// normalize to the same key. This is the single shared key function, used when
+// building the index and when looking up at construction time.
+func keyFor(parts []string) string {
+	filtered := parts[:0:0]
+	for _, p := range parts {
+		if p != "" {
+			filtered = append(filtered, p)
+		}
+	}
+	return strings.Join(filtered, keySep)
+}
+
+// Index holds the precomputed lookups derived from a StatsFile.
+type Index struct {
+	// price maps a group key to its P95 duration in ms. Every prefix of every
+	// leaf's full path (hierarchy + leaf) is an entry: a lone It's full-path key
+	// holds its own duration, and an Ordered container's key holds the summed
+	// duration of its whole subtree, so a single lookup prices either kind of
+	// execution group.
+	price map[string]int
+	// thresholdMillis is the 80th-percentile leaf duration in ms. Execution groups
+	// with a raw priority below this value (the fastest ~80%) receive a spread
+	// priority drawn from [1, thresholdMillis) instead of their raw duration,
+	// spreading them throughout the run rather than concentrating them in a
+	// low-priority tail that raises platform load just as the run ends. Capping the
+	// spread strictly below thresholdMillis guarantees a spread draw can never
+	// outrank a retained raw LPT priority (every retained priority is >=
+	// thresholdMillis) — sizing the spread off maxKnownMillis instead let spread
+	// draws for small, unmeasured specs bury the heaviest Ordered execution groups
+	// behind noise. Zero means spread is disabled (no leaf durations).
+	thresholdMillis int
+	// spreadSeed salts the per-group spread hash. It MUST be identical across all
+	// parallel ginkgo processes: each process builds the spec tree and sorts
+	// execution groups by SpecPriority independently, and ginkgo dispatches work
+	// by a shared counter index into each process's sorted list, so divergent
+	// priorities would make some groups run on several workers and others never
+	// run at all. A per-run (but cross-process-constant) seed keeps the ordering
+	// consistent within a run while still varying the spread between runs so
+	// flakes surface in different spec combinations.
+	spreadSeed string
+}
+
+// BuildIndex precomputes the lookups from sf using the P95 metric. spreadSeed salts
+// the spread hash and must be the same value in every parallel ginkgo process (see
+// Index.spreadSeed).
+func BuildIndex(sf *StatsFile, spreadSeed string) *Index {
+	ix := &Index{
+		price:      map[string]int{},
+		spreadSeed: spreadSeed,
+	}
+	if sf == nil {
+		return ix
+	}
+
+	// leafMillis collects only leaf durations so the 80th-percentile threshold is
+	// computed over leaves, not container sums.
+	leafMillis := make([]int, 0, len(sf.Specs))
+	priceSum := map[string]float64{}
+	for i := range sf.Specs {
+		s := sf.Specs[i]
+		v := s.P95Seconds
+		if v < 0 {
+			v = 0
+		}
+
+		full := make([]string, 0, len(s.ContainerHierarchy)+1)
+		full = append(full, s.ContainerHierarchy...)
+		full = append(full, s.Leaf)
+
+		leafMillis = append(leafMillis, floorMillis(v))
+
+		// Add this leaf's duration to every prefix key so an Ordered container at
+		// any depth is priced by the sum of its subtree while the full-path key
+		// prices the lone leaf itself.
+		filtered := make([]string, 0, len(full))
+		for _, p := range full {
+			if p != "" {
+				filtered = append(filtered, p)
+			}
+		}
+		for j := 1; j <= len(filtered); j++ {
+			priceSum[keyFor(filtered[:j])] += v
+		}
+	}
+
+	for k, v := range priceSum {
+		ix.price[k] = floorMillis(v)
+	}
+
+	sort.Ints(leafMillis)
+	if len(leafMillis) > 0 {
+		ix.thresholdMillis = leafMillis[len(leafMillis)*8/10]
+	}
+
+	return ix
+}
+
+// priceGroup prices an execution group identified by its full path parts (parent
+// hierarchy plus the node's own text). ms is the priority in milliseconds to attach,
+// and matched reports whether a historical row was found (used only for the CI
+// match-rate signal). Groups below the spread threshold (the fastest ~80%) and
+// unmatched groups receive a spread priority so they interleave throughout the run;
+// the slowest ~20% keep their raw LPT priority.
+func (ix *Index) priceGroup(parts []string) (ms int, matched bool) {
+	key := keyFor(parts)
+	if v, ok := ix.price[key]; ok {
+		if ix.thresholdMillis > 0 && v < ix.thresholdMillis {
+			return ix.spreadPriority(key), true
+		}
+		return v, true
+	}
+	return ix.spreadPriority(key), false
+}
+
+// spreadPriority returns a priority in [1, thresholdMillis) derived deterministically
+// from the group key and the seed, used to scatter a group throughout the run
+// instead of clustering it at one end. It is a pure function of (spreadSeed, key),
+// so every parallel process computes the same value for the same group (required
+// for consistent dispatch ordering) while a different seed reshuffles the spread
+// between runs. The range is capped below thresholdMillis, not maxKnownMillis, so a
+// spread draw can never outrank a retained raw LPT priority. When there is no known
+// range to sample from (no leaf durations) it returns 1, leaving such groups at a
+// uniform low priority.
+func (ix *Index) spreadPriority(key string) int {
+	spreadCap := ix.thresholdMillis - 1
+	if spreadCap < 1 {
+		return 1
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(ix.spreadSeed))
+	_, _ = h.Write([]byte(keySep))
+	_, _ = h.Write([]byte(key))
+	return int(h.Sum64()%uint64(spreadCap)) + 1
+}
+
+// floorMillis converts seconds to whole milliseconds with a floor of 1, so a
+// matched-but-known-fast group stays below the unmatched band yet never collides
+// with the default-0 priority of non-target nodes.
+func floorMillis(seconds float64) int {
+	if seconds <= 0 {
+		return 1
+	}
+	if ms := int(math.Round(seconds * 1000)); ms > 1 {
+		return ms
+	}
+	return 1
+}

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/specpriority/stats.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/specpriority/stats.go
@@ -1,0 +1,32 @@
+// Package specpriority assigns ginkgo SpecPriority decorators from historical
+// per-spec duration data so the suite dispatches the heaviest execution groups
+// first across the parallel workers (a Longest-Processing-Time schedule), keeping
+// wall-clock time short and stable.
+//
+// The data is a daily per-spec duration export, downloaded to the path named by
+// E2E_SPEC_STATS_FILE. When that variable is unset or the file is missing the
+// package is a clean no-op and the suite runs in its normal order.
+//
+// The unit tests here are plain testing.T tests, not Ginkgo specs: they call no
+// RunSpecs and use no Ginkgo DSL. That is deliberate. Inside a consumer's e2e tree
+// a `ginkgo -r` scan treats any directory with test files as a suite, so a Ginkgo-
+// importing package with test files but no RunSpecs would hang the parallel run
+// waiting for worker procs that never report back. Here the package ships as an
+// imported dependency under pkg/ and is never part of a consumer's `ginkgo -r`
+// scan, so plain testing.T tests are safe and run under the normal `go test`
+// entrypoint. Keep any tests added here as plain testing.T tests, not Ginkgo specs.
+package specpriority
+
+// SpecStat is one leaf (It) aggregate from the duration export. The JSON field
+// names match the export emitted by the loft-prod e2e-insights export function.
+type SpecStat struct {
+	ContainerHierarchy []string `json:"container_hierarchy"`
+	Leaf               string   `json:"leaf"`
+	P95Seconds         float64  `json:"p95_seconds"`
+}
+
+// StatsFile is the top-level export document.
+type StatsFile struct {
+	Version int        `json:"_version"`
+	Specs   []SpecStat `json:"specs"`
+}

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/specpriority/transformer.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/specpriority/transformer.go
@@ -1,0 +1,145 @@
+package specpriority
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+const (
+	// EnvStatsFile is the path to the duration stats file. When unset or unreadable
+	// the transformer is a no-op.
+	EnvStatsFile = "E2E_SPEC_STATS_FILE"
+	// EnvSpreadSeed salts the per-group spread hash. CI must set it to a value that
+	// is the same for all parallel processes of one run but differs between runs
+	// (e.g. the GitHub run id), so spec ordering is consistent within a run yet
+	// flakes surface in different combinations across runs. When unset the spread is
+	// deterministic, which is fine for local single-process runs.
+	EnvSpreadSeed = "E2E_SPEC_SPREAD_SEED"
+)
+
+var (
+	loadOnce    sync.Once
+	index       *Index // nil => no data => no-op
+	loadedSpecs int
+
+	matched atomic.Int64
+	total   atomic.Int64
+)
+
+// Transformer is a ginkgo NodeArgsTransformer registered during tree construction.
+// It appends a SpecPriority decorator to the execution-group representative nodes
+// (outermost Ordered containers and lone Its) based on historical durations, so
+// ginkgo dispatches the heaviest groups first across the parallel workers.
+//
+// It is a no-op when no stats file is configured, and it never overrides a
+// manually-set SpecPriority on a node.
+func Transformer(nodeType types.NodeType, _ ginkgo.Offset, text string, args []any) (string, []any, []error) {
+	load()
+	if index == nil {
+		return text, args, nil
+	}
+	if hasExplicitPriority(args) {
+		// Respect a deliberate manual priority and let it win.
+		return text, args, nil
+	}
+
+	ancestors, inOrdered := ancestorsAndOrdered()
+
+	// Classify the node: an outermost Ordered container (the whole subtree is one
+	// execution group) or a lone It not inside any Ordered container (its own
+	// execution group). Everything else carries no priority.
+	switch {
+	case nodeType.Is(types.NodeTypeContainer) && !inOrdered && containsOrdered(args):
+	case nodeType.Is(types.NodeTypeIt) && !inOrdered:
+	default:
+		return text, args, nil
+	}
+
+	ms, ok := index.priceGroup(append(ancestors[:len(ancestors):len(ancestors)], text))
+	total.Add(1)
+	if ok {
+		matched.Add(1)
+	}
+	return text, append(args, ginkgo.SpecPriority(ms)), nil
+}
+
+// load reads and indexes the stats file exactly once. It is safe (and cheap) to
+// call on every node; the env var is read at first node construction, which works
+// for both top-level nodes (package init) and nested nodes (BuildTree).
+func load() {
+	loadOnce.Do(func() {
+		path := os.Getenv(EnvStatsFile)
+		if path == "" {
+			return
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "specpriority: cannot open %s: %v\n", path, err)
+			return
+		}
+		defer f.Close()
+
+		var sf StatsFile
+		if err := json.NewDecoder(f).Decode(&sf); err != nil {
+			fmt.Fprintf(os.Stderr, "specpriority: cannot parse %s: %v\n", path, err)
+			return
+		}
+
+		index = BuildIndex(&sf, os.Getenv(EnvSpreadSeed))
+		loadedSpecs = len(sf.Specs)
+	})
+}
+
+// ancestorsAndOrdered returns the parent container hierarchy and whether the node
+// is inside an Ordered container. CurrentTreeConstructionNodeReport panics for
+// top-level nodes, which are created at package-init time before tree construction
+// begins; a top-level node has no ancestors, so recovering to (nil, false) is the
+// correct answer, not merely a fallback.
+func ancestorsAndOrdered() (ancestors []string, inOrdered bool) {
+	defer func() { _ = recover() }()
+
+	r := ginkgo.CurrentTreeConstructionNodeReport()
+	return r.ContainerHierarchyTexts, r.IsInOrderedContainer
+}
+
+// containsOrdered reports whether args carry the Ordered decorator. By the time a
+// transformer runs, ginkgo has already unrolled any decorator slices, so a direct
+// scan is sufficient.
+func containsOrdered(args []any) bool {
+	for _, a := range args {
+		if a == ginkgo.Ordered {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExplicitPriority(args []any) bool {
+	for _, a := range args {
+		if _, ok := a.(ginkgo.SpecPriority); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Report a one-line summary on the primary process when the feature is active, so
+// CI logs show how many execution groups matched the historical data. A low match
+// rate signals spec renames have drifted from the stats — the only drift detector.
+// Multiple ReportAfterSuite nodes are allowed; this is a no-op when no stats file
+// was loaded.
+var _ = ginkgo.ReportAfterSuite("specpriority", func(_ ginkgo.Report) {
+	if index == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"specpriority: active — %d specs loaded, matched %d/%d execution-group nodes\n",
+		loadedSpecs, matched.Load(), total.Load())
+})

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/stack.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/e2e/stack.go
@@ -2,8 +2,10 @@ package e2e
 
 // Stack is a generic stack implementation using a slice.
 type Stack[T any] struct {
-	items []T
-	last  *T
+	items          []T
+	last           *T
+	generation     uint64
+	lastGeneration uint64
 }
 
 // NewStack creates a new empty stack.
@@ -29,6 +31,7 @@ func (s *Stack[T]) Pop() (T, bool) {
 	item := s.items[idx]
 	s.items = s.items[:idx]
 	s.last = &item
+	s.lastGeneration = s.generation
 	return item, true
 }
 
@@ -44,13 +47,21 @@ func (s *Stack[T]) Peek() (T, bool) {
 }
 
 // Last returns the most recently popped item.
-// Returns the zero value of T and false if no item has been popped yet.
+// Returns the zero value of T and false if no item has been popped yet or if
+// the last popped item was invalidated by NextGeneration.
 func (s *Stack[T]) Last() (T, bool) {
-	if s.last == nil {
+	if s.last == nil || s.lastGeneration != s.generation {
 		var zero T
 		return zero, false
 	}
 	return *s.last, true
+}
+
+// NextGeneration invalidates the most recently popped item so that Last no
+// longer returns it. Callers use this to mark a boundary (e.g. a new spec)
+// across which previously popped items must not be observable.
+func (s *Stack[T]) NextGeneration() {
+	s.generation++
 }
 
 // IsEmpty returns true if the stack is empty.

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/provider/vcluster/vcluster.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/provider/vcluster/vcluster.go
@@ -54,19 +54,20 @@ const (
 )
 
 type Cluster struct {
-	path                 string
-	name                 string
-	kubecfgFile          string // kubeconfig file for the vcluster
-	version              string
-	namespace            string // namespace to create the vcluster in
-	hostKubeCfg          string // kubeconfig file for the host cluster
-	hostKubeContext      string // kubeconfig context for the host cluster
-	upgrade              bool
-	add                  *bool // nil = default CLI behavior, non-nil = explicit --add=true/false
-	localChartDir        string
+	path                    string
+	name                    string
+	kubecfgFile             string // kubeconfig file for the vcluster
+	version                 string
+	namespace               string // namespace to create the vcluster in
+	hostKubeCfg             string // kubeconfig file for the host cluster
+	hostKubeContext         string // kubeconfig context for the host cluster
+	upgrade                 bool
+	add                     *bool // nil = default CLI behavior, non-nil = explicit --add=true/false
+	localChartDir           string
 	backgroundProxyImage    string
 	driver                  string
 	skipWaitForControlPlane bool
+	ignoreNotFoundOnDestroy bool
 	rc                      *rest.Config
 }
 
@@ -167,6 +168,19 @@ func WithSkipWaitForControlPlane() support.ClusterOpts {
 		v, ok := c.(*Cluster)
 		if ok {
 			v.skipWaitForControlPlane = true
+		}
+	}
+}
+
+// WithIgnoreNotFoundOnDestroy makes Destroy() pass --ignore-not-found, so tearing
+// down an already-deleted vcluster succeeds instead of erroring. Opt-in: use for
+// specs that delete the vcluster themselves (e.g. delete-mid-join), where the
+// suite teardown would otherwise double-delete and fail.
+func WithIgnoreNotFoundOnDestroy() support.ClusterOpts {
+	return func(c support.E2EClusterProvider) {
+		v, ok := c.(*Cluster)
+		if ok {
+			v.ignoreNotFoundOnDestroy = true
 		}
 	}
 }
@@ -404,6 +418,9 @@ func (c *Cluster) Destroy(ctx context.Context) error {
 	}
 
 	command := fmt.Sprintf("%s delete %s", c.path, c.name)
+	if c.ignoreNotFoundOnDestroy {
+		command = fmt.Sprintf("%s --ignore-not-found", command)
+	}
 	if len(args) > 0 {
 		command = fmt.Sprintf("%s %s", command, strings.Join(args, " "))
 	}
@@ -510,16 +527,16 @@ const Type = "vcluster"
 // The rest.Config field (rc) is excluded from serialization as it contains non-serializable
 // runtime configuration.
 type clusterJSON struct {
-	Type                 string `json:"type"`
-	Path                 string `json:"path"`
-	Name                 string `json:"name"`
-	KubecfgFile          string `json:"kubecfgFile"`
-	Version              string `json:"version"`
-	Namespace            string `json:"namespace"`
-	HostKubeCfg          string `json:"hostKubeCfg"`
-	HostKubeContext      string `json:"hostKubeContext"`
-	Upgrade              bool   `json:"upgrade"`
-	Add                  *bool  `json:"add,omitempty"`
+	Type                    string `json:"type"`
+	Path                    string `json:"path"`
+	Name                    string `json:"name"`
+	KubecfgFile             string `json:"kubecfgFile"`
+	Version                 string `json:"version"`
+	Namespace               string `json:"namespace"`
+	HostKubeCfg             string `json:"hostKubeCfg"`
+	HostKubeContext         string `json:"hostKubeContext"`
+	Upgrade                 bool   `json:"upgrade"`
+	Add                     *bool  `json:"add,omitempty"`
 	LocalChartDir           string `json:"localChartDir"`
 	BackgroundProxyImage    string `json:"backgroundProxyImage"`
 	SkipWaitForControlPlane bool   `json:"skipWaitForControlPlane,omitempty"`
@@ -557,16 +574,16 @@ func (c *Cluster) UnmarshalJSON(data []byte) error {
 
 func (c *Cluster) MarshalJSON() ([]byte, error) {
 	return json.Marshal(clusterJSON{
-		Type:                 Type,
-		Path:                 c.path,
-		Name:                 c.name,
-		KubecfgFile:          c.kubecfgFile,
-		Version:              c.version,
-		Namespace:            c.namespace,
-		HostKubeCfg:          c.hostKubeCfg,
-		HostKubeContext:      c.hostKubeContext,
-		Upgrade:              c.upgrade,
-		Add:                  c.add,
+		Type:                    Type,
+		Path:                    c.path,
+		Name:                    c.name,
+		KubecfgFile:             c.kubecfgFile,
+		Version:                 c.version,
+		Namespace:               c.namespace,
+		HostKubeCfg:             c.hostKubeCfg,
+		HostKubeContext:         c.hostKubeContext,
+		Upgrade:                 c.upgrade,
+		Add:                     c.add,
 		LocalChartDir:           c.localChartDir,
 		BackgroundProxyImage:    c.backgroundProxyImage,
 		SkipWaitForControlPlane: c.skipWaitForControlPlane,

--- a/vendor/github.com/loft-sh/e2e-framework/pkg/setup/vcluster/lifecycle.go
+++ b/vendor/github.com/loft-sh/e2e-framework/pkg/setup/vcluster/lifecycle.go
@@ -87,6 +87,9 @@ func Create(ctx context.Context, spec Spec) context.Context {
 	var err error
 	//nolint:defercleanupcluster // teardown is conditional on spec failure; see DeferCleanupCtx below.
 	ctx, err = cluster.Create(createOpts...)(ctx)
+	if err != nil {
+		DumpDiagnostics(ctx, spec.HostClusterName, spec.Name, spec.ConfigFile)
+	}
 	Expect(err).To(Succeed(), "vcluster %q create", spec.Name)
 
 	name, hostName, configFile := spec.Name, spec.HostClusterName, spec.ConfigFile

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -724,10 +724,11 @@ github.com/loft-sh/api/v4/pkg/vclusterconfig/constants
 # github.com/loft-sh/apiserver v0.0.0-20260424174643-365191901530
 ## explicit; go 1.26.0
 github.com/loft-sh/apiserver/pkg/builders
-# github.com/loft-sh/e2e-framework v0.0.0-20260423133544-5291e728f979
+# github.com/loft-sh/e2e-framework v0.0.0-20260717104111-3d76694dc267
 ## explicit; go 1.24.0
 github.com/loft-sh/e2e-framework/pkg/context
 github.com/loft-sh/e2e-framework/pkg/e2e
+github.com/loft-sh/e2e-framework/pkg/e2e/specpriority
 github.com/loft-sh/e2e-framework/pkg/provider
 github.com/loft-sh/e2e-framework/pkg/provider/kind
 github.com/loft-sh/e2e-framework/pkg/provider/vcluster


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind test
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)

Makes vcluster consume the shared `specpriority` scheduling fixture from
`e2e-framework` (`github.com/loft-sh/e2e-framework/pkg/e2e/specpriority`).

- `e2e-next/init/init.go` registers `specpriority.Transformer` as an additional
  tree-construction node-args transformer, alongside the existing
  `suite.NodeTransformer` and `e2e.ContextualNodeTransformer`.
- Adds an inline **Download spec duration stats** step to both ginkgo workflows
  (`.github/workflows/e2e-ginkgo.yaml` PR suite and
  `.github/workflows/e2e-ginkgo-nightly.yaml`). The step downloads the recorded
  spec-duration stats from `gs://${{ vars.E2E_INSIGHTS_BUCKET }}/stats/specs/v1/latest/<slug>.json.gz`,
  gunzips it, and writes `E2E_SPEC_STATS_FILE` and `E2E_SPEC_SPREAD_SEED` into
  `$GITHUB_ENV` so the ginkgo test process (in the same job) picks them up at
  runtime. It is `continue-on-error: true`, so it is a safe no-op when stats are
  unavailable.

> **Intermediate state:** `e2e-framework` is pinned to the framework PR branch
> `janroehrich/spec-priority-e2e-framework` (framework PR loft-sh/e2e-framework#48).
> Once #48 merges to `e2e-framework` `main`, a follow-up commit will move the pin
> from the branch pseudo-version back to `main`.

**Please provide a short message that should be published in the vcluster release notes**

N/A (internal e2e tooling only).

**What else do we need to know?**

Part of a coordinated multi-repo migration onto the shared specpriority fixture.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically.

Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```
