### PR TITLE
fix(ci): trigger release validators on published, not created (v0.32)

### DIFF
--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -6,7 +6,12 @@ permissions:
 
 on:
   release:
-    types: [created]
+    # published, not created: goreleaser creates the release as a draft, uploads
+    # the assets, then publishes it. GitHub does not deliver `created` for draft
+    # releases, so `created` stopped firing once releases stopped being made by
+    # hand, and this workflow silently stopped validating releases altogether.
+    # See DEVOPS-1185.
+    types: [published]
   workflow_dispatch:
     inputs:
       ginkgo-label:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,12 @@ name: E2E CI
 
 on:
   release:
-    types: [created]
+    # published, not created: goreleaser creates the release as a draft, uploads
+    # the assets, then publishes it. GitHub does not deliver `created` for draft
+    # releases, so `created` stopped firing once releases stopped being made by
+    # hand, and this workflow silently stopped validating releases altogether.
+    # See DEVOPS-1185.
+    types: [published]
   pull_request:
     branches:
       - main

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,7 +2,14 @@ name: Unit tests
 
 on:
   release:
-    types: [created]
+    # published, not created: goreleaser creates the release as a draft, uploads
+    # the assets, then publishes it. GitHub does not deliver `created` for draft
+    # releases, so `created` stopped firing once releases stopped being made by
+    # hand, and this workflow silently stopped validating releases altogether.
+    # See DEVOPS-1185.
+    types: [published]
+  # Lets a release be re-validated at its tag without re-cutting it.
+  workflow_dispatch:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
No release cut from this line has been validated since releases stopped being created by hand. Verified against `v0.35.3-rc.0` and `v0.36.1-rc.0` (cut 2026-07-27): **zero** validator runs in this repo for either.

## Why `release: [created]` no longer fires

goreleaser creates the GitHub release as a **draft**, uploads the assets, then publishes it:

```
• releasing         tag=v0.36.1-rc.0
• created           url=.../releases/tag/untagged-9e688ef01fb008a2af3a   <- draft
• release published url=.../releases/tag/v0.36.1-rc.0
```

GitHub does not deliver the `created` activity type for draft releases, so `published` is the only event emitted.

This worked until recently only because a human ran `gh release create` (non-draft, which does fire `created`) as part of the cut — `v0.36.0-rc.1/2/3` were created by `mfranczy`/`deniseschannon` and their e2e runs did fire. The release dispatcher removed that step, so the last release-triggered run in this repo was `v0.37.0-next.internal.7` on 2026-07-21, whose OSS release is still made with `gh release create`.

## Changes

All three validators on this branch keyed on `created`:

- `e2e.yaml`: `[created]` -> `[published]`
- `e2e-ginkgo.yaml`: `[created]` -> `[published]`
- `unit-tests.yaml`: `[created]` -> `[published]`, plus `workflow_dispatch` — it was the only one of the three with no manual trigger, so a release could not be re-validated at its tag without re-cutting it.

`actionlint` clean. No `-next` gating added: `-next`/`-next.internal` are pro-only from feature branches under the current source-branch matrix, so they cannot reach this line.

Paired with the vcluster-pro half for this line, which must merge alongside it. Pro PRs: #2093 (main), #2094 (v0.36), #2095 (v0.34), #2096 (v0.33), #2097 (v0.32) in `loft-sh/vcluster-pro`.

Refs DEVOPS-1185

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only changes with no application or runtime behavior; restores release validation that had silently stopped.
> 
> **Overview**
> Release validation workflows were not running on goreleaser-cut releases because those releases are created as **drafts** first; GitHub does not emit `release` **`created`** for drafts, only **`published`**.
> 
> **`e2e.yaml`**, **`e2e-ginkgo.yaml`**, and **`unit-tests.yaml`** now listen for **`release: types: [published]`** instead of **`[created]`**, with inline comments pointing at DEVOPS-1185. **`unit-tests.yaml`** also gains **`workflow_dispatch`** so unit tests can be re-run against an existing release tag without cutting a new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfcab3a1e47d921bec55c9585e260683f634798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->