### PR TITLE
feat(release): default to pre-release and drop build-time docker moving tags (v0.35)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -122,7 +122,13 @@ changelog:
       - "^test:"
 
 release:
-  prerelease: auto
+  # DEVOPS-1083: every release (including stable) starts as a GitHub
+  # pre-release. Promoting to stable/Latest is a deliberate human edit
+  # (uncheck "pre-release") on the release, which is what fires the
+  # release:released event that vcluster-pro's promote-release workflow
+  # listens for. A pre-release publish only ever emits `prereleased`, so the
+  # build cannot self-trigger promotion.
+  prerelease: true
   make_latest: false
   # Re-runs of this workflow against the same tag re-upload assets to an
   # already-populated GitHub Release and 422 with `already_exists`. This
@@ -156,7 +162,13 @@ brews:
     commit_author:
       name: loft-bot
       email: 73976634+loft-bot@users.noreply.github.com
-    skip_upload: auto
+    # DEVOPS-1083: the stable vcluster formula is never uploaded at build
+    # time now (was `auto`, which still uploaded stable vX.Y.Z). Updating it
+    # is a promotion-time step: vcluster-pro's promote-release workflow
+    # patches Formula/vcluster.rb from the OSS release checksums when a human
+    # promotes the release, matching the docker moving-tag behavior.
+    # vcluster-experimental below is unchanged - it tracks every build.
+    skip_upload: true
   - name: vcluster-experimental
     ids:
       - vcluster_cli_archives
@@ -180,13 +192,13 @@ brews:
       name: loft-bot
       email: 73976634+loft-bot@users.noreply.github.com
 
