### PR TITLE
[0.36] chore: bump platform MinimumVersionTag to v4.11.1

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.11.0"
+	MinimumVersionTag = "v4.11.1"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind enhancement

fixes ENG-12395

**What does this pull request do? Which issues does it resolve?**
Bumps the minimum required vCluster Platform version for `v0.36` from `v4.11.0` to `v4.11.1`, since a release candidate (`v4.11.1-rc.1`) is already in flight for that line. No GA release of `v4.11.1` exists yet.

**Please provide a short message that should be published in the vcluster release notes**
N/A — internal minimum-Platform-version tracking change.

**What else do we need to know?**
Requested as part of a routine Platform version-drift check. Not blocking on this PR alone — `v4.11.1` should be confirmed GA before merge.

Supersedes loft-sh/vcluster-pro#2179, which targeted the wrong repo — this constant lives in `loft-sh/vcluster` for release branches, not vendored into `vcluster-pro`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wCbJJURrhybXVN6YPSzJv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant bump with no logic changes; only tightens the declared Platform floor for compatibility checks.
> 
> **Overview**
> Raises the **minimum required vCluster Platform version** for the v0.36 line from `v4.11.0` to `v4.11.1` by updating `MinimumVersionTag` in `pkg/platform/version.go`. That constant drives `MinimumVersion` and is used when resolving compatible Platform releases (including fallbacks in `LatestCompatibleVersion`).
> 
> This is routine version-drift tracking ahead of the `v4.11.1` Platform line; merge should wait until `v4.11.1` is GA, since release workflows require a stable tag format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9190fc37595aad8b6e887145f87cca6bdd17bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->