### PR TITLE
docs: add AI conformance reference copies for v1.34 and v1.35

### DIFF
--- a/ai-conformance/v1.34/vcluster-private-nodes/PRODUCT.yaml
+++ b/ai-conformance/v1.34/vcluster-private-nodes/PRODUCT.yaml
@@ -1,0 +1,119 @@
+# Kubernetes AI Conformance Checklist
+# Notes: This checklist is based on the Kubernetes AI Conformance document.
+# Participants should fill in the 'status', 'evidence', and 'notes' fields for each requirement.
+# Submission target: https://github.com/cncf/k8s-ai-conformance/tree/main/v1.34/vcluster-private-nodes
+
+metadata:
+  kubernetesVersion: v1.34
+  platformName: "vCluster with Private Nodes"
+  platformVersion: "v0.32.0"
+  vendorName: "vCluster"
+  websiteUrl: "https://www.vcluster.com/"
+  repoUrl: "https://github.com/loft-sh/vcluster"
+  documentationUrl: "https://www.vcluster.com/docs"
+  productLogoUrl: "https://static.loft.sh/branding/logos/vcluster/square/vcluster_square.svg"
+  description: "vCluster creates fully functional virtual Kubernetes clusters inside host cluster namespaces, with Private Nodes providing exclusive attachment of real physical GPU nodes directly to a virtual cluster for AI/ML workloads."
+  contactEmailAddress: "cncf@vcluster.com"
+  k8sConformanceUrl: "https://github.com/cncf/k8s-conformance/tree/master/v1.34/vcluster-private-nodes"
+
+spec:
+  accelerators:
+    - id: dra_support
+      description: "Support Dynamic Resource Allocation (DRA) APIs to enable more flexible and fine-grained resource requests beyond simple counts."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://kubernetes.io/blog/2025/09/01/kubernetes-v1-34-dra-updates/"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://github.com/loft-sh/vcluster/releases/tag/v0.32.0"
+      notes: "With Private Nodes, vCluster attaches real physical Kubernetes nodes exclusively to the virtual cluster. Since those nodes run Kubernetes v1.34, the DRA APIs (ResourceClaim, DeviceClass, ResourceClaimTemplate) are natively available at GA — no virtual-to-host syncing is required. The Kubernetes v1.34 blog post confirms DRA graduation to stable. vCluster v0.32.0 introduced DRA support, enabling Private Nodes vClusters to use ResourceClaims and DeviceClasses as native Kubernetes resources for fine-grained GPU and accelerator allocation."
+
+  networking:
+    - id: ai_inference
+      description: "Support the Kubernetes Gateway API with an implementation for advanced traffic management for inference services, which enables capabilities like weighted traffic splitting, header-based routing (for OpenAI protocol headers), and optional integration with service meshes."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://github.com/loft-sh/vcluster/blob/main/chart/templates/tlsroute.yaml"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/configure/vcluster-yaml/sync/to-host/advanced/custom-resources#configure-kubernetes-gateway-api-sync"
+      notes: "vCluster natively implements a Kubernetes Gateway API TLSRoute resource for its own control-plane TLS exposure (see chart/templates/tlsroute.yaml) — a production-grade Gateway API implementation shipped as part of the vCluster Helm chart. With Private Nodes, workloads run on dedicated physical Kubernetes nodes that belong exclusively to the virtual cluster, exposing the full Kubernetes API surface. This means any Gateway API controller (such as Envoy Gateway, Traefik v3, or NGINX Gateway Fabric) can be installed as a native workload inside the vCluster without host-level syncing or custom resource proxying. Installed controllers provide advanced traffic management for AI inference workloads via standard Gateway API resources (HTTPRoute, GRPCRoute), enabling weighted traffic splitting across model versions and header-based routing for inference protocol selection. The custom-resources documentation demonstrates how vCluster supports Gateway API resource synchronization including waypoint gateway configuration for ambient mesh integration."
+
+  schedulingOrchestration:
+    - id: gang_scheduling
+      description: "The platform must allow for the installation and successful operation of at least one gang scheduling solution that ensures all-or-nothing scheduling for distributed AI workloads (e.g. Kueue, Volcano, etc.) To be conformant, the vendor must demonstrate that their platform can successfully run at least one such solution."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/solutions/volcano"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+      notes: "With Private Nodes, the virtual scheduler is automatically enabled and is the required scheduler for private-node vClusters. This allows installing any third-party gang scheduling solution (Volcano, NVIDIA KAI Scheduler, Kueue) natively as a workload inside the virtual cluster without host syncing. vCluster has a dedicated Volcano integration page demonstrating successful all-or-nothing scheduling for distributed GPU workloads. Each virtual cluster maintains isolated CRD versions, eliminating scheduler version conflicts between AI tenants."
+
+    - id: cluster_autoscaling
+      description: "If the platform provides a cluster autoscaler or an equivalent mechanism, it must be able to scale up/down node groups containing specific accelerator types based on pending pods requesting those accelerators."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/platform/administer/node-providers/overview"
+        - "https://www.vcluster.com/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes"
+        - "https://www.vcluster.com/blog/kubernetes-node-autoscaling-with-auto-nodes"
+        - "https://www.vcluster.com/blog/introducing-vcluster-auto-nodes-karpenter-based-dynamic-autoscaling-anywhere"
+        - "https://www.vcluster.com/docs/platform/4.6.0/administer/node-providers/bcm"
+      notes: "vCluster Platform's Auto Nodes feature provides Karpenter-based dynamic autoscaling of private node groups, including GPU-equipped nodes. Node types specify accelerator resources (e.g., nvidia.com/gpu) and nodes are provisioned on-demand only when workloads explicitly request them, and scale back down when demand drops. The NVIDIA Base Command Manager (BCM) node provider enables elastic GPU cluster provisioning on DGX hardware."
+
+    - id: pod_autoscaling
+      description: "If the platform supports the HorizontalPodAutoscaler, it must function correctly for pods utilizing accelerators. This includes the ability to scale these Pods based on custom metrics relevant to AI/ML workloads."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/deploy"
+        - "https://www.vcluster.com/docs/vcluster/integrations/gpu-hpa-dcgm"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://www.vcluster.com/guides/gpu-multi-tenancy-kubernetes-virtual-clusters"
+      notes: "For Private Nodes, vCluster deploys metrics-server natively inside the virtual cluster via `deploy.metricsServer.enabled: true`, enabling HPA based on CPU/memory for workloads on dedicated GPU nodes. For GPU custom metrics, NVIDIA DCGM-Exporter runs as a DaemonSet on private GPU nodes and exposes per-GPU metrics in Prometheus format. These are scraped by Prometheus and exposed to the Kubernetes Custom Metrics API via Prometheus Adapter, enabling HPA driven by GPU utilization metrics (DCGM_FI_DEV_GPU_UTIL). The gpu-hpa-dcgm integration guide provides a complete step-by-step walkthrough for this Private Nodes GPU autoscaling setup."
+
+  observability:
+    - id: accelerator_metrics
+      description: "For supported accelerator types, the platform must allow for the installation and successful operation of at least one accelerator metrics solution that exposes fine-grained performance metrics via a standardized, machine-readable metrics endpoint. This must include a core set of metrics for per-accelerator utilization and memory usage. Additionally, other relevant metrics such as temperature, power draw, and interconnect bandwidth should be exposed if the underlying hardware or virtualization layer makes them available. The list of metrics should align with emerging standards, such as OpenTelemetry metrics, to ensure interoperability. The platform may provide a managed solution, but this is not required for conformance."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/integrations/gpu-hpa-dcgm"
+        - "https://www.vcluster.com/guides/gpu-multi-tenancy-kubernetes-virtual-clusters"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://www.vcluster.com/guides/gpus-without-the-headache-scaling-ai-factory-infrastructure"
+        - "https://www.vcluster.com/docs/platform/maintenance/monitoring/fleet-monitoring-otel"
+      notes: "vCluster with Private Nodes exposes real GPU hardware directly to virtual cluster workloads. NVIDIA DCGM-Exporter is installed via its official Helm chart as a DaemonSet on the private GPU nodes and collects fine-grained per-GPU metrics in Prometheus exposition format at port 9400/metrics. Metrics include: utilization (DCGM_FI_DEV_GPU_UTIL), framebuffer memory used/free (DCGM_FI_DEV_FB_USED, DCGM_FI_DEV_FB_FREE), temperature (DCGM_FI_DEV_GPU_TEMP), power draw (DCGM_FI_DEV_POWER_USAGE), and NVLink bandwidth. MIG partition-level monitoring is supported for multi-tenant GPU isolation. The fleet-monitoring-otel guide documents how vCluster integrates with OpenTelemetry pipelines for workload observability, aligning with the OTel metrics standard referenced in the requirement."
+
+    - id: ai_service_metrics
+      description: "Provide a monitoring system capable of discovering and collecting metrics from workloads that expose them in a standard format (e.g. Prometheus exposition format). This ensures easy integration for collecting key metrics from common AI frameworks and servers."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/platform/maintenance/monitoring/fleet-monitoring-otel#private-nodes"
+        - "https://www.vcluster.com/docs/vcluster/integrations/gpu-hpa-dcgm"
+      notes: "With Private Nodes, a full Prometheus monitoring stack (Prometheus Operator, kube-prometheus-stack) can be installed natively inside the vCluster as regular workloads — no host-cluster sync or external plugin required. ServiceMonitor and PodMonitor resources defined inside the virtual cluster automatically discover and scrape any workload exposing metrics in Prometheus exposition format, including common AI inference servers (TensorFlow Serving, TorchServe, Triton Inference Server, vLLM). The gpu-hpa-dcgm integration guide demonstrates this pattern in full: it installs kube-prometheus-stack inside the vCluster and configures a ServiceMonitor to scrape DCGM Exporter running on private GPU nodes. The fleet-monitoring-otel private-nodes section describes the complementary OTel collector pipeline that runs as a DaemonSet inside the vCluster, collecting infrastructure observability data and forwarding it to a central platform-level Prometheus."
+
+  security:
+    - id: secure_accelerator_access
+      description: "Ensure that access to accelerators from within containers is properly isolated and mediated by the Kubernetes resource management framework (device plugin or DRA) and container runtime, preventing unauthorized access or interference between workloads."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://www.vcluster.com/blog/deploy-vcluster-gpu-kubernetes-tutorial"
+        - "https://kubernetes.io/blog/2025/09/01/kubernetes-v1-34-dra-updates/"
+      notes: "vCluster enforces accelerator isolation at two levels. (1) Node-level isolation: Private Nodes are attached exclusively to a single vCluster — no other workload on the host cluster can schedule onto those nodes, providing physical-level GPU isolation between tenants. This is the primary isolation boundary: nodes cannot be shared across virtual clusters. (2) DRA-mediated device access: With Private Nodes running Kubernetes v1.34, the DRA framework (ResourceClaim, DeviceClass) and the NVIDIA device plugin run directly on the dedicated physical nodes, mediating all GPU hardware access at the container level via the Kubernetes resource management framework. The Kubernetes v1.34 DRA blog confirms the admin access labeling feature (restricts device access to authorized namespaces), which platform administrators can use to prevent unauthorized accelerator access across tenant workloads."
+
+  operator:
+    - id: robust_controller
+      description: "The platform must prove that at least one complex AI operator with a CRD (e.g., Ray, Kubeflow) can be installed and functions reliably. This includes verifying that the operator's pods run correctly, its webhooks are operational, and its custom resources can be reconciled."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/blog/kubernetes-ai-pipelines-with-vcluster-and-kubeflow-tutorial"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/configure/vcluster-yaml/policies/admission-control"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/integrations/external-secrets-operator"
+        - "https://www.vcluster.com/blog/deploying-machine-learning-models-on-kubernetes-with-vcluster-tutorial"
+        - "https://www.vcluster.com/docs/platform/integrations/certified-stacks"
+      notes: "vCluster has a complete tutorial deploying Kubeflow Pipelines v2.0.1 inside a virtual cluster, demonstrating: CRD installation (applications.app.k8s.io), operator pods running, and custom resource reconciliation. KServe (InferenceService CRD) is demonstrated inside vCluster in the ML models tutorial with inference endpoints verified. Regarding webhooks: vCluster's admission-control documentation explicitly states that 'a user can still install a webhook service or webhook configuration into the virtual cluster outside of this config, and it would run inside the virtual cluster like any other workload' — confirming that operator ValidatingWebhookConfiguration and MutatingWebhookConfiguration resources are fully supported inside vCluster's API server. The External Secrets Operator integration (with its webhook component, externalSecrets.webhook) is a documented example of an operator with webhooks running successfully inside vCluster. The Certified Stacks documentation demonstrates certified AI platforms (NVIDIA Run:ai, Slinky/Slurm) running successfully inside vCluster with Private Nodes, confirming robust operator support for production AI workloads."

--- a/ai-conformance/v1.34/vcluster-private-nodes/README.md
+++ b/ai-conformance/v1.34/vcluster-private-nodes/README.md
@@ -1,0 +1,40 @@
+# vCluster AI Conformance — v1.34 (Private Nodes)
+
+CNCF Kubernetes AI Platform Conformance submission for vCluster with Private Nodes.
+
+- **Kubernetes version:** v1.34
+- **Platform version:** v0.32.0
+- **Submission:** https://github.com/cncf/k8s-ai-conformance/tree/main/v1.34/vcluster-private-nodes
+- **k8s-conformance baseline:** https://github.com/cncf/k8s-conformance/tree/master/v1.34/vcluster-private-nodes
+
+## What is vCluster with Private Nodes?
+
+Private Nodes attach real physical Kubernetes nodes exclusively to a virtual cluster.
+This gives the vCluster dedicated GPU hardware for AI/ML workloads with node-level isolation —
+no other workload on the host cluster can schedule onto those nodes.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `PRODUCT.yaml` | CNCF AI conformance self-assessment — all 8 MUST items with evidence |
+| `README.md` | This file |
+
+## Conformance requirements covered
+
+| Category | Requirement | Status |
+|----------|-------------|--------|
+| Accelerators | DRA support (ResourceClaim, DeviceClass) | Implemented |
+| Networking | Gateway API for AI inference traffic management | Implemented |
+| Scheduling | Gang scheduling (Volcano, NVIDIA KAI) | Implemented |
+| Scheduling | Cluster autoscaling with GPU node groups (Auto Nodes) | Implemented |
+| Scheduling | HPA with GPU custom metrics (DCGM + Prometheus Adapter) | Implemented |
+| Observability | Accelerator metrics (DCGM-Exporter, OTel) | Implemented |
+| Observability | AI service metrics (Prometheus discovery) | Implemented |
+| Security | Secure accelerator access (node-level + DRA isolation) | Implemented |
+| Operators | AI CRD operators (Kubeflow, KServe, webhooks) | Implemented |
+
+## Re-certification
+
+Run `/k8s-ai-conformance-research` annually when a new Kubernetes minor version is released
+to check for spec changes and dead evidence URLs before updating for the next cycle.

--- a/ai-conformance/v1.35/vcluster-private-nodes/PRODUCT.yaml
+++ b/ai-conformance/v1.35/vcluster-private-nodes/PRODUCT.yaml
@@ -1,0 +1,150 @@
+# Kubernetes AI Conformance Checklist
+# Notes: This checklist is based on the Kubernetes AI Conformance document.
+# Participants should fill in the 'status', 'evidence', and 'notes' fields for each requirement.
+# Submission target: https://github.com/cncf/k8s-ai-conformance/tree/main/v1.35/vcluster-private-nodes
+
+metadata:
+  kubernetesVersion: v1.35
+  platformName: "vCluster with Private Nodes"
+  platformVersion: "v0.32.0"
+  vendorName: "vCluster"
+  websiteUrl: "https://www.vcluster.com/"
+  repoUrl: "https://github.com/loft-sh/vcluster"
+  documentationUrl: "https://www.vcluster.com/docs"
+  productLogoUrl: "https://static.loft.sh/branding/logos/vcluster/square/vcluster_square.svg"
+  description: "vCluster creates fully functional virtual Kubernetes clusters inside host cluster namespaces, with Private Nodes providing exclusive attachment of real physical GPU nodes directly to a virtual cluster for AI/ML workloads."
+  contactEmailAddress: "cncf@vcluster.com"
+  k8sConformanceUrl: "https://github.com/cncf/k8s-conformance/tree/master/v1.35/vcluster-with-private-nodes"
+
+spec:
+  accelerators:
+    - id: dra_support
+      description: "Support Dynamic Resource Allocation (DRA) APIs to enable more flexible and fine-grained resource requests beyond simple counts."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://github.com/loft-sh/vcluster/releases/tag/v0.32.0"
+      notes: "With Private Nodes, vCluster attaches real physical Kubernetes nodes exclusively to the virtual cluster — this is the key distinction from Shared Nodes, where workloads run on the host's shared node pool. Because those dedicated nodes run Kubernetes v1.35, the DRA APIs (ResourceClaim, DeviceClass, ResourceClaimTemplate) are natively available at GA with no virtual-to-host syncing required. vCluster v0.32.0 introduced DRA support, enabling Private Nodes vClusters to use ResourceClaims and DeviceClasses as native Kubernetes resources for fine-grained GPU and accelerator allocation."
+
+    - id: driver_runtime_management
+      description: "Provide a verifiable mechanism for ensuring that compatible accelerator drivers and corresponding container runtime configurations are correctly installed and maintained on nodes with accelerators. Once the accelerator supports exposing driver and runtime version information as part of DRA, then the platform should use the DRA mechanism for verification."
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html"
+      notes: "With Private Nodes, each dedicated node is joined exclusively to a single virtual cluster. This means platform administrators can install the NVIDIA GPU Operator (or any other driver management solution) directly inside the vCluster as a standard Kubernetes workload. The GPU Operator manages driver lifecycle, container runtime configuration (NVIDIA Container Toolkit), and device plugin deployment on the private nodes. Since nodes belong solely to the vCluster, driver versions are fully under the tenant's control with no interference from other tenants — a key advantage over Shared Nodes where driver management is a host-cluster concern. As DRA driver/runtime version introspection matures, vCluster's native DRA support on Private Nodes positions it to adopt that mechanism without architectural changes."
+
+    - id: gpu_sharing
+      description: "For accelerators that support static GPU sharing, provide well-defined mechanisms for at least one GPU sharing strategy to improve utilization for workloads that do not require a full dedicated GPU. If hardware-level partitioning is supported, then these fractional GPU resources should be exposed as schedulable resources. If software-based sharing (e.g. time-slicing) is supported, then oversubscription of GPUs should be allowed. Forward-looking: Once the accelerator supports static GPU sharing as part of DRA, the platform should expose the DRA mechanism to allow users to leverage static GPU sharing. Once the accelerator supports dynamic GPU sharing as part of DRA and the partitionable devices feature is GA, the platform should expose the DRA mechanism to allow users to leverage dynamic GPU sharing."
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://www.vcluster.com/guides/gpu-multi-tenancy-kubernetes-virtual-clusters"
+        - "https://www.vcluster.com/guides/gpus-without-the-headache-scaling-ai-factory-infrastructure"
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html"
+      notes: "Private Nodes exposes the physical GPU hardware directly to the virtual cluster's workloads. GPU sharing strategies available on Private Nodes include: (1) NVIDIA MIG (Multi-Instance GPU) partitioning on A100/H100 GPUs — MIG slices are exposed as schedulable resources (e.g. nvidia.com/mig-1g.5gb) and the virtual cluster scheduler allocates them to pods as first-class Kubernetes resources; (2) NVIDIA time-slicing, configured via the GPU Operator's device plugin ConfigMap inside the vCluster, allowing oversubscription of a physical GPU across multiple pods. Since the private nodes belong exclusively to the virtual cluster, the tenant has full control over MIG geometry and time-slicing configuration without impacting other tenants. vCluster's native DRA support positions Private Nodes to adopt DRA-based static and dynamic GPU sharing (partitionable devices) as those features graduate to GA."
+
+    - id: virtualized_accelerator
+      description: "For accelerators that support virtualized accelerator technologies (e.g. vGPU), provide well-defined mechanisms for these to be exposed and managed, maintaining consistency with physical fractional GPUs. Forward-looking: Once the accelerator supports virtualized accelerator technologies as part of DRA, then the platform should use the DRA mechanism."
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html"
+      notes: "With Private Nodes, virtualized accelerator technologies (NVIDIA vGPU, MIG vGPU profiles) are supported by installing the NVIDIA GPU Operator with vGPU licensing inside the virtual cluster. Because the private nodes are exclusively attached to the vCluster, the GPU Operator can configure the NVIDIA vGPU driver and vGPU Manager on those nodes without interference from other tenants. vGPU profiles are exposed as schedulable resources consistent with physical fractional GPUs. This is fundamentally different from the Shared Nodes tenancy model, where vGPU management would be a host-cluster responsibility. vCluster's DRA support on Private Nodes provides the foundation to adopt DRA-based virtualized accelerator management as that mechanism matures."
+
+  networking:
+    - id: ai_inference
+      description: "Support the Kubernetes Gateway API with an implementation for advanced traffic management for inference services, which enables capabilities like weighted traffic splitting, header-based routing (for OpenAI protocol headers), and optional integration with service meshes."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://github.com/loft-sh/vcluster/blob/main/chart/templates/tlsroute.yaml"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/configure/vcluster-yaml/sync/to-host/advanced/custom-resources#configure-kubernetes-gateway-api-sync"
+      notes: "vCluster natively implements a Kubernetes Gateway API TLSRoute resource for its own control-plane TLS exposure (see chart/templates/tlsroute.yaml) — a production-grade Gateway API implementation shipped as part of the vCluster Helm chart. With Private Nodes, workloads run on dedicated physical Kubernetes nodes that belong exclusively to the virtual cluster, exposing the full Kubernetes API surface. This means any Gateway API controller (such as Envoy Gateway, Traefik v3, or NGINX Gateway Fabric) can be installed as a native workload inside the vCluster without host-level syncing or custom resource proxying. Installed controllers provide advanced traffic management for AI inference workloads via standard Gateway API resources (HTTPRoute, GRPCRoute), enabling weighted traffic splitting across model versions and header-based routing for inference protocol selection. The custom-resources documentation demonstrates how vCluster supports Gateway API resource synchronization including waypoint gateway configuration for ambient mesh integration. Under the Shared Nodes model, Gateway API controllers would require host-level CRD sync; Private Nodes eliminates this constraint entirely."
+
+  schedulingOrchestration:
+    - id: gang_scheduling
+      description: "The platform must allow for the installation and successful operation of at least one gang scheduling solution that ensures all-or-nothing scheduling for distributed AI workloads (e.g. Kueue, Volcano, etc.) To be conformant, the vendor must demonstrate that their platform can successfully run at least one such solution."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/solutions/volcano"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+      notes: "With Private Nodes, the virtual scheduler is automatically enabled and is the required scheduler for private-node vClusters. This allows installing any third-party gang scheduling solution (Volcano, NVIDIA KAI Scheduler, Kueue) natively as a workload inside the virtual cluster without host syncing. vCluster has a dedicated Volcano integration page demonstrating successful all-or-nothing scheduling for distributed GPU workloads. Each virtual cluster maintains isolated CRD versions, eliminating scheduler version conflicts between AI tenants. The Private Nodes tenancy model is specifically suited for distributed AI workloads that require gang scheduling across multiple dedicated GPU nodes, as all nodes in the gang are guaranteed to be part of the same virtual cluster."
+
+    - id: cluster_autoscaling
+      description: "If the platform provides a cluster autoscaler or an equivalent mechanism, it must be able to scale up/down node groups containing specific accelerator types based on pending pods requesting those accelerators."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/platform/administer/node-providers/overview"
+        - "https://www.vcluster.com/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes"
+        - "https://www.vcluster.com/blog/kubernetes-node-autoscaling-with-auto-nodes"
+        - "https://www.vcluster.com/blog/introducing-vcluster-auto-nodes-karpenter-based-dynamic-autoscaling-anywhere"
+        - "https://www.vcluster.com/docs/platform/4.6.0/administer/node-providers/bcm"
+      notes: "vCluster Platform's Auto Nodes feature provides Karpenter-based dynamic autoscaling of private node groups, including GPU-equipped nodes. Node types specify accelerator resources (e.g., nvidia.com/gpu) and nodes are provisioned on-demand only when workloads explicitly request them, and scale back down when demand drops. The NVIDIA Base Command Manager (BCM) node provider enables elastic GPU cluster provisioning on DGX hardware. With Private Nodes, autoscaling operates at the tenant level — each virtual cluster independently scales its own dedicated node pool, unlike Shared Nodes where the host cluster autoscaler serves all tenants."
+
+    - id: pod_autoscaling
+      description: "If the platform supports the HorizontalPodAutoscaler, it must function correctly for pods utilizing accelerators. This includes the ability to scale these Pods based on custom metrics relevant to AI/ML workloads."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/deploy"
+        - "https://www.vcluster.com/docs/vcluster/integrations/gpu-hpa-dcgm"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://www.vcluster.com/guides/gpu-multi-tenancy-kubernetes-virtual-clusters"
+      notes: "For Private Nodes, vCluster deploys metrics-server natively inside the virtual cluster via `deploy.metricsServer.enabled: true`, enabling HPA based on CPU/memory for workloads on dedicated GPU nodes. For GPU custom metrics, NVIDIA DCGM-Exporter runs as a DaemonSet on private GPU nodes and exposes per-GPU metrics in Prometheus format. These are scraped by Prometheus and exposed to the Kubernetes Custom Metrics API via Prometheus Adapter, enabling HPA driven by GPU utilization metrics (DCGM_FI_DEV_GPU_UTIL). The gpu-hpa-dcgm integration guide provides a complete step-by-step walkthrough for this Private Nodes GPU autoscaling setup. Because the private nodes are exclusively attached to the virtual cluster, DCGM-Exporter has unmediated access to GPU hardware — no host-level proxy or plugin bridge is required, unlike the Shared Nodes model."
+
+  observability:
+    - id: accelerator_metrics
+      description: "For supported accelerator types, the platform must allow for the installation and successful operation of at least one accelerator metrics solution that exposes fine-grained performance metrics via a standardized, machine-readable metrics endpoint. This must include a core set of metrics for per-accelerator utilization and memory usage. Additionally, other relevant metrics such as temperature, power draw, and interconnect bandwidth should be exposed if the underlying hardware or virtualization layer makes them available. The list of metrics should align with emerging standards, such as OpenTelemetry metrics, to ensure interoperability. The platform may provide a managed solution, but this is not required for conformance."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/integrations/gpu-hpa-dcgm"
+        - "https://www.vcluster.com/guides/gpu-multi-tenancy-kubernetes-virtual-clusters"
+        - "https://www.vcluster.com/blog/gpu-multitenancy-kubernetes-strategies"
+        - "https://www.vcluster.com/guides/gpus-without-the-headache-scaling-ai-factory-infrastructure"
+        - "https://www.vcluster.com/docs/platform/maintenance/monitoring/fleet-monitoring-otel"
+      notes: "vCluster with Private Nodes exposes real GPU hardware directly to virtual cluster workloads. NVIDIA DCGM-Exporter is installed via its official Helm chart as a DaemonSet on the private GPU nodes and collects fine-grained per-GPU metrics in Prometheus exposition format at port 9400/metrics. Metrics include: utilization (DCGM_FI_DEV_GPU_UTIL), framebuffer memory used/free (DCGM_FI_DEV_FB_USED, DCGM_FI_DEV_FB_FREE), temperature (DCGM_FI_DEV_GPU_TEMP), power draw (DCGM_FI_DEV_POWER_USAGE), and NVLink bandwidth. MIG partition-level monitoring is supported for multi-tenant GPU isolation. The fleet-monitoring-otel guide documents how vCluster integrates with OpenTelemetry pipelines for workload observability, aligning with the OTel metrics standard referenced in the requirement. With Private Nodes, DCGM-Exporter runs inside the virtual cluster with direct hardware access — no host-level metric forwarding is needed, which is a constraint present in the Shared Nodes model."
+
+    - id: ai_service_metrics
+      description: "Provide a monitoring system capable of discovering and collecting metrics from workloads that expose them in a standard format (e.g. Prometheus exposition format). This ensures easy integration for collecting key metrics from common AI frameworks and servers."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/platform/maintenance/monitoring/fleet-monitoring-otel#private-nodes"
+        - "https://www.vcluster.com/docs/vcluster/integrations/gpu-hpa-dcgm"
+      notes: "With Private Nodes, a full Prometheus monitoring stack (Prometheus Operator, kube-prometheus-stack) can be installed natively inside the vCluster as regular workloads — no host-cluster sync or external plugin required. ServiceMonitor and PodMonitor resources defined inside the virtual cluster automatically discover and scrape any workload exposing metrics in Prometheus exposition format, including common AI inference servers (TensorFlow Serving, TorchServe, Triton Inference Server, vLLM). The gpu-hpa-dcgm integration guide demonstrates this pattern in full: it installs kube-prometheus-stack inside the vCluster and configures a ServiceMonitor to scrape DCGM Exporter running on private GPU nodes. The fleet-monitoring-otel private-nodes section describes the complementary OTel collector pipeline that runs as a DaemonSet inside the vCluster, collecting infrastructure observability data and forwarding it to a central platform-level Prometheus."
+
+  security:
+    - id: secure_accelerator_access
+      description: "Ensure that access to accelerators from within containers is properly isolated and mediated by the Kubernetes resource management framework (device plugin or DRA) and container runtime, preventing unauthorized access or interference between workloads."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/deploy/worker-nodes/private-nodes"
+        - "https://www.vcluster.com/blog/deploy-vcluster-gpu-kubernetes-tutorial"
+        - "https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/"
+      notes: "vCluster enforces accelerator isolation at two levels. (1) Node-level isolation: Private Nodes are attached exclusively to a single vCluster — no other workload on the host cluster can schedule onto those nodes, providing physical-level GPU isolation between tenants. This is the primary isolation boundary distinguishing Private Nodes from the Shared Nodes model, where GPU access isolation depends entirely on device plugin quotas and namespace boundaries on shared host nodes. (2) DRA-mediated device access: With Private Nodes running Kubernetes v1.35, the DRA framework (ResourceClaim, DeviceClass) and the NVIDIA device plugin run directly on the dedicated physical nodes, mediating all GPU hardware access at the container level via the Kubernetes resource management framework. DRA admin access controls (restricting device access to authorized namespaces) can be used to prevent unauthorized accelerator access across tenant workloads within a virtual cluster."
+
+  operator:
+    - id: robust_controller
+      description: "The platform must prove that at least one complex AI operator with a CRD (e.g., Ray, Kubeflow) can be installed and functions reliably. This includes verifying that the operator's pods run correctly, its webhooks are operational, and its custom resources can be reconciled."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://www.vcluster.com/blog/kubernetes-ai-pipelines-with-vcluster-and-kubeflow-tutorial"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/configure/vcluster-yaml/policies/admission-control"
+        - "https://www.vcluster.com/docs/vcluster/0.32.0/integrations/external-secrets-operator"
+        - "https://www.vcluster.com/blog/deploying-machine-learning-models-on-kubernetes-with-vcluster-tutorial"
+        - "https://www.vcluster.com/docs/platform/integrations/certified-stacks"
+      notes: "vCluster has a complete tutorial deploying Kubeflow Pipelines v2.0.1 inside a virtual cluster, demonstrating: CRD installation (applications.app.k8s.io), operator pods running, and custom resource reconciliation. KServe (InferenceService CRD) is demonstrated inside vCluster in the ML models tutorial with inference endpoints verified. Regarding webhooks: vCluster's admission-control documentation explicitly states that 'a user can still install a webhook service or webhook configuration into the virtual cluster outside of this config, and it would run inside the virtual cluster like any other workload' — confirming that operator ValidatingWebhookConfiguration and MutatingWebhookConfiguration resources are fully supported inside vCluster's API server. The External Secrets Operator integration (with its webhook component, externalSecrets.webhook) is a documented example of an operator with webhooks running successfully inside vCluster. The Certified Stacks documentation demonstrates certified AI platforms (NVIDIA Run:ai, Slinky/Slurm) running successfully inside vCluster with Private Nodes, confirming robust operator support for production AI workloads. With Private Nodes, operator pods run on dedicated physical nodes with full resource access — no host-level CRD or webhook proxying required, unlike the Shared Nodes model where operator webhook endpoints must be reachable from the host API server."

--- a/ai-conformance/v1.35/vcluster-private-nodes/README.md
+++ b/ai-conformance/v1.35/vcluster-private-nodes/README.md
@@ -1,0 +1,43 @@
+# vCluster AI Conformance — v1.35 (Private Nodes)
+
+CNCF Kubernetes AI Platform Conformance submission for vCluster with Private Nodes.
+
+- **Kubernetes version:** v1.35
+- **Platform version:** v0.32.0
+- **Submission:** https://github.com/cncf/k8s-ai-conformance/tree/main/v1.35/vcluster-private-nodes
+- **k8s-conformance baseline:** https://github.com/cncf/k8s-conformance/tree/master/v1.35/vcluster-with-private-nodes
+
+## What is vCluster with Private Nodes?
+
+Private Nodes attach real physical Kubernetes nodes exclusively to a virtual cluster.
+This gives the vCluster dedicated GPU hardware for AI/ML workloads with node-level isolation —
+no other workload on the host cluster can schedule onto those nodes.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `PRODUCT.yaml` | CNCF AI conformance self-assessment — 8 MUST + 3 SHOULD items with evidence |
+| `README.md` | This file |
+
+## Conformance requirements covered
+
+| Category | Requirement | Level | Status |
+|----------|-------------|-------|--------|
+| Accelerators | DRA support (ResourceClaim, DeviceClass) | MUST | Implemented |
+| Accelerators | Driver & runtime management (NVIDIA GPU Operator) | SHOULD | Implemented |
+| Accelerators | GPU sharing (MIG, time-slicing) | SHOULD | Implemented |
+| Accelerators | Virtualized accelerators (vGPU) | SHOULD | Implemented |
+| Networking | Gateway API for AI inference traffic management | MUST | Implemented |
+| Scheduling | Gang scheduling (Volcano, NVIDIA KAI) | MUST | Implemented |
+| Scheduling | Cluster autoscaling with GPU node groups (Auto Nodes) | MUST | Implemented |
+| Scheduling | HPA with GPU custom metrics (DCGM + Prometheus Adapter) | MUST | Implemented |
+| Observability | Accelerator metrics (DCGM-Exporter, OTel) | MUST | Implemented |
+| Observability | AI service metrics (Prometheus discovery) | MUST | Implemented |
+| Security | Secure accelerator access (node-level + DRA isolation) | MUST | Implemented |
+| Operators | AI CRD operators (Kubeflow, KServe, webhooks) | MUST | Implemented |
+
+## Re-certification
+
+Run `/k8s-ai-conformance-research` annually when a new Kubernetes minor version is released
+to check for spec changes and dead evidence URLs before updating for the next cycle.


### PR DESCRIPTION
**What issue type does this pull request address?**

/kind documentation

**Please provide a short message that should be published in the vcluster release notes**

Adds reference copies of the CNCF Kubernetes AI Platform Conformance submissions for vCluster with Private Nodes (v1.34 and v1.35) under `ai-conformance/`.

**What else do we need to know?**

Both CNCF submissions are now merged:

- k8s v1.34 → https://github.com/cncf/k8s-ai-conformance/pull/82
- k8s v1.35 → https://github.com/cncf/k8s-ai-conformance/pull/83

Each `PRODUCT.yaml` in this PR is byte-identical to the corresponding merged CNCF submission, kept here as an in-repo reference alongside a short `README.md` per version.

Supersedes #3735 (which covered only v1.34); that PR is being closed in favor of this single combined one.

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, API, or security behavior changes.
> 
> **Overview**
> Adds in-repo reference copies of the merged **CNCF Kubernetes AI Platform Conformance** submissions for **vCluster with Private Nodes** at Kubernetes **v1.34** and **v1.35**, under `ai-conformance/`.
> 
> Each version gets a **`PRODUCT.yaml`** (byte-identical to the upstream CNCF submission) and a short **`README.md`** with submission links, a requirements checklist, and re-certification notes. The v1.34 bundle documents **8 MUST** items; v1.35 adds **three SHOULD** accelerator items (driver/runtime management, GPU sharing, virtualized accelerators) and updates metadata/evidence for the v1.35 spec (e.g. `k8sConformanceUrl` path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5d39e7460ad909c73f7b176bb1b3c2c02e346f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->