### PR TITLE
[v0.36] chore: bump minimum platform version to v4.11.2

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.11.1"
+	MinimumVersionTag = "v4.11.2"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
## Summary
- Bumps `MinimumVersionTag` in `pkg/platform/version.go` from `v4.11.1` to `v4.11.2` on the `v0.36` release line, since `v4.11.2` is the latest non-prerelease patch in the 4.11 Platform release line (per `loft-sh/loft-enterprise` releases) and `v0.36` was still pinned to `v4.11.1`.

Found by an automated vCluster Platform version drift check against `loft-sh/loft-enterprise` release tags and the [supported versions doc](https://www.vcluster.com/docs/vcluster/manage/upgrade/supported_versions).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change aligning the minimum Platform version with the latest 4.11 patch; no logic changes beyond the version gate.
> 
> **Overview**
> Raises the **minimum supported vCluster Platform version** on the v0.36 line by updating `MinimumVersionTag` in `pkg/platform/version.go` from `v4.11.1` to `v4.11.2`.
> 
> That constant drives `MinimumVersion` and is used when resolving compatible Platform releases (including fallbacks in `LatestCompatibleVersion`), so deployments below 4.11.2 are no longer treated as meeting the minimum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc24642ee0e59cc3a1074008048925b9e53971c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->