### PR TITLE
fix(servicesync): avoid invalid load balancer status sync

### DIFF
--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -237,7 +237,9 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 	}
 
 	// sync the loadbalancer status
-	if fromService.Spec.Type == corev1.ServiceTypeLoadBalancer && !apiequality.Semantic.DeepEqual(fromService.Status.LoadBalancer, toService.Status.LoadBalancer) {
+	if fromService.Spec.Type == corev1.ServiceTypeLoadBalancer &&
+		toService.Spec.Type == corev1.ServiceTypeLoadBalancer &&
+		!apiequality.Semantic.DeepEqual(fromService.Status.LoadBalancer, toService.Status.LoadBalancer) {
 		e.Log.Infof("Update target service %s/%s because the loadbalancer status changed", to.Namespace, to.Name)
 		toService.Status.LoadBalancer = fromService.Status.LoadBalancer
 		return ctrl.Result{}, e.To.GetClient().Status().Update(ctx, toService)

--- a/pkg/controllers/servicesync/servicesync_test.go
+++ b/pkg/controllers/servicesync/servicesync_test.go
@@ -186,3 +186,105 @@ func TestFromHostReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestFromHostReconcileLoadBalancerCreatesEndpoints(t *testing.T) {
+	name := "test-map-host-service-syncer"
+	hostService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "host-namespace",
+			Name:      "host-service",
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeLoadBalancer,
+			ClusterIP: "10.0.0.1",
+			Ports: []corev1.ServicePort{
+				{
+					Name: "http",
+					Port: 8080,
+				},
+			},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.2",
+					},
+				},
+			},
+		},
+	}
+	virtualService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "virtual-namespace",
+			Name:      "virtual-service",
+			Labels: map[string]string{
+				translate.ControllerLabel: "vcluster",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Ports:     hostService.Spec.Ports,
+		},
+	}
+
+	pClient := testingutil.NewFakeClient(scheme.Scheme, hostService)
+	vClient := testingutil.NewFakeClient(scheme.Scheme, virtualService)
+	fakeConfig := testingutil.NewFakeConfig()
+	fakeContext := syncertesting.NewFakeRegisterContext(fakeConfig, pClient, vClient)
+	serviceSyncer := &ServiceSyncer{
+		Name:        name,
+		SyncContext: fakeContext.ToSyncContext(name),
+		SyncServices: map[string]types.NamespacedName{
+			"host-namespace/host-service": {
+				Namespace: "virtual-namespace",
+				Name:      "virtual-service",
+			},
+		},
+		CreateNamespace:       true,
+		CreateEndpoints:       true,
+		From:                  fakeContext.HostManager,
+		IsVirtualToHostSyncer: false,
+		To:                    fakeContext.VirtualManager,
+		Log:                   loghelper.New(name),
+	}
+
+	_, err := serviceSyncer.Reconcile(fakeContext, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: hostService.Namespace,
+			Name:      hostService.Name,
+		},
+	})
+	assert.NilError(t, err)
+
+	actualVirtualService := &corev1.Service{}
+	err = vClient.Get(fakeContext, types.NamespacedName{
+		Namespace: virtualService.Namespace,
+		Name:      virtualService.Name,
+	}, actualVirtualService)
+	assert.NilError(t, err)
+	assert.Equal(t, len(actualVirtualService.Status.LoadBalancer.Ingress), 0)
+
+	//nolint:staticcheck // SA1019: corev1.Endpoints is deprecated, but still required for compatibility
+	virtualEndpoints := &corev1.Endpoints{}
+	err = vClient.Get(fakeContext, types.NamespacedName{
+		Namespace: virtualService.Namespace,
+		Name:      virtualService.Name,
+	}, virtualEndpoints)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, virtualEndpoints.Subsets, []corev1.EndpointSubset{
+		{
+			Addresses: []corev1.EndpointAddress{
+				{
+					IP: hostService.Spec.ClusterIP,
+				},
+			},
+			Ports: []corev1.EndpointPort{
+				{
+					Name: "http",
+					Port: 8080,
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix
/kind test

**What does this pull request do? Which issues does it resolve?**
resolves #4154

When `networking.replicateServices.fromHost` maps a `LoadBalancer` Service,
the target Service is headless and therefore has type `ClusterIP`. The syncer
previously copied the source's load-balancer status to that target. Kubernetes
rejects the status update, and reconciliation returns before creating the
target Endpoints.

This change only synchronizes load-balancer status when both the source and
target Services are `LoadBalancer` Services. A regression test verifies that a
mapped host `LoadBalancer` does not receive invalid status and that its target
Endpoints are created from the host Service ClusterIP.

**Please provide a short message that should be published in the vcluster release notes**
Fixed host `LoadBalancer` Service replication failing before target Endpoints
were created.

**What else do we need to know?**

Focused test run:

```console
go test -p 2 ./pkg/controllers/servicesync
```

## E2E Tests

Additional test suite(s) that will be executed before the mandatory PR suite:

```label-filter
none
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped bugfix in service sync with a guard on status updates; behavior change only affects invalid LB status copies to non-LoadBalancer targets.
> 
> **Overview**
> Fixes **from-host service replication** when the source is a `LoadBalancer` Service but the mapped target is a headless `ClusterIP` Service (typical for `networking.replicateServices.fromHost` with endpoint creation).
> 
> **Load-balancer status** is now copied only when **both** sides are `LoadBalancer` Services. Previously, status was synced whenever the source was `LoadBalancer`, which made Kubernetes reject the target status update and stopped reconciliation before **Endpoints** could be created.
> 
> A regression test confirms the virtual Service keeps empty load-balancer ingress and that target Endpoints are created using the host Service’s `ClusterIP`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b38ed09cb69ecaa7181e9b64fda8cd03c8195b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->