### PR TITLE
fix(syncer): preserve externally-injected scheduling gates on host Pods

### DIFF
--- a/pkg/controllers/resources/pods/translate/diff.go
+++ b/pkg/controllers/resources/pods/translate/diff.go
@@ -52,7 +52,7 @@ func (t *translator) Diff(ctx *synccontext.SyncContext, event *synccontext.SyncE
 	}
 
 	// spec diff
-	t.calcSpecDiff(pPod, vPod)
+	t.calcSpecDiff(pPod, event.VirtualOld, vPod)
 
 	// bi-directionally sync labels & annotations
 	event.Virtual.Annotations, event.Host.Annotations = translate.AnnotationsBidirectionalUpdate(
@@ -104,7 +104,7 @@ func (t *translator) Diff(ctx *synccontext.SyncContext, event *synccontext.SyncE
 }
 
 func GetExcludedAnnotations(pPod *corev1.Pod) []string {
-	annotations := []string{ClusterAutoScalerAnnotation, OwnerReferences, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, VClusterLabelsAnnotation}
+	annotations := []string{ClusterAutoScalerAnnotation, OwnerReferences, OwnerSetKind, NamespaceAnnotation, NameAnnotation, UIDAnnotation, ServiceAccountNameAnnotation, HostsRewrittenAnnotation, VClusterLabelsAnnotation, ManagedSchedulingGatesAnnotation}
 	if pPod != nil {
 		for _, v := range pPod.Spec.Volumes {
 			if v.Projected != nil {
@@ -137,7 +137,7 @@ func GetExcludedAnnotations(pPod *corev1.Pod) []string {
 // - spec.tolerations (can be added not removed)
 //
 // TODO: check for ephemereal containers
-func (t *translator) calcSpecDiff(pObj, vObj *corev1.Pod) {
+func (t *translator) calcSpecDiff(pObj, vObjOld, vObj *corev1.Pod) {
 	// active deadlines different?
 	pObj.Spec.ActiveDeadlineSeconds = vObj.Spec.ActiveDeadlineSeconds
 
@@ -160,7 +160,28 @@ func (t *translator) calcSpecDiff(pObj, vObj *corev1.Pod) {
 		pObj.Spec.InitContainers = updatedContainer
 	}
 
-	pObj.Spec.SchedulingGates = vObj.Spec.SchedulingGates
+	var virtualOldGates []corev1.PodSchedulingGate
+	if vObjOld != nil {
+		virtualOldGates = vObjOld.Spec.SchedulingGates
+	}
+	pObj.Spec.SchedulingGates = mergeSchedulingGates(
+		pObj.Spec.SchedulingGates,
+		virtualOldGates,
+		vObj.Spec.SchedulingGates,
+		pObj.Annotations,
+	)
+
+	// Persist the current vCluster-managed gate names in a host annotation so that
+	// after a syncer restart (cache miss) we can still distinguish vCluster-managed
+	// gates from externally-injected ones.
+	if pObj.Annotations == nil {
+		pObj.Annotations = make(map[string]string)
+	}
+	if len(vObj.Spec.SchedulingGates) > 0 {
+		pObj.Annotations[ManagedSchedulingGatesAnnotation] = formatSchedulingGatesAnnotation(vObj.Spec.SchedulingGates)
+	} else {
+		delete(pObj.Annotations, ManagedSchedulingGatesAnnotation)
+	}
 
 	newTolerations := append([]corev1.Toleration{}, vObj.Spec.Tolerations...)
 	for _, hostTol := range pObj.Spec.Tolerations {
@@ -272,7 +293,72 @@ func (t *translator) convertResourceClaimStatuses(ctx *synccontext.SyncContext, 
 	return nil
 }
 
-// hasToleration reports whether tol is already present in the slice (full equality).
+// mergeSchedulingGates preserves gates that were injected only on the host Pod.
+// A host gate is removed only when it existed on the previous virtual Pod but no
+// longer exists on the current virtual Pod.
+//
+// When virtualOldGates is empty (syncer restart / cache miss), the function falls
+// back to the ManagedSchedulingGatesAnnotation on the host Pod to determine which
+// gates were previously managed by vCluster. This prevents externally-injected
+// gates from being accidentally removed after a restart.
+func mergeSchedulingGates(hostGates, virtualOldGates, virtualGates []corev1.PodSchedulingGate, hostAnnotations map[string]string) []corev1.PodSchedulingGate {
+	// Determine which gates were previously managed by vCluster.
+	// Prefer the in-memory virtualOldGates; fall back to the persistent annotation
+	// when the former is unavailable (syncer restart / cache miss).
+	managedGates := virtualOldGates
+	if len(managedGates) == 0 {
+		if annotated, ok := hostAnnotations[ManagedSchedulingGatesAnnotation]; ok {
+			managedGates = parseSchedulingGatesAnnotation(annotated)
+		}
+	}
+
+	merged := append([]corev1.PodSchedulingGate{}, virtualGates...)
+	for _, hostGate := range hostGates {
+		if hasSchedulingGate(merged, hostGate.Name) {
+			continue
+		}
+		if hasSchedulingGate(managedGates, hostGate.Name) {
+			continue
+		}
+		merged = append(merged, hostGate)
+	}
+	return merged
+}
+
+func hasSchedulingGate(gates []corev1.PodSchedulingGate, name string) bool {
+	for _, gate := range gates {
+		if gate.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// formatSchedulingGatesAnnotation serialises gate names into the annotation value
+// (a JSON array of strings, e.g. `["gate-a","gate-b"]`).
+func formatSchedulingGatesAnnotation(gates []corev1.PodSchedulingGate) string {
+	names := make([]string, 0, len(gates))
+	for _, g := range gates {
+		names = append(names, g.Name)
+	}
+	data, _ := json.Marshal(names)
+	return string(data)
+}
+
+// parseSchedulingGatesAnnotation deserialises the annotation value back into
+// scheduling gates. Returns nil on any parse error (treated as "no prior info").
+func parseSchedulingGatesAnnotation(annotation string) []corev1.PodSchedulingGate {
+	var names []string
+	if err := json.Unmarshal([]byte(annotation), &names); err != nil {
+		return nil
+	}
+	gates := make([]corev1.PodSchedulingGate, 0, len(names))
+	for _, name := range names {
+		gates = append(gates, corev1.PodSchedulingGate{Name: name})
+	}
+	return gates
+}
+
 func hasToleration(tolerations []corev1.Toleration, tol corev1.Toleration) bool {
 	for _, t := range tolerations {
 		if apiequality.Semantic.DeepEqual(t, tol) {

--- a/pkg/controllers/resources/pods/translate/diff_test.go
+++ b/pkg/controllers/resources/pods/translate/diff_test.go
@@ -145,3 +145,169 @@ func TestDiffTolerationSync(t *testing.T) {
 		})
 	}
 }
+
+func TestDiffSchedulingGateSync(t *testing.T) {
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+
+	imageTranslator, err := NewImageTranslator(map[string]string{})
+	assert.NilError(t, err)
+
+	tr := &translator{
+		vClient:         vClient,
+		imageTranslator: imageTranslator,
+		log:             loghelper.New("diff-test"),
+	}
+
+	registerCtx := generictesting.NewFakeRegisterContext(testingutil.NewFakeConfig(), pClient, vClient)
+	syncCtx := registerCtx.ToSyncContext("test")
+	vNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "testns"}}
+	assert.NilError(t, vClient.Create(syncCtx.Context, vNamespace))
+
+	virtualGate := corev1.PodSchedulingGate{Name: "virtual.example.com/gate"}
+	externalGate := corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}
+	lateExternalGate := corev1.PodSchedulingGate{Name: "external.example.com/late-gate"}
+
+	tests := []struct {
+		name                      string
+		virtualOldGates           []corev1.PodSchedulingGate
+		virtualNewGates           []corev1.PodSchedulingGate
+		hostGates                 []corev1.PodSchedulingGate
+		hostLiveGates             []corev1.PodSchedulingGate
+		hostAnnotations           map[string]string
+		expectedHostGates         []corev1.PodSchedulingGate
+		expectedHostAnnotationVal string // expected value for ManagedSchedulingGatesAnnotation; "" means deleted
+	}{
+		{
+			name:                      "preserves an externally injected host gate",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:                      "adds a virtual gate while preserving an external host gate",
+			virtualOldGates:           nil,
+			virtualNewGates:           []corev1.PodSchedulingGate{virtualGate},
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostAnnotationVal: `["virtual.example.com/gate"]`,
+		},
+		{
+			name:                      "removes a gate explicitly removed from the virtual pod",
+			virtualOldGates:           []corev1.PodSchedulingGate{virtualGate},
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:            "preserves a host gate added after the old host snapshot",
+			virtualOldGates: []corev1.PodSchedulingGate{virtualGate},
+			virtualNewGates: []corev1.PodSchedulingGate{virtualGate},
+			hostGates:       []corev1.PodSchedulingGate{virtualGate},
+			hostLiveGates:   []corev1.PodSchedulingGate{virtualGate, lateExternalGate},
+			expectedHostGates: []corev1.PodSchedulingGate{
+				virtualGate,
+				lateExternalGate,
+			},
+			expectedHostAnnotationVal: `["virtual.example.com/gate"]`,
+		},
+		{
+			// When VirtualOld is not available (cache miss / restart) and there is
+			// no annotation, all host gates are treated as externally-injected.
+			name:                      "treats all host gates as external when VirtualOld gates are empty and no annotation (cache miss / restart)",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			// After a restart, the annotation on the host Pod serves as the fallback
+			// for VirtualOld, allowing the syncer to correctly remove a previously
+			// vCluster-managed gate that has been removed from the virtual Pod.
+			name:                      "after restart, annotation allows correct removal of previously vCluster-managed gate",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `["virtual.example.com/gate"]`},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			// After a restart, if the virtual Pod still has the gate, it stays.
+			// The annotation is just the fallback — the live virtualGates take priority.
+			name:                      "after restart, annotation is fallback but live virtual gates take priority",
+			virtualOldGates:           nil,
+			virtualNewGates:           []corev1.PodSchedulingGate{virtualGate},
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `["virtual.example.com/gate"]`},
+			expectedHostGates:         []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostAnnotationVal: `["virtual.example.com/gate"]`,
+		},
+		{
+			// If the annotation contains invalid JSON, it is ignored and all host
+			// gates are treated as externally-injected (conservative fallback).
+			name:                      "after restart, invalid annotation falls back to treating all host gates as external",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `not-valid-json`},
+			expectedHostGates:         []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			// After a restart, if the annotation lists a gate as vCluster-managed but
+			// that gate is NOT present on the host, nothing goes wrong — the gate is
+			// simply not in the merged result because it isn't in hostGates either.
+			name:                      "after restart, annotation gate not on host is ignored",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `["virtual.example.com/gate"]`},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vOld := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod", Namespace: "testns"},
+				Spec:       corev1.PodSpec{SchedulingGates: tc.virtualOldGates},
+			}
+			vNew := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod", Namespace: "testns"},
+				Spec:       corev1.PodSpec{SchedulingGates: tc.virtualNewGates},
+			}
+			liveGates := tc.hostLiveGates
+			if liveGates == nil {
+				liveGates = tc.hostGates
+			}
+			pOld := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod-x-testns", Namespace: "test"},
+				Spec:       corev1.PodSpec{SchedulingGates: tc.hostGates},
+			}
+			pNew := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testpod-x-testns",
+					Namespace:   "test",
+					Annotations: tc.hostAnnotations,
+				},
+				Spec: corev1.PodSpec{SchedulingGates: liveGates},
+			}
+	
+			event := synccontext.NewSyncEventWithOld(pOld, pNew, vOld, vNew)
+			assert.NilError(t, tr.Diff(syncCtx, event))
+			assert.Assert(t, cmp.DeepEqual(pNew.Spec.SchedulingGates, tc.expectedHostGates),
+				"test case %q: unexpected host scheduling gates after Diff", tc.name)
+	
+			// Verify the annotation value on the host pod
+			actualAnnVal, _ := pNew.Annotations[ManagedSchedulingGatesAnnotation]
+			assert.Equal(t, actualAnnVal, tc.expectedHostAnnotationVal,
+				"test case %q: unexpected ManagedSchedulingGatesAnnotation value", tc.name)
+		})
+	}
+}

