### PR TITLE
fix(ci): stop no-op edited runs masking the real e2e result

### DIFF
--- a/.github/workflows/e2e-ginkgo.yaml
+++ b/.github/workflows/e2e-ginkgo.yaml
@@ -167,7 +167,11 @@ jobs:
           retention-days: 7
 
   ginkgo-e2e-tests:
-    name: Execute test suites
+    # A no-op `edited` run must not publish a check under the same name as the
+    # run that actually executed the suite. GitHub surfaces only the newest run
+    # per check name, so the skip silently overwrote the real pass/fail and the
+    # PR showed "skipping" for a suite that had already gone red. DEVOPS-1203.
+    name: "${{ needs.parse_label-filter.outputs.skip-edited == 'true' && 'Execute test suites (skipped, PR description edit)' || 'Execute test suites' }}"
     needs:
       - build
       - parse_label-filter


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

Closes DEVOPS-1203

A PR-description edit fires a second run of the e2e workflow on the same head SHA. That run correctly skips the suite (`skip-edited=true`, DEVOPS-1057), but it published its check under the same name as the run that actually executed the tests. GitHub surfaces only the newest run per check name, so the skip overwrote the real pass/fail and the PR showed "skipping" for a suite that had already finished, sometimes red.

This names the skipped job differently, so both checks stay visible and the real result wins. The DEVOPS-1057 skip behaviour is untouched.

**Evidence**

Measured across recent PRs, counting cases where the newest run of the workflow skipped the test job while an earlier run on the same SHA executed it:

| Repo / workflow | Masked | Sampled |
| --- | --- | --- |
| vcluster `e2e-ginkgo.yaml` | 24 | 29 |
| vcluster-pro `e2e-oss-ginkgo.yaml` | 4 | 6 |
| vcluster-pro `e2e.yaml` | 7 | 18 |
| loft-enterprise `e2e-ginkgo.yaml` | 11 | 24 |

Three PRs merged with a failing suite displayed as skipping:

| PR | Real run | Visible run |
| --- | --- | --- |
| #4037 | [30466414251](https://github.com/loft-sh/vcluster/actions/runs/30466414251) failed 15:48:55 | 30466439411 skipped, merged 16:02:06 |
| #4121 | [30468864161](https://github.com/loft-sh/vcluster/actions/runs/30468864161) failed | 30468895732 skipped, merged |
| #4114 | [30351654374](https://github.com/loft-sh/vcluster/actions/runs/30351654374) failed | 30351690516 skipped, merged |

vcluster is the worst affected because Cursor Bugbot edits the description on nearly every PR.

**Why this shape and not the other**

The alternative is dropping `edited` from the `pull_request` types entirely and moving label-filter retargeting to an explicit trigger. That removes the duplicate run rather than renaming it, and remains available as a follow-up. I did not take it here because it changes how people request extra suites, which is a UX decision for the team rather than a bug fix. This change does not preclude it.

**Verification, and its limit**

`actionlint` passes and the YAML parses. Job-level `name:` accepts the `needs` context (confirmed against actionlint's context table, with a negative control showing it rejects `steps`). No repo gates merges on these checks: vcluster and vcluster-pro have no required status checks configured, and loft-enterprise requires only `Build Loft`, `lint`, `unit-tests` and `check`, so no branch protection breaks.

This PR cannot demonstrate the fix on itself. `e2e-ginkgo.yaml`'s `detect_changes` path list watches `.github/workflows/e2e.yaml` but not `e2e-ginkgo.yaml`, so a workflow-only change reports `has_changed=false` and the suite is skipped for an unrelated reason. The behaviour will be visible on the next code PR. That the e2e workflow does not watch itself is a separate issue and I have left it alone.

**Please provide a short message that should be published in the vcluster release notes**

CI only, no release note needed.

**What else do we need to know?**

Companion PRs, same change:

- loft-sh/vcluster-pro (`e2e.yaml`, `e2e-oss-ginkgo.yaml`)
- loft-sh/loft-enterprise (`e2e-ginkgo.yaml`)

Two things found while investigating and deliberately not fixed here: vcluster-pro `e2e-oss-ginkgo.yaml` inlines its own copy of the skip-edited shell instead of calling `parse-label-filter@parse-label-filter/v1`; and loft-enterprise has no `edited`/`code` concurrency split at all, where 7 of 24 sampled PRs ran the workflow repeatedly, one 36 times, without the test job ever executing.

## E2E Tests

### Additional test suites

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow display-name only; no change to when tests run or application code.
> 
> **Overview**
> **Fixes misleading PR checks when a PR description edit retriggers e2e without running tests** (DEVOPS-1203).
> 
> The `ginkgo-e2e-tests` job now uses a **dynamic `name:`**: when `parse_label-filter` sets `skip-edited=true` on a no-op `edited` event, the check is published as **Execute test suites (skipped, PR description edit)** instead of sharing **Execute test suites** with the run that actually executed Ginkgo. That keeps both checks visible so the newest run no longer replaces a real pass/fail with “skipped.”
> 
> Skip logic from DEVOPS-1057 is unchanged; only the displayed check name differs on skipped edited runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d4a1107d3882a198f719d3c2de1b1c183b66cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->