### PR TITLE
ci: convert release builder to workflow_dispatch (v0.36)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,14 @@
 name: Release
 
+# Builder for the vCluster release pipeline (DEVOPS-1050). The GitHub Release is
+# a pipeline OUTPUT, not a trigger: goreleaser creates it at the end of a green
+# build. This workflow is dispatched by the loft-sh/github-actions
+# vcluster-release action via `gh workflow run release.yaml --ref <tag>`, so
+# github.ref is refs/tags/<version> and github.ref_name is the version. It no
+# longer triggers on release:created, so a monorepo-created OSS release can never
+# re-trigger this builder.
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   check_minimum_version_tag:
@@ -10,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        if: ${{ !contains(github.event.release.tag_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.ref_name }}
       - name: Validate MinimumVersionTag is stable
-        if: ${{ !contains(github.event.release.tag_name, '-') }}
+        if: ${{ !contains(github.ref_name, '-') }}
         run: |
           MINIMUM_VERSION_TAG=$(grep -oP 'MinimumVersionTag\s*=\s*"\Kv[^"]+' pkg/platform/version.go)
           if [[ ! "$MINIMUM_VERSION_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -72,7 +78,10 @@ jobs:
         run: |
           RELEASE_VERSION=$(echo "$GITHUB_REF" | sed -nE 's!refs/tags/!!p')
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "previous_tag=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=1 --max-count=1)")" >> "$GITHUB_OUTPUT"
+          # Branch-local previous tag: the tag reachable from this commit's
+          # parent on THIS branch, not the global latest tag (which would be
+          # wrong on a release branch). See DEVOPS-1050.
+          echo "previous_tag=$(git describe --tags --abbrev=0 --match 'v*' "${GITHUB_SHA}^" 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
       - name: Validate semver
         id: semver
         uses: loft-sh/github-actions/.github/actions/semver-validation@semver-validation/v1
@@ -239,7 +248,7 @@ jobs:
       contents: read
     uses: loft-sh/github-actions/.github/workflows/notify-release.yaml@release-notification/v2
     with:
-      release_version: ${{ github.event.release.tag_name }}
+      release_version: ${{ github.ref_name }}
       target_repo: ${{ github.repository }}
       product: vCluster
       status: failure


### PR DESCRIPTION
Part of the DEVOPS-1050 phase-4 fan-out (loft-sh/vcluster legacy line). **Builder-only** conversion, sibling to vcluster#4073–#4077 (v0.31–v0.35).

## What
Converts only the builder `release.yaml`:
- Drops the `release:created` trigger; the workflow is dispatched via `workflow_dispatch --ref <tag>`, so `github.ref`/`github.ref_name` carry the version.
- Decouples `github.event.release.tag_name` → `github.ref_name` in `check_minimum_version_tag` and the failure Slack notification.
- Derives `previous_tag` from branch-local history (`git describe --tags --abbrev=0 --match 'v*' "${GITHUB_SHA}^"`) instead of `git rev-list --tags --skip=1`, which picks the global latest tag (wrong on a release branch).

## Validators intentionally unchanged
Legacy lines get **no post-build validation wired** — matches current behavior (no regression). Release validation for new lines (`>= v0.37`) is handled by `main`'s tag-dispatched validators (reference PR vcluster#4072).

v0.36 is still the old (pre-monorepo) layout, so this is identical to the v0.35 conversion (#4073) apart from a pre-existing base delta (`linear-release-sync` tag bump) the conversion does not touch.

Actionlint-clean. Draft to match the sibling PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production releases are triggered and how Goreleaser’s previous tag is chosen; mis-dispatch or a bad previous_tag could block releases or skew release notes, but no app runtime or security paths are touched.
> 
> **Overview**
> Part of **DEVOPS-1050**: the `release.yaml` builder no longer runs on `release:created`. It is started with `gh workflow run release.yaml --ref <tag>`, so the version comes from `github.ref` / `github.ref_name` instead of `github.event.release.tag_name` (minimum-version check, checkout ref, failure Slack notify).
> 
> **`previous_tag`** is now computed with `git describe` from `${GITHUB_SHA}^` on the current branch, replacing the global “second-latest tag” lookup so Goreleaser’s `GORELEASER_PREVIOUS_TAG` / changelog baseline is correct on release branches.
> 
> Comments document that the GitHub Release is produced at the end of a green build, avoiding monorepo OSS releases re-firing this workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ad370523037dba9f5430946e03c4f43d364944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->