--- a/pkg/controllers/resources/pods/translate/diff_test.go
+++ b/pkg/controllers/resources/pods/translate/diff_test.go
@@ -147,6 +147,159 @@ func TestDiffTolerationSync(t *testing.T) {
 	}
 }
 
+func TestDiffSchedulingGateSync(t *testing.T) {
+	pClient := testingutil.NewFakeClient(scheme.Scheme)
+	vClient := testingutil.NewFakeClient(scheme.Scheme)
+
+	imageTranslator, err := NewImageTranslator(map[string]string{})
+	assert.NilError(t, err)
+
+	tr := &translator{
+		vClient:         vClient,
+		imageTranslator: imageTranslator,
+		log:             loghelper.New("diff-test"),
+	}
+
+	registerCtx := generictesting.NewFakeRegisterContext(testingutil.NewFakeConfig(), pClient, vClient)
+	syncCtx := registerCtx.ToSyncContext("test")
+	vNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "testns"}}
+	assert.NilError(t, vClient.Create(syncCtx.Context, vNamespace))
+
+	virtualGate := corev1.PodSchedulingGate{Name: "virtual.example.com/gate"}
+	externalGate := corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}
+	lateExternalGate := corev1.PodSchedulingGate{Name: "external.example.com/late-gate"}
+
+	tests := []struct {
+		name                      string
+		virtualOldGates           []corev1.PodSchedulingGate
+		virtualNewGates           []corev1.PodSchedulingGate
+		hostGates                 []corev1.PodSchedulingGate
+		hostLiveGates             []corev1.PodSchedulingGate
+		hostAnnotations           map[string]string
+		expectedHostGates         []corev1.PodSchedulingGate
+		expectedHostAnnotationVal string
+	}{
+		{
+			name:                      "preserves an externally injected host gate",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:                      "adds a virtual gate while preserving an external host gate",
+			virtualOldGates:           nil,
+			virtualNewGates:           []corev1.PodSchedulingGate{virtualGate},
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostAnnotationVal: `["virtual.example.com/gate"]`,
+		},
+		{
+			name:                      "removes a gate explicitly removed from the virtual pod",
+			virtualOldGates:           []corev1.PodSchedulingGate{virtualGate},
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:            "preserves a host gate added after the old host snapshot",
+			virtualOldGates: []corev1.PodSchedulingGate{virtualGate},
+			virtualNewGates: []corev1.PodSchedulingGate{virtualGate},
+			hostGates:       []corev1.PodSchedulingGate{virtualGate},
+			hostLiveGates:   []corev1.PodSchedulingGate{virtualGate, lateExternalGate},
+			expectedHostGates: []corev1.PodSchedulingGate{
+				virtualGate,
+				lateExternalGate,
+			},
+			expectedHostAnnotationVal: `["virtual.example.com/gate"]`,
+		},
+		{
+			name:                      "treats all host gates as external when VirtualOld gates are empty and no annotation",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:                      "after restart annotation allows removal of a previously vCluster-managed gate",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `["virtual.example.com/gate"]`},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:                      "after restart live virtual gates take priority over the annotation",
+			virtualOldGates:           nil,
+			virtualNewGates:           []corev1.PodSchedulingGate{virtualGate},
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `["virtual.example.com/gate"]`},
+			expectedHostGates:         []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostAnnotationVal: `["virtual.example.com/gate"]`,
+		},
+		{
+			name:                      "after restart an invalid annotation treats all host gates as external",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{virtualGate, externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: "not-valid-json"},
+			expectedHostGates:         []corev1.PodSchedulingGate{virtualGate, externalGate},
+			expectedHostAnnotationVal: "",
+		},
+		{
+			name:                      "after restart an annotation gate absent on the host is ignored",
+			virtualOldGates:           nil,
+			virtualNewGates:           nil,
+			hostGates:                 []corev1.PodSchedulingGate{externalGate},
+			hostAnnotations:           map[string]string{ManagedSchedulingGatesAnnotation: `["virtual.example.com/gate"]`},
+			expectedHostGates:         []corev1.PodSchedulingGate{externalGate},
+			expectedHostAnnotationVal: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vOld := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod", Namespace: "testns"},
+				Spec:       corev1.PodSpec{SchedulingGates: tc.virtualOldGates},
+			}
+			vNew := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod", Namespace: "testns"},
+				Spec:       corev1.PodSpec{SchedulingGates: tc.virtualNewGates},
+			}
+			liveGates := tc.hostLiveGates
+			if liveGates == nil {
+				liveGates = tc.hostGates
+			}
+			pOld := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod-x-testns", Namespace: "test"},
+				Spec:       corev1.PodSpec{SchedulingGates: tc.hostGates},
+			}
+			pNew := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testpod-x-testns",
+					Namespace:   "test",
+					Annotations: tc.hostAnnotations,
+				},
+				Spec: corev1.PodSpec{SchedulingGates: liveGates},
+			}
+
+			event := synccontext.NewSyncEventWithOld(pOld, pNew, vOld, vNew)
+			assert.NilError(t, tr.Diff(syncCtx, event))
+			assert.Assert(t, cmp.DeepEqual(pNew.Spec.SchedulingGates, tc.expectedHostGates),
+				"test case %q: unexpected host scheduling gates after Diff", tc.name)
+
+			actualAnnVal, _ := pNew.Annotations[ManagedSchedulingGatesAnnotation]
+			assert.Equal(t, actualAnnVal, tc.expectedHostAnnotationVal,
+				"test case %q: unexpected ManagedSchedulingGatesAnnotation value", tc.name)
+		})
+	}
+}
+
 func TestConditionsCopyBidirectionalObservedGeneration(t *testing.T) {
 	v131 := utilversion.MustParseSemantic("1.31.0")
 	v133 := utilversion.MustParseSemantic("1.33.0")

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -46,6 +46,7 @@ const (
 	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
 	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
 	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
+	ManagedSchedulingGatesAnnotation     = "vcluster.loft.sh/managed-scheduling-gates"
 )
 
 var (

--- a/pkg/controllers/resources/pods/translate/translator.go
+++ b/pkg/controllers/resources/pods/translate/translator.go
@@ -45,6 +45,7 @@ const (
 	ClusterAutoScalerDaemonSetAnnotation = "cluster-autoscaler.kubernetes.io/daemonset-pod"
 	ServiceAccountNameAnnotation         = "vcluster.loft.sh/service-account-name"
 	ServiceAccountTokenAnnotation        = "vcluster.loft.sh/token-"
+	ManagedSchedulingGatesAnnotation     = "vcluster.loft.sh/managed-scheduling-gates"
 )
 
 var (


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #4106

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster syncer cleared externally-injected scheduling gates (e.g., `kueue.x-k8s.io/admission`) on host Pods, breaking integration with external controllers like Kueue that rely on scheduling gates to manage Pod admission.

**What else do we need to know?**

## Problem

The syncer's `calcSpecDiff()` currently replaces the host Pod's entire `spec.schedulingGates` with the vPod's gates unconditionally (`pObj.Spec.SchedulingGates = vObj.Spec.SchedulingGates`). This strips externally-injected gates (such as Kueue's `kueue.x-k8s.io/admission`) from the host Pod, because the vPod does not carry those gates.

**Kubernetes scheduling gate semantics** dictate that gates can only be added at creation time and removed afterwards — they cannot be re-added. So once the syncer strips an external gate, the damage is irreversible.

## Proposed fix

Change the scheduling gate diff logic from **full replacement** to **union-merge with removal tracking** using the previous vPod state (`vObjOld`):

- **Keep** gates on the host Pod that are not in the vPod (externally-injected gates like `kueue.x-k8s.io/admission`).
- **Sync** gates that exist on both vPod and host Pod.
- **Remove** gates from the host Pod only if they were previously present on the vPod (`vObjOld`) and have since been removed (vCluster-managed gate lifecycle).

### Implementation approach

Modify the gate sync in `calcSpecDiff()` to accept `vObjOld` and use `mergeSchedulingGates()`, which follows the same merge pattern already used for `Tolerations` in the same function:

```go
// Before (latest main — unconditional overwrite):
pObj.Spec.SchedulingGates = vObj.Spec.SchedulingGates

// After (union-merge, preserving external gates):
pObj.Spec.SchedulingGates = mergeSchedulingGates(
    pObj.Spec.SchedulingGates,
    vObjOld.Spec.SchedulingGates,
    vObj.Spec.SchedulingGates,
)
```

The `mergeSchedulingGates()` function:
1. Starts with all vPod gates (the current desired state)
2. Adds host gates that are neither in the vPod nor in the old vPod — these are externally-injected and must be preserved
3. Skips host gates that were in the old vPod but not in the current vPod — these are vCluster-managed gates being intentionally removed

This mirrors the existing `Tolerations` merge pattern in the same `calcSpecDiff()` function, making review straightforward.

### Key design decisions

- This change only affects the **host Pod spec update direction** (physical Pod sync). It does not change how vCluster syncs gates from the vPod to the host Pod at creation time.
- The merge strategy uses `vObjOld` (the previous vPod state) to distinguish between externally-injected gates and vCluster-managed gates. A gate present on the host Pod but not on `vObjOld` must have been injected externally (by a host-side webhook at creation time), and is preserved.
- This is related to the Kueue community issue: https://github.com/kubernetes-sigs/kueue/issues/13133
- The `Tolerations` merge pattern in the same `calcSpecDiff()` function is the community-accepted precedent for this approach.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites

### Additional test suites

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes host Pod scheduling gate updates on every reconcile; incorrect merge could block or mis-schedule workloads, though behavior is conservative for unknown gates and is covered by unit tests.
> 
> **Overview**
> Fixes host Pod sync **overwriting** `spec.schedulingGates` with only the virtual Pod’s gates, which stripped externally injected gates (e.g. Kueue’s `kueue.x-k8s.io/admission`) and broke admission controllers that rely on them.
> 
> **Scheduling gate reconciliation** in `calcSpecDiff` now uses `mergeSchedulingGates` with the previous virtual Pod (`VirtualOld`): current virtual gates are applied, host-only gates are kept unless they were previously vCluster-managed and were removed from the virtual Pod, matching the existing toleration merge pattern.
> 
> After a **syncer restart** (no `VirtualOld`), vCluster-managed gate names are recovered from host annotation `vcluster.loft.sh/managed-scheduling-gates` (JSON list); invalid JSON is ignored so all host gates are treated as external. The annotation is written during diff and excluded from bidirectional annotation sync.
> 
> Adds **`TestDiffSchedulingGateSync`** covering external preservation, virtual add/remove, late host gates, and restart/annotation fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a272b45a0faa720e709d4e88e4a2c4c17046e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->