### PR TITLE
[v0.21] chore: bump minimum platform version to v4.0.1

### DIFF
--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	MinimumVersionTag = "v4.0.0-alpha.18"
+	MinimumVersionTag = "v4.0.1"
 	MinimumVersion    = semver.MustParse(strings.TrimPrefix(MinimumVersionTag, "v"))
 )
 


### PR DESCRIPTION
Bumps `MinimumVersionTag` in `pkg/platform/version.go` from `v4.0.0-alpha.18` (itself a pre-release tag) to `v4.0.1`, the latest non-prerelease patch in the 4.0.x line per `loft-sh/loft-enterprise` releases.

Note: the branch name includes the base branch (`v0.21-v4.0.1`) because three other EOS branches (`v0.20`, `v0.22`, `v0.23`) also need a bump to the same target version, and branch names must be unique within the repo.

Found by the automated vCluster Platform version drift check run against `loft-sh/vcluster-pro`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvUfVsRnsnuwRg8SN193ke)_