### PR TITLE
[0.35] chore: bump platform MinimumVersionTag to v4.10.7

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.10.6"
+	MinimumVersionTag = "v4.10.7"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind enhancement

fixes ENG-12403

**What does this pull request do? Which issues does it resolve?**
Bumps the minimum required vCluster Platform version for `v0.35` from `v4.10.6` to `v4.10.7`, since a release candidate (`v4.10.7-rc.1`) is already in flight for that line. No GA release of `v4.10.7` exists yet.

**Please provide a short message that should be published in the vcluster release notes**
N/A — internal minimum-Platform-version tracking change.

**What else do we need to know?**
Requested as part of a routine Platform version-drift check. Not blocking on this PR alone — `v4.10.7` should be confirmed GA before merge.

Supersedes loft-sh/vcluster-pro#2180, which targeted the wrong repo — this constant lives in `loft-sh/vcluster` for release branches, not vendored into `vcluster-pro`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wCbJJURrhybXVN6YPSzJv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant bump for internal minimum-Platform-version tracking; no behavioral code changes beyond requiring a slightly newer Platform floor.
> 
> **Overview**
> Raises the **minimum required vCluster Platform version** for the `v0.35` line from `v4.10.6` to `v4.10.7` by updating `MinimumVersionTag` in `pkg/platform/version.go`.
> 
> That constant drives `MinimumVersion` and flows into compatibility checks (e.g. `LatestCompatibleVersion` fallbacks and `vclusterctl platform start` when version is `latest`/empty). **No logic changes**—only the floor version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7edda963bf0aa4992edc69170aa91145c039eef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->