### PR TITLE
Preserve pod DNS options when translating ClusterFirst DNS

### DIFF
--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -777,10 +777,33 @@ func translateDNSClusterFirstConfig(pPod *corev1.Pod, vPod *corev1.Pod, clusterD
 	if existingDNSConfig != nil {
 		dnsConfig.Nameservers = deleteDuplicates(append(dnsConfig.Nameservers, existingDNSConfig.Nameservers...))
 		dnsConfig.Searches = deleteDuplicates(append(dnsConfig.Searches, existingDNSConfig.Searches...))
+		dnsConfig.Options = mergeDNSOptions(dnsConfig.Options, existingDNSConfig.Options)
 	}
 
 	pPod.Spec.DNSPolicy = corev1.DNSNone
 	pPod.Spec.DNSConfig = dnsConfig
+}
+
+// mergeDNSOptions merges the pod's own DNS options into the injected defaults.
+// An option set on the pod takes precedence over a default with the same name,
+// so an explicit ndots replaces the injected one instead of being dropped.
+func mergeDNSOptions(defaults, existing []corev1.PodDNSConfigOption) []corev1.PodDNSConfigOption {
+	if len(existing) == 0 {
+		return defaults
+	}
+
+	overridden := make(map[string]bool, len(existing))
+	for _, option := range existing {
+		overridden[option.Name] = true
+	}
+
+	options := make([]corev1.PodDNSConfigOption, 0, len(defaults)+len(existing))
+	for _, option := range defaults {
+		if !overridden[option.Name] {
+			options = append(options, option)
+		}
+	}
+	return append(options, existing...)
 }
 
 func deleteDuplicates(strs []string) []string {

--- a/pkg/controllers/resources/pods/translate/translator_test.go
+++ b/pkg/controllers/resources/pods/translate/translator_test.go
@@ -1048,3 +1048,55 @@ func TestTranslateEnforcedTolerationDedup(t *testing.T) {
 	}
 	assert.Equal(t, count, 1, "enforced toleration must appear exactly once on the physical pod, got %d", count)
 }
+
+func TestTranslateDNSClusterFirstConfigOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		existing    *corev1.PodDNSConfig
+		wantOptions []corev1.PodDNSConfigOption
+	}{
+		{
+			name:        "no existing dns config keeps the injected default",
+			existing:    nil,
+			wantOptions: []corev1.PodDNSConfigOption{{Name: "ndots", Value: ptr.To("5")}},
+		},
+		{
+			name: "pod options are preserved alongside the injected default",
+			existing: &corev1.PodDNSConfig{
+				Options: []corev1.PodDNSConfigOption{{Name: "single-request-reopen"}},
+			},
+			wantOptions: []corev1.PodDNSConfigOption{
+				{Name: "ndots", Value: ptr.To("5")},
+				{Name: "single-request-reopen"},
+			},
+		},
+		{
+			name: "pod ndots overrides the injected default",
+			existing: &corev1.PodDNSConfig{
+				Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: ptr.To("2")}},
+			},
+			wantOptions: []corev1.PodDNSConfigOption{{Name: "ndots", Value: ptr.To("2")}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pPod := &corev1.Pod{Spec: corev1.PodSpec{DNSConfig: tt.existing}}
+			vPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "testns"}}
+
+			translateDNSClusterFirstConfig(pPod, vPod, "cluster.local", "10.0.0.10")
+
+			assert.Equal(t, pPod.Spec.DNSPolicy, corev1.DNSNone)
+			assert.Equal(t, len(pPod.Spec.DNSConfig.Options), len(tt.wantOptions))
+			for i, want := range tt.wantOptions {
+				got := pPod.Spec.DNSConfig.Options[i]
+				assert.Equal(t, got.Name, want.Name)
+				if want.Value == nil {
+					assert.Assert(t, cmp.Nil(got.Value))
+				} else {
+					assert.Equal(t, ptr.Deref(got.Value, ""), *want.Value)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1120

When a pod uses `ClusterFirst` DNS, `translateDNSClusterFirstConfig` builds a DNS config (nameserver + search domains + an injected `ndots=5`) and then merges the pod's own config back in — but only its `Nameservers` and `Searches`:

```go
existingDNSConfig := pPod.Spec.DNSConfig
if existingDNSConfig != nil {
    dnsConfig.Nameservers = deleteDuplicates(append(dnsConfig.Nameservers, existingDNSConfig.Nameservers...))
    dnsConfig.Searches = deleteDuplicates(append(dnsConfig.Searches, existingDNSConfig.Searches...))
}
```

`Options` was never merged, so anything a pod set in `dnsConfig.options` (e.g. `single-request-reopen`, or a custom `ndots`) was silently dropped — exactly what the issue reports.

This merges the options too, via a small `mergeDNSOptions` helper. An option set on the pod takes precedence over the injected default with the same name, so an explicit `ndots: "2"` replaces the injected `ndots=5` rather than colliding with it; options the pod sets that aren't in the defaults are simply appended.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster dropped a pod's `dnsConfig.options` when translating `ClusterFirst` DNS.

**What else do we need to know?** 

`translateDNSClusterFirstConfig` is a pure function over `corev1.Pod`, so this is covered by a table-driven unit test (`TestTranslateDNSClusterFirstConfigOptions`) with no cluster required: default kept when the pod sets nothing, pod options preserved alongside the default, and pod `ndots` overriding the injected one. The test fails on `main` and passes with this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized pod DNS translation fix with table-driven unit tests and no auth or data-path changes.
> 
> **Overview**
> Fixes a bug where virtual pods with **`ClusterFirst`** DNS lost **`dnsConfig.options`** on the host pod. **`translateDNSClusterFirstConfig`** already merged nameservers and search domains from the pod spec but ignored options, so settings like **`single-request-reopen`** or a custom **`ndots`** never reached the physical pod.
> 
> The merge path now calls **`mergeDNSOptions`**, which keeps injected defaults (including **`ndots=5`**) unless the pod defines the same option name—in which case the pod value wins. Other pod-only options are kept alongside the defaults.
> 
> **`TestTranslateDNSClusterFirstConfigOptions`** covers no existing config, extra pod options, and pod **`ndots`** overriding the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3b0ed0893d3f6af33a8ddaf9beef0c5eb66aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->