### PR TITLE
fix(docker): specify host platform for helper containers and isolate stdout

### DIFF
--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -1143,7 +1143,7 @@ func extractContainerID(out string) string {
 func isDockerNetworkReachable(ctx context.Context, networkName string) (bool, error) {
 	// 1. Start a container listening on port 8080.
 	// We use 'nc -l -p 8080' instead of 'tail -f' so we have a target to connect to.
-	out, err := exec.CommandContext(ctx, "docker", "run", "--platform", "linux/"+runtime.GOARCH, "-q", "-d", "--network", networkName, "alpine", "nc", "-l", "-p", "8080").Output()
+	out, err := exec.CommandContext(ctx, "docker", "run", "--platform", "linux/"+runtime.GOARCH, "-q", "-d", "--rm", "--network", networkName, "alpine", "nc", "-l", "-p", "8080").Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -1112,7 +1112,11 @@ func getHostDNSServer(ctx context.Context, log log.Logger) (string, error) {
 	// We use "sh -c" to run the complex command string.
 	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "alpine", "sh", "-c", cmd).Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get real dns name: %s: %w", string(out), err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("failed to get real dns name: %s: %w", string(exitErr.Stderr), err)
+		}
+		return "", fmt.Errorf("failed to get real dns name: %w", err)
 	}
 
 	result := strings.TrimSpace(string(out))
@@ -1124,15 +1128,34 @@ func getHostDNSServer(ctx context.Context, log log.Logger) (string, error) {
 	return result, nil
 }
 
+func extractContainerID(out string) string {
+	lines := strings.Split(out, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" || strings.HasPrefix(line, "WARNING:") || strings.HasPrefix(line, "Unable to find image") {
+			continue
+		}
+		return line
+	}
+	return strings.TrimSpace(out)
+}
+
 func isDockerNetworkReachable(ctx context.Context, networkName string) (bool, error) {
 	// 1. Start a container listening on port 8080.
 	// We use 'nc -l -p 8080' instead of 'tail -f' so we have a target to connect to.
-	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "-d", "--rm", "--network", networkName, "alpine", "nc", "-l", "-p", "8080").CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "-d", "--network", networkName, "alpine", "nc", "-l", "-p", "8080").Output()
 	if err != nil {
-		return false, fmt.Errorf("failed to start test network container: %s: %w", string(out), err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, fmt.Errorf("failed to start test network container: %s: %w", string(exitErr.Stderr), err)
+		}
+		return false, fmt.Errorf("failed to start test network container: %w", err)
 	}
 
-	containerID := strings.TrimSpace(string(out))
+	containerID := extractContainerID(string(out))
+	if containerID == "" {
+		return false, fmt.Errorf("failed to start test network container: empty container ID returned")
+	}
 
 	// 2. Ensure cleanup: Kill the container when function exits.
 	// We use a background context here because if 'ctx' is cancelled,
