### PR TITLE
ci: grant checks and statuses read to the auto-approve caller (v0.34)

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -8,8 +8,10 @@ on:
 # granted here, not there: a reusable workflow can only downgrade the caller's
 # GITHUB_TOKEN permissions, never elevate them, and anything omitted defaults to
 # none. GITHUB_TOKEN is scoped strictly by this block whatever the repository's
-# visibility, so omitting them makes the poll fail and the bot silently never
-# approve, while both the check and the job still report success.
+# visibility, so a public repo does not get them for free either. Omitting them
+# does not just break the poll at run time: the called job requests both scopes
+# explicitly, so GitHub rejects the call before anything starts and the run ends
+# as a startup failure, with no jobs and no logs to read.
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -4,9 +4,17 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# checks/statuses are what the shared workflow's CI poll reads. They must be
+# granted here, not there: a reusable workflow can only downgrade the caller's
+# GITHUB_TOKEN permissions, never elevate them, and anything omitted defaults to
+# none. GITHUB_TOKEN is scoped strictly by this block whatever the repository's
+# visibility, so omitting them makes the poll fail and the bot silently never
+# approve, while both the check and the job still report success.
 permissions:
   contents: read
   pull-requests: write
+  checks: read
+  statuses: read
 
 jobs:
   auto-approve:


### PR DESCRIPTION
## What

Adds `checks: read` and `statuses: read` to the caller-side `permissions` block of the auto-approve workflow.

## Why

The shared reusable workflow at `loft-sh/github-actions@auto-approve-bot-prs/v1` declares those two scopes on its job. A reusable workflow can only downgrade the caller's `GITHUB_TOKEN`, never elevate it, so a caller that omits them makes the whole workflow file invalid:

```
Error calling workflow '...@auto-approve-bot-prs/v1'. The nested job 'auto-approve'
is requesting 'checks: read, statuses: read', but is only allowed
'checks: none, statuses: none'.
```

That is a startup failure, not a failing run. The run has no jobs and no logs, every PR opened against this branch gets no auto-approval, and nothing turns red where anyone would look.

Confirmed on this repository: runs [30897354311](https://github.com/loft-sh/vcluster/actions/runs/30897354311) (`v0.34`), [30897356319](https://github.com/loft-sh/vcluster/actions/runs/30897356319) (`v0.35`) and [30897359397](https://github.com/loft-sh/vcluster/actions/runs/30897359397) (`v0.36`), all from branches without this fix, are `startup_failure` with zero jobs. The three branches carrying the fix run to completion.

## Scope check

The reusable workflow's job declares exactly `pull-requests: write`, `contents: read`, `checks: read`, `statuses: read`. This caller already had the first two, so these two complete the set. A partial grant would leave the file just as invalid.

The poll runs under `GITHUB_TOKEN`, not under `BOT_APPROVER_PAT`: the composite sets `GH_TOKEN` to `ci-read-token || github.token` and this caller passes no `ci-read-token`. So `checks: read` here is the grant that matters, and the repository being public does not supply it, because a declared `permissions:` block sets everything unlisted to `none`.

## Why this branch needs its own PR

The fix landed on `main` via loft-sh/vcluster-pro#2149 and synced here as 190d33a2. This release line predates the monorepo, so `staging/github.com/loft-sh/vcluster/.github/` does not exist on the corresponding `vcluster-pro` branch and the sync cannot reach it. The file is maintained directly here.

## One deliberate difference from `main`

The `permissions:` block is byte-identical to `main`'s, including the existing `# a889ee9` pin comment. The explanatory comment above it is not.

`main`'s version says omitting the scopes lets the poll fail "while both the check and the job still report success". That is true for a **direct consumer of the composite action**, which has no nested-permission validation. This file is a **reusable-workflow caller**, so the run never starts at all, and an operator sent looking for five poll-time 403s will find no logs to look in. Corrected here to describe the startup failure.

The same wording is on `main` (via `staging/` in `vcluster-pro`) and originates in `loft-sh/github-actions`: the reusable workflow's job comment, `docs/workflows/auto-approve-bot-prs.md`, and the composite README. Correcting those is a follow-up, not done here.

Known nit, left alone for parity with `main`: the `# a889ee9` pin comment is stale. The `auto-approve-bot-prs/v1` tag now resolves to `7857031`; `a889ee9` is an unrelated `ai-pr-review` commit.

Ref: DEVOPS-1254


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission and comment changes; no application or runtime code affected.
> 
> **Overview**
> Fixes **startup failures** when the auto-approve workflow calls the shared `loft-sh/github-actions` reusable workflow for backport PRs.
> 
> The caller `permissions` block now includes **`checks: read`** and **`statuses: read`**, which the nested job requires to poll CI. Reusable workflows cannot raise token scope above what the caller grants, so missing scopes caused GitHub to reject the workflow before any job ran. A short comment documents that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862c833d7423227bb59c048302b92811a25e859f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