+# DEVOPS-1083: each image_templates list below builds only the immutable
+# {{ .Version }} tag. The moving tags it used to build alongside it are now
+# applied at promotion time instead - see the docker_manifests note below.
 dockers:
   # --- Vcluster images ---
   - image_templates:
       - ghcr.io/loft-sh/vcluster-oss:{{ .Version }}-amd64
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-oss:latest-amd64{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-oss:{{ .Major }}-amd64{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-oss:{{ .Major }}.{{ .Minor }}-amd64{{ end }}'
     use: buildx
     dockerfile: Dockerfile.release
     ids:
@@ -201,9 +213,6 @@ dockers:
 
   - image_templates:
       - ghcr.io/loft-sh/vcluster-oss:{{ .Version }}-arm64v8
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-oss:latest-arm64v8{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-oss:{{ .Major }}-arm64v8{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-oss:{{ .Major }}.{{ .Minor }}-arm64v8{{ end }}'
     use: buildx
     goarch: arm64
     dockerfile: Dockerfile.release
@@ -220,9 +229,6 @@ dockers:
   # --- Vcluster-cli images ---
   - image_templates:
       - ghcr.io/loft-sh/vcluster-cli:{{ .Version }}-amd64
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-cli:latest-amd64{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-cli:{{ .Major }}-amd64{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-cli:{{ .Major }}.{{ .Minor }}-amd64{{ end }}'
     use: buildx
     dockerfile: Dockerfile.cli.release
     ids:
@@ -237,9 +243,6 @@ dockers:
 
   - image_templates:
       - ghcr.io/loft-sh/vcluster-cli:{{ .Version }}-arm64v8
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-cli:latest-arm64v8{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-cli:{{ .Major }}-arm64v8{{ end }}'
-      - '{{ if eq .Prerelease "" }}ghcr.io/loft-sh/vcluster-cli:{{ .Major }}.{{ .Minor }}-arm64v8{{ end }}'
     use: buildx
     goarch: arm64
     dockerfile: Dockerfile.cli.release
@@ -253,6 +256,11 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
 
+# DEVOPS-1083: only the immutable {{ .Version }} manifest is built and pushed
+# here. The moving tags (:latest, :{{ .Major }}, :{{ .Major }}.{{ .Minor }})
+# are retagged onto this manifest's digest by vcluster-pro's promote-release
+# workflow when a human promotes the release, which is a digest-preserving
+# copy rather than a rebuild.
 docker_manifests:
   # --- Vcluster multi arch ---
   - name_template: ghcr.io/loft-sh/vcluster-oss:{{ .Version }}
@@ -260,53 +268,11 @@ docker_manifests:
       - ghcr.io/loft-sh/vcluster-oss:{{ .Version }}-amd64
       - ghcr.io/loft-sh/vcluster-oss:{{ .Version }}-arm64v8
 
-  - name_template: ghcr.io/loft-sh/vcluster-oss:latest
-    image_templates:
-      - ghcr.io/loft-sh/vcluster-oss:latest-amd64
-      - ghcr.io/loft-sh/vcluster-oss:latest-arm64v8
-    skip_push: auto
-
-  - name_template: ghcr.io/loft-sh/vcluster-oss:{{ .Major }}
-    image_templates:
-      - ghcr.io/loft-sh/vcluster-oss:{{ .Major }}-amd64
-      - ghcr.io/loft-sh/vcluster-oss:{{ .Major }}-arm64v8
-    skip_push: auto
-
-  - name_template: ghcr.io/loft-sh/vcluster-oss:{{ .Major }}.{{ .Minor }}
-    image_templates:
-      - ghcr.io/loft-sh/vcluster-oss:{{ .Major }}.{{ .Minor }}-amd64
-      - ghcr.io/loft-sh/vcluster-oss:{{ .Major }}.{{ .Minor }}-arm64v8
-    skip_push: auto
-
   # --- Vcluster-cli multi arch ---
   - name_template: ghcr.io/loft-sh/vcluster-cli:{{ .Version }}
     image_templates:
       - ghcr.io/loft-sh/vcluster-cli:{{ .Version }}-amd64
       - ghcr.io/loft-sh/vcluster-cli:{{ .Version }}-arm64v8
-
-  - name_template: ghcr.io/loft-sh/vcluster-cli:latest
-    image_templates:
-      - ghcr.io/loft-sh/vcluster-cli:latest-amd64
-      - ghcr.io/loft-sh/vcluster-cli:latest-arm64v8
-    skip_push: auto
-
-  - name_template: ghcr.io/loft-sh/vcluster-cli:{{ .Major }}
-    image_templates:
-      - ghcr.io/loft-sh/vcluster-cli:{{ .Major }}-amd64
-      - ghcr.io/loft-sh/vcluster-cli:{{ .Major }}-arm64v8
-    skip_push: auto
-
-  - name_template: ghcr.io/loft-sh/vcluster-cli:{{ .Major }}.{{ .Minor }}
-    image_templates:
-      - ghcr.io/loft-sh/vcluster-cli:{{ .Major }}.{{ .Minor }}-amd64
-      - ghcr.io/loft-sh/vcluster-cli:{{ .Major }}.{{ .Minor }}-arm64v8
-    skip_push: auto
-
-  - name_template: loftsh/vcluster-cli:{{ .Major }}
-    image_templates:
-      - loftsh/vcluster-cli:{{ .Major }}-amd64
-      - loftsh/vcluster-cli:{{ .Major }}-arm64v8
-    skip_push: auto
 
 docker_signs:
   - cmd: cosign


### PR DESCRIPTION
The OSS half of `loft-sh/vcluster-pro#2064` for the `v0.35` release line. Pairs with **loft-sh/vcluster-pro#2084** and must land together with it.

## Why this PR exists at all

On the monorepo-era lines a single root `.goreleaser.yaml` in `vcluster-pro` produces every artifact, OSS included, so #2064 covered both halves at once. The legacy lines predate that: here in `loft-sh/vcluster`, this branch's own `release.yaml` and `.goreleaser.yaml` build `vcluster-oss`, `vcluster-cli` and both Homebrew formulas independently, dispatched alongside the pro builder.

Those files have no counterpart under `staging/` in the monorepo, so `backport-legacy-split` finds no OSS-path content in #2064's diff and can only ever open the pro half. This half has to be authored directly against this branch — there is no monorepo path that produces it.

## What changes

`.goreleaser.yaml` only:

- `release.prerelease: auto` → `true`, so every cut on this line — stable included — is published as a GitHub pre-release.
- `brews[vcluster].skip_upload: auto` → `true`. The stable `Formula/vcluster.rb` is no longer pushed at build time; promotion owns it. This also fixes a real ordering bug on this line: goreleaser pushed the formula during its run while the OSS release assets its `url_template` points at were uploaded later in the same job, so the tap could briefly reference assets that did not exist yet. `vcluster-experimental` is deliberately unchanged and keeps tracking every build.
- All 12 build-time moving-tag `image_template` entries removed (the `{{ if eq .Prerelease "" }}` guarded lines), plus 7 `docker_manifests` entries: `:latest`, `:{{ .Major }}` and `:{{ .Major }}.{{ .Minor }}` for both `vcluster-oss` and `vcluster-cli`.

`.github/workflows/release.yaml` is untouched. Its `check_latest_stable` downgrade guard stays exactly as-is — with the stable formula now promotion-gated, that guard is what still protects `vcluster-experimental` from a tap rollback on an older-line stable rerun.

## Also removed: a dead Docker Hub manifest

The `loftsh/vcluster-cli:{{ .Major }}` manifest goes too. It is unreachable config: no `dockers` block builds its `loftsh/vcluster-cli:{{ .Major }}-amd64` / `-arm64v8` inputs — every block targets `ghcr.io` — and `https://hub.docker.com/v2/repositories/loftsh/vcluster-cli/` returns **404**, so that Docker Hub repository does not exist. It is also a `{{ .Major }}` moving tag, the exact category this change removes. Worth flagging explicitly: nothing reinstates it, because the promote-release `images` list covers `ghcr.io` only.

## Why this line needs it

`skip_push: auto` keys off the version *string*, not the release flag, so a `v0.35.x` patch cut after a newer stable already shipped drags `vcluster-oss:latest` and `vcluster-cli:latest` **backward** at build time. The `is_latest_stable()` guard in the promote-release action cannot help, because the build-time path never consults it.

## What restores the moving tags

`.github/workflows/promote-release.yaml` on `vcluster-pro`'s default branch, which fires on the paired pro release's `released` event. Its `images` list already covers `ghcr.io/loft-sh/vcluster-oss` and `ghcr.io/loft-sh/vcluster-cli` including their `-amd64` and `-arm64v8` suffixes, and it promotes this repository's matching release through its `oss-repo` input. Retagging uses `crane tag`, a digest-preserving copy, so cosign signatures survive.

## Verification

- `goreleaser check` reports the transformed config exactly as valid as the original — same pre-existing deprecation warnings (`dockers`/`docker_manifests`, `brews`), nothing new.
- YAML parses; no `{{ if eq .Prerelease "" }}`, `:latest`, `{{ .Major }}` or `loftsh/` references remain outside explanatory comments.

Part of DEVOPS-1083.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how releases, container tags, and Homebrew stable formula are published; misconfiguration or a missing paired promote workflow would leave users on stale `latest`/tap until promotion runs.
> 
> **Overview**
> **Goreleaser now publishes every GitHub release as a pre-release** (`prerelease: true` instead of `auto`), so stable/Latest and downstream promotion only happen when someone manually unchecks pre-release—avoiding build-time `released` events that could auto-promote.
> 
> **Stable distribution artifacts are no longer updated at build time.** The main Homebrew `vcluster` formula always uses `skip_upload: true` (was `auto`); `vcluster-experimental` is unchanged. Docker builds and manifests push **only** immutable `{{ .Version }}` tags for `vcluster-oss` and `vcluster-cli` on GHCR—removed all `latest`, `{{ .Major }}`, and `{{ .Major }}.{{ .Minor }}` image templates and multi-arch manifests, plus the unused `loftsh/vcluster-cli:{{ .Major }}` manifest.
> 
> Moving tags and the stable Homebrew formula are expected to be applied later by **vcluster-pro’s promote-release** workflow (digest-preserving retag via `crane`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad98bea8db9664d862c6d5331d7ff741aef1df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->