### PR TITLE
[0.32] chore: bump minimum platform version to v4.7.2

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.7.0"
+	MinimumVersionTag = "v4.7.2"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
## Summary
- Raises `MinimumVersionTag` in `pkg/platform/version.go` from `v4.7.0` to `v4.7.2`, the latest stable vCluster Platform patch release on the 4.7.x line.
- `v0.32` is within the active support window per the [version support lifecycle](https://www.vcluster.com/docs/vcluster/manage/upgrade/supported_versions).

## Test plan
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change on a patch bump; no logic changes, but clusters on Platform 4.7.0–4.7.1 may now be treated as below minimum.
> 
> **Overview**
> Raises the **minimum supported vCluster Platform version** from `v4.7.0` to **`v4.7.2`** by updating `MinimumVersionTag` in `pkg/platform/version.go`. The derived `MinimumVersion` semver is updated automatically and continues to drive `LatestCompatibleVersion` (GitHub release selection, eligibility filtering, and fallbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e135a33ada4a021e260096376ad9177cb57730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->