### PR TITLE
Reverts print in help commands to avoid gorleeaser test failures and …

### DIFF
--- a/cmd/vclusterctl/cmd/root.go
+++ b/cmd/vclusterctl/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"github.com/loft-sh/vcluster/pkg/platform/defaults"
 	"github.com/loft-sh/vcluster/pkg/telemetry"
 	"github.com/loft-sh/vcluster/pkg/upgrade"
-	"github.com/loft-sh/vcluster/pkg/util/clihelper"
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -69,7 +68,7 @@ func NewRootCmd(log log.Logger) *cobra.Command {
 
 			return nil
 		},
-		Long: "\n" + clihelper.ASCIIArt,
+		Long: `vcluster root command`,
 	}
 }
 


### PR DESCRIPTION
Reverts first half of this PR: https://github.com/loft-sh/vcluster/pull/3915

```
Replacing the root command Long text with ASCIIArt removes the string vcluster root command from vcluster --help. 
The live Homebrew formula tests in .goreleaser.yaml still assert_match that exact string, 
so brew test for vcluster and vcluster-experimental fails after this CLI ships.
```

We could fix this easily, but for now I think its better to start small and add more later. Worried about it causing clutter. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI help display only; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Reverts the **vclusterctl** root command `Long` help from ASCII art back to the literal string `vcluster root command`, and drops the unused `pkg/util/clihelper` import from `cmd/vclusterctl/cmd/root.go`.
> 
> This undoes part of PR #3915 so `vcluster --help` again includes text that **goreleaser** Homebrew formula tests in `.goreleaser.yaml` assert via `assert_match` for both `vcluster` and `vcluster-experimental` brew tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bea27f82126b3537b8ec0888048387fa44a455. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->