### PR TITLE
[0.33] chore: bump minimum platform version to v4.8.2

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.8.0"
+	MinimumVersionTag = "v4.8.2"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
## Summary
- Raises `MinimumVersionTag` in `pkg/platform/version.go` from `v4.8.0` to `v4.8.2`, the latest stable vCluster Platform patch release on the 4.8.x line.
- `v0.33` is within the active support window per the [version support lifecycle](https://www.vcluster.com/docs/vcluster/manage/upgrade/supported_versions).

## Test plan
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-constant change with no logic edits; main effect is stricter platform version requirements for installs and compatibility checks.
> 
> **Overview**
> Raises the required **vCluster Platform** floor by updating `MinimumVersionTag` in `pkg/platform/version.go` from **v4.8.0** to **v4.8.2** (latest stable on the 4.8.x line).
> 
> `MinimumVersion` is derived from that tag and feeds compatibility logic such as `LatestCompatibleVersion` (GitHub release selection and fallbacks) and the default platform version when `vclusterctl platform start` uses `latest` or an empty version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c636d4aa81fd36f52d2c2daf61340384f702b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->