### PR TITLE
Bump platform version to 4.10.6

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.10.3"
+	MinimumVersionTag = "v4.10.6"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
Closes ENG-12213

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant bump for platform compatibility; no logic changes beyond the new floor version.
> 
> **Overview**
> Raises the **minimum supported Loft platform version** from `v4.10.3` to `v4.10.6` by updating `MinimumVersionTag` in `pkg/platform/version.go`.
> 
> That constant drives `MinimumVersion` and is used when resolving compatible Loft releases (including GitHub lookup fallbacks and filtering eligible stable releases), so environments below 4.10.6 are no longer treated as compatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9920992a4e84f4559027b46a77dd61966cf32c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->