@@ -1144,9 +1167,13 @@ func isDockerNetworkReachable(ctx context.Context, networkName string) (bool, er
 	// 3. Inspect the container to get its IP address.
 	// This format string grabs the IP from the first network found.
 	inspectCmd := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", containerID)
-	ipOut, err := inspectCmd.CombinedOutput()
+	ipOut, err := inspectCmd.Output()
 	if err != nil {
-		return false, fmt.Errorf("failed to inspect test network container: %s: %w", string(ipOut), err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, fmt.Errorf("failed to inspect test network container: %s: %w", string(exitErr.Stderr), err)
+		}
+		return false, fmt.Errorf("failed to inspect test network container: %w", err)
 	}
 
 	ip := strings.TrimSpace(string(ipOut))

--- a/pkg/cli/create_docker.go
+++ b/pkg/cli/create_docker.go
@@ -525,7 +525,7 @@ func ensureVClusterJoinToken(globalFlags *flags.GlobalFlags, vClusterName string
 }
 
 func canMountPrivilegedPort(ctx context.Context, log log.Logger) bool {
-	args := []string{"run", "-q", "--rm", "-p", "127.0.0.1:879:80", "alpine", "echo", "1"}
+	args := []string{"run", "--platform", "linux/" + runtime.GOARCH, "-q", "--rm", "-p", "127.0.0.1:879:80", "alpine", "echo", "1"}
 	log.Debugf("Running command: docker %s", strings.Join(args, " "))
 	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
 	if err != nil {
@@ -1110,7 +1110,7 @@ func getHostDNSServer(ctx context.Context, log log.Logger) (string, error) {
     `
 
 	// We use "sh -c" to run the complex command string.
-	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "alpine", "sh", "-c", cmd).Output()
+	out, err := exec.CommandContext(ctx, "docker", "run", "--platform", "linux/"+runtime.GOARCH, "-q", "--rm", "alpine", "sh", "-c", cmd).Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -1143,7 +1143,7 @@ func extractContainerID(out string) string {
 func isDockerNetworkReachable(ctx context.Context, networkName string) (bool, error) {
 	// 1. Start a container listening on port 8080.
 	// We use 'nc -l -p 8080' instead of 'tail -f' so we have a target to connect to.
-	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "-d", "--network", networkName, "alpine", "nc", "-l", "-p", "8080").Output()
+	out, err := exec.CommandContext(ctx, "docker", "run", "--platform", "linux/"+runtime.GOARCH, "-q", "-d", "--network", networkName, "alpine", "nc", "-l", "-p", "8080").Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -1316,7 +1316,7 @@ func getDockerSocketPath(ctx context.Context) (string, error) {
         fi
     `
 
-	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).Output()
+	out, err := exec.CommandContext(ctx, "docker", "run", "--platform", "linux/"+runtime.GOARCH, "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -1353,7 +1353,7 @@ func getContainerdSocketPath(ctx context.Context) (string, error) {
         fi
     `
 
-	out, err := exec.CommandContext(ctx, "docker", "run", "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).Output()
+	out, err := exec.CommandContext(ctx, "docker", "run", "--platform", "linux/"+runtime.GOARCH, "-q", "--rm", "--privileged", "--pid=host", "alpine", "nsenter", "-t", "1", "-m", "-p", "-u", "-i", "-n", "sh", "-c", cmdStr).Output()
 	if err != nil {
 		// Extract stderr for better debugging if the command actually fails
 		var exitErr *exec.ExitError

--- a/pkg/cli/create_docker_test.go
+++ b/pkg/cli/create_docker_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import "testing"
+
+func TestExtractContainerID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "clean 64-char ID",
+			input:    "23e586d93b4ca2d51a8d21e27ad14807b1fefb4445adc275adcb03093a76b216\n",
+			expected: "23e586d93b4ca2d51a8d21e27ad14807b1fefb4445adc275adcb03093a76b216",
+		},
+		{
+			name:     "warning prepended on stderr/stdout",
+			input:    "WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)\n23e586d93b4ca2d51a8d21e27ad14807b1fefb4445adc275adcb03093a76b216\n",
+			expected: "23e586d93b4ca2d51a8d21e27ad14807b1fefb4445adc275adcb03093a76b216",
+		},
+		{
+			name:     "unable to find image warning prepended",
+			input:    "Unable to find image 'alpine:latest' locally\nlatest: Pulling from library/alpine\nWARNING: The requested image's platform (linux/amd64) does not match\n23e586d93b4ca2d51a8d21e27ad14807b1fefb4445adc275adcb03093a76b216\n",
+			expected: "23e586d93b4ca2d51a8d21e27ad14807b1fefb4445adc275adcb03093a76b216",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractContainerID(tt.input)
+			if got != tt.expected {
+				t.Errorf("extractContainerID() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4152

### Gist & Summary
When creating a virtual cluster in Docker driver mode, `vcluster` executes short-lived helper containers to perform pre-flight checks (verifying network reachability, detecting host DNS, and checking container sockets).

If a user's host has a non-native CPU architecture image cached locally (e.g. an `amd64` helper image cached on an ARM64 Mac, or an `arm64` helper image cached on an AMD64 Linux VM), Docker CLI outputs architecture mismatch warning messages:
`WARNING: The requested image's platform does not match the detected host platform...`

Because `vcluster` captured raw output expecting only container IDs, it prepended the warning text to the container ID string and attempted to inspect a container named `WARNING: ...`, causing a fatal crash:
`fatal failed to configure network: failed to inspect test network container: error: no such object: WARNING: ...`

### Changes Implemented
1. **Host-Native Platform Enforcement**: Explicitly specify the host's native platform (`linux/arm64` or `linux/amd64`) when invoking helper containers, ensuring Docker always pulls and executes native binaries without architecture mismatch warnings.
2. **Robust Output Stream Isolation**: Separate standard output from error streams and filter out system log prefixes (such as image pull progress or engine warnings) before parsing container IDs.
3. **Unit Tests**: Added test cases covering container ID extraction across clean IDs, first-time pull logs, and warning outputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Docker create-time networking, DNS, and socket discovery; low logic risk but on a critical path that previously failed fatally on mixed-arch hosts.
> 
> **Overview**
> Fixes Docker driver pre-flight checks that crashed when Docker printed platform-mismatch or pull warnings ahead of the container ID (e.g. **failed to inspect test network container: no such object: WARNING: ...**).
> 
> Short-lived **alpine** helper runs now pass **`--platform linux/` + `runtime.GOARCH`** so images match the host and warnings are less likely. Parsing is tightened: several probes use **`Output()`** instead of **`CombinedOutput()`**, failures surface **`exec.ExitError` stderr**, and **`extractContainerID`** picks the real ID while skipping **`WARNING:`** and **`Unable to find image`** lines. Network reachability also rejects an empty ID before **`docker inspect`**.
> 
> Adds **`TestExtractContainerID`** for clean IDs, platform warnings, and pull noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6e806a4fd0b40d8070b276e34a045deb942e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->