### PR TITLE
[v0.28] chore: bump minimum platform version to v4.3.10

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.3.5"
+	MinimumVersionTag = "v4.3.10"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
Bumps `MinimumVersionTag` in `pkg/platform/version.go` from `v4.3.5` to `v4.3.10`, the latest non-prerelease patch in the 4.3.x line per `loft-sh/loft-enterprise` releases.

Note: the branch name includes the base branch (`v0.28-v4.3.10`) rather than the plain `bump-platform-version/v4.3.10` because another EOS branch (`v0.27`) also needs a bump to the same target version, and branch names must be unique within the repo.

Found by the automated vCluster Platform version drift check run against `loft-sh/vcluster-pro`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvUfVsRnsnuwRg8SN193ke)_