### PR TITLE
feat(snapshot): add etcd snapshot to kv conversion for external db migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.etcd.io/etcd/etcdutl/v3 v3.6.8
+	go.etcd.io/etcd/pkg/v3 v3.6.8
 	go.etcd.io/etcd/server/v3 v3.6.8
 	go.uber.org/atomic v1.11.0
 	golang.org/x/mod v0.35.0
@@ -176,7 +177,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
-	go.etcd.io/etcd/pkg/v3 v3.6.8 // indirect
 	go.etcd.io/raft/v3 v3.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
@@ -213,7 +213,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-semver v0.3.1
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/evanphx/json-patch v5.8.1+incompatible

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	Compact(ctx context.Context, revision int64) error
 	Close() error
 	SnapshotWithVersion(ctx context.Context) (*clientv3.SnapshotResponse, error)
+	CurrentRevision(ctx context.Context) (int64, error)
 }
 
 type client struct {
@@ -179,6 +180,24 @@ func listStream(
 	}()
 
 	return retChan
+}
+
+func (c *client) CurrentRevision(ctx context.Context) (int64, error) {
+	return currentRevision(ctx, c.c.Get)
+}
+
+// currentRevision reads the store's current revision off a response header,
+// without transferring any key data (WithCountOnly).
+func currentRevision(
+	ctx context.Context,
+	getFn func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error),
+) (int64, error) {
+	resp, err := getFn(ctx, "/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+	if err != nil {
+		return 0, err
+	}
+
+	return resp.Header.Revision, nil
 }
 
 func (c *client) Compact(ctx context.Context, revision int64) error {

--- a/pkg/etcd/client_test.go
+++ b/pkg/etcd/client_test.go
@@ -197,6 +197,39 @@ func TestListStream_ErrorAfterFirstPage(t *testing.T) {
 	assert.Equal(t, 2, callCount, "error on second page should stop pagination")
 }
 
+// This test verifies CurrentRevision reads the revision off the response header
+// without requiring any keys to be returned.
+func TestCurrentRevision(t *testing.T) {
+	t.Parallel()
+
+	const wantRev = int64(4242)
+
+	var gotOp clientv3.Op
+	get := func(_ context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+		gotOp = clientv3.OpGet(key, opts...)
+		return &clientv3.GetResponse{
+			Header: &etcdserverpb.ResponseHeader{Revision: wantRev},
+		}, nil
+	}
+
+	gotRev, err := currentRevision(context.Background(), get)
+	assert.NilError(t, err)
+	assert.Equal(t, wantRev, gotRev)
+	assert.Assert(t, gotOp.IsCountOnly(), "current-revision read must not transfer key data")
+}
+
+func TestCurrentRevision_Error(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	get := func(_ context.Context, _ string, _ ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+		return nil, sentinel
+	}
+
+	_, err := currentRevision(context.Background(), get)
+	assert.ErrorIs(t, err, sentinel)
+}
+
 func makeKVs(prefix string, start, end int, modRevStart int64) []*mvccpb.KeyValue {
 	kvs := make([]*mvccpb.KeyValue, 0, end-start)
 	for i := start; i < end; i++ {

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -269,7 +269,9 @@ func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Clie
 		}
 	}()
 
-	// pin the revision before listing so it reflects the state being snapshotted
+	// pin a revision before listing; this is a lower bound on the state being
+	// snapshotted, since CurrentRevision and ListStream are separate etcd
+	// reads and a write landing between them isn't reflected here
 	revision, err := etcdClient.CurrentRevision(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current revision: %w", err)

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -243,17 +243,30 @@ func (c *Client) writeEtcdSnapshot(ctx context.Context, etcdClient etcd.Client, 
 	return nil
 }
 
-func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Client, objectStore types.Storage) error {
+// writeKeyValueSnapshot streams etcd key/value pairs into objectStore as a
+// gzipped tar archive. err is a named return so the deferred cleanup below
+// can abort the in-flight upload with the real failure (instead of a clean
+// EOF that would look like a successful, truncated upload) on every early
+// return, and always drain the upload goroutine's result.
+func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Client, objectStore types.Storage) (err error) {
 	// now stream objects from etcd to object store
-	errChan := make(chan error)
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		return fmt.Errorf("failed to create pipe: %w", err)
-	}
-	defer writer.Close()
+	errChan := make(chan error, 1)
+	reader, writer := io.Pipe()
 	go func() {
 		defer reader.Close()
 		errChan <- objectStore.PutObject(ctx, reader)
+	}()
+	// uploadResultReceived tracks whether the select loop below already
+	// consumed errChan's single buffered value, so the cleanup defer never
+	// tries to receive from it a second time (which would block forever).
+	uploadResultReceived := false
+	defer func() {
+		_ = writer.CloseWithError(err)
+		if !uploadResultReceived {
+			if uploadErr := <-errChan; uploadErr != nil && err == nil {
+				err = fmt.Errorf("failed to write snapshot: %w", uploadErr)
+			}
+		}
 	}()
 
 	// pin the revision before listing so it reflects the state being snapshotted
@@ -311,9 +324,10 @@ func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Clie
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context: %w", ctx.Err())
-		case err := <-errChan:
-			if err != nil {
-				return fmt.Errorf("failed to write snapshot: %w", err)
+		case uploadErr := <-errChan:
+			uploadResultReceived = true
+			if uploadErr != nil {
+				return fmt.Errorf("failed to write snapshot: %w", uploadErr)
 			}
 			return nil
 		case obj := <-listChan:
@@ -343,11 +357,11 @@ func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Clie
 			} else {
 				klog.Infof("Successfully backed up %d etcd keys", backedUpKeys)
 
-				// close the writer to signal we are done, but wait until object store has finished writing
+				// flush the archive; the deferred cleanup closes the pipe
+				// writer and waits for the upload to finish
 				_ = tarWriter.Close()
 				_ = gzipWriter.Close()
-				_ = writer.Close()
-				return <-errChan
+				return nil
 			}
 		}
 	}

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
 	"github.com/loft-sh/api/v4/pkg/snapshot/storage/types"
@@ -29,6 +30,9 @@ const (
 	RequestStoreKey  = "/vcluster/snapshot/request"
 	DBStoreKey       = "/vcluster/snapshot/db"
 	SkipKeysStoreKey = "/vcluster/snapshot/skipkeys"
+	// RevisionStoreKey holds the backing store's revision at the time the
+	// snapshot was taken (decimal-encoded int64).
+	RevisionStoreKey = "/vcluster/snapshot/revision"
 )
 
 type Client struct {
@@ -252,6 +256,12 @@ func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Clie
 		errChan <- objectStore.PutObject(ctx, reader)
 	}()
 
+	// pin the revision before listing so it reflects the state being snapshotted
+	revision, err := etcdClient.CurrentRevision(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current revision: %w", err)
+	}
+
 	// start listing the keys
 	listChan := etcdClient.ListStream(ctx, "/")
 
@@ -287,6 +297,12 @@ func (c *Client) writeKeyValueSnapshot(ctx context.Context, etcdClient etcd.Clie
 		if err != nil {
 			return fmt.Errorf("failed to snapshot request: %w", err)
 		}
+	}
+
+	// write the pinned revision
+	err = writeArchiveEntry(tarWriter, []byte(RevisionStoreKey), []byte(strconv.FormatInt(revision, 10)))
+	if err != nil {
+		return fmt.Errorf("failed to snapshot revision: %w", err)
 	}
 
 	// now write the snapshot

--- a/pkg/snapshot/client_test.go
+++ b/pkg/snapshot/client_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
 	"github.com/loft-sh/api/v4/pkg/snapshot/storage/container"
@@ -20,6 +22,7 @@ type fakeEtcdClient struct {
 	revision    int64
 	revisionErr error
 	values      []etcd.Value
+	listErr     error
 }
 
 func (f *fakeEtcdClient) CurrentRevision(context.Context) (int64, error) {
@@ -27,9 +30,12 @@ func (f *fakeEtcdClient) CurrentRevision(context.Context) (int64, error) {
 }
 
 func (f *fakeEtcdClient) ListStream(context.Context, string) <-chan *etcd.ValueOrError {
-	ch := make(chan *etcd.ValueOrError, len(f.values))
+	ch := make(chan *etcd.ValueOrError, len(f.values)+1)
 	for _, v := range f.values {
 		ch <- &etcd.ValueOrError{Value: v}
+	}
+	if f.listErr != nil {
+		ch <- &etcd.ValueOrError{Error: f.listErr}
 	}
 	close(ch)
 	return ch
@@ -106,5 +112,59 @@ func TestWriteKeyValueSnapshot_CurrentRevisionError(t *testing.T) {
 	err := c.writeKeyValueSnapshot(context.Background(), fake, objectStore)
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("expected CurrentRevision error to propagate, got: %v", err)
+	}
+}
+
+func TestWriteKeyValueSnapshot_ListStreamError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	fake := &fakeEtcdClient{
+		revision: 1,
+		values:   []etcd.Value{{Key: []byte("/registry/a"), Data: []byte("va1")}},
+		listErr:  sentinel,
+	}
+
+	storePath := filepath.Join(t.TempDir(), "snapshot.tar.gz")
+	objectStore := container.NewStore(&snapshotapi.ContainerOptions{Path: storePath})
+
+	c := &Client{}
+	err := c.writeKeyValueSnapshot(context.Background(), fake, objectStore)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected ListStream error to propagate, got: %v", err)
+	}
+}
+
+// TestWriteKeyValueSnapshot_NoGoroutineLeakOnEarlyError guards against the
+// upload goroutine blocking forever on an unbuffered errChan send when
+// writeKeyValueSnapshot returns early (e.g. before etcd is even listed).
+// Deliberately not run in parallel with other tests: it compares
+// process-wide goroutine counts and needs a quiet baseline to be reliable.
+func TestWriteKeyValueSnapshot_NoGoroutineLeakOnEarlyError(t *testing.T) {
+	sentinel := errors.New("boom")
+	fake := &fakeEtcdClient{revisionErr: sentinel}
+
+	storePath := filepath.Join(t.TempDir(), "snapshot.tar.gz")
+	objectStore := container.NewStore(&snapshotapi.ContainerOptions{Path: storePath})
+
+	c := &Client{}
+
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	if err := c.writeKeyValueSnapshot(context.Background(), fake, objectStore); !errors.Is(err, sentinel) {
+		t.Fatalf("expected CurrentRevision error to propagate, got: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		after := runtime.NumGoroutine()
+		if after <= before {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("upload goroutine appears leaked: goroutines before=%d, after=%d", before, after)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/pkg/snapshot/client_test.go
+++ b/pkg/snapshot/client_test.go
@@ -1,0 +1,110 @@
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	"github.com/loft-sh/api/v4/pkg/snapshot/storage/container"
+	"github.com/loft-sh/vcluster/pkg/etcd"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// fakeEtcdClient is a minimal etcd.Client fake for testing code that only
+// needs a handful of methods - unimplemented methods panic if called, so a
+// test that exercises them accidentally fails loudly instead of silently
+// returning zero values.
+type fakeEtcdClient struct {
+	revision    int64
+	revisionErr error
+	values      []etcd.Value
+}
+
+func (f *fakeEtcdClient) CurrentRevision(context.Context) (int64, error) {
+	return f.revision, f.revisionErr
+}
+
+func (f *fakeEtcdClient) ListStream(context.Context, string) <-chan *etcd.ValueOrError {
+	ch := make(chan *etcd.ValueOrError, len(f.values))
+	for _, v := range f.values {
+		ch <- &etcd.ValueOrError{Value: v}
+	}
+	close(ch)
+	return ch
+}
+
+func (f *fakeEtcdClient) List(context.Context, string) ([]etcd.Value, error) {
+	panic("not implemented")
+}
+func (f *fakeEtcdClient) Watch(context.Context, string) clientv3.WatchChan { panic("not implemented") }
+func (f *fakeEtcdClient) Get(context.Context, string) (etcd.Value, error) {
+	panic("not implemented")
+}
+func (f *fakeEtcdClient) Put(context.Context, string, []byte) (int64, error) {
+	panic("not implemented")
+}
+func (f *fakeEtcdClient) PutAtRevision(context.Context, string, int64, []byte) (int64, error) {
+	panic("not implemented")
+}
+func (f *fakeEtcdClient) Delete(context.Context, string) error       { panic("not implemented") }
+func (f *fakeEtcdClient) DeletePrefix(context.Context, string) error { panic("not implemented") }
+func (f *fakeEtcdClient) Compact(context.Context, int64) error       { panic("not implemented") }
+func (f *fakeEtcdClient) Close() error                               { return nil }
+func (f *fakeEtcdClient) SnapshotWithVersion(context.Context) (*clientv3.SnapshotResponse, error) {
+	panic("not implemented")
+}
+
+func TestWriteKeyValueSnapshot_WritesRevision(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeEtcdClient{
+		revision: 4242,
+		values: []etcd.Value{
+			{Key: []byte("/registry/a"), Data: []byte("va1")},
+			{Key: []byte("/registry/b"), Data: []byte("vb1")},
+		},
+	}
+
+	storePath := filepath.Join(t.TempDir(), "snapshot.tar.gz")
+	objectStore := container.NewStore(&snapshotapi.ContainerOptions{Path: storePath})
+
+	c := &Client{}
+	if err := c.writeKeyValueSnapshot(context.Background(), fake, objectStore); err != nil {
+		t.Fatalf("writeKeyValueSnapshot failed: %v", err)
+	}
+
+	entries := readAllArchiveEntries(t, storePath)
+
+	revBytes, ok := entries[RevisionStoreKey]
+	if !ok {
+		t.Fatal("expected a RevisionStoreKey entry")
+	}
+	if string(revBytes) != "4242" {
+		t.Errorf("expected revision 4242, got %q", revBytes)
+	}
+
+	if string(entries["/registry/a"]) != "va1" {
+		t.Errorf("expected /registry/a=va1, got %q", entries["/registry/a"])
+	}
+	if string(entries["/registry/b"]) != "vb1" {
+		t.Errorf("expected /registry/b=vb1, got %q", entries["/registry/b"])
+	}
+}
+
+func TestWriteKeyValueSnapshot_CurrentRevisionError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("boom")
+	fake := &fakeEtcdClient{revisionErr: sentinel}
+
+	storePath := filepath.Join(t.TempDir(), "snapshot.tar.gz")
+	objectStore := container.NewStore(&snapshotapi.ContainerOptions{Path: storePath})
+
+	c := &Client{}
+	err := c.writeKeyValueSnapshot(context.Background(), fake, objectStore)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected CurrentRevision error to propagate, got: %v", err)
+	}
+}

--- a/pkg/snapshot/convert.go
+++ b/pkg/snapshot/convert.go
@@ -55,17 +55,17 @@ func ConvertEtcdSnapshotToKeyValueSnapshot(ctx context.Context, tempDir string, 
 		return fmt.Errorf("source snapshot is not an etcd snapshot (kind: %s)", kind)
 	}
 
-	dbPath, releaseBytes, requestKey, requestBytes, skipKeys, err := parseEtcdSnapshotArchive(srcPath, tempDir)
+	parsed, err := parseEtcdSnapshotArchive(srcPath, tempDir)
 	if err != nil {
 		return err
 	}
-	defer os.Remove(dbPath)
+	defer os.Remove(parsed.DBPath)
 
 	lg := zap.NewNop()
 
 	// the snapshot's own recorded revision - captured for parity with live KV
 	// snapshots; using it as a restore-time floor is separate, later work.
-	status, err := snapshot.NewV3(lg).Status(dbPath)
+	status, err := snapshot.NewV3(lg).Status(parsed.DBPath)
 	if err != nil {
 		return fmt.Errorf("failed to get snapshot status: %w", err)
 	}
@@ -81,7 +81,7 @@ func ConvertEtcdSnapshotToKeyValueSnapshot(ctx context.Context, tempDir string, 
 		scratchPeerURL = "https://127.0.0.1:2380"
 	)
 	if err := snapshot.NewV3(lg).Restore(snapshot.RestoreConfig{
-		SnapshotPath:        dbPath,
+		SnapshotPath:        parsed.DBPath,
 		Name:                scratchName,
 		OutputDataDir:       scratchDir,
 		OutputWALDir:        datadir.ToWALDir(scratchDir),
@@ -117,13 +117,13 @@ func ConvertEtcdSnapshotToKeyValueSnapshot(ctx context.Context, tempDir string, 
 	tarWriter := tar.NewWriter(gzipWriter)
 	defer tarWriter.Close()
 
-	if releaseBytes != nil {
-		if err := writeArchiveEntry(tarWriter, []byte(snapshotapi.SnapshotReleaseKey), releaseBytes); err != nil {
+	if parsed.ReleaseBytes != nil {
+		if err := writeArchiveEntry(tarWriter, []byte(snapshotapi.SnapshotReleaseKey), parsed.ReleaseBytes); err != nil {
 			return fmt.Errorf("failed to write release: %w", err)
 		}
 	}
-	if requestBytes != nil {
-		if err := writeArchiveEntry(tarWriter, []byte(requestKey), requestBytes); err != nil {
+	if parsed.RequestBytes != nil {
+		if err := writeArchiveEntry(tarWriter, []byte(parsed.RequestKey), parsed.RequestBytes); err != nil {
 			return fmt.Errorf("failed to write request: %w", err)
 		}
 	}
@@ -131,7 +131,7 @@ func ConvertEtcdSnapshotToKeyValueSnapshot(ctx context.Context, tempDir string, 
 		return fmt.Errorf("failed to write revision: %w", err)
 	}
 
-	if err := writeLiveKeyValues(ctx, tarWriter, store, skipKeys); err != nil {
+	if err := writeLiveKeyValues(ctx, tarWriter, store, parsed.SkipKeys); err != nil {
 		return err
 	}
 
@@ -145,24 +145,35 @@ func ConvertEtcdSnapshotToKeyValueSnapshot(ctx context.Context, tempDir string, 
 	return nil
 }
 
+// parsedEtcdSnapshotArchive is the result of parseEtcdSnapshotArchive. DBPath
+// names a temp file under the caller-supplied tempDir - the caller must
+// remove it.
+type parsedEtcdSnapshotArchive struct {
+	DBPath       string
+	ReleaseBytes []byte
+	RequestKey   string
+	RequestBytes []byte
+	SkipKeys     map[string]struct{}
+}
+
 // parseEtcdSnapshotArchive extracts the raw etcd db file (to a temp file under
 // tempDir - caller must remove it), the optional release/request passthrough
 // entries, and the optional skip-keys set from an EtcdSnapshotKind archive.
-func parseEtcdSnapshotArchive(srcPath, tempDir string) (dbPath string, releaseBytes []byte, requestKey string, requestBytes []byte, skipKeys map[string]struct{}, err error) {
+func parseEtcdSnapshotArchive(srcPath, tempDir string) (result parsedEtcdSnapshotArchive, err error) {
 	reader, err := os.Open(srcPath)
 	if err != nil {
-		return "", nil, "", nil, nil, fmt.Errorf("failed to open source snapshot: %w", err)
+		return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to open source snapshot: %w", err)
 	}
 	defer reader.Close()
 
 	gzipReader, err := gzip.NewReader(reader)
 	if err != nil {
-		return "", nil, "", nil, nil, fmt.Errorf("failed to create gzip reader: %w", err)
+		return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to create gzip reader: %w", err)
 	}
 	defer gzipReader.Close()
 
-	// dbFile tracks the temp file written for DBStoreKey independently of the
-	// named dbPath return, which every error path below blanks to "" - without
+	// dbFile tracks the temp file written for DBStoreKey independently of
+	// result.DBPath, which every error path below leaves unset - without
 	// this, a failure on a later tar entry would lose the path to a file that
 	// already exists on disk, leaking it.
 	var dbFile string
@@ -179,43 +190,44 @@ func parseEtcdSnapshotArchive(srcPath, tempDir string) (dbPath string, releaseBy
 			if errors.Is(nextErr, io.EOF) {
 				break
 			}
-			return "", nil, "", nil, nil, fmt.Errorf("failed to read tar header: %w", nextErr)
+			return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to read tar header: %w", nextErr)
 		}
 
 		switch {
 		case header.Name == snapshotapi.SnapshotReleaseKey:
-			releaseBytes, err = io.ReadAll(tarReader)
+			result.ReleaseBytes, err = io.ReadAll(tarReader)
 			if err != nil {
-				return "", nil, "", nil, nil, fmt.Errorf("failed to read release: %w", err)
+				return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to read release: %w", err)
 			}
 		case strings.HasPrefix(header.Name, RequestStoreKey):
-			requestKey = header.Name
-			requestBytes, err = io.ReadAll(tarReader)
+			result.RequestKey = header.Name
+			result.RequestBytes, err = io.ReadAll(tarReader)
 			if err != nil {
-				return "", nil, "", nil, nil, fmt.Errorf("failed to read request: %w", err)
+				return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to read request: %w", err)
 			}
 		case header.Name == DBStoreKey:
 			dbFile, err = writeTempFile(tempDir, tarReader)
 			if err != nil {
-				return "", nil, "", nil, nil, fmt.Errorf("failed to write etcd snapshot to temp file: %w", err)
+				return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to write etcd snapshot to temp file: %w", err)
 			}
 		case header.Name == SkipKeysStoreKey:
 			skipKeysBytes, readErr := io.ReadAll(tarReader)
 			if readErr != nil {
-				return "", nil, "", nil, nil, fmt.Errorf("failed to read skipKeys: %w", readErr)
+				return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to read skipKeys: %w", readErr)
 			}
-			skipKeys = make(map[string]struct{})
-			if err := json.Unmarshal(skipKeysBytes, &skipKeys); err != nil {
-				return "", nil, "", nil, nil, fmt.Errorf("failed to unmarshal skipKeys: %w", err)
+			result.SkipKeys = make(map[string]struct{})
+			if err := json.Unmarshal(skipKeysBytes, &result.SkipKeys); err != nil {
+				return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to unmarshal skipKeys: %w", err)
 			}
 		}
 	}
 
 	if dbFile == "" {
-		return "", nil, "", nil, nil, fmt.Errorf("failed to find etcd snapshot in source archive")
+		return parsedEtcdSnapshotArchive{}, fmt.Errorf("failed to find etcd snapshot in source archive")
 	}
 
-	return dbFile, releaseBytes, requestKey, requestBytes, skipKeys, nil
+	result.DBPath = dbFile
+	return result, nil
 }
 
 // writeLiveKeyValues pages through every live key/value in store (tombstoned/

--- a/pkg/snapshot/convert.go
+++ b/pkg/snapshot/convert.go
@@ -1,0 +1,246 @@
+package snapshot
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/go-semver/semver"
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/etcd"
+	"go.etcd.io/etcd/etcdutl/v3/snapshot"
+	"go.etcd.io/etcd/pkg/v3/traceutil"
+	"go.etcd.io/etcd/server/v3/lease"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/datadir"
+	"go.etcd.io/etcd/server/v3/storage/mvcc"
+	"go.uber.org/zap"
+)
+
+// noopCluster satisfies lease.Lessor's unexported cluster dependency for a
+// throwaway lessor that never actually joins a cluster or checkpoints leases.
+type noopCluster struct{}
+
+func (noopCluster) Version() *semver.Version { return &semver.Version{Major: 3, Minor: 6} }
+
+// ConvertEtcdSnapshotToKeyValueSnapshot reads a raw etcd binary snapshot
+// archive (EtcdSnapshotKind, as produced for an embedded-etcd backing store)
+// and writes an equivalent KeyValueSnapshotKind archive to dst. This lets a
+// snapshot taken from an embedded-etcd tenant cluster be restored into a
+// backing store that only supports KV-style restore (external database,
+// deployed/external etcd) - e.g. migrating a tenant cluster from embedded
+// etcd to an external database.
+//
+// The raw snapshot is decoded by restoring it into a scratch data directory
+// (never the real one) and reading the resulting bbolt file directly through
+// the etcd MVCC engine - no etcd server, ports, or exec'd binary involved.
+func ConvertEtcdSnapshotToKeyValueSnapshot(ctx context.Context, tempDir string, src io.Reader, dst io.Writer) error {
+	srcPath, err := writeTempFile(tempDir, src)
+	if err != nil {
+		return fmt.Errorf("failed to write source snapshot to temp file: %w", err)
+	}
+	defer os.Remove(srcPath)
+
+	kind, err := getSnapshotArchiveKind(srcPath)
+	if err != nil {
+		return fmt.Errorf("failed to determine snapshot archive kind: %w", err)
+	} else if kind != EtcdSnapshotKind {
+		return fmt.Errorf("source snapshot is not an etcd snapshot (kind: %s)", kind)
+	}
+
+	dbPath, releaseBytes, requestKey, requestBytes, skipKeys, err := parseEtcdSnapshotArchive(srcPath, tempDir)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(dbPath)
+
+	lg := zap.NewNop()
+
+	// the snapshot's own recorded revision - captured for parity with live KV
+	// snapshots; using it as a restore-time floor is separate, later work.
+	status, err := snapshot.NewV3(lg).Status(dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot status: %w", err)
+	}
+
+	scratchDir, err := os.MkdirTemp(tempDir, "convert-etcd-")
+	if err != nil {
+		return fmt.Errorf("failed to create scratch directory: %w", err)
+	}
+	defer os.RemoveAll(scratchDir)
+
+	const (
+		scratchName    = "convert"
+		scratchPeerURL = "https://127.0.0.1:2380"
+	)
+	if err := snapshot.NewV3(lg).Restore(snapshot.RestoreConfig{
+		SnapshotPath:        dbPath,
+		Name:                scratchName,
+		OutputDataDir:       scratchDir,
+		OutputWALDir:        datadir.ToWALDir(scratchDir),
+		PeerURLs:            []string{scratchPeerURL},
+		InitialCluster:      scratchName + "=" + scratchPeerURL,
+		InitialClusterToken: "vcluster-convert",
+		// Snapshots taken via etcdClient.SnapshotWithVersion (vcluster's own
+		// "vcluster snapshot create") never carry the sha256 trailer that
+		// etcdctl's separate "snapshot save" CLI path appends - requiring one
+		// here would reject the primary input this tool exists to handle.
+		// Status() above already performs a full bbolt structural integrity
+		// check independent of this trailer.
+		SkipHashCheck: true,
+	}); err != nil {
+		return fmt.Errorf("failed to restore etcd snapshot into scratch directory: %w", err)
+	}
+
+	be := backend.NewDefaultBackend(lg, datadir.ToBackendFileName(scratchDir))
+	defer be.Close()
+
+	lessor := lease.NewLessor(lg, be, noopCluster{}, lease.LessorConfig{MinLeaseTTL: 60})
+	defer lessor.Stop()
+
+	store := mvcc.New(lg, be, lessor, mvcc.StoreConfig{})
+	defer store.Close()
+
+	gzipWriter, err := gzip.NewWriterLevel(dst, 3)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip writer: %w", err)
+	}
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	if releaseBytes != nil {
+		if err := writeArchiveEntry(tarWriter, []byte(snapshotapi.SnapshotReleaseKey), releaseBytes); err != nil {
+			return fmt.Errorf("failed to write release: %w", err)
+		}
+	}
+	if requestBytes != nil {
+		if err := writeArchiveEntry(tarWriter, []byte(requestKey), requestBytes); err != nil {
+			return fmt.Errorf("failed to write request: %w", err)
+		}
+	}
+	if err := writeArchiveEntry(tarWriter, []byte(RevisionStoreKey), []byte(strconv.FormatInt(status.Revision, 10))); err != nil {
+		return fmt.Errorf("failed to write revision: %w", err)
+	}
+
+	if err := writeLiveKeyValues(ctx, tarWriter, store, skipKeys); err != nil {
+		return err
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close tar writer: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	return nil
+}
+
+// parseEtcdSnapshotArchive extracts the raw etcd db file (to a temp file under
+// tempDir - caller must remove it), the optional release/request passthrough
+// entries, and the optional skip-keys set from an EtcdSnapshotKind archive.
+func parseEtcdSnapshotArchive(srcPath, tempDir string) (dbPath string, releaseBytes []byte, requestKey string, requestBytes []byte, skipKeys map[string]struct{}, err error) {
+	reader, err := os.Open(srcPath)
+	if err != nil {
+		return "", nil, "", nil, nil, fmt.Errorf("failed to open source snapshot: %w", err)
+	}
+	defer reader.Close()
+
+	gzipReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return "", nil, "", nil, nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, nextErr := tarReader.Next()
+		if nextErr != nil {
+			if errors.Is(nextErr, io.EOF) {
+				break
+			}
+			return "", nil, "", nil, nil, fmt.Errorf("failed to read tar header: %w", nextErr)
+		}
+
+		switch {
+		case header.Name == snapshotapi.SnapshotReleaseKey:
+			releaseBytes, err = io.ReadAll(tarReader)
+			if err != nil {
+				return "", nil, "", nil, nil, fmt.Errorf("failed to read release: %w", err)
+			}
+		case strings.HasPrefix(header.Name, RequestStoreKey):
+			requestKey = header.Name
+			requestBytes, err = io.ReadAll(tarReader)
+			if err != nil {
+				return "", nil, "", nil, nil, fmt.Errorf("failed to read request: %w", err)
+			}
+		case header.Name == DBStoreKey:
+			dbPath, err = writeTempFile(tempDir, tarReader)
+			if err != nil {
+				return "", nil, "", nil, nil, fmt.Errorf("failed to write etcd snapshot to temp file: %w", err)
+			}
+		case header.Name == SkipKeysStoreKey:
+			skipKeysBytes, readErr := io.ReadAll(tarReader)
+			if readErr != nil {
+				return "", nil, "", nil, nil, fmt.Errorf("failed to read skipKeys: %w", readErr)
+			}
+			skipKeys = make(map[string]struct{})
+			if err := json.Unmarshal(skipKeysBytes, &skipKeys); err != nil {
+				return "", nil, "", nil, nil, fmt.Errorf("failed to unmarshal skipKeys: %w", err)
+			}
+		}
+	}
+
+	if dbPath == "" {
+		return "", nil, "", nil, nil, fmt.Errorf("failed to find etcd snapshot in source archive")
+	}
+
+	return dbPath, releaseBytes, requestKey, requestBytes, skipKeys, nil
+}
+
+// writeLiveKeyValues pages through every live key/value in store (tombstoned/
+// superseded revisions already resolved away by the MVCC engine) and writes
+// each one not present in skipKeys into tarWriter, mirroring how
+// writeKeyValueSnapshot streams a live cluster's keys.
+func writeLiveKeyValues(ctx context.Context, tarWriter *tar.Writer, store mvcc.KV, skipKeys map[string]struct{}) error {
+	startKey := []byte{0}
+	var pinnedRev int64
+
+	for {
+		txn := store.Read(mvcc.ConcurrentReadTxMode, traceutil.TODO())
+		result, err := txn.Range(ctx, startKey, []byte{}, mvcc.RangeOptions{
+			Limit: etcd.EtcdPaginationLimit,
+			Rev:   pinnedRev,
+		})
+		txn.End()
+		if err != nil {
+			return fmt.Errorf("failed to range over restored keys: %w", err)
+		}
+		if pinnedRev == 0 {
+			pinnedRev = result.Rev
+		}
+
+		for _, kv := range result.KVs {
+			if _, ok := skipKeys[string(kv.Key)]; ok {
+				continue
+			}
+			if err := writeArchiveEntry(tarWriter, kv.Key, kv.Value); err != nil {
+				return fmt.Errorf("failed to write key %s: %w", kv.Key, err)
+			}
+		}
+
+		if len(result.KVs) < etcd.EtcdPaginationLimit {
+			return nil
+		}
+		startKey = append(append([]byte{}, result.KVs[len(result.KVs)-1].Key...), 0x00)
+	}
+}

--- a/pkg/snapshot/convert.go
+++ b/pkg/snapshot/convert.go
@@ -161,6 +161,17 @@ func parseEtcdSnapshotArchive(srcPath, tempDir string) (dbPath string, releaseBy
 	}
 	defer gzipReader.Close()
 
+	// dbFile tracks the temp file written for DBStoreKey independently of the
+	// named dbPath return, which every error path below blanks to "" - without
+	// this, a failure on a later tar entry would lose the path to a file that
+	// already exists on disk, leaking it.
+	var dbFile string
+	defer func() {
+		if err != nil && dbFile != "" {
+			_ = os.Remove(dbFile)
+		}
+	}()
+
 	tarReader := tar.NewReader(gzipReader)
 	for {
 		header, nextErr := tarReader.Next()
@@ -184,7 +195,7 @@ func parseEtcdSnapshotArchive(srcPath, tempDir string) (dbPath string, releaseBy
 				return "", nil, "", nil, nil, fmt.Errorf("failed to read request: %w", err)
 			}
 		case header.Name == DBStoreKey:
-			dbPath, err = writeTempFile(tempDir, tarReader)
+			dbFile, err = writeTempFile(tempDir, tarReader)
 			if err != nil {
 				return "", nil, "", nil, nil, fmt.Errorf("failed to write etcd snapshot to temp file: %w", err)
 			}
@@ -200,11 +211,11 @@ func parseEtcdSnapshotArchive(srcPath, tempDir string) (dbPath string, releaseBy
 		}
 	}
 
-	if dbPath == "" {
+	if dbFile == "" {
 		return "", nil, "", nil, nil, fmt.Errorf("failed to find etcd snapshot in source archive")
 	}
 
-	return dbPath, releaseBytes, requestKey, requestBytes, skipKeys, nil
+	return dbFile, releaseBytes, requestKey, requestBytes, skipKeys, nil
 }
 
 // writeLiveKeyValues pages through every live key/value in store (tombstoned/

--- a/pkg/snapshot/convert_test.go
+++ b/pkg/snapshot/convert_test.go
@@ -258,7 +258,7 @@ func TestParseEtcdSnapshotArchive_CleansUpDBFileOnLaterError(t *testing.T) {
 	)
 
 	tempDir := t.TempDir()
-	_, _, _, _, _, err := parseEtcdSnapshotArchive(srcPath, tempDir)
+	_, err := parseEtcdSnapshotArchive(srcPath, tempDir)
 	if err == nil {
 		t.Fatal("expected an error from a malformed skipKeys entry")
 	}

--- a/pkg/snapshot/convert_test.go
+++ b/pkg/snapshot/convert_test.go
@@ -7,12 +7,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	"github.com/loft-sh/vcluster/pkg/etcd"
+	"go.etcd.io/etcd/etcdutl/v3/snapshot"
 	"go.etcd.io/etcd/pkg/v3/traceutil"
 	"go.etcd.io/etcd/server/v3/lease"
 	"go.etcd.io/etcd/server/v3/storage/backend"
@@ -121,12 +125,21 @@ func TestConvertEtcdSnapshotToKeyValueSnapshot(t *testing.T) {
 		}
 	}
 
+	wantStatus, err := snapshot.NewV3(zap.NewNop()).Status(writeBytesToTempFile(t, dbBytes))
+	if err != nil {
+		t.Fatalf("failed to get expected snapshot status: %v", err)
+	}
+
 	revBytes, ok := entries[RevisionStoreKey]
 	if !ok {
 		t.Fatal("expected a RevisionStoreKey entry in the output archive")
 	}
-	if string(revBytes) == "" {
-		t.Fatal("expected a non-empty recorded revision")
+	gotRevision, err := strconv.ParseInt(string(revBytes), 10, 64)
+	if err != nil {
+		t.Fatalf("failed to parse recorded revision %q: %v", revBytes, err)
+	}
+	if gotRevision != wantStatus.Revision {
+		t.Errorf("expected recorded revision %d, got %d", wantStatus.Revision, gotRevision)
 	}
 }
 
@@ -226,20 +239,75 @@ func TestConvertEtcdSnapshotToKeyValueSnapshot_AlreadyKeyValueKind(t *testing.T)
 	}
 }
 
-func TestConvertEtcdSnapshotToKeyValueSnapshot_MissingDBStoreKey(t *testing.T) {
+// TestParseEtcdSnapshotArchive_MissingDBStoreKey exercises parseEtcdSnapshotArchive's
+// dbFile == "" sentinel directly. Going through the public
+// ConvertEtcdSnapshotToKeyValueSnapshot entry point can't reach this: any
+// archive lacking DBStoreKey makes getSnapshotArchiveKind return
+// KeyValueSnapshotKind, so the caller's kind != EtcdSnapshotKind guard errors
+// out first - the same path TestConvertEtcdSnapshotToKeyValueSnapshot_AlreadyKeyValueKind
+// already covers.
+func TestParseEtcdSnapshotArchive_MissingDBStoreKey(t *testing.T) {
 	t.Parallel()
 
-	// no DBStoreKey entry at all, but also no ordinary key either - forces
-	// getSnapshotArchiveKind down the EtcdSnapshotKind-only path is not
-	// possible without DBStoreKey, so use a release-only archive to still
-	// exercise the "malformed etcd snapshot" error from parseEtcdSnapshotArchive
-	// by asserting kind detection directly instead.
-	srcBytes := newTestArchiveBytes(t, archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: []byte("{}")})
+	srcPath := newTestArchive(t, archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: []byte("{}")})
 
-	var out bytes.Buffer
-	err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out)
+	_, err := parseEtcdSnapshotArchive(srcPath, t.TempDir())
 	if err == nil {
 		t.Fatal("expected an error for an archive without a DBStoreKey entry")
+	}
+	if !strings.Contains(err.Error(), "failed to find etcd snapshot in source archive") {
+		t.Errorf("expected the missing-db sentinel error, got: %v", err)
+	}
+}
+
+// TestConvertEtcdSnapshotToKeyValueSnapshot_Pagination exercises
+// writeLiveKeyValues' multi-page path: startKey advancement via
+// lastKey+0x00, cross-page pinnedRev pinning, and the exact-limit boundary
+// (len(result.KVs) < etcd.EtcdPaginationLimit) - none of which any
+// single-page test (every other case here seeds a handful of keys) reaches.
+func TestConvertEtcdSnapshotToKeyValueSnapshot_Pagination(t *testing.T) {
+	t.Parallel()
+
+	for _, n := range []int{etcd.EtcdPaginationLimit - 1, etcd.EtcdPaginationLimit, etcd.EtcdPaginationLimit + 1} {
+		t.Run(fmt.Sprintf("%d_keys", n), func(t *testing.T) {
+			t.Parallel()
+
+			ops := make([]struct{ key, value string }, n)
+			for i := range n {
+				key := fmt.Sprintf("/registry/pagination/%05d", i)
+				ops[i] = struct{ key, value string }{key: key, value: key + "-value"}
+			}
+			dbBytes := buildRawEtcdSnapshot(t, ops)
+			srcBytes := newTestArchiveBytes(t, archiveEntry{key: DBStoreKey, value: dbBytes})
+
+			var out bytes.Buffer
+			if err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out); err != nil {
+				t.Fatalf("ConvertEtcdSnapshotToKeyValueSnapshot failed: %v", err)
+			}
+
+			entries := readAllArchiveEntries(t, writeBytesToTempFile(t, out.Bytes()))
+			liveKeys := 0
+			for k := range entries {
+				if k != RevisionStoreKey {
+					liveKeys++
+				}
+			}
+			if liveKeys != n {
+				t.Fatalf("expected %d live keys, got %d", n, liveKeys)
+			}
+			for i := range n {
+				key := fmt.Sprintf("/registry/pagination/%05d", i)
+				want := key + "-value"
+				got, ok := entries[key]
+				if !ok {
+					t.Errorf("missing key %s", key)
+					continue
+				}
+				if string(got) != want {
+					t.Errorf("key %s: expected %q, got %q", key, want, got)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/snapshot/convert_test.go
+++ b/pkg/snapshot/convert_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
@@ -239,6 +240,37 @@ func TestConvertEtcdSnapshotToKeyValueSnapshot_MissingDBStoreKey(t *testing.T) {
 	err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out)
 	if err == nil {
 		t.Fatal("expected an error for an archive without a DBStoreKey entry")
+	}
+}
+
+func TestParseEtcdSnapshotArchive_CleansUpDBFileOnLaterError(t *testing.T) {
+	t.Parallel()
+
+	dbBytes := buildRawEtcdSnapshot(t, []struct{ key, value string }{{"/registry/a", "v1"}})
+
+	// DBStoreKey is written to a temp file successfully, then the malformed
+	// SkipKeysStoreKey entry that follows it fails - this exercises the leak
+	// that used to occur when an error on a later archive entry discarded the
+	// path to the already-written db temp file.
+	srcPath := newTestArchive(t,
+		archiveEntry{key: DBStoreKey, value: dbBytes},
+		archiveEntry{key: SkipKeysStoreKey, value: []byte("not-json")},
+	)
+
+	tempDir := t.TempDir()
+	_, _, _, _, _, err := parseEtcdSnapshotArchive(srcPath, tempDir)
+	if err == nil {
+		t.Fatal("expected an error from a malformed skipKeys entry")
+	}
+
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("failed to read temp dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "snapshot-") {
+			t.Errorf("expected the db temp file to be cleaned up on error, found leaked file %q", e.Name())
+		}
 	}
 }
 

--- a/pkg/snapshot/convert_test.go
+++ b/pkg/snapshot/convert_test.go
@@ -1,0 +1,288 @@
+package snapshot
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	snapshotapi "github.com/loft-sh/api/v4/pkg/snapshot"
+	"go.etcd.io/etcd/pkg/v3/traceutil"
+	"go.etcd.io/etcd/server/v3/lease"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/mvcc"
+	"go.uber.org/zap"
+)
+
+// buildRawEtcdSnapshot creates a real bbolt-backed etcd snapshot file (no
+// server, no ports) with the given key/value pairs applied in order - "" as
+// a value means delete the key - and returns the raw db file bytes, exactly
+// as etcdClient.SnapshotWithVersion would stream them (no hash trailer).
+func buildRawEtcdSnapshot(t *testing.T, ops []struct{ key, value string }) []byte {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := dir + "/db"
+	lg := zap.NewNop()
+
+	func() {
+		be := backend.NewDefaultBackend(lg, path)
+		defer be.Close()
+
+		le := lease.NewLessor(lg, be, noopCluster{}, lease.LessorConfig{MinLeaseTTL: 60})
+		defer le.Stop()
+
+		store := mvcc.New(lg, be, le, mvcc.StoreConfig{})
+		defer store.Close()
+
+		for _, op := range ops {
+			w := store.Write(traceutil.TODO())
+			if op.value == "" {
+				w.DeleteRange([]byte(op.key), nil)
+			} else {
+				w.Put([]byte(op.key), []byte(op.value), lease.NoLease)
+			}
+			w.End()
+		}
+		store.Commit()
+	}()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read raw snapshot file: %v", err)
+	}
+	return data
+}
+
+func newTestArchiveBytes(t *testing.T, entries ...archiveEntry) []byte {
+	t.Helper()
+	path := newTestArchive(t, entries...)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read test archive: %v", err)
+	}
+	return data
+}
+
+func TestConvertEtcdSnapshotToKeyValueSnapshot(t *testing.T) {
+	t.Parallel()
+
+	dbBytes := buildRawEtcdSnapshot(t, []struct{ key, value string }{
+		{"/registry/a", "va1"},
+		{"/registry/b", "vb1"},
+		{"/registry/c", "vc1"},
+		{"/registry/b", ""}, // delete
+		{"/registry/b", "vb2-recreated"},
+	})
+
+	srcBytes := newTestArchiveBytes(t, archiveEntry{key: DBStoreKey, value: dbBytes})
+
+	var out bytes.Buffer
+	err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out)
+	if err != nil {
+		t.Fatalf("ConvertEtcdSnapshotToKeyValueSnapshot failed: %v", err)
+	}
+
+	outPath := writeBytesToTempFile(t, out.Bytes())
+	kind, err := getSnapshotArchiveKind(outPath)
+	if err != nil {
+		t.Fatalf("getSnapshotArchiveKind failed: %v", err)
+	}
+	if kind != KeyValueSnapshotKind {
+		t.Fatalf("expected KeyValueSnapshotKind, got %s", kind)
+	}
+
+	entries := readAllArchiveEntries(t, outPath)
+
+	want := map[string]string{
+		"/registry/a": "va1",
+		"/registry/b": "vb2-recreated",
+		"/registry/c": "vc1",
+	}
+	got := map[string]string{}
+	for k, v := range entries {
+		if k == RevisionStoreKey {
+			continue
+		}
+		got[k] = string(v)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d live keys, got %d: %v", len(want), len(got), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %s: expected %q, got %q", k, v, got[k])
+		}
+	}
+
+	revBytes, ok := entries[RevisionStoreKey]
+	if !ok {
+		t.Fatal("expected a RevisionStoreKey entry in the output archive")
+	}
+	if string(revBytes) == "" {
+		t.Fatal("expected a non-empty recorded revision")
+	}
+}
+
+func TestConvertEtcdSnapshotToKeyValueSnapshot_SkipKeys(t *testing.T) {
+	t.Parallel()
+
+	dbBytes := buildRawEtcdSnapshot(t, []struct{ key, value string }{
+		{"/registry/keep", "v1"},
+		{"/registry/skip", "v2"},
+	})
+
+	skipKeysBytes, err := json.Marshal(map[string]struct{}{"/registry/skip": {}})
+	if err != nil {
+		t.Fatalf("failed to marshal skipKeys: %v", err)
+	}
+
+	srcBytes := newTestArchiveBytes(t,
+		archiveEntry{key: DBStoreKey, value: dbBytes},
+		archiveEntry{key: SkipKeysStoreKey, value: skipKeysBytes},
+	)
+
+	var out bytes.Buffer
+	if err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out); err != nil {
+		t.Fatalf("ConvertEtcdSnapshotToKeyValueSnapshot failed: %v", err)
+	}
+
+	entries := readAllArchiveEntries(t, writeBytesToTempFile(t, out.Bytes()))
+	if _, ok := entries["/registry/skip"]; ok {
+		t.Error("expected /registry/skip to be excluded from the converted archive")
+	}
+	if _, ok := entries["/registry/keep"]; !ok {
+		t.Error("expected /registry/keep to be present in the converted archive")
+	}
+}
+
+func TestConvertEtcdSnapshotToKeyValueSnapshot_ReleaseAndRequestPassthrough(t *testing.T) {
+	t.Parallel()
+
+	dbBytes := buildRawEtcdSnapshot(t, []struct{ key, value string }{{"/registry/a", "v1"}})
+
+	releaseBytes := []byte(`{"name":"my-release"}`)
+	requestKey := RequestStoreKey + "/" + snapshotapi.APIVersion
+	requestBytes := []byte(`{"apiVersion":"v1beta1"}`)
+
+	srcBytes := newTestArchiveBytes(t,
+		archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: releaseBytes},
+		archiveEntry{key: requestKey, value: requestBytes},
+		archiveEntry{key: DBStoreKey, value: dbBytes},
+	)
+
+	var out bytes.Buffer
+	if err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out); err != nil {
+		t.Fatalf("ConvertEtcdSnapshotToKeyValueSnapshot failed: %v", err)
+	}
+
+	entries := readAllArchiveEntries(t, writeBytesToTempFile(t, out.Bytes()))
+	if !bytes.Equal(entries[snapshotapi.SnapshotReleaseKey], releaseBytes) {
+		t.Errorf("release passthrough mismatch: got %q", entries[snapshotapi.SnapshotReleaseKey])
+	}
+	if !bytes.Equal(entries[requestKey], requestBytes) {
+		t.Errorf("request passthrough mismatch: got %q", entries[requestKey])
+	}
+}
+
+func TestConvertEtcdSnapshotToKeyValueSnapshot_EmptyDatabase(t *testing.T) {
+	t.Parallel()
+
+	dbBytes := buildRawEtcdSnapshot(t, nil)
+	srcBytes := newTestArchiveBytes(t, archiveEntry{key: DBStoreKey, value: dbBytes})
+
+	var out bytes.Buffer
+	if err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out); err != nil {
+		t.Fatalf("ConvertEtcdSnapshotToKeyValueSnapshot failed: %v", err)
+	}
+
+	entries := readAllArchiveEntries(t, writeBytesToTempFile(t, out.Bytes()))
+	liveKeys := 0
+	for k := range entries {
+		if k != RevisionStoreKey {
+			liveKeys++
+		}
+	}
+	if liveKeys != 0 {
+		t.Errorf("expected zero live keys for an empty database, got %d: %v", liveKeys, entries)
+	}
+}
+
+func TestConvertEtcdSnapshotToKeyValueSnapshot_AlreadyKeyValueKind(t *testing.T) {
+	t.Parallel()
+
+	srcBytes := newTestArchiveBytes(t, archiveEntry{key: "/registry/pods/default/foo", value: []byte("bar")})
+
+	var out bytes.Buffer
+	err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out)
+	if err == nil {
+		t.Fatal("expected an error when converting an already KeyValueSnapshotKind archive")
+	}
+}
+
+func TestConvertEtcdSnapshotToKeyValueSnapshot_MissingDBStoreKey(t *testing.T) {
+	t.Parallel()
+
+	// no DBStoreKey entry at all, but also no ordinary key either - forces
+	// getSnapshotArchiveKind down the EtcdSnapshotKind-only path is not
+	// possible without DBStoreKey, so use a release-only archive to still
+	// exercise the "malformed etcd snapshot" error from parseEtcdSnapshotArchive
+	// by asserting kind detection directly instead.
+	srcBytes := newTestArchiveBytes(t, archiveEntry{key: snapshotapi.SnapshotReleaseKey, value: []byte("{}")})
+
+	var out bytes.Buffer
+	err := ConvertEtcdSnapshotToKeyValueSnapshot(context.Background(), t.TempDir(), bytes.NewReader(srcBytes), &out)
+	if err == nil {
+		t.Fatal("expected an error for an archive without a DBStoreKey entry")
+	}
+}
+
+func writeBytesToTempFile(t *testing.T, data []byte) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "out-")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	return f.Name()
+}
+
+// readAllArchiveEntries reads every tar entry of a gzip'd tar file at path
+// into a map keyed by entry name.
+func readAllArchiveEntries(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer f.Close()
+
+	gzipReader, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	entries := map[string][]byte{}
+	for {
+		key, value, err := readArchiveEntry(tarReader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("failed to read archive entry: %v", err)
+		}
+		entries[string(key)] = value
+	}
+	return entries
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Part of [ENGCP-557](https://linear.app/loft/issue/ENGCP-557) (restore support for external database). One use case needs a way to migrate a tenant cluster from embedded etcd to an external database, which requires converting an embedded-etcd snapshot (raw etcd binary format) into the generic key-value snapshot format external-database restore already consumes.

This PR adds the conversion function and its tests only. It does **not** wire this into any CLI command or restore flow - where/when it runs (automatic during restore vs. manually triggered) is still an open decision on the issue.

- `pkg/snapshot/convert.go`: `ConvertEtcdSnapshotToKeyValueSnapshot` reads a raw etcd binary snapshot archive and writes an equivalent key-value archive. It restores the raw snapshot into a scratch directory (never the real one) and reads the resulting bbolt file directly through etcd's own MVCC engine (`backend`/`mvcc`/`lease`) - no etcd server, ports, or exec'd binary involved, so it needs no new runtime dependencies beyond packages already vendored for this module. Preserves release/request metadata passthrough and skip-keys filtering.
- `pkg/etcd/client.go`: adds `CurrentRevision` to the `etcd.Client` interface.
- `pkg/snapshot/client.go`: `writeKeyValueSnapshot` (the existing live-cluster path) now also records the backing store's revision into a new `RevisionStoreKey` archive entry, so every key-value-style archive carries it consistently whether it came from a live cluster or from this conversion. Older archives without the entry are unaffected - restore simply won't find it.

**Known gap, deliberately deferred**: this PR does not implement setting/bumping the revision on restore. The recorded revision is captured for a future restore-time floor, but we haven't decided whether that's better implemented via SQL-engine-specific logic (Postgres `setval`/MySQL `ALTER TABLE ... AUTO_INCREMENT`) or via dummy PUT/DELETE writes through the existing etcd-protocol client (backend-agnostic, no new drivers). That decision - and the restore-side wiring - is intentionally left for a follow-up once we're clearer on where/how the conversion tool itself gets invoked.


**Please provide a short message that should be published in the vcluster release notes**
No user-facing change in this PR - this is internal groundwork for an upcoming embedded-etcd-to-external-database migration path.


**What else do we need to know?** 
- Verified locally: `go build ./...`, `go test ./pkg/snapshot/... ./pkg/etcd/...` (all passing), `go vet`, `gofmt -l` clean. Could not run the project's full custom `golangci-lint` build here (the `defercleanupctx` plugin needs private-repo access unavailable in this environment) - a standard-linter dry run surfaced only pre-existing patterns already pervasive elsewhere in the codebase, nothing new from this diff.
- No new SQL drivers or exec'd binaries added - the raw-snapshot decode step uses only already-vendored `go.etcd.io/etcd/server/v3/storage/{backend,mvcc}` and `.../lease` packages (`go.mod`/vendor changes are just marking two already-vendored transitive deps as direct).

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches snapshot archive format and etcd storage internals for migration groundwork, but changes are additive (optional revision entry) and conversion is not yet invoked in production restore flows.
> 
> **Overview**
> Adds **`ConvertEtcdSnapshotToKeyValueSnapshot`** so embedded-etcd **EtcdSnapshot** archives can be turned into **KeyValueSnapshot** tarballs for external-database restore. Conversion restores the raw DB into a scratch dir and reads keys through etcd’s MVCC stack (no running etcd server), preserving release/request metadata, **skip-keys**, and pagination consistent with live backups.
> 
> **`etcd.Client`** gains **`CurrentRevision`** (count-only prefix get). Live **`writeKeyValueSnapshot`** now writes **`RevisionStoreKey`** with that revision, hardens streaming upload with **`io.Pipe`**, deferred cleanup, and avoids upload goroutine leaks on early errors.
> 
> **`go.mod`** promotes **`go.etcd.io/etcd/pkg/v3`** and **`github.com/coreos/go-semver`** to direct deps for conversion. Conversion and snapshot client behavior are covered by new tests; **no CLI or restore wiring** in this PR (revision is recorded only; restore-time floor is follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41ce102a15d13bbdcbaa467426d1cdf3fd99ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->