### PR TITLE
fix(release): publish stable cuts as none on the v0.35 line

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,12 @@ jobs:
       - uses: "goreleaser/goreleaser-action@v6"
         with:
           args: release --clean --timeout 60m ${{ steps.check_latest_stable.outputs.skip_homebrew == 'true' && '--skip=homebrew' || '' }}
-          version: "~> v2"
+          # Pinned to the minor, not the major: the GitHub label a release
+          # gets is decided by goreleaser internals (release.prerelease: auto
+          # reads ctx.Semver.Prerelease; make_latest is applied on publish), and
+          # this config still uses deprecated properties. A floating "~> v2"
+          # could change either out from under this maintenance line.
+          version: "~> v2.17"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           TELEMETRY_PRIVATE_KEY: ${{ secrets.VCLUSTER_TELEMETRY_PRIVATE_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -122,13 +122,17 @@ changelog:
       - "^test:"
 
 release:
-  # DEVOPS-1083: every release (including stable) starts as a GitHub
-  # pre-release. Promoting to stable/Latest is a deliberate human edit
-  # (uncheck "pre-release") on the release, which is what fires the
-  # release:released event that vcluster-pro's promote-release workflow
-  # listens for. A pre-release publish only ever emits `prereleased`, so the
-  # build cannot self-trigger promotion.
-  prerelease: true
+  # DEVOPS-1083: the GitHub label is decided by the tag alone. `auto` flags a
+  # release as a pre-release exactly when the tag carries a semver prerelease
+  # suffix, so a stable vX.Y.Z plus make_latest: false lands with the GitHub
+  # "None" label - published and downloadable at its exact tag, but not Latest.
+  # Promotion (Latest, the moving image tags, the stable Homebrew formula) is the
+  # Promote release workflow in vcluster-pro, dispatched by hand with the version
+  # to promote. It is deliberately NOT triggered by a release event: `released`
+  # fires the moment a stable cut is published, and a `release:` trigger resolves
+  # its workflow file from the release's own tag ref - which on this maintenance
+  # line predates that file, so it would never fire here at all.
+  prerelease: auto
   make_latest: false
   # Re-runs of this workflow against the same tag re-upload assets to an
   # already-populated GitHub Release and 422 with `already_exists`. This


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)
References DEVOPS-1270

The OSS half of the None-label change for the `v0.35` line. Pro side: loft-sh/vcluster-pro#2160 (main, full rationale) and its `v0.35` sibling.

- `release.prerelease`: `true` -> **`auto`**, so the GitHub label follows the tag: a stable `v0.35.N` is no longer flagged a pre-release and, with `make_latest: false`, lands with the GitHub **None** label — published and downloadable at its exact tag, but not Latest. Every suffixed tag stays a pre-release.
- goreleaser pinned `~> v2.17`, since the label now depends on goreleaser internals (`prerelease: auto` reads the parsed semver prerelease) and this config still uses deprecated properties.

Promotion of both halves is a single `workflow_dispatch` on `vcluster-pro` main, which sets this release to Latest, retags the moving image tags and patches the stable Homebrew formula. Nothing here needs a promotion trigger.

**Why this is a direct PR against a release branch rather than the monorepo:** this line predates the monorepo layout, so there is no `staging/` counterpart in `vcluster-pro` `v0.35` — this branch carries its own `release.yaml` and `.goreleaser.yaml`, and builds this line's OSS release itself. `main` needs no equivalent change: its config is mirrored from the monorepo's `staging/` tree and is already `auto`.

**Please provide a short message that should be published in the vcluster release notes**
Stable releases are now published with the GitHub "None" label instead of "Pre-release", and become "Latest" when the release is promoted.

**What else do we need to know?**

Independent of the shared-actions PR — no reusable-workflow inputs change here, so this can merge on its own.

Verified: `goreleaser check` valid, actionlint clean.

## E2E Tests

### Default Test Execution
The mandatory PR suite runs automatically. Only specify additional test suites below if needed.

### Adding New Test Suites
When adding a new ginkgo test suite:
- [ ] **Add labels** to the test suite
- [ ] **Update label-filter section** below to execute the new test suite
- [ ] **Verify test suite runs** in CI/CD pipeline

### Additional test suites
Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub labels stable OSS releases on the maintenance line and pins goreleaser; misconfiguration could mislabel releases or break the release workflow, but scope is CI/release config only with no runtime product code.
> 
> **Overview**
> Aligns the **v0.35** OSS release pipeline with the None-label model: stable tags are published as normal releases (not flagged pre-release) while **Latest** stays off until manual promotion in `vcluster-pro`.
> 
> In `.goreleaser.yaml`, **`release.prerelease`** changes from **`true`** to **`auto`**, so only semver prerelease suffixes get the pre-release flag; stable `v0.35.N` with existing **`make_latest: false`** lands on GitHub’s **None** label. Comments are updated to document promotion via the hand-dispatched Promote release workflow rather than `release:` events on this maintenance line.
> 
> In **`release.yaml`**, the goreleaser action version is pinned from **`~> v2`** to **`~> v2.17`** so label behavior tied to goreleaser’s semver parsing and deprecated config fields does not drift on this branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d8e1d90cf38be1d4b73ab813631e9c59abee92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->