### PR TITLE
[v0.31] chore: bump minimum platform version to v4.6.3

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.6.0"
+	MinimumVersionTag = "v4.6.3"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
Bumps `MinimumVersionTag` in `pkg/platform/version.go` from `v4.6.0` to `v4.6.3`, the latest non-prerelease patch in the 4.6.x line per `loft-sh/loft-enterprise` releases.

Found by the automated vCluster Platform version drift check run against `loft-sh/vcluster-pro`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvUfVsRnsnuwRg8SN193ke)_