### PR TITLE
fix(docker): support running the docker driver on podman

### DIFF
--- a/cmd/vclusterctl/cmd/node/load-docker-image.go
+++ b/cmd/vclusterctl/cmd/node/load-docker-image.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/loft-sh/log"
+	"github.com/loft-sh/vcluster/pkg/cli"
 	"github.com/loft-sh/vcluster/pkg/cli/flags"
 	"github.com/loft-sh/vcluster/pkg/snapshot/pod"
 	"github.com/spf13/cobra"
@@ -67,6 +68,11 @@ func (o *LoadImageOptions) Run(ctx context.Context, nodeName string) error {
 
 	// save image to archive
 	if o.Image != "" {
+		// make sure a docker daemon is reachable, falling back to podman if available
+		if err := cli.EnsureDockerDaemon(ctx, o.Log); err != nil {
+			return err
+		}
+
 		o.Log.Infof("Saving image %s to archive...", o.Image)
 		if err := runCommand("docker", "save", "-o", "image.tar.gz", o.Image); err != nil {
 			return fmt.Errorf("failed to save image: %w", err)

--- a/pkg/cli/connect_docker.go
+++ b/pkg/cli/connect_docker.go
@@ -52,6 +52,12 @@ type connectDocker struct {
 }
 
 func ConnectDocker(ctx context.Context, options *ConnectOptions, globalFlags *flags.GlobalFlags, vClusterName string, command []string, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, log)
+	if err != nil {
+		return err
+	}
+
 	cmd := &connectDocker{
 		GlobalFlags:    globalFlags,
 		ConnectOptions: options,

--- a/pkg/cli/connect_docker.go
+++ b/pkg/cli/connect_docker.go
@@ -53,7 +53,7 @@ type connectDocker struct {
 
 func ConnectDocker(ctx context.Context, options *ConnectOptions, globalFlags *flags.GlobalFlags, vClusterName string, command []string, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, log)
+	err := EnsureDockerDaemon(ctx, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -76,7 +76,7 @@ func CreateDocker(ctx context.Context, options *CreateOptions, globalFlags *flag
 	}
 
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, log)
+	err := EnsureDockerDaemon(ctx, log)
 	if err != nil {
 		return err
 	}
@@ -477,10 +477,13 @@ func getInstallStandaloneScript(ctx context.Context, vClusterVersion string, glo
 		return script, nil
 	}
 
-	// check the cache first
+	// check the cache first, discarding a corrupted entry so it gets re-downloaded
 	cachePath := filepath.Join(filepath.Dir(globalFlags.Config), "docker", "install-standalone", "v"+vClusterVersion, "install-standalone.sh")
 	if script, err := os.ReadFile(cachePath); err == nil {
-		return script, nil
+		if err := validateInstallStandaloneScript(script); err == nil {
+			return script, nil
+		}
+		_ = os.Remove(cachePath)
 	}
 
 	scriptURL := fmt.Sprintf("https://github.com/loft-sh/vcluster/releases/download/v%s/install-standalone.sh", vClusterVersion)
@@ -489,7 +492,8 @@ func getInstallStandaloneScript(ctx context.Context, vClusterVersion string, glo
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	httpClient := &http.Client{Timeout: time.Minute}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("download %s (set %s to a local copy of the script if this environment can't reach github): %w", scriptURL, installStandaloneScriptEnv, err)
 	}
@@ -502,13 +506,35 @@ func getInstallStandaloneScript(ctx context.Context, vClusterVersion string, glo
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", scriptURL, err)
 	}
+	if err := validateInstallStandaloneScript(script); err != nil {
+		return nil, fmt.Errorf("downloaded %s is not a valid install script (an intercepting proxy might have returned an error page): %w", scriptURL, err)
+	}
 
-	// cache the script for offline reuse, best effort
+	// cache the script for offline reuse, best effort. Write to a temp file and
+	// rename so an interrupted write can't leave a truncated script behind.
 	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err == nil {
-		_ = os.WriteFile(cachePath, script, 0644)
+		if tmpFile, err := os.CreateTemp(filepath.Dir(cachePath), "install-standalone-*.sh"); err == nil {
+			_, writeErr := tmpFile.Write(script)
+			closeErr := tmpFile.Close()
+			if writeErr == nil && closeErr == nil {
+				_ = os.Rename(tmpFile.Name(), cachePath)
+			} else {
+				_ = os.Remove(tmpFile.Name())
+			}
+		}
 	}
 
 	return script, nil
+}
+
+// validateInstallStandaloneScript makes sure the given bytes look like a shell
+// script instead of e.g. an error page returned by an intercepting proxy.
+func validateInstallStandaloneScript(script []byte) error {
+	if !bytes.HasPrefix(script, []byte("#!")) {
+		return fmt.Errorf("script doesn't start with a shebang")
+	}
+
+	return nil
 }
 
 func ensureK8sResolvConf(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
@@ -1332,20 +1358,27 @@ func findTailIPs(ctx context.Context, networkName string, tailSize int) ([]strin
 }
 
 func getDockerSocketPath(ctx context.Context) (string, error) {
-	// Check the well-known socket paths first: a symlink to a live socket passes the
-	// -S test, which covers podman machines where /var/run/docker.sock is a symlink
-	// to podman.sock and therefore never shows up in netstat. Only fall back to
-	// scanning the listening unix sockets if none of the known paths exist.
+	// Scan the listening unix sockets first so a live docker listener always wins
+	// over a stale socket file. If that yields nothing, fall back to the well-known
+	// socket paths: a symlink to a live socket passes the -S test, which covers
+	// podman machines where /var/run/docker.sock is a symlink to podman.sock and
+	// therefore never shows up in netstat. The netstat scan intentionally only
+	// matches docker.sock, since matching podman.sock would also pick up rootless
+	// per-user sockets in /run/user, while the fallback list pins the rootful one.
 	cmdStr := `
+        if command -v netstat >/dev/null 2>&1; then
+            found=$(netstat -xlp | awk '$NF ~ /\/docker\.sock(\.real)?$/ {print $NF}')
+            if [ -n "$found" ]; then
+                echo "$found"
+                exit 0
+            fi
+        fi
         for p in /var/run/docker.sock.real /var/run/docker.sock /run/podman/podman.sock; do
             if [ -S "$p" ]; then
                 echo "$p"
                 exit 0
             fi
         done
-        if command -v netstat >/dev/null 2>&1; then
-            netstat -xlp | awk '$NF ~ /\/(docker|podman)\.sock(\.real)?$/ {print $NF}'
-        fi
     `
 
 	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).Output()

--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -72,6 +75,12 @@ func CreateDocker(ctx context.Context, options *CreateOptions, globalFlags *flag
 		os.Remove(hostnameFile)
 	}
 
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, log)
+	if err != nil {
+		return err
+	}
+
 	// check if container exists
 	exists, err := containerExists(ctx, getControlPlaneContainerName(vClusterName))
 	if err != nil {
@@ -108,29 +117,9 @@ func CreateDocker(ctx context.Context, options *CreateOptions, globalFlags *flag
 		return fmt.Errorf("failed to load docker config: %w", err)
 	}
 
-	// On Linux, load kernel modules required for node join (bridge, br_netfilter, overlay).
-	// Only run modprobe for modules not already loaded (check via /proc/modules, no sudo).
-	if runtime.GOOS == "linux" {
-		required := []string{"overlay", "bridge", "br_netfilter"}
-		loaded := make(map[string]bool)
-		if data, err := os.ReadFile("/proc/modules"); err == nil {
-			scanner := bufio.NewScanner(strings.NewReader(string(data)))
-			for scanner.Scan() {
-				fields := strings.Fields(scanner.Text())
-				if len(fields) > 0 {
-					loaded[fields[0]] = true
-				}
-			}
-		}
-		for _, mod := range required {
-			if loaded[mod] {
-				continue
-			}
-			if err := exec.CommandContext(ctx, "modprobe", mod).Run(); err != nil {
-				log.Warnf("Could not load kernel module %s: %v. If node join fails, run: sudo modprobe overlay && sudo modprobe bridge && sudo modprobe br_netfilter", mod, err)
-			}
-		}
-	}
+	// load kernel modules required for node join (bridge, br_netfilter, overlay),
+	// either on the host or inside the VM the container daemon runs in
+	ensureKernelModules(ctx, log)
 
 	// configure the network and update user values if needed
 	networkName, extraDockerArgs, err := configureNetwork(ctx, userValuesRaw, vClusterName, log)
@@ -234,7 +223,7 @@ func CreateDocker(ctx context.Context, options *CreateOptions, globalFlags *flag
 
 	// install vCluster standalone
 	if !exists {
-		err = installVClusterStandalone(ctx, vClusterName, vClusterVersion, vConfig, extraVClusterArgs, log)
+		err = installVClusterStandalone(ctx, vClusterName, vClusterVersion, vConfig, globalFlags, extraVClusterArgs, log)
 		if err != nil {
 			return err
 		}
@@ -350,11 +339,13 @@ func addVClusterDocker(ctx context.Context, name string, vClusterConfig *config.
 }
 
 // runDockerCommand runs a docker command and captures its combined output.
-// If the command runs longer than streamDelay, all buffered output is flushed
-// to the logger and subsequent lines are streamed in real time.
-func runDockerCommand(ctx context.Context, args []string, streamDelay time.Duration, logger log.Logger) (string, error) {
+// If stdin is not nil, it is passed to the command. If the command runs longer
+// than streamDelay, all buffered output is flushed to the logger and subsequent
+// lines are streamed in real time.
+func runDockerCommand(ctx context.Context, args []string, stdin io.Reader, streamDelay time.Duration, logger log.Logger) (string, error) {
 	logger.Debugf("Running command: docker %s", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdin = stdin
 
 	pr, pw, err := os.Pipe()
 	if err != nil {
@@ -419,16 +410,25 @@ func runDockerCommand(ctx context.Context, args []string, streamDelay time.Durat
 	return allOutput, nil
 }
 
-func installVClusterStandalone(ctx context.Context, vClusterName, vClusterVersion string, vClusterConfig *config.Config, extraArgs []string, log log.Logger) error {
+func installVClusterStandalone(ctx context.Context, vClusterName, vClusterVersion string, vClusterConfig *config.Config, globalFlags *flags.GlobalFlags, extraArgs []string, log log.Logger) error {
 	log.Infof("Starting vCluster standalone %s", vClusterName)
+
+	// get the install script on the host instead of downloading it inside the
+	// container, since corporate proxies often block direct github downloads
+	// from containers while the host has the proxy and CA configuration
+	installScript, err := getInstallStandaloneScript(ctx, vClusterVersion, globalFlags)
+	if err != nil {
+		return fmt.Errorf("failed to get install-standalone script: %w", err)
+	}
+
 	containerName := getControlPlaneContainerName(vClusterName)
 	joinedArgs := strings.Join(extraArgs, " ")
 	args := []string{
-		"exec", containerName,
-		"bash", "-c", fmt.Sprintf(`set -e -o pipefail; for i in $(seq 1 120); do state=$(systemctl is-system-running 2>/dev/null || true); [ "$state" = "running" ] || [ "$state" = "degraded" ] && break; sleep 0.5; done; curl -sfLk "https://github.com/loft-sh/vcluster/releases/download/v%s/install-standalone.sh" | sh -s -- --skip-download --skip-wait %s`, vClusterVersion, joinedArgs),
+		"exec", "-i", containerName,
+		"bash", "-c", fmt.Sprintf(`set -e -o pipefail; for i in $(seq 1 120); do state=$(systemctl is-system-running 2>/dev/null || true); [ "$state" = "running" ] || [ "$state" = "degraded" ] && break; sleep 0.5; done; sh -s -- --skip-download --skip-wait %s`, joinedArgs),
 	}
 
-	out, err := runDockerCommand(ctx, args, 2*time.Minute, log)
+	out, err := runDockerCommand(ctx, args, bytes.NewReader(installScript), 2*time.Minute, log)
 	if err != nil {
 		return fmt.Errorf("failed to start vCluster standalone: %w: %s", err, out)
 	}
@@ -459,6 +459,56 @@ func installVClusterStandalone(ctx context.Context, vClusterName, vClusterVersio
 	}
 
 	return nil
+}
+
+// installStandaloneScriptEnv allows providing the install-standalone.sh script from
+// a local file instead of downloading it, e.g. in air-gapped environments.
+const installStandaloneScriptEnv = "VCLUSTER_INSTALL_STANDALONE_SCRIPT"
+
+// getInstallStandaloneScript returns the version matched install-standalone.sh
+// script, either from the environment variable override, the local cache or the
+// github release of the requested vCluster version.
+func getInstallStandaloneScript(ctx context.Context, vClusterVersion string, globalFlags *flags.GlobalFlags) ([]byte, error) {
+	if path := os.Getenv(installStandaloneScriptEnv); path != "" {
+		script, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read install script from %s=%s: %w", installStandaloneScriptEnv, path, err)
+		}
+		return script, nil
+	}
+
+	// check the cache first
+	cachePath := filepath.Join(filepath.Dir(globalFlags.Config), "docker", "install-standalone", "v"+vClusterVersion, "install-standalone.sh")
+	if script, err := os.ReadFile(cachePath); err == nil {
+		return script, nil
+	}
+
+	scriptURL := fmt.Sprintf("https://github.com/loft-sh/vcluster/releases/download/v%s/install-standalone.sh", vClusterVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, scriptURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s (set %s to a local copy of the script if this environment can't reach github): %w", scriptURL, installStandaloneScriptEnv, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download %s: unexpected status %s (set %s to a local copy of the script if this environment can't reach github)", scriptURL, resp.Status, installStandaloneScriptEnv)
+	}
+
+	script, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", scriptURL, err)
+	}
+
+	// cache the script for offline reuse, best effort
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err == nil {
+		_ = os.WriteFile(cachePath, script, 0644)
+	}
+
+	return script, nil
 }
 
 func ensureK8sResolvConf(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
@@ -669,7 +719,7 @@ sh /tmp/join.sh --bundle-path /var/lib/vcluster/bin/kubernetes-%s-%s.tar.gz --fo
 `, vClusterName, url.QueryEscape(vClusterJoinToken), kubernetesVersion, runtime.GOARCH)
 	args := []string{"exec", containerName, "bash", "-c", joinScript}
 
-	out, err := runDockerCommand(ctx, args, 2*time.Minute, log)
+	out, err := runDockerCommand(ctx, args, nil, 2*time.Minute, log)
 	if err != nil {
 		return fmt.Errorf("failed to join vCluster node: %w: %s", err, out)
 	}
@@ -1009,7 +1059,7 @@ func configureLoadBalancer(ctx context.Context, fullConfigRaw map[string]interfa
 				return nil, fmt.Errorf("failed to set nested field: %w", err)
 			}
 
-			log.Warnf("Load balancer type services are not supported inside the vCluster because privileged port mapping is not allowed. If you are using Docker Desktop, please enable it in the Docker Desktop settings")
+			log.Warnf("Load balancer type services are not supported inside the vCluster because privileged port mapping is not allowed. If you are using Docker Desktop, please enable it in the Docker Desktop settings. If you are using Podman, mapping privileged ports to a specific host IP is currently not supported (see https://github.com/containers/podman/issues/28009)")
 			return extraArgs, nil
 		}
 
@@ -1036,10 +1086,17 @@ func configureLoadBalancer(ctx context.Context, fullConfigRaw map[string]interfa
 		}
 	}
 
-	// mount the docker socket
+	// mount the docker socket, if it can't be found disable the load balancer
+	// instead of failing the whole create
 	dockerSocketPath, err := getDockerSocketPath(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get docker socket path: %w", err)
+		setErr := unstructured.SetNestedField(fullConfigRaw, false, "experimental", "docker", "loadBalancer", "enabled")
+		if setErr != nil {
+			return nil, fmt.Errorf("failed to set nested field: %w", setErr)
+		}
+
+		log.Warnf("Load balancer type services are not supported inside the vCluster because the docker socket couldn't be found: %v", err)
+		return extraArgs, nil
 	}
 	extraArgs = append(extraArgs, "--mount", fmt.Sprintf("type=bind,src=%s,dst=%s,ro", dockerSocketPath, constants.DockerSocketPath))
 	return extraArgs, nil
@@ -1275,17 +1332,19 @@ func findTailIPs(ctx context.Context, networkName string, tailSize int) ([]strin
 }
 
 func getDockerSocketPath(ctx context.Context) (string, error) {
-	// Updated awk regex: /\/docker\.sock(\.real)?$/
-	// This matches paths ending in "/docker.sock" OR "/docker.sock.real"
+	// Check the well-known socket paths first: a symlink to a live socket passes the
+	// -S test, which covers podman machines where /var/run/docker.sock is a symlink
+	// to podman.sock and therefore never shows up in netstat. Only fall back to
+	// scanning the listening unix sockets if none of the known paths exist.
 	cmdStr := `
+        for p in /var/run/docker.sock.real /var/run/docker.sock /run/podman/podman.sock; do
+            if [ -S "$p" ]; then
+                echo "$p"
+                exit 0
+            fi
+        done
         if command -v netstat >/dev/null 2>&1; then
-            netstat -xlp | awk '$NF ~ /\/docker\.sock(\.real)?$/ {print $NF}'
-        else
-            for p in /var/run/docker.sock.real /var/run/docker.sock; do
-                if [ -S "$p" ]; then
-                    echo "$p"
-                fi
-            done
+            netstat -xlp | awk '$NF ~ /\/(docker|podman)\.sock(\.real)?$/ {print $NF}'
         fi
     `
 

--- a/pkg/cli/create_docker_test.go
+++ b/pkg/cli/create_docker_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/loft-sh/vcluster/pkg/cli/flags"
+	"gotest.tools/v3/assert"
+)
+
+func TestGetInstallStandaloneScript(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("environment variable override", func(t *testing.T) {
+		scriptPath := filepath.Join(t.TempDir(), "install-standalone.sh")
+		assert.NilError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho override"), 0644))
+		t.Setenv(installStandaloneScriptEnv, scriptPath)
+
+		globalFlags := &flags.GlobalFlags{Config: filepath.Join(t.TempDir(), "config.json")}
+		script, err := getInstallStandaloneScript(ctx, "0.31.0", globalFlags)
+		assert.NilError(t, err)
+		assert.Equal(t, string(script), "#!/bin/sh\necho override")
+	})
+
+	t.Run("environment variable override with missing file", func(t *testing.T) {
+		t.Setenv(installStandaloneScriptEnv, filepath.Join(t.TempDir(), "does-not-exist.sh"))
+
+		globalFlags := &flags.GlobalFlags{Config: filepath.Join(t.TempDir(), "config.json")}
+		_, err := getInstallStandaloneScript(ctx, "0.31.0", globalFlags)
+		assert.ErrorContains(t, err, installStandaloneScriptEnv)
+	})
+
+	t.Run("cached script is used without downloading", func(t *testing.T) {
+		configDir := t.TempDir()
+		cachePath := filepath.Join(configDir, "docker", "install-standalone", "v0.31.0", "install-standalone.sh")
+		assert.NilError(t, os.MkdirAll(filepath.Dir(cachePath), 0755))
+		assert.NilError(t, os.WriteFile(cachePath, []byte("#!/bin/sh\necho cached"), 0644))
+
+		globalFlags := &flags.GlobalFlags{Config: filepath.Join(configDir, "config.json")}
+		script, err := getInstallStandaloneScript(ctx, "0.31.0", globalFlags)
+		assert.NilError(t, err)
+		assert.Equal(t, string(script), "#!/bin/sh\necho cached")
+	})
+}

--- a/pkg/cli/create_docker_test.go
+++ b/pkg/cli/create_docker_test.go
@@ -31,6 +31,12 @@ func TestGetInstallStandaloneScript(t *testing.T) {
 		assert.ErrorContains(t, err, installStandaloneScriptEnv)
 	})
 
+	t.Run("script validation", func(t *testing.T) {
+		assert.NilError(t, validateInstallStandaloneScript([]byte("#!/bin/sh\necho ok")))
+		assert.ErrorContains(t, validateInstallStandaloneScript([]byte("<html>proxy error page</html>")), "shebang")
+		assert.ErrorContains(t, validateInstallStandaloneScript(nil), "shebang")
+	})
+
 	t.Run("cached script is used without downloading", func(t *testing.T) {
 		configDir := t.TempDir()
 		cachePath := filepath.Join(configDir, "docker", "install-standalone", "v0.31.0", "install-standalone.sh")

--- a/pkg/cli/delete_docker.go
+++ b/pkg/cli/delete_docker.go
@@ -26,7 +26,7 @@ type deleteDocker struct {
 
 func DeleteDocker(ctx context.Context, platformClient platform.Client, options *DeleteOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, log)
+	err := EnsureDockerDaemon(ctx, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/delete_docker.go
+++ b/pkg/cli/delete_docker.go
@@ -25,6 +25,12 @@ type deleteDocker struct {
 }
 
 func DeleteDocker(ctx context.Context, platformClient platform.Client, options *DeleteOptions, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, log)
+	if err != nil {
+		return err
+	}
+
 	cmd := &deleteDocker{
 		GlobalFlags:   globalFlags,
 		DeleteOptions: options,

--- a/pkg/cli/describe_docker.go
+++ b/pkg/cli/describe_docker.go
@@ -86,7 +86,7 @@ type dockerInspectDetails struct {
 
 func DescribeDocker(ctx context.Context, flags *flags.GlobalFlags, output io.Writer, l log.Logger, name string, configOnly bool, format string) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, l)
+	err := EnsureDockerDaemon(ctx, l)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/describe_docker.go
+++ b/pkg/cli/describe_docker.go
@@ -85,6 +85,12 @@ type dockerInspectDetails struct {
 }
 
 func DescribeDocker(ctx context.Context, flags *flags.GlobalFlags, output io.Writer, l log.Logger, name string, configOnly bool, format string) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, l)
+	if err != nil {
+		return err
+	}
+
 	containerName := getControlPlaneContainerName(name)
 
 	// inspect the container

--- a/pkg/cli/docker_runtime.go
+++ b/pkg/cli/docker_runtime.go
@@ -18,11 +18,11 @@ var (
 	errEnsureDockerDaemon  error
 )
 
-// ensureDockerDaemon makes sure the docker CLI can reach a container daemon before
+// EnsureDockerDaemon makes sure the docker CLI can reach a container daemon before
 // any docker command is run. If the default docker daemon is not reachable, it falls
 // back to Podman's Docker-compatible API socket by setting DOCKER_HOST for this
 // process, which every subsequent docker command inherits.
-func ensureDockerDaemon(ctx context.Context, log log.Logger) error {
+func EnsureDockerDaemon(ctx context.Context, log log.Logger) error {
 	ensureDockerDaemonOnce.Do(func() {
 		errEnsureDockerDaemon = findDockerDaemon(ctx, log)
 	})
@@ -63,7 +63,9 @@ func findDockerDaemon(ctx context.Context, log log.Logger) error {
 		return fmt.Errorf("podman socket %s is not reachable via the docker CLI, please make sure the podman machine is running and rootful: %w", socketPath, err)
 	}
 
-	log.Infof("Docker daemon not found, using Podman's Docker-compatible API at %s", socketPath)
+	// use Warnf so the notice goes to stderr and doesn't corrupt commands that
+	// print machine readable output (e.g. vcluster list --output json)
+	log.Warnf("Docker daemon not found, using Podman's Docker-compatible API at %s", socketPath)
 	return nil
 }
 
@@ -80,6 +82,12 @@ func pingDockerDaemon(ctx context.Context) error {
 func findPodmanSocket(ctx context.Context) (string, error) {
 	if _, err := exec.LookPath("podman"); err != nil {
 		return "", fmt.Errorf("podman not found: %w", err)
+	}
+
+	// podman machine on windows exposes a named pipe instead of a unix socket,
+	// which the fallback below doesn't handle
+	if runtime.GOOS == "windows" {
+		return "", fmt.Errorf("automatic podman fallback is not supported on windows, please set DOCKER_HOST to the podman machine's docker API endpoint manually")
 	}
 
 	// on linux podman serves the API directly on the host, on other platforms it
@@ -146,13 +154,22 @@ func ensureVMKernelModules(ctx context.Context, log log.Logger) {
 	// Docker Desktop preloads these modules, but other VM based runtimes like
 	// podman machine, colima or rancher desktop don't necessarily do so. Enter the
 	// VM's namespaces through a privileged container and load whatever is missing.
+	// The sysctls are only set when a module had to be loaded, so machines that
+	// already have everything in place are never modified.
 	cmdStr := `
+        loaded=""
         for mod in overlay bridge br_netfilter; do
             if ! grep -q "^$mod " /proc/modules; then
-                modprobe "$mod" 2>/dev/null || echo "could not load kernel module $mod"
+                if modprobe "$mod" 2>/dev/null; then
+                    loaded="$loaded $mod"
+                else
+                    echo "could not load kernel module $mod"
+                fi
             fi
         done
-        sysctl -qw net.bridge.bridge-nf-call-iptables=1 net.bridge.bridge-nf-call-ip6tables=1 net.ipv4.ip_forward=1 2>/dev/null || true
+        if [ -n "$loaded" ]; then
+            sysctl -qw net.bridge.bridge-nf-call-iptables=1 net.bridge.bridge-nf-call-ip6tables=1 net.ipv4.ip_forward=1 2>/dev/null || true
+        fi
     `
 
 	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).CombinedOutput()

--- a/pkg/cli/docker_runtime.go
+++ b/pkg/cli/docker_runtime.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/loft-sh/log"
+)
+
+var (
+	ensureDockerDaemonOnce sync.Once
+	errEnsureDockerDaemon  error
+)
+
+// ensureDockerDaemon makes sure the docker CLI can reach a container daemon before
+// any docker command is run. If the default docker daemon is not reachable, it falls
+// back to Podman's Docker-compatible API socket by setting DOCKER_HOST for this
+// process, which every subsequent docker command inherits.
+func ensureDockerDaemon(ctx context.Context, log log.Logger) error {
+	ensureDockerDaemonOnce.Do(func() {
+		errEnsureDockerDaemon = findDockerDaemon(ctx, log)
+	})
+	return errEnsureDockerDaemon
+}
+
+func findDockerDaemon(ctx context.Context, log log.Logger) error {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return fmt.Errorf("couldn't find the docker CLI, please make sure docker (or podman plus the docker CLI) is installed: %w", err)
+	}
+
+	// check if the docker daemon is already reachable
+	pingErr := pingDockerDaemon(ctx)
+	if pingErr == nil {
+		return nil
+	}
+
+	// if the user explicitly configured a docker endpoint, don't second-guess it
+	if dockerHost := os.Getenv("DOCKER_HOST"); dockerHost != "" {
+		return fmt.Errorf("docker daemon at DOCKER_HOST=%s is not reachable: %w", dockerHost, pingErr)
+	}
+
+	// the docker daemon is not reachable, try to fall back to podman's
+	// docker-compatible API socket
+	socketPath, err := findPodmanSocket(ctx)
+	if err != nil {
+		log.Debugf("Podman fallback not available: %v", err)
+		return fmt.Errorf("docker daemon is not reachable, please make sure docker is running (if you are using podman, make sure the podman machine is running): %w", pingErr)
+	}
+
+	err = os.Setenv("DOCKER_HOST", "unix://"+socketPath)
+	if err != nil {
+		return fmt.Errorf("set DOCKER_HOST: %w", err)
+	}
+
+	err = pingDockerDaemon(ctx)
+	if err != nil {
+		return fmt.Errorf("podman socket %s is not reachable via the docker CLI, please make sure the podman machine is running and rootful: %w", socketPath, err)
+	}
+
+	log.Infof("Docker daemon not found, using Podman's Docker-compatible API at %s", socketPath)
+	return nil
+}
+
+func pingDockerDaemon(ctx context.Context) error {
+	out, err := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	return nil
+}
+
+// findPodmanSocket returns the host path of Podman's Docker-compatible API socket.
+func findPodmanSocket(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("podman"); err != nil {
+		return "", fmt.Errorf("podman not found: %w", err)
+	}
+
+	// on linux podman serves the API directly on the host, on other platforms it
+	// runs inside a podman machine that forwards a socket to the host
+	args := []string{"machine", "inspect", "--format", "{{.ConnectionInfo.PodmanSocket.Path}}"}
+	if runtime.GOOS == "linux" {
+		args = []string{"info", "--format", "{{.Host.RemoteSocket.Path}}"}
+	}
+
+	out, err := exec.CommandContext(ctx, "podman", args...).Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("podman %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(exitErr.Stderr)), err)
+		}
+		return "", fmt.Errorf("podman %s: %w", strings.Join(args, " "), err)
+	}
+
+	socketPath := strings.TrimPrefix(strings.TrimSpace(string(out)), "unix://")
+	if socketPath == "" || strings.Contains(socketPath, "<nil>") {
+		return "", fmt.Errorf("podman did not return a socket path, is the podman machine running?")
+	}
+
+	return socketPath, nil
+}
+
+// ensureKernelModules loads the kernel modules required for node join and pod
+// networking (overlay, bridge, br_netfilter). On linux hosts the modules are loaded
+// directly, on other platforms the container daemon runs inside a VM, so they are
+// loaded there through a privileged container. Failures are logged as warnings
+// because the modules might be built into the kernel.
+func ensureKernelModules(ctx context.Context, log log.Logger) {
+	if runtime.GOOS == "linux" {
+		ensureHostKernelModules(ctx, log)
+		return
+	}
+
+	ensureVMKernelModules(ctx, log)
+}
+
+func ensureHostKernelModules(ctx context.Context, log log.Logger) {
+	// only run modprobe for modules not already loaded (check via /proc/modules, no sudo)
+	loaded := map[string]bool{}
+	if data, err := os.ReadFile("/proc/modules"); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				loaded[fields[0]] = true
+			}
+		}
+	}
+
+	for _, mod := range []string{"overlay", "bridge", "br_netfilter"} {
+		if loaded[mod] {
+			continue
+		}
+		if err := exec.CommandContext(ctx, "modprobe", mod).Run(); err != nil {
+			log.Warnf("Could not load kernel module %s: %v. If node join fails, run: sudo modprobe overlay && sudo modprobe bridge && sudo modprobe br_netfilter", mod, err)
+		}
+	}
+}
+
+func ensureVMKernelModules(ctx context.Context, log log.Logger) {
+	// Docker Desktop preloads these modules, but other VM based runtimes like
+	// podman machine, colima or rancher desktop don't necessarily do so. Enter the
+	// VM's namespaces through a privileged container and load whatever is missing.
+	cmdStr := `
+        for mod in overlay bridge br_netfilter; do
+            if ! grep -q "^$mod " /proc/modules; then
+                modprobe "$mod" 2>/dev/null || echo "could not load kernel module $mod"
+            fi
+        done
+        sysctl -qw net.bridge.bridge-nf-call-iptables=1 net.bridge.bridge-nf-call-ip6tables=1 net.ipv4.ip_forward=1 2>/dev/null || true
+    `
+
+	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).CombinedOutput()
+	if err != nil {
+		log.Warnf("Could not ensure kernel modules inside the docker VM: %v: %s. If node join fails, load the overlay, bridge and br_netfilter kernel modules in the VM manually", err, strings.TrimSpace(string(out)))
+		return
+	}
+	if output := strings.TrimSpace(string(out)); output != "" {
+		log.Warnf("%s. If node join fails, load the overlay, bridge and br_netfilter kernel modules in the VM manually", output)
+	}
+}

--- a/pkg/cli/list_docker.go
+++ b/pkg/cli/list_docker.go
@@ -28,6 +28,12 @@ type dockerVCluster struct {
 }
 
 func ListDocker(ctx context.Context, options *ListOptions, globalFlags *flags.GlobalFlags, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, log)
+	if err != nil {
+		return err
+	}
+
 	// find all vcluster containers
 	vClusters, err := findDockerContainer(ctx, constants.DockerControlPlanePrefix)
 	if err != nil {

--- a/pkg/cli/list_docker.go
+++ b/pkg/cli/list_docker.go
@@ -29,7 +29,7 @@ type dockerVCluster struct {
 
 func ListDocker(ctx context.Context, options *ListOptions, globalFlags *flags.GlobalFlags, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, log)
+	err := EnsureDockerDaemon(ctx, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/pause_docker.go
+++ b/pkg/cli/pause_docker.go
@@ -12,7 +12,7 @@ import (
 
 func PauseDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, log)
+	err := EnsureDockerDaemon(ctx, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/pause_docker.go
+++ b/pkg/cli/pause_docker.go
@@ -11,6 +11,12 @@ import (
 )
 
 func PauseDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, log)
+	if err != nil {
+		return err
+	}
+
 	containerName := getControlPlaneContainerName(vClusterName)
 
 	// check if container exists

--- a/pkg/cli/restore_docker.go
+++ b/pkg/cli/restore_docker.go
@@ -25,6 +25,11 @@ import (
 // entries are piped directly to Docker, and config files are written directly to disk.
 // callerOpts may be nil (standalone restore) or the user's CreateOptions (create --restore).
 func RestoreDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotPath, targetName string, callerOpts *CreateOptions, tempDir string, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	if err := ensureDockerDaemon(ctx, log); err != nil {
+		return err
+	}
+
 	// If the snapshot path is a remote URL, pull it to a temp file first.
 	localPath := snapshotPath
 	if isRemoteSnapshotURL(snapshotPath) {

--- a/pkg/cli/restore_docker.go
+++ b/pkg/cli/restore_docker.go
@@ -26,7 +26,7 @@ import (
 // callerOpts may be nil (standalone restore) or the user's CreateOptions (create --restore).
 func RestoreDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotPath, targetName string, callerOpts *CreateOptions, tempDir string, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	if err := ensureDockerDaemon(ctx, log); err != nil {
+	if err := EnsureDockerDaemon(ctx, log); err != nil {
 		return err
 	}
 

--- a/pkg/cli/resume_docker.go
+++ b/pkg/cli/resume_docker.go
@@ -12,7 +12,7 @@ import (
 
 func ResumeDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	err := ensureDockerDaemon(ctx, log)
+	err := EnsureDockerDaemon(ctx, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/resume_docker.go
+++ b/pkg/cli/resume_docker.go
@@ -11,6 +11,12 @@ import (
 )
 
 func ResumeDocker(ctx context.Context, globalFlags *flags.GlobalFlags, vClusterName string, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	err := ensureDockerDaemon(ctx, log)
+	if err != nil {
+		return err
+	}
+
 	containerName := getControlPlaneContainerName(vClusterName)
 
 	// check if container exists

--- a/pkg/cli/snapshot_docker.go
+++ b/pkg/cli/snapshot_docker.go
@@ -52,7 +52,7 @@ type SnapshotVolume struct {
 // and configuration directory into a single gzipped tar archive.
 func SnapshotDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, vClusterName, outputPath string, log log.Logger) error {
 	// make sure a docker daemon is reachable, falling back to podman if available
-	if err := ensureDockerDaemon(ctx, log); err != nil {
+	if err := EnsureDockerDaemon(ctx, log); err != nil {
 		return err
 	}
 

--- a/pkg/cli/snapshot_docker.go
+++ b/pkg/cli/snapshot_docker.go
@@ -51,6 +51,11 @@ type SnapshotVolume struct {
 // SnapshotDocker creates a snapshot of a Docker-based vCluster by exporting its Docker volumes
 // and configuration directory into a single gzipped tar archive.
 func SnapshotDocker(ctx context.Context, globalFlags *flags.GlobalFlags, snapshotOpts *snapshotapi.Options, vClusterName, outputPath string, log log.Logger) error {
+	// make sure a docker daemon is reachable, falling back to podman if available
+	if err := ensureDockerDaemon(ctx, log); err != nil {
+		return err
+	}
+
 	cpContainer := getControlPlaneContainerName(vClusterName)
 
 	// Verify the vCluster exists.


### PR DESCRIPTION
## What does this PR do?

Makes `vcluster create --driver docker` (vind) work on Podman without manual workarounds. With a rootful podman machine running, `vcluster create my-cluster --driver docker` now works out of the box, no `DOCKER_HOST` export, no socket shims, no manual modprobe.

Four changes, each addressing a failure users currently work around by hand:

1. **Podman fallback for the container daemon** (`pkg/cli/docker_runtime.go`)
   Every docker driver entry point now verifies the docker CLI can reach a daemon. If not, and Podman is installed, the CLI resolves Podman's Docker-compatible API socket (`podman machine inspect` on macOS/Windows, `podman info` on Linux) and sets `DOCKER_HOST` for the process. An explicitly set `DOCKER_HOST` is never overridden; unreachable endpoints now produce a clear error instead of a confusing downstream failure.

2. **Socket detection fixed for Podman VMs** (`getDockerSocketPath`)
   The load balancer setup detected the docker socket by scanning `netstat -xlp` for `docker.sock`. In a podman machine, `/var/run/docker.sock` is a symlink to `/run/podman/podman.sock`, which never appears in netstat, so the whole create failed with `no docker socket path found`. Detection now checks well-known socket paths first (a symlink to a live socket passes `[ -S ]`) with netstat as the fallback, and a detection failure disables the load balancer with a warning instead of failing the create.

3. **Kernel modules loaded inside the runtime VM** (`ensureKernelModules`)
   Node join and Flannel need `overlay`, `bridge` and `br_netfilter`. Docker Desktop preloads them; podman machine (Fedora CoreOS) does not, and the existing modprobe only ran on Linux hosts. On non-Linux hosts the CLI now loads missing modules and sets the bridge netfilter sysctls inside the VM, using the same privileged `nsenter` container pattern the socket detection already uses. This also hardens Colima, Lima and Rancher Desktop setups. Failures stay warnings, since the modules can be built into the kernel.

4. **install-standalone.sh fetched on the host** (`getInstallStandaloneScript`)
   The control plane bootstrap used to `curl` the script from github.com inside the container, which corporate proxies commonly block. The CLI now downloads the version-matched script on the host (where proxy and CA configuration exist), caches it under `~/.vcluster/docker/install-standalone/<version>/`, and streams it into the container over stdin. Air-gapped environments can point `VCLUSTER_INSTALL_STANDALONE_SCRIPT` at a local copy.

Also updates the privileged port warning to explain the Podman limitation (fixes loft-sh/vind#5): Podman cannot publish privileged ports bound to a specific host IP through gvproxy, see containers/podman#28009. Load balancer support on Podman is blocked on that upstream issue and degrades gracefully.

## Why?

Users have been building elaborate manual workarounds to run vind on Podman (socat systemd units to fake a netstat-visible docker.sock, manual modprobe over `podman machine ssh`, pre-downloading and `podman cp`-ing the install script after an expected failure). Related reports: loft-sh/vind#5, and the kernel module gap likely explains "Flannel stuck / pods pending" style reports on non Docker Desktop runtimes (loft-sh/vind#16, loft-sh/vind#19).

## Testing

All flows tested live on macOS (arm64):

**Podman 6.1.0, rootful applehv machine, freshly restarted (no kernel modules loaded), Docker Desktop stopped, no `DOCKER_HOST` set:**
- `vcluster create podtest --driver docker --chart-version 0.36.0 -f worker.yaml`: CLI logged `Docker daemon not found, using Podman's Docker-compatible API at ...`, loaded bridge/br_netfilter inside the VM, streamed the install script over stdin, control plane and worker both reached Ready, Flannel and CoreDNS Running, pod scheduling and service DNS verified.
- `vcluster connect / list / delete` all work through the fallback.
- Script cache written and reused on subsequent creates.

**Docker Desktop (regression):**
- Same create succeeds unchanged; no fallback triggered.
- New socket detection command returns the identical path as the old netstat scan inside the Docker Desktop VM.

**Error paths:**
- `DOCKER_HOST` pointing at a dead socket: clear error, no silent podman override.
- Unit tests for the install script override and cache (`create_docker_test.go`).

**Not covered:** load balancer end-to-end on Podman (blocked upstream, degrades gracefully with an explanatory warning), Windows podman machine (the fallback returns an explicit "set DOCKER_HOST manually" error there since podman on Windows uses a named pipe), sudo load balancer path on macOS (socket detection verified manually inside both VMs instead).

## Hardening after adversarial review

A second commit addresses findings from an internal review of the first commit:

- Socket detection scans netstat listeners **first** (exact pre-existing behavior for docker hosts, so a stale socket file can never shadow a live listener) and only falls back to the well-known paths when netstat yields nothing, which is the podman machine case.
- The podman fallback notice logs at warn level (stderr), so `vcluster list --driver docker --output json` output stays clean, and the fallback is explicitly unsupported on Windows with an actionable error instead of a misleading one.
- The install script download has a 1 minute timeout, validates the payload starts with a shebang (an intercepting proxy returning an HTML error page is rejected instead of executed), and the cache is written atomically (temp file + rename) and self-heals if a corrupted entry is found.
- The VM kernel module helper only sets the bridge netfilter sysctls when it actually had to load a module, so docker daemons that already have everything in place (including remote `DOCKER_HOST` machines) are never modified.
- `EnsureDockerDaemon` is exported and wired into `vcluster node load-image`, which also shells out to docker.

Known trade-offs called out for reviewers: if the docker daemon is briefly down while podman runs, the CLI falls back for that invocation (visible via the warn log); a socket detection failure disables the load balancer in the persisted config the same way the existing privileged-port and sudo checks do (re-running `create --upgrade` re-evaluates it); other podman-compat gaps in `vcluster platform start --docker` and the kind/minikube helpers are pre-existing and out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container daemon selection, VM kernel networking, and control-plane bootstrap paths; failures degrade with warnings in several places but incorrect socket or module handling could still break cluster creation on non-Docker Desktop runtimes.
> 
> **Overview**
> Makes **`vcluster create --driver docker`** work on Podman without manual `DOCKER_HOST` or socket shims by centralizing runtime setup in **`EnsureDockerDaemon`**, which pings Docker and falls back to Podman’s Docker-compatible socket (respecting an explicit **`DOCKER_HOST`**).
> 
> **Runtime and networking:** **`ensureKernelModules`** loads `overlay`, `bridge`, and `br_netfilter` on Linux hosts or inside the container VM (Podman machine, Colima, etc.). **`getDockerSocketPath`** prefers live `netstat` listeners, then well-known paths (including Podman’s socket); missing socket disables load balancer with a warning instead of failing create. Privileged-port messaging mentions Podman’s upstream limitation.
> 
> **Bootstrap:** **`install-standalone.sh`** is fetched on the host (cache, **`VCLUSTER_INSTALL_STANDALONE_SCRIPT`**, shebang validation, atomic cache writes) and piped into the control-plane container instead of curling from inside the VM.
> 
> **Coverage:** Daemon check is wired into connect, list, delete, describe, pause/resume, snapshot/restore, and **`vcluster node load-image`**. Tests cover install-script override, cache, and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912689742f1c09db98f4bc43757910c6751356a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->