### PR TITLE
fix(snapshot): delete existing data before restore for external database

### DIFF
--- a/pkg/snapshot/restoreclient.go
+++ b/pkg/snapshot/restoreclient.go
@@ -546,7 +546,8 @@ func newRestoreEtcdClient(ctx context.Context, vConfig *config.VirtualClusterCon
 	// * embedded etcd: delete the files locally and make sure revision is not decreasing, this is important as otherwise watches will not work correctly
 	// * deploy etcd: range delete request
 	// * embedded database: delete the files locally and make sure revision is not decreasing, this is important as otherwise watches will not work correctly
-	// * external database: we can't so we skip and then check later if there are any already
+	// * external etcd: range delete request
+	// * external database: range delete request (reached through kine, which handles delete-by-prefix)
 	if vConfig.BackingStoreType() == vclusterconfig.StoreTypeEmbeddedDatabase {
 		// get latest revision from database
 		latestRevision, err := getLatestRevisionSQLite(ctx, constants.K8sSqliteDatabase)
@@ -621,9 +622,9 @@ func newRestoreEtcdClient(ctx context.Context, vConfig *config.VirtualClusterCon
 		return nil, revertBackup, err
 	}
 
-	// delete contents in external etcd
-	if vConfig.BackingStoreType() == vclusterconfig.StoreTypeDeployedEtcd || vConfig.BackingStoreType() == vclusterconfig.StoreTypeExternalEtcd {
-		klog.FromContext(ctx).Info("Delete existing etcd data before restore...")
+	// delete contents in stores we reach over the etcd protocol but don't own on disk
+	if shouldDeleteBeforeRestore(vConfig.BackingStoreType()) {
+		klog.FromContext(ctx).Info("Delete existing data before restore...")
 		err = etcdClient.DeletePrefix(ctx, "/")
 		if err != nil {
 			return nil, revertBackup, err
@@ -631,6 +632,22 @@ func newRestoreEtcdClient(ctx context.Context, vConfig *config.VirtualClusterCon
 	}
 
 	return etcdClient, revertBackup, nil
+}
+
+// shouldDeleteBeforeRestore reports whether the backing store's existing data
+// must be cleared with an etcd range delete before restore (as opposed to
+// deleting local files). True for stores vCluster reaches over the etcd
+// protocol but does not own on disk: deployed etcd, external etcd, and
+// external database (via kine).
+func shouldDeleteBeforeRestore(storeType vclusterconfig.StoreType) bool {
+	switch storeType {
+	case vclusterconfig.StoreTypeDeployedEtcd,
+		vclusterconfig.StoreTypeExternalEtcd,
+		vclusterconfig.StoreTypeExternalDatabase:
+		return true
+	default:
+		return false
+	}
 }
 
 func setLatestRevisionSQLite(ctx context.Context, file string, revision int64) error {

--- a/pkg/snapshot/restoreclient_test.go
+++ b/pkg/snapshot/restoreclient_test.go
@@ -9,7 +9,50 @@ import (
 	"testing"
 
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	vclusterconfig "github.com/loft-sh/vcluster/config"
 )
+
+func TestShouldDeleteBeforeRestore(t *testing.T) {
+	tests := []struct {
+		name      string
+		storeType vclusterconfig.StoreType
+		expected  bool
+	}{
+		{
+			name:      "embedded etcd deletes files, not via range delete",
+			storeType: vclusterconfig.StoreTypeEmbeddedEtcd,
+			expected:  false,
+		},
+		{
+			name:      "embedded database deletes files, not via range delete",
+			storeType: vclusterconfig.StoreTypeEmbeddedDatabase,
+			expected:  false,
+		},
+		{
+			name:      "deployed etcd uses range delete",
+			storeType: vclusterconfig.StoreTypeDeployedEtcd,
+			expected:  true,
+		},
+		{
+			name:      "external etcd uses range delete",
+			storeType: vclusterconfig.StoreTypeExternalEtcd,
+			expected:  true,
+		},
+		{
+			name:      "external database uses range delete",
+			storeType: vclusterconfig.StoreTypeExternalDatabase,
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldDeleteBeforeRestore(tt.storeType); got != tt.expected {
+				t.Errorf("shouldDeleteBeforeRestore(%q) = %v; want %v", tt.storeType, got, tt.expected)
+			}
+		})
+	}
+}
 
 func TestSnapshotRestoreBumpRevision(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
resolves #ENGCP-557

Clears the existing data before restoring a snapshot into an **external database** backing store.

Before a restore, vCluster clears the target store so that resources created *after* the snapshot was taken do not survive the restore. This worked for every backing store except external database, which was skipped entirely, so snapshot keys were replayed on top of stale data and post-snapshot resources survived the restore.

An external database is reached through a local kine process that speaks the etcd v3 protocol, so the same `etcdClient.DeletePrefix(ctx, "/")` already used for deployed/external etcd works against it. No file deletion or revision bump is needed, kine's delete operations advance the revision monotonically just like the deployed/external etcd branch.

- Add a `rangeDeleteBeforeRestore` helper (deployed etcd, external etcd, and now external database) and use it at the pre-restore delete site in `newRestoreEtcdClient`.
- Add `TestRangeDeleteBeforeRestore` covering all five store types.

Scope: only the deletion aspect. Backup & rollback for external database is intentionally out of scope (deployed/external etcd also lack it today) and tracked as follow-up.

Reported via Pylon #8006.

Closes ENGCP-557

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where restoring a snapshot into a vCluster backed by an external database did not delete the existing data first, leaving stale resources behind after the restore.

**What else do we need to know?**

External database is a Pro-gated feature, so this path only executes in a Pro build against a real database. OSS behavior is unchanged.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Additional test suites

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pre-restore wipes all keys in external DB/etcd-backed stores; incorrect classification could delete the wrong store or skip cleanup, but scope is limited to snapshot restore and matches existing etcd behavior.
> 
> **Overview**
> Fixes snapshot restore for **external database** backing stores by running the same pre-restore **`DeletePrefix("/")`** path already used for deployed and external etcd. External DB is reached via kine’s etcd API, so stale keys are removed before snapshot keys are replayed instead of being layered on top.
> 
> The restore logic is refactored behind **`shouldDeleteBeforeRestore`**, which returns true for deployed etcd, external etcd, and external database (false for embedded etcd/SQLite, which still clear local files). Comments and log text are generalized accordingly. **`TestShouldDeleteBeforeRestore`** covers all five store types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2191490c25ccbf19022638e0c1d99c7c2f6de461